### PR TITLE
feat(categories): complete equipment part registry and remove hardcoded defaults

### DIFF
--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -35,13 +35,13 @@ LogLevel = Info
 Enabled = true
 Hotkey = V
 DefaultHidden = false
-Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Bola, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_L, CD_MainWeapon_HandCannon, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Bola, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_L, CD_MainWeapon_HandCannon, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux
 
 [TwoHandWeapons]
 Enabled = true
 Hotkey = V
 DefaultHidden = false
-Parts = CD_TwoHandWeapon_Sword, CD_TwoHandWeapon_Axe, CD_TwoHandWeapon_Axe_Aux, CD_TwoHandWeapon_Mace, CD_TwoHandWeapon_WarHammer, CD_TwoHandWeapon_Hammer, CD_TwoHandWeapon_Cannon, CD_TwoHandWeapon_CannonBall, CD_TwoHandWeapon_Thrower, CD_TwoHandWeapon_Spear, CD_TwoHandWeapon_Alebard, CD_MainWeapon_Pike, CD_TwoHandWeapon_Rod, CD_TwoHandWeapon_Flail, CD_TwoHandWeapon_BlowPipe, CD_TwoHandWeapon_Scythe
+Parts = CD_TwoHandWeapon_Sword, CD_TwoHandWeapon_Axe, CD_TwoHandWeapon_Axe_Aux, CD_TwoHandWeapon_Mace, CD_TwoHandWeapon_WarHammer, CD_TwoHandWeapon_Hammer, CD_TwoHandWeapon_Cannon, CD_TwoHandWeapon_CannonBall, CD_TwoHandWeapon_Thrower, CD_TwoHandWeapon_Spear, CD_TwoHandWeapon_Alebard, CD_MainWeapon_Pike, CD_TwoHandWeapon_Rod, CD_TwoHandWeapon_Flail, CD_TwoHandWeapon_BlowPipe, CD_TwoHandWeapon_Scythe, CD_TwoHandWeapon_Flag
 
 [Shields]
 Enabled = true
@@ -53,25 +53,22 @@ Parts = CD_MainWeapon_Shield_L, CD_MainWeapon_Shield_R, CD_MainWeapon_TowerShiel
 Enabled = true
 Hotkey = V
 DefaultHidden = false
-; Gap IDs (unnamed runtime parts): 0xADF3
-Parts = CD_MainWeapon_Bow, CD_MainWeapon_Quiver, CD_MainWeapon_Quiver_Arw_01, CD_MainWeapon_Quiver_Arw_02, CD_MainWeapon_Quiver_Arw_03, CD_MainWeapon_Arw, CD_MainWeapon_Arwline, 0xADF3
+Parts = CD_MainWeapon_Bow, CD_MainWeapon_Quiver, CD_MainWeapon_Quiver_Arw, CD_MainWeapon_Quiver_Arw_01, CD_MainWeapon_Quiver_Arw_02, CD_MainWeapon_Quiver_Arw_03, CD_MainWeapon_Arw, CD_MainWeapon_Arwline, CD_MainWeapon_Arw_IN
 
 [SpecialWeapons]
 Enabled = true
 Hotkey = V
 DefaultHidden = false
-Parts = CD_MainWeapon_ArwHead, CD_MainWeapon_CrossBow, CD_MainWeapon_Pistol_R, CD_MainWeapon_Pistol_L, CD_MainWeapon_Musket, CD_MainWeapon_Trap, CD_MainWeapon_Bomb, CD_MainWeapon_Fan, CD_MainWeapon_ThrownSpear_R, CD_MainWeapon_ThrownSpear_L
+Parts = CD_MainWeapon_ArwHead, CD_MainWeapon_CrossBow, CD_MainWeapon_Pistol_R, CD_MainWeapon_Pistol_L, CD_MainWeapon_Musket, CD_MainWeapon_Trap, CD_MainWeapon_Bomb, CD_MainWeapon_Fan, CD_MainWeapon_ThrownSpear_R, CD_MainWeapon_ThrownSpear_L, CD_MainWeapon_Whip_R
 
 [Tools]
 Enabled = true
 Hotkey = V
 DefaultHidden = false
