### PR TITLE
fix(categories): suppress spurious empty-parts warning

### DIFF
--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -342,7 +342,8 @@ namespace EquipHide
 
         if (partsStr.find_first_not_of(" ,") == std::string::npos)
         {
-            logger.warning("{}: no parts configured (check INI file)", category_section(cat));
+            if (!partsStr.empty())
+                logger.warning("{}: no parts configured (check INI file)", category_section(cat));
             return;
         }
 


### PR DESCRIPTION
## Summary
- Fix false "no parts configured" warnings for all 7 categories on startup
- The `register_parts` callback was firing with the default empty string during `Config::register_string()`, before the INI file was loaded
- Now only warns when the string is non-empty but contains no valid part names (e.g. `Parts = ,,,`)
