### PR TITLE
feat(hook): reliable hook init with process-wide memory scan

### DIFF
--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(CrimsonDesertEquipHide VERSION 0.1.0 LANGUAGES CXX)
+project(CrimsonDesertEquipHide VERSION 0.2.0 LANGUAGES CXX)
 
 # --- Standard and Compiler Options ---
 set(CMAKE_CXX_STANDARD 23)

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -135,8 +135,8 @@ cmake --build build --config Release --parallel
 ```bash
 git submodule update --init --recursive
 cd CrimsonDesertEquipHide
-cmake -S . -B build -G "Visual Studio 17 2022" -A x64
-cmake --build build --config Release --parallel
+cmake -S . -B build/msvc -G "Visual Studio 17 2022" -A x64
+cmake --build build/msvc --config Release --parallel
 ```
 
 The output binary (`CrimsonDesertEquipHide.asi`) will be placed in the build directory.

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -28,8 +28,6 @@
 ; Enabled = false to disable a category entirely (parts won't be tracked).
 
 [General]
-; Delay in milliseconds before scanning for hooks (game needs time to unpack).
-InitDelayMs = 3000
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
 

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide_Readme.txt
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide_Readme.txt
@@ -1,16 +1,25 @@
 CRIMSON DESERT - EQUIP HIDE
 Version 0.1.0
 
+REQUIREMENTS:
+- Ultimate ASI Loader from:
+  https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases
+
 INSTALLATION:
-1. Extract all files to: <Crimson Desert installation folder>/
-2. Launch the game
+1. Pick one ASI Loader DLL variant (e.g. version.dll) and place it in
+   the game root directory. If it doesn't work, rename it to another
+   variant (dinput8.dll, winmm.dll, etc.) and try again.
+2. Extract the remaining files to: <Crimson Desert>/bin64/
+3. Launch the game
 
 CONFIGURATION:
 Edit CrimsonDesertEquipHide.ini to customize options.
 
 TROUBLESHOOTING:
-- Set LogLevel = DEBUG in the INI file
+- Set LogLevel = Debug in the INI file
 - Check CrimsonDesertEquipHide.log for details
+- If hooks fail to install, the mod will log an error and remain inert
+  (the game continues normally without equipment hiding)
 
 SOURCE & SUPPORT:
 https://github.com/tkhquang/CrimsonDesertTools

--- a/CrimsonDesertEquipHide/src/constants.hpp
+++ b/CrimsonDesertEquipHide/src/constants.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "version.hpp"
+
+namespace EquipHide
+{
+    // =========================================================================
+    // Mod identity
+    // =========================================================================
+    inline constexpr const char *MOD_VERSION = VERSION_STRING;
+    inline constexpr const char *MOD_NAME = "CrimsonDesertEquipHide";
+    inline constexpr const char *LOG_FILE = "CrimsonDesertEquipHide.log";
+    inline constexpr const char *INI_FILE = "CrimsonDesertEquipHide.ini";
+    inline constexpr const wchar_t *INSTANCE_MUTEX_PREFIX = L"CrimsonDesertEquipHide_";
+
+    // =========================================================================
+    // Process gate
+    // =========================================================================
+    inline constexpr const char *GAME_PROCESS_NAME = "CrimsonDesert.exe";
+
+} // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/dllmain.cpp
+++ b/CrimsonDesertEquipHide/src/dllmain.cpp
@@ -1,21 +1,48 @@
+#include "constants.hpp"
 #include "equip_hide.hpp"
 
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
 
-static HMODULE g_hModule = nullptr;
+#include <cstring>
+
 static HANDLE g_shutdownEvent = nullptr;
+static HANDLE g_instanceMutex = nullptr;
 
 /// Mod lifecycle thread — runs init, waits for shutdown signal, then tears down
 /// outside the loader lock (joining threads from DllMain would deadlock).
 static DWORD WINAPI lifecycle_thread(LPVOID /*param*/)
 {
-    DMK::Logger::configure("EquipHide", "CrimsonDesertEquipHide.log", "%Y-%m-%d %H:%M:%S");
-    auto& logger = DMK::Logger::get_instance();
-    logger.enable_async_mode();
+    {
+        char exePath[MAX_PATH];
+        GetModuleFileNameA(nullptr, exePath, MAX_PATH);
+        const char *exeName = std::strrchr(exePath, '\\');
+        exeName = exeName ? exeName + 1 : exePath;
+        if (_stricmp(exeName, EquipHide::GAME_PROCESS_NAME) != 0)
+            return 0;
+    }
+
+    DMK::Logger::configure("EquipHide", EquipHide::LOG_FILE, "%Y-%m-%d %H:%M:%S");
+    auto &logger = DMK::Logger::get_instance();
+
+    DMK::AsyncLoggerConfig asyncCfg;
+    asyncCfg.overflow_policy = DMK::OverflowPolicy::SyncFallback;
+    logger.enable_async_mode(asyncCfg);
 
     logger.info("DLL loaded, runtime dir: {}", DMK::Filesystem::get_runtime_directory());
+
+    wchar_t mutexName[64];
+    wsprintfW(mutexName, L"%s%lu", EquipHide::INSTANCE_MUTEX_PREFIX, GetCurrentProcessId());
+    g_instanceMutex = CreateMutexW(nullptr, FALSE, mutexName);
+    if (g_instanceMutex && GetLastError() == ERROR_ALREADY_EXISTS)
+    {
+        logger.error("Another instance of CrimsonDesertEquipHide is already loaded. "
+                     "Check for duplicate .asi files in the game directory.");
+        CloseHandle(g_instanceMutex);
+        g_instanceMutex = nullptr;
+        return 1;
+    }
 
     if (!EquipHide::init())
     {
@@ -38,7 +65,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
     switch (ul_reason_for_call)
     {
     case DLL_PROCESS_ATTACH:
-        g_hModule = hModule;
         DisableThreadLibraryCalls(hModule);
 
         g_shutdownEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
@@ -68,6 +94,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 
             CloseHandle(g_shutdownEvent);
             g_shutdownEvent = nullptr;
+        }
+        if (g_instanceMutex)
+        {
+            CloseHandle(g_instanceMutex);
+            g_instanceMutex = nullptr;
         }
         break;
 

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -1,6 +1,6 @@
 #include "equip_hide.hpp"
 #include "categories.hpp"
-#include "version.hpp"
+#include "constants.hpp"
 
 #include <DetourModKit.hpp>
 
@@ -13,12 +13,6 @@
 
 namespace EquipHide
 {
-    // =========================================================================
-    // Constants
-    // =========================================================================
-    static constexpr const char *MOD_VERSION = VERSION_STRING;
-    static uint32_t s_initDelayMs = 3000;
-
     // =========================================================================
     // Hook target: sub_140818340 — visibility decision function
     //
@@ -123,13 +117,61 @@ namespace EquipHide
 #endif
 
     // =========================================================================
+    // AOB scan with unpack retry
+    //
+    // Packed/protected binaries may decompress code into dynamically
+    // allocated memory outside the main module.  Scan all readable-
+    // executable regions in the process to find the hook target
+    // regardless of where the unpacker places the code.
+    // =========================================================================
+
+    struct CompiledCandidate
+    {
+        const AobCandidate *source;
+        DMK::Scanner::CompiledPattern compiled;
+    };
+
+    /// Scan all executable committed memory regions for the AOB patterns.
+    /// Returns the resolved hook address and sets matchedSource on success.
+    static uintptr_t scan_for_hook_target(
+        const std::vector<CompiledCandidate> &candidates,
+        const AobCandidate *&matchedSource)
+    {
+        const uint8_t *addr = nullptr;
+        MEMORY_BASIC_INFORMATION mbi;
+
+        while (VirtualQuery(addr, &mbi, sizeof(mbi)))
+        {
+            if (mbi.State == MEM_COMMIT &&
+                (mbi.Protect & (PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE |
+                                PAGE_EXECUTE_WRITECOPY)))
+            {
+                const auto regionBase = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
+
+                for (const auto &c : candidates)
+                {
+                    const auto *match = DMK::Scanner::find_pattern(
+                        reinterpret_cast<const std::byte *>(regionBase),
+                        mbi.RegionSize, c.compiled);
+                    if (match)
+                    {
+                        matchedSource = c.source;
+                        return reinterpret_cast<uintptr_t>(match) + c.source->offsetToHook;
+                    }
+                }
+            }
+
+            addr = static_cast<const uint8_t *>(mbi.BaseAddress) + mbi.RegionSize;
+        }
+
+        return 0;
+    }
+
+    // =========================================================================
     // Config
     // =========================================================================
     static void load_config()
     {
-        DMK::Config::register_int("General", "InitDelayMs", "Init Delay (ms)", [](int val)
-                                  { s_initDelayMs = static_cast<uint32_t>(val); }, 3000);
-
         DMK::Config::register_string("General", "LogLevel", "Log Level", [](const std::string &val)
                                      {
                 auto& logger = DMK::Logger::get_instance();
@@ -153,7 +195,7 @@ namespace EquipHide
                                          { register_parts(cat, val); }, std::string{default_parts(cat)});
         }
 
-        DMK::Config::load("CrimsonDesertEquipHide.ini");
+        DMK::Config::load(INI_FILE);
         DMK::Config::log_all();
         build_part_lookup();
     }
@@ -239,98 +281,51 @@ namespace EquipHide
     {
         auto &logger = DMK::Logger::get_instance();
 
-        logger.info("=== CrimsonDesertEquipHide v{} ===", MOD_VERSION);
+        logger.info("=== {} v{} ===", MOD_NAME, MOD_VERSION);
 
         load_config();
 
-        // Wait for unpack: configurable delay + SizeOfImage poll
-        if (s_initDelayMs > 0)
-        {
-            logger.info("Waiting {}ms initial delay...", s_initDelayMs);
-            Sleep(s_initDelayMs);
-        }
-
-        logger.info("Polling for game unpack (SizeOfImage > 10 MB, timeout 5 min)...");
-        constexpr int kMaxPolls = 3000;
-        bool unpacked = false;
-        for (int poll = 0; poll < kMaxPolls; ++poll)
-        {
-            const auto *dh = reinterpret_cast<const IMAGE_DOS_HEADER *>(GetModuleHandleW(nullptr));
-            const auto *nh = reinterpret_cast<const IMAGE_NT_HEADERS *>(
-                reinterpret_cast<const uint8_t *>(dh) + dh->e_lfanew);
-            if (nh->OptionalHeader.SizeOfImage > 10u * 1024u * 1024u)
-            {
-                unpacked = true;
-                break;
-            }
-            Sleep(100);
-        }
-
-        if (!unpacked)
-            logger.error("Timed out waiting for game to unpack.");
-        else
-            logger.info("Game unpacked.");
-
-        HMODULE gameModule = GetModuleHandleW(nullptr);
-        const auto moduleBase = reinterpret_cast<uintptr_t>(gameModule);
-        const auto *dosHeader = reinterpret_cast<const IMAGE_DOS_HEADER *>(gameModule);
-        const auto *ntHeaders = reinterpret_cast<const IMAGE_NT_HEADERS *>(
-            reinterpret_cast<const uint8_t *>(gameModule) + dosHeader->e_lfanew);
-        auto moduleSize = static_cast<size_t>(ntHeaders->OptionalHeader.SizeOfImage);
-
-        {
-            const auto *firstSection = IMAGE_FIRST_SECTION(ntHeaders);
-            size_t maxExtent = 0;
-            for (WORD i = 0; i < ntHeaders->FileHeader.NumberOfSections; ++i)
-            {
-                auto secEnd = static_cast<size_t>(firstSection[i].VirtualAddress) + firstSection[i].Misc.VirtualSize;
-                if (secEnd > maxExtent)
-                    maxExtent = secEnd;
-            }
-            if (maxExtent > moduleSize)
-                moduleSize = maxExtent;
-        }
-
-        logger.info("Game module: base=0x{:X}, size=0x{:X} ({:.1f} MB)",
-                    moduleBase, moduleSize, moduleSize / (1024.0 * 1024.0));
-
-        // Install mid-hook using cascading AOB scan (try each pattern until one works)
-        auto &hookMgr = DMK::HookManager::get_instance();
-        bool hookInstalled = false;
-
+        // Pre-compile AOB patterns once
+        std::vector<CompiledCandidate> compiledCandidates;
         for (const auto &candidate : k_aobCandidates)
         {
-            logger.info("Trying AOB pattern '{}' (offset +0x{:X})...",
-                        candidate.name, candidate.offsetToHook);
-
-            auto hookResult = hookMgr.create_mid_hook_aob(
-                "EquipVisCheck",
-                moduleBase,
-                moduleSize,
-                candidate.pattern,
-                candidate.offsetToHook,
-                on_vis_check);
-
-            if (hookResult.has_value())
-            {
-                logger.info("Hook '{}' installed via pattern '{}' successfully",
-                            hookResult.value(), candidate.name);
-                hookInstalled = true;
-                break;
-            }
-
-            logger.warning("Pattern '{}' failed: {}",
-                           candidate.name,
-                           DetourModKit::Hook::error_to_string(hookResult.error()));
+            auto compiled = DMK::Scanner::parse_aob(candidate.pattern);
+            if (compiled)
+                compiledCandidates.push_back({&candidate, std::move(*compiled)});
+            else
+                logger.warning("Failed to parse AOB pattern '{}'", candidate.name);
         }
 
-        if (!hookInstalled)
+        if (compiledCandidates.empty())
         {
-            logger.error("All AOB patterns failed. The mod may be outdated for this game version.");
-            logger.error("The game will continue normally without equipment hiding.");
-            // Don't return false — still register hotkeys so the mod doesn't crash,
-            // and the user sees toggle messages (even though they have no effect).
+            logger.error("No valid AOB patterns available.");
+            return false;
         }
+
+        // Scan all executable memory regions for the hook target.
+        // The process gate in dllmain ensures we run after the protector
+        // has finished unpacking, so a single scan pass is sufficient.
+        const AobCandidate *matchedSource = nullptr;
+        uintptr_t hookAddr = scan_for_hook_target(compiledCandidates, matchedSource);
+
+        if (hookAddr == 0)
+        {
+            logger.error("No AOB pattern matched. The mod may be outdated for this game version.");
+            return false;
+        }
+
+        auto &hookMgr = DMK::HookManager::get_instance();
+        auto hookResult = hookMgr.create_mid_hook("EquipVisCheck", hookAddr, on_vis_check);
+
+        if (!hookResult.has_value())
+        {
+            logger.error("Hook creation failed at 0x{:X}: {}",
+                         hookAddr, DetourModKit::Hook::error_to_string(hookResult.error()));
+            return false;
+        }
+
+        logger.info("Hook installed via pattern '{}' at 0x{:X}",
+                    matchedSource->name, hookAddr);
 
         register_hotkeys();
 
@@ -343,7 +338,7 @@ namespace EquipHide
 
     void shutdown()
     {
-        DMK::Logger::get_instance().info("CrimsonDesertEquipHide shutting down...");
+        DMK::Logger::get_instance().info("{} shutting down...", MOD_NAME);
         DMK_Shutdown();
     }
 


### PR DESCRIPTION
## Summary
- Replace broken SizeOfImage polling and module-only AOB scan with a process-wide executable memory scan via VirtualQuery, fixing hook failure on packed binaries where the protector unpacks code into VirtualAlloc'd regions outside the 0.6 MB main module stub
- Gate on process name before logger init to prevent non-game processes (crashpad_handler.exe) from truncating the log file
- Add per-process named mutex for duplicate ASI detection, SyncFallback logger overflow policy, fail-fast on hook failure (no misleading hotkey registration), and centralized constants

## Test plan
- [x] Launch game, verify hook installs at 0ms via log
- [x] Verify crashpad_handler.exe produces no log output
- [x] Verify hotkeys only register when hook succeeds
- [x] Verify duplicate ASI detection logs error and exits
- [x] Test with Debug log level to confirm no dropped messages