-; Gap IDs (unnamed runtime parts): 0xAE0F, 0xAE10, 0xAE14, 0xAE15, 0xAE17, 0xAE19
-Parts = CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Saw, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_Flute, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Torch, CD_Tool_FishingRod_Sub, 0xAE0F, 0xAE10, 0xAE14, 0xAE15, 0xAE17, 0xAE19
+Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Saw, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Shooter, CD_Tool_Flute, CD_Tool_FireCan, CD_Tool_Cigarette, CD_Tool_Sprayer, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Torch, CD_Tool_Pan, CD_Tool_Trumpet, CD_Tool_Pipe, CD_Tool_Book
 
 [Lanterns]
 Enabled = true
 Hotkey = V
 DefaultHidden = false
-; Gap IDs (unnamed runtime parts): 0xAE1E, 0xAE20
-Parts = CD_Lantern, 0xAE1E, 0xAE20
+Parts = CD_Tool_Hyperspace_RemoteControl, CD_Lantern, CD_Lantern_Ring

--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -26,7 +26,7 @@ namespace EquipHide
     //
     // ---- Complete Part Hash Reference ----
     //
-    // OneHandWeapons (0xADC7 - 0xADDE):
+    // OneHandWeapons (0xADC7 - 0xADDE, 0xB049 - 0xB04A):
     //   0xADC7  CD_MainWeapon_Sword_R         Sword (Right, drawn)
     //   0xADC8  CD_MainWeapon_Sword_IN_R      Sword (Right, sheathed)
     //   0xADC9  CD_MainWeapon_Sword_L         Sword (Left, drawn)
@@ -51,8 +51,10 @@ namespace EquipHide
     //   0xADDC  CD_MainWeapon_Lance           Lance
     //   0xADDD  CD_MainWeapon_Gauntlet        Gauntlet (Right)
     //   0xADDE  CD_MainWeapon_Gauntlet_L      Gauntlet (Left)
+    //   0xB049  CD_MainWeapon_Sword_R_Aux     Sword Aux (Right, drawn)
+    //   0xB04A  CD_MainWeapon_Sword_IN_R_Aux  Sword Aux (Right, sheathed)
     //
-    // TwoHandWeapons (0xADDF - 0xADED, 0xAE05):
+    // TwoHandWeapons (0xADDF - 0xADED, 0xAE05, 0xAEEE):
     //   0xADDF  CD_TwoHandWeapon_Sword        Greatsword
     //   0xADE0  CD_TwoHandWeapon_Axe          2H Axe
     //   0xADE1  CD_TwoHandWeapon_Axe_Aux      2H Axe (Auxiliary)
@@ -69,22 +71,30 @@ namespace EquipHide
     //   0xADEC  CD_TwoHandWeapon_Flail        2H Flail
     //   0xADED  CD_TwoHandWeapon_BlowPipe     Blow Pipe
     //   0xAE05  CD_TwoHandWeapon_Scythe       Scythe
+    //   0xAEEE  CD_TwoHandWeapon_Flag         Flag
     //
     // Shields (0xADEE - 0xADF0):
     //   0xADEE  CD_MainWeapon_Shield_L        Shield (Left)
     //   0xADEF  CD_MainWeapon_Shield_R        Shield (Right)
     //   0xADF0  CD_MainWeapon_TowerShield_L   Tower Shield (Left)
     //
-    // Bows (0xADF1 - 0xADF8):
+    //   NOTE: Only 3 shield slot hashes exist in the IndexedStringA table.
+    //   All shields (including unique/legendary like "Shield of Conviction")
+    //   must use one of these slots. If a shield doesn't get hidden, it may
+    //   render via an alternate VFX/overlay code path (see equip_hide.cpp).
+    //
+    // Bows (0xADF1 - 0xADF8, 0xAEEC):
     //   0xADF1  CD_MainWeapon_Bow             Bow
     //   0xADF2  CD_MainWeapon_Quiver          Quiver
+    //   0xADF3  CD_MainWeapon_Quiver_Arw      Quiver Arrow (base)
     //   0xADF4  CD_MainWeapon_Quiver_Arw_01   Quiver Arrow 1
     //   0xADF5  CD_MainWeapon_Quiver_Arw_02   Quiver Arrow 2
     //   0xADF6  CD_MainWeapon_Quiver_Arw_03   Quiver Arrow 3
     //   0xADF7  CD_MainWeapon_Arw             Arrow
     //   0xADF8  CD_MainWeapon_Arwline         Arrow Line
+    //   0xAEEC  CD_MainWeapon_Arw_IN          Arrow (Sheathed)
     //
-    // SpecialWeapons (0xADF9 - 0xAE02):
+    // SpecialWeapons (0xADF9 - 0xAE03):
     //   0xADF9  CD_MainWeapon_ArwHead         Arrow Head
     //   0xADFA  CD_MainWeapon_CrossBow        Crossbow
     //   0xADFB  CD_MainWeapon_Pistol_R        Pistol (Right)
@@ -95,9 +105,10 @@ namespace EquipHide
     //   0xAE00  CD_MainWeapon_Fan             Fan
     //   0xAE01  CD_MainWeapon_ThrownSpear_R   Thrown Spear (Right)
     //   0xAE02  CD_MainWeapon_ThrownSpear_L   Thrown Spear (Left)
+    //   0xAE03  CD_MainWeapon_Whip_R          Whip (Right)
     //
-    // Tools (0xAE06 - 0xAE1D, 0x0F4F):
-    //   0x0F4F  CD_Tool_FishingRod_Sub        Fishing Rod
+    // Tools (0x0F4E, 0xAE06 - 0xAE1D, 0xAEEF, 0xAEF2, 0xAF2F, 0x12435):
+    //   0x0F4E  CD_Tool_FishingRod             Fishing Rod
     //   0xAE06  CD_Tool                       Tool (generic)
     //   0xAE07  CD_Tool_01                    Tool variant
     //   0xAE08  CD_Tool_02                    Tool variant
@@ -107,36 +118,83 @@ namespace EquipHide
     //   0xAE0C  CD_Tool_Hoe                   Tool Hoe
     //   0xAE0D  CD_Tool_Broom                 Tool Broom
     //   0xAE0E  CD_Tool_FarmScythe            Farm Scythe
+    //   0xAE0F  CD_Tool_Hayfork               Hayfork
+    //   0xAE10  CD_Tool_Pickaxe               Pickaxe
     //   0xAE11  CD_Tool_Rake                  Tool Rake
     //   0xAE12  CD_Tool_Shovel                Tool Shovel
     //   0xAE13  CD_Tool_Crutch                Tool Crutch
+    //   0xAE14  CD_Tool_FishingRod_Sub        Fishing Rod (Sub)
+    //   0xAE15  CD_Tool_Shooter               Shooter
     //   0xAE16  CD_Tool_Flute                 Flute
+    //   0xAE17  CD_Tool_FireCan               Fire Can
     //   0xAE18  CD_Tool_Cigarette             Cigarette
+    //   0xAE19  CD_Tool_Sprayer               Sprayer
     //   0xAE1A  CD_Tool_HandDrum              Hand Drum
     //   0xAE1B  CD_Tool_DrumStick_R           Drum Stick (Right)
     //   0xAE1C  CD_Tool_DrumStick_L           Drum Stick (Left)
     //   0xAE1D  CD_Tool_Torch                 Torch
-    //   (0xAE0F, 0xAE10, 0xAE14, 0xAE15, 0xAE17, 0xAE19 = gap IDs, no string entry)
+    //   0xAEEF  CD_Tool_Pan                   Pan
+    //   0xAEF2  CD_Tool_Trumpet               Trumpet
+    //   0xAF2F  CD_Tool_Pipe                  Pipe
+    // 0x12435  CD_Tool_Book                  Book
     //
     // Lanterns (0xAE1E - 0xAE20):
-    //   0xAE1F  CD_Lantern                    Lantern
-    //   (0xAE1E, 0xAE20 = gap IDs seen at runtime, no string entry)
+    //   0xAE1E  CD_Tool_Hyperspace_RemoteControl  Remote Control
+    //   0xAE1F  CD_Lantern                        Lantern
+    //   0xAE20  CD_Lantern_Ring                   Lantern Ring
     //
-    // NOT classified (system / NPC / excluded):
-    //   0xAD8D  CD_Ring_L                     Accessory (ring)
+    // NOT classified (system / accessories / mount / excluded):
+    //   0xAD55  CD_Horse_Hair                 Horse Hair
+    //   0xAD5B  CD_Helm                       Helm
+    //   0xAD5C  CD_Helm_Acc                   Helm Accessory
+    //   0xAD5D  CD_Helm_Acc_01                Helm Accessory 1
+    //   0xAD5E  CD_Helm_Acc_02                Helm Accessory 2
+    //   0xAD5F  CD_Helm_Small                 Helm (Small)
+    //   0xAD60  CD_Helm_Visione_Belt          Helm Visione Belt
+    //   0xAD8C  CD_Ring_R                     Accessory (ring R)
+    //   0xAD8D  CD_Ring_L                     Accessory (ring L)
     //   0xAD8E  CD_Glasses                    Accessory (glasses)
-    //   0xAD90  CD_Earring_R                  Accessory (earring)
+    //   0xAD8F  CD_Earring_L                  Accessory (earring L)
+    //   0xAD90  CD_Earring_R                  Accessory (earring R)
     //   0xAD91  CD_Necklace                   Accessory (necklace)
+    //   0xADA3  CD_Abyss_Wing                 Abyss Wing
+    //   0xADA4  CD_Abyss_Wing_01              Abyss Wing 1
+    //   0xADA5  CD_Abyss_Wing_02              Abyss Wing 2
+    //   0xADA6  CD_Abyss_Wing_03              Abyss Wing 3
+    //   0xADA7  CD_Abyss_Glider               Abyss Glider
+    //   0xADA8  CD_Abyss_Glider_01            Abyss Glider 1
+    //   0xADA9  CD_Abyss_Glider_02            Abyss Glider 2
+    //   0xADAA  CD_Abyss_WingSuit             Abyss WingSuit
+    //   0xADAB  CD_Abyss_WingSuit_01          Abyss WingSuit 1
+    //   0xADAC  CD_Abyss_WingSuit_02          Abyss WingSuit 2
+    //   0xADB1  CD_Wrist_BindingRope          Binding Rope
+    //   0xADB2  CD_HyperspacePlug             Hyperspace Plug
     //   0xADB3  CD_AbyssGauntlet              Abyss Gauntlet
+    //   0xADB4  CD_AbyssController            Abyss Controller
+    //   0xADB5  CD_Abyss_Gauntlet             Abyss Gauntlet (variant)
+    //   0xADB6  CD_Abyss_Gauntlet_01          Abyss Gauntlet 1
+    //   0xADB7  CD_Abyss_Gauntlet_02          Abyss Gauntlet 2
     //   0xADB8  CD_Helm_Flight                Flight Helmet
+    //   0xADB9  CD_Saddle                     Saddle
+    //   0xADBA  CD_Saddle_Hook                Saddle Hook
+    //   0xADBB  CD_Saddle_Belt                Saddle Belt
+    //   0xADBC  CD_Armor_Halterbind           Armor Halterbind
+    //   0xADBD  CD_Halterbind                 Halterbind
+    //   0xADBF  CD_HorseShoe                  Horse Shoe
+    //   0xADC0  CD_HorseHel                   Horse Helmet
+    //   0xADC1  CD_HorseArmor                 Horse Armor
+    //   0xADC2  CD_HorseArmor_01              Horse Armor 1
+    //   0xADC3  CD_HorsePack                  Horse Pack
+    //   0xADC4  CD_HorsePack_01               Horse Pack 1
+    //   0xADC5  CD_Parachute                  Parachute
+    //   0xADC6  CD_WagonWheel                 Wagon Wheel
     //   0xAE04  CD_PartHider                  System (never hide)
     //   0xAE21  CD_Wagon_Lantern_R            Wagon Lantern R (excluded)
     //   0xAE22  CD_Wagon_Lantern_L            Wagon Lantern L (excluded)
     //   0xAE23  CD_Wagon_Lantern_Ring         Wagon Lantern Ring (excluded)
-    //   0xAE24  CD_LandSpider_Shell           Land Spider Shell (excluded)
-    //   0xAExx  (dynamic)                     NPC/mount slots
-    //   0xAFxx  (dynamic)                     NPC/mount slots
-    //   0xB0xx  (dynamic)                     NPC/mount slots
+    //   0xAE24  CD_LandSpider_Shell           Land Spider Shell
+    //   0xAE25  CD_LandSpider_Shell_01        Land Spider Shell 1
+    //   0xAEF0  CD_MainWeapon_Parachute       Parachute (weapon slot)
     //
     // =========================================================================
     // =========================================================================
@@ -175,6 +233,8 @@ namespace EquipHide
         {"CD_MainWeapon_Lance",         0xADDC},
         {"CD_MainWeapon_Gauntlet",      0xADDD},
         {"CD_MainWeapon_Gauntlet_L",    0xADDE},
+        {"CD_MainWeapon_Sword_R_Aux",   0xB049},
+        {"CD_MainWeapon_Sword_IN_R_Aux",0xB04A},
         // 2H Weapons
         {"CD_TwoHandWeapon_Sword",      0xADDF},
         {"CD_TwoHandWeapon_Axe",        0xADE0},
@@ -192,6 +252,7 @@ namespace EquipHide
         {"CD_TwoHandWeapon_Flail",      0xADEC},
         {"CD_TwoHandWeapon_BlowPipe",   0xADED},
         {"CD_TwoHandWeapon_Scythe",     0xAE05},
+        {"CD_TwoHandWeapon_Flag",       0xAEEE},
         // Shields
         {"CD_MainWeapon_Shield_L",      0xADEE},
         {"CD_MainWeapon_Shield_R",      0xADEF},
@@ -199,11 +260,13 @@ namespace EquipHide
         // Bows / Arrows
         {"CD_MainWeapon_Bow",           0xADF1},
         {"CD_MainWeapon_Quiver",        0xADF2},
+        {"CD_MainWeapon_Quiver_Arw",    0xADF3},
         {"CD_MainWeapon_Quiver_Arw_01", 0xADF4},
         {"CD_MainWeapon_Quiver_Arw_02", 0xADF5},
         {"CD_MainWeapon_Quiver_Arw_03", 0xADF6},
         {"CD_MainWeapon_Arw",           0xADF7},
         {"CD_MainWeapon_Arwline",       0xADF8},
+        {"CD_MainWeapon_Arw_IN",        0xAEEC},
         // Special / Ranged
         {"CD_MainWeapon_ArwHead",       0xADF9},
         {"CD_MainWeapon_CrossBow",      0xADFA},
@@ -215,7 +278,9 @@ namespace EquipHide
         {"CD_MainWeapon_Fan",           0xAE00},
         {"CD_MainWeapon_ThrownSpear_R", 0xAE01},
         {"CD_MainWeapon_ThrownSpear_L", 0xAE02},
+        {"CD_MainWeapon_Whip_R",        0xAE03},
         // Tools
+        {"CD_Tool_FishingRod",          0x0F4E},
         {"CD_Tool",                     0xAE06},
         {"CD_Tool_01",                  0xAE07},
         {"CD_Tool_02",                  0xAE08},
@@ -223,20 +288,31 @@ namespace EquipHide
         {"CD_Tool_Hammer",              0xAE0A},
         {"CD_Tool_Saw",                 0xAE0B},
         {"CD_Tool_Hoe",                 0xAE0C},
-        {"CD_Tool_Broom",              0xAE0D},
+        {"CD_Tool_Broom",               0xAE0D},
         {"CD_Tool_FarmScythe",          0xAE0E},
+        {"CD_Tool_Hayfork",             0xAE0F},
+        {"CD_Tool_Pickaxe",             0xAE10},
         {"CD_Tool_Rake",                0xAE11},
         {"CD_Tool_Shovel",              0xAE12},
         {"CD_Tool_Crutch",              0xAE13},
+        {"CD_Tool_FishingRod_Sub",      0xAE14},
+        {"CD_Tool_Shooter",             0xAE15},
         {"CD_Tool_Flute",               0xAE16},
+        {"CD_Tool_FireCan",             0xAE17},
         {"CD_Tool_Cigarette",           0xAE18},
+        {"CD_Tool_Sprayer",             0xAE19},
         {"CD_Tool_HandDrum",            0xAE1A},
         {"CD_Tool_DrumStick_R",         0xAE1B},
         {"CD_Tool_DrumStick_L",         0xAE1C},
         {"CD_Tool_Torch",               0xAE1D},
-        {"CD_Tool_FishingRod_Sub",      0x0F4F},
+        {"CD_Tool_Pan",                 0xAEEF},
+        {"CD_Tool_Trumpet",             0xAEF2},
+        {"CD_Tool_Pipe",                0xAF2F},
+        {"CD_Tool_Book",                0x12435},
         // Lanterns
+        {"CD_Tool_Hyperspace_RemoteControl", 0xAE1E},
         {"CD_Lantern",                  0xAE1F},
+        {"CD_Lantern_Ring",             0xAE20},
     };
     // clang-format on
 
@@ -253,59 +329,6 @@ namespace EquipHide
     }
 
     // =========================================================================
-    // Default parts strings (human-readable names, used when INI omits "Parts")
-    // =========================================================================
-    // clang-format off
-    static constexpr std::string_view k_defaultParts[] = {
-        // OneHandWeapons
-        "CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, "
-        "CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, "
-        "CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, "
-        "CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Bola, "
-        "CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_L, CD_MainWeapon_HandCannon, "
-        "CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, "
-        "CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L",
-
-        // TwoHandWeapons
-        "CD_TwoHandWeapon_Sword, CD_TwoHandWeapon_Axe, CD_TwoHandWeapon_Axe_Aux, "
-        "CD_TwoHandWeapon_Mace, CD_TwoHandWeapon_WarHammer, CD_TwoHandWeapon_Hammer, "
-        "CD_TwoHandWeapon_Cannon, CD_TwoHandWeapon_CannonBall, CD_TwoHandWeapon_Thrower, "
-        "CD_TwoHandWeapon_Spear, CD_TwoHandWeapon_Alebard, CD_MainWeapon_Pike, "
-        "CD_TwoHandWeapon_Rod, CD_TwoHandWeapon_Flail, CD_TwoHandWeapon_BlowPipe, "
-        "CD_TwoHandWeapon_Scythe",
-
-        // Shields
-        "CD_MainWeapon_Shield_L, CD_MainWeapon_Shield_R, CD_MainWeapon_TowerShield_L",
-
-        // Bows (0xADF3 = gap ID seen at runtime)
-        "CD_MainWeapon_Bow, CD_MainWeapon_Quiver, "
-        "CD_MainWeapon_Quiver_Arw_01, CD_MainWeapon_Quiver_Arw_02, CD_MainWeapon_Quiver_Arw_03, "
-        "CD_MainWeapon_Arw, CD_MainWeapon_Arwline, 0xADF3",
-
-        // SpecialWeapons
-        "CD_MainWeapon_ArwHead, CD_MainWeapon_CrossBow, "
-        "CD_MainWeapon_Pistol_R, CD_MainWeapon_Pistol_L, CD_MainWeapon_Musket, "
-        "CD_MainWeapon_Trap, CD_MainWeapon_Bomb, CD_MainWeapon_Fan, "
-        "CD_MainWeapon_ThrownSpear_R, CD_MainWeapon_ThrownSpear_L",
-
-        // Tools (gap IDs at end: 0xAE0F, 0xAE10, 0xAE14, 0xAE15, 0xAE17, 0xAE19)
-        "CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Saw, "
-        "CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Rake, CD_Tool_Shovel, "
-        "CD_Tool_Crutch, CD_Tool_Flute, CD_Tool_Cigarette, CD_Tool_HandDrum, "
-        "CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Torch, CD_Tool_FishingRod_Sub, "
-        "0xAE0F, 0xAE10, 0xAE14, 0xAE15, 0xAE17, 0xAE19",
-
-        // Lanterns (gap IDs at end: 0xAE1E, 0xAE20)
-        "CD_Lantern, 0xAE1E, 0xAE20",
-    };
-    // clang-format on
-
-    std::string_view default_parts(Category cat)
-    {
-        return k_defaultParts[static_cast<std::size_t>(cat)];
-    }
-
-    // =========================================================================
     // Parts parser + lookup map
     //
     // Accepts comma-separated part names (e.g. "CD_Tool_Torch, CD_Lantern").
@@ -316,6 +339,13 @@ namespace EquipHide
     void register_parts(Category cat, const std::string& partsStr)
     {
         auto& logger = DMK::Logger::get_instance();
+
+        if (partsStr.find_first_not_of(" ,") == std::string::npos)
+        {
+            logger.warning("{}: no parts configured (check INI file)", category_section(cat));
+            return;
+        }
+
         const auto& nameMap = name_to_hash_map();
 
         std::size_t pos = 0;

--- a/CrimsonDesertEquipHide/src/categories.hpp
+++ b/CrimsonDesertEquipHide/src/categories.hpp
@@ -54,12 +54,9 @@ namespace EquipHide
     // =========================================================================
     // Part classification
     //
-    // Default ranges are hardcoded but can be overridden via INI "Parts" key.
-    // Format: "0xADC7-0xADDE, 0xAE05" (ranges and individual hex IDs).
+    // Parts are loaded exclusively from the INI file. Each category's "Parts"
+    // key contains a comma-separated list of part names or raw hex IDs.
     // =========================================================================
-
-    /// Returns the default "Parts" string for a category.
-    std::string_view default_parts(Category cat);
 
     /// Parse a "Parts" string and register all contained IDs for the given category.
     void register_parts(Category cat, const std::string& partsStr);

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -70,8 +70,9 @@ namespace EquipHide
 
         auto partHash = *reinterpret_cast<const uint32_t *>(r10);
 
-        // Quick range check before map lookup — skip obviously out-of-range hashes
-        if (partHash < 0x0F00 || (partHash > 0x0F50 && partHash < 0xAD00) || partHash > 0xBFFF)
+        // Quick range check before map lookup — skip obviously out-of-range hashes.
+        // Equipment part hashes span 0xAD00-0xBFFF with outliers at 0x0F4E and 0x12435.
+        if (partHash != 0x0F4E && partHash != 0x12435 && (partHash < 0xAD00 || partHash > 0xBFFF))
             return;
 
         const auto cat = classify_part(partHash);
@@ -192,7 +193,7 @@ namespace EquipHide
                                        { category_states()[i].hidden.store(val, std::memory_order_relaxed); }, false);
 
             DMK::Config::register_string(section, "Parts", section + " Parts", [cat](const std::string &val)
-                                         { register_parts(cat, val); }, std::string{default_parts(cat)});
+                                         { register_parts(cat, val); }, "");
         }
 
         DMK::Config::load(INI_FILE);


### PR DESCRIPTION
## Summary
- Add 30+ newly discovered equipment part hashes from the IndexedStringA table, replacing former unnamed gap IDs (e.g. `0xAE0F` → `CD_Tool_Hayfork`) with proper named entries across all categories
- Remove `k_defaultParts` fallback array and `default_parts()` function — parts are now loaded exclusively from INI, with a warning logged when a category section has no parts configured
- Update the quick range check in the render hook to cover outlier hashes (`0x0F4E`, `0x12435`) and tighten the main range to `0xAD00–0xBFFF`
- Expand INI template with all new part names for OneHandWeapons, TwoHandWeapons, Bows, SpecialWeapons, Tools, and Lanterns
