### PR TITLE
feat(equip-hide): add player-only filtering, show/hide hotkeys, and direct-write visibility

### DIFF
--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -6,10 +6,10 @@
 
 ## Features
 
-- Toggle equipment visibility per category with hotkeys (default: V)
+- Toggle, force-show, or force-hide equipment visibility per category with hotkeys
+- Global show-all / hide-all hotkeys to control every category at once
 - Categories: One-Hand Weapons, Two-Hand Weapons, Shields, Bows, Special Weapons, Tools, Lanterns
-- Per-category configuration: enable/disable, hotkey, default hidden state, part list
-- Cascading AOB pattern scanning for resilience across game updates
+- Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
 - SEH-protected hook callback to prevent crashes if mod is outdated
 - Fully customizable settings via INI configuration
 
@@ -25,7 +25,7 @@
 
    Example: `D:\Games\SteamLibrary\steamapps\common\Crimson Desert\bin64`
 
-4. Launch the game and use the configured hotkey (default: V) to toggle equipment visibility
+4. Launch the game and use the configured hotkey (default: `V`) to toggle equipment visibility
 
 ## Configuration
 
@@ -33,30 +33,54 @@ The mod is configured via the `CrimsonDesertEquipHide.ini` file:
 
 ```ini
 [General]
-; Delay in milliseconds before scanning for hooks (game needs time to unpack)
-InitDelayMs = 3000
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
+; Apply only to player characters
+PlayerOnly = true
+; Force all categories visible / hidden at once (empty = disabled)
+ShowAllHotkey =
+HideAllHotkey =
 
 [OneHandWeapons]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, ...
 
 [Shields]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_Shield_L, CD_MainWeapon_Shield_R, ...
 ```
+
+### Hotkey Types
+
+Each category supports three independent hotkey bindings:
+
+| Key | Behavior |
+|-----|----------|
+| `ToggleHotkey` | Flips between hidden and visible |
+| `ShowHotkey` | Always forces visible |
+| `HideHotkey` | Always forces hidden |
+
+Global overrides in `[General]`:
+
+| Key | Behavior |
+|-----|----------|
+| `ShowAllHotkey` | Forces ALL categories visible |
+| `HideAllHotkey` | Forces ALL categories hidden |
 
 ### Hotkey Format
 
 - Named keys: `V`, `F3`, `Numpad1`, `Mouse4`, `Gamepad_A`, etc.
 - Modifiers: `Ctrl`, `Shift`, `Alt` (or `LCtrl`, `RCtrl`, etc.)
 - Multiple combos: `V,Gamepad_LB+Gamepad_Y` (V alone OR hold LB + press Y)
-- Empty `Hotkey =` disables toggle for that category
+- Empty value disables the binding
 
 See the full list at the [Supported Input Names](https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#supported-input-names) reference.
 
@@ -65,9 +89,9 @@ See the full list at the [Supported Input Names](https://github.com/tkhquang/Det
 DetourModKit supports gamepad input natively via the **XInput** API:
 
 ```ini
-Hotkey = Gamepad_Y
-Hotkey = Gamepad_LB+Gamepad_Y
-Hotkey = V,Gamepad_LB+Gamepad_Y
+ToggleHotkey = Gamepad_Y
+ToggleHotkey = Gamepad_LB+Gamepad_Y
+ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 ```
 
 > **XInput only:** Xbox controllers work natively. For PS4/PS5/Switch controllers, use an XInput translation layer (e.g. DS4Windows, DualSenseX, BetterJoy) or Steam Input. See [Gamepad Compatibility](https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#gamepad-compatibility) for details.

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -1,20 +1,29 @@
 ; CrimsonDesertEquipHide.ini
 ; Toggle visibility of equipment parts with hotkeys.
 ;
-; --- Hotkey ---
+; --- Hotkeys ---
 ; Format: modifier+trigger (modifiers joined with +, last segment = trigger keys)
 ;   - Named keys: V, F3, Numpad1, Mouse4, Gamepad_A, etc.
 ;   - Modifiers: Ctrl, Shift, Alt (or LCtrl, RCtrl, LShift, RShift, LAlt, RAlt)
 ;   - Multiple independent combos: V,Gamepad_LB+Gamepad_Y  (V alone OR hold LB + press Y)
-;   - If empty (Hotkey = ), no toggle for that category.
+;   - If empty, the binding is disabled.
+;
+; Three hotkey types per category:
+;   ToggleHotkey = toggles hidden/visible (flip current state)
+;   ShowHotkey   = always forces visible
+;   HideHotkey   = always forces hidden
+;
+; Global overrides in [General]:
+;   ShowAllHotkey = forces ALL categories visible
+;   HideAllHotkey = forces ALL categories hidden
 ;
 ; Examples:
-;   Hotkey = V                            ; V key
-;   Hotkey = Numpad1                      ; Numpad 1
-;   Hotkey = Ctrl+V                       ; Ctrl + V
-;   Hotkey = Ctrl+Shift+H                 ; Ctrl + Shift + H
-;   Hotkey = F3,Gamepad_LB+Gamepad_Y      ; F3 alone OR (hold LB + press Y)
-;   Hotkey =                              ; disabled (no toggle)
+;   ToggleHotkey = V                       ; V key (toggles hidden/visible)
+;   ToggleHotkey = Numpad1                 ; Numpad 1
+;   ShowHotkey = Ctrl+V                    ; Ctrl + V forces visible
+;   HideHotkey = Ctrl+Shift+H             ; Ctrl + Shift + H forces hidden
+;   ToggleHotkey = F3,Gamepad_LB+Gamepad_Y ; F3 alone OR (hold LB + press Y)
+;   ToggleHotkey =                         ; disabled (no binding)
 ;
 ; Refer to https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#supported-input-names
 ; for the full list of supported input names.
@@ -30,45 +39,64 @@
 [General]
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
+; Apply only to player characters
+PlayerOnly = true
+; Force all categories visible / hidden at once (empty = disabled)
+ShowAllHotkey =
+HideAllHotkey =
 
 [OneHandWeapons]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Bola, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_L, CD_MainWeapon_HandCannon, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux
 
 [TwoHandWeapons]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_TwoHandWeapon_Sword, CD_TwoHandWeapon_Axe, CD_TwoHandWeapon_Axe_Aux, CD_TwoHandWeapon_Mace, CD_TwoHandWeapon_WarHammer, CD_TwoHandWeapon_Hammer, CD_TwoHandWeapon_Cannon, CD_TwoHandWeapon_CannonBall, CD_TwoHandWeapon_Thrower, CD_TwoHandWeapon_Spear, CD_TwoHandWeapon_Alebard, CD_MainWeapon_Pike, CD_TwoHandWeapon_Rod, CD_TwoHandWeapon_Flail, CD_TwoHandWeapon_BlowPipe, CD_TwoHandWeapon_Scythe, CD_TwoHandWeapon_Flag
 
 [Shields]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_Shield_L, CD_MainWeapon_Shield_R, CD_MainWeapon_TowerShield_L
 
 [Bows]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_Bow, CD_MainWeapon_Quiver, CD_MainWeapon_Quiver_Arw, CD_MainWeapon_Quiver_Arw_01, CD_MainWeapon_Quiver_Arw_02, CD_MainWeapon_Quiver_Arw_03, CD_MainWeapon_Arw, CD_MainWeapon_Arwline, CD_MainWeapon_Arw_IN
 
 [SpecialWeapons]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_ArwHead, CD_MainWeapon_CrossBow, CD_MainWeapon_Pistol_R, CD_MainWeapon_Pistol_L, CD_MainWeapon_Musket, CD_MainWeapon_Trap, CD_MainWeapon_Bomb, CD_MainWeapon_Fan, CD_MainWeapon_ThrownSpear_R, CD_MainWeapon_ThrownSpear_L, CD_MainWeapon_Whip_R
 
 [Tools]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Saw, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Shooter, CD_Tool_Flute, CD_Tool_FireCan, CD_Tool_Cigarette, CD_Tool_Sprayer, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Torch, CD_Tool_Pan, CD_Tool_Trumpet, CD_Tool_Pipe, CD_Tool_Book
 
 [Lanterns]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_Tool_Hyperspace_RemoteControl, CD_Lantern, CD_Lantern_Ring

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,25 @@
-## [Title for next release]
+## Player-Only Mode, Show/Hide Hotkeys, and Reliable Hook Init
 
-- New feature
-- Bug fix
-- Improvement
+### Added
+- Player-only filtering mode that restricts equipment hiding to player characters using a global pointer chain with d8-based fallback
+- Per-category `ShowHotkey` / `HideHotkey` bindings alongside existing toggle
+- Global `ShowAllHotkey` / `HideAllHotkey` overrides for one-press show/hide
+- Direct-write visibility updates via map lookup for immediate visual feedback on hotkey press
+- Complete equipment part registry covering all known part hashes, removing hardcoded defaults
+- Process-wide executable memory scan (VirtualQuery over all PAGE_EXECUTE_READ regions) to find hook targets in VirtualAlloc'd code outside the main module
+- Per-process named mutex to detect duplicate ASI instances
+- SyncFallback async logger overflow policy to prevent message drops
+- Fail-fast when hook installation fails (no hotkeys, no input thread)
+- Centralized constants into `constants.hpp`
+
+### Fixed
+- Suppress spurious empty-parts warning during config registration
+- Hook init no longer relies on SizeOfImage polling or module-only AOB scan, which failed because the game's protector unpacks code into regions outside the 0.6 MB main module stub
+- Gate on process name before logger init to prevent `crashpad_handler` and other non-game processes from truncating the log file
+
+### Changed
+- Upgraded DetourModKit to v2.1.1
+- Removed redundant `InitDelayMs` config and retry loop
+
+### Docs
+- Updated installation docs with ASI loader instructions

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -5,10 +5,10 @@ This mod allows you to hide equipped gear visually in Crimson Desert using custo
 
 [size=5]Key Features[/size]
 [list]
-[*] Toggle equipment visibility per category with hotkeys (default: V)
+[*] Toggle, force-show, or force-hide equipment visibility per category with hotkeys
+[*] Global show-all / hide-all hotkeys to control every category at once
 [*] Categories: One-Hand Weapons, Two-Hand Weapons, Shields, Bows, Special Weapons, Tools, Lanterns
-[*] Per-category configuration: enable/disable, hotkey, default hidden state, part list
-[*] Cascading AOB patterns for resilience across game updates
+[*] Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
 [*] Fully customizable settings through INI configuration
 [*] Open-source with full transparency
 [/list]
@@ -20,39 +20,62 @@ This mod allows you to hide equipped gear visually in Crimson Desert using custo
 
 [size=5]Installation[/size]
 1. Make sure you have an ASI Loader installed for Crimson Desert. If you don't have one, download [code]version.dll[/code] from the [url=https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases]Ultimate ASI Loader releases[/url] and place it in your Crimson Desert game directory (where the game executable is located).
+
 2. Extract all files from the archive to your Crimson Desert game directory:
   [code]<Crimson Desert installation folder>/bin64/[/code]
   Example: [code]D:\Games\SteamLibrary\steamapps\common\Crimson Desert\bin64[/code]
+
 3. Launch the game and press V (default) to toggle equipment visibility
 
 [size=5]Configuration[/size]
 The mod can be configured by editing the CrimsonDesertEquipHide.ini file:
 [code]
 [General]
-; Delay in milliseconds before scanning for hooks
-InitDelayMs = 3000
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
+; Apply only to player characters
+PlayerOnly = true
+; Force all categories visible / hidden at once (empty = disabled)
+ShowAllHotkey =
+HideAllHotkey =
 
 [OneHandWeapons]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, ...
 
 [Shields]
 Enabled = true
-Hotkey = V
+ToggleHotkey = V
+ShowHotkey =
+HideHotkey =
 DefaultHidden = false
 Parts = CD_MainWeapon_Shield_L, CD_MainWeapon_Shield_R, ...
 [/code]
+
+[size=5]Hotkey Types[/size]
+Each category supports three independent hotkey bindings:
+[list]
+[*] [b]ToggleHotkey[/b] — flips between hidden and visible
+[*] [b]ShowHotkey[/b] — always forces visible
+[*] [b]HideHotkey[/b] — always forces hidden
+[/list]
+
+Global overrides in [General]:
+[list]
+[*] [b]ShowAllHotkey[/b] — forces ALL categories visible
+[*] [b]HideAllHotkey[/b] — forces ALL categories hidden
+[/list]
 
 [size=5]Hotkey Format[/size]
 [list]
 [*] Named keys: V, F3, Numpad1, Mouse4, Gamepad_A, etc.
 [*] Modifiers: Ctrl, Shift, Alt (or LCtrl, RCtrl, etc.)
 [*] Multiple combos: V,Gamepad_LB+Gamepad_Y (V alone OR hold LB + press Y)
-[*] Empty Hotkey = disables toggle for that category
+[*] Empty value disables the binding
 [/list]
 
 See the full list at the [url=https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#supported-input-names]Supported Input Names[/url] reference.
@@ -62,13 +85,13 @@ DetourModKit supports gamepad input natively via the [b]XInput[/b] API. Use game
 
 [code]
 ; Toggle with gamepad Y button
-Hotkey = Gamepad_Y
+ToggleHotkey = Gamepad_Y
 
 ; Use a modifier combo
-Hotkey = Gamepad_LB+Gamepad_Y
+ToggleHotkey = Gamepad_LB+Gamepad_Y
 
 ; Multiple independent combos (comma = OR)
-Hotkey = V,Gamepad_LB+Gamepad_Y
+ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 [/code]
 
 [b]XInput only:[/b] Xbox controllers work natively. For PS4/PS5/Switch controllers, use an XInput translation layer (e.g. DS4Windows, DualSenseX, BetterJoy) or Steam Input to present your controller as XInput. See [url=https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#gamepad-compatibility]Gamepad Compatibility[/url] for details.

--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -423,4 +423,9 @@ namespace EquipHide
                st.hidden.load(std::memory_order_relaxed);
     }
 
+    const std::unordered_map<uint32_t, Category>& get_part_map()
+    {
+        return s_partMap;
+    }
+
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/categories.hpp
+++ b/CrimsonDesertEquipHide/src/categories.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <optional>
 #include <string_view>
+#include <unordered_map>
 
 namespace EquipHide
 {
@@ -46,7 +47,9 @@ namespace EquipHide
     {
         std::atomic<bool> enabled{true};
         std::atomic<bool> hidden{false};
-        DMK::Config::KeyComboList hotkeyCombos;
+        DMK::Config::KeyComboList toggleHotkeyCombos;
+        DMK::Config::KeyComboList showHotkeyCombos;
+        DMK::Config::KeyComboList hideHotkeyCombos;
     };
 
     std::array<CategoryState, CATEGORY_COUNT>& category_states();
@@ -69,6 +72,9 @@ namespace EquipHide
 
     /// Returns true if a specific category is currently hidden (and enabled).
     bool is_category_hidden(Category cat);
+
+    /// Returns the registered part-hash to category map.
+    const std::unordered_map<uint32_t, Category>& get_part_map();
 
 } // namespace EquipHide
 

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -33,12 +33,301 @@ namespace EquipHide
     //
     // See .idea/research/update_resilience.md for full analysis.
     // =========================================================================
+
+    static std::atomic<bool> s_playerOnly{true};
+
+    static constexpr int k_maxProtagonists = 8;
+    static std::atomic<uintptr_t> s_playerVisCtrls[k_maxProtagonists]{};
+    static std::atomic<int> s_playerCount{0};
+    static std::atomic<uint32_t> s_resolveCounter{0};
+    static constexpr uint32_t k_resolveInterval = 512;
+
+    static uintptr_t s_worldSystemPtr = 0;
+    static uintptr_t s_childActorVtbl = 0;
+    static uintptr_t s_mapLookupAddr  = 0;
+
+    static std::atomic<bool> s_needsDirectWrite{false};
+
+    static DMK::Config::KeyComboList s_showAllCombos;
+    static DMK::Config::KeyComboList s_hideAllCombos;
+
+    // d8-based fallback: activates when global pointer chain AOBs fail
+    static std::atomic<bool> s_fallbackMode{false};
+
+    static uintptr_t read_ptr(uintptr_t base, ptrdiff_t off) noexcept
+    {
+        const auto *addr = reinterpret_cast<const uintptr_t *>(base + off);
+        if (!DMK::Memory::is_readable(addr, sizeof(uintptr_t)))
+            return 0;
+        return (*addr > 0x10000) ? *addr : 0;
+    }
+
+    // =========================================================================
+    // AOB-based address resolution
+    //
+    // Each target address (global pointer, vtable, function) is resolved at
+    // init via cascading AOB patterns.  Two resolution modes:
+    //   Direct:      target = match_addr + offset
+    //   RipRelative: target = match_addr + instrEnd + *(int32*)(match + dispOffset)
+    // =========================================================================
+    enum class ResolveMode : uint8_t { Direct, RipRelative };
+
+    struct AddrCandidate
+    {
+        const char *name;
+        const char *pattern;
+        ResolveMode mode;
+        ptrdiff_t dispOffset;
+        ptrdiff_t instrEndOffset;
+    };
+
+    static uintptr_t resolve_match(uintptr_t match, const AddrCandidate &c) noexcept
+    {
+        if (c.mode == ResolveMode::Direct)
+            return match + c.dispOffset;
+        auto disp = *reinterpret_cast<const int32_t *>(match + c.dispOffset);
+        return static_cast<uintptr_t>(
+            static_cast<int64_t>(match + c.instrEndOffset) + disp);
+    }
+
+    static uintptr_t scan_for_address(
+        const AddrCandidate *candidates, std::size_t count,
+        const char *&matchedName)
+    {
+        auto &logger = DMK::Logger::get_instance();
+
+        struct Compiled
+        {
+            const AddrCandidate *src;
+            DMK::Scanner::CompiledPattern pat;
+        };
+        std::vector<Compiled> compiled;
+
+        for (std::size_t i = 0; i < count; ++i)
+        {
+            auto p = DMK::Scanner::parse_aob(candidates[i].pattern);
+            if (p)
+                compiled.push_back({&candidates[i], std::move(*p)});
+            else
+                logger.warning("Failed to parse address AOB '{}'", candidates[i].name);
+        }
+
+        if (compiled.empty())
+            return 0;
+
+        const uint8_t *addr = nullptr;
+        MEMORY_BASIC_INFORMATION mbi;
+
+        while (VirtualQuery(addr, &mbi, sizeof(mbi)))
+        {
+            if (mbi.State == MEM_COMMIT &&
+                (mbi.Protect & (PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE |
+                                PAGE_EXECUTE_WRITECOPY)))
+            {
+                const auto regionBase = reinterpret_cast<uintptr_t>(mbi.BaseAddress);
+
+                for (const auto &c : compiled)
+                {
+                    const auto *match = DMK::Scanner::find_pattern(
+                        reinterpret_cast<const std::byte *>(regionBase),
+                        mbi.RegionSize, c.pat);
+                    if (match)
+                    {
+                        matchedName = c.src->name;
+                        return resolve_match(
+                            reinterpret_cast<uintptr_t>(match), *c.src);
+                    }
+                }
+            }
+
+            addr = static_cast<const uint8_t *>(mbi.BaseAddress) + mbi.RegionSize;
+        }
+
+        return 0;
+    }
+
+    static constexpr AddrCandidate k_worldSystemCandidates[] = {
+        {"WS_P1_SmallFunc",
+         "48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 8B 49 50 E8 ?? ?? ?? ?? 84 C0 0F 94 C0 48 83 C4 28 C3",
+         ResolveMode::RipRelative, 7, 11},
+
+        {"WS_P2_StructField",
+         "80 B8 49 01 00 00 00 75 ?? 48 8B 05 ?? ?? ?? ?? 48 8B 88 D8 00 00 00",
+         ResolveMode::RipRelative, 12, 16},
+    };
+
+    static constexpr AddrCandidate k_childActorVtblCandidates[] = {
+        {"VT_P1_DtorConst",
+         "48 8D 05 ?? ?? ?? ?? 48 89 01 E8 ?? ?? ?? ?? F6 C3 01 74 ?? BA 87 EE 08 4C",
+         ResolveMode::RipRelative, 3, 7},
+
+        {"VT_P2_CtorStore",
+         "48 89 F1 E8 ?? ?? ?? ?? 90 48 8D 05 ?? ?? ?? ?? 48 89 06 EB 03 4C",
+         ResolveMode::RipRelative, 12, 16},
+    };
+
+    static constexpr AddrCandidate k_mapLookupCandidates[] = {
+        {"ML_P1_FullPrologue",
+         "48 83 EC 08 83 79 04 00 4C 8B C1 75 07 33 C0 48 83 C4 08 C3 48 8B 05 ?? ?? ?? ?? 48 89 1C 24 8B 1A",
+         ResolveMode::Direct, 0, 0},
+
+        {"ML_P2_HashBody",
+         "8B 48 58 48 03 D2 44 8B 5C D1 08 41 8B 08 85 C9 74 ?? 33 D2 41 8B C3 F7 F1",
+         ResolveMode::Direct, -0x24, 0},
+    };
+
+    static uintptr_t resolve_address(
+        const AddrCandidate *candidates, std::size_t count,
+        const char *label)
+    {
+        auto &logger = DMK::Logger::get_instance();
+        const char *matchedName = nullptr;
+        auto result = scan_for_address(candidates, count, matchedName);
+
+        if (result)
+        {
+            logger.info("{} resolved via '{}' at {:#x}", label, matchedName, result);
+            return result;
+        }
+
+        logger.warning("{} AOB scan failed — feature disabled", label);
+        return 0;
+    }
+
+    static uintptr_t body_to_vis_ctrl(uintptr_t body) noexcept
+    {
+        if (!body)
+            return 0;
+        auto inner = read_ptr(body, 0x68);
+        if (!inner)
+            return 0;
+        auto sub = read_ptr(inner, 0x40);
+        if (!sub)
+            return 0;
+        return read_ptr(sub, 0xE8);
+    }
+
+    static void resolve_player_vis_ctrls() noexcept
+    {
+        if (!s_worldSystemPtr || !s_childActorVtbl)
+            return;
+
+#ifdef _MSC_VER
+        __try
+        {
+#endif
+            auto ws = read_ptr(s_worldSystemPtr, 0);
+            if (!ws) return;
+            auto am = read_ptr(ws, 0x30);
+            if (!am) return;
+            auto user = read_ptr(am, 0x28);
+            if (!user) return;
+
+            static constexpr ptrdiff_t k_bodyOffsets[] = {
+                0xD0, 0xD8, 0xE0, 0xE8, 0xF0, 0xF8, 0x100, 0x108};
+
+            int count = 0;
+            for (auto off : k_bodyOffsets)
+            {
+                if (count >= k_maxProtagonists)
+                    break;
+
+                auto candidate = read_ptr(user, off);
+                if (!candidate)
+                    continue;
+
+                auto vt = read_ptr(candidate, 0);
+                if (vt != s_childActorVtbl)
+                    continue;
+
+                auto vc = body_to_vis_ctrl(candidate);
+                if (vc)
+                    s_playerVisCtrls[count++] = vc;
+            }
+
+            for (int i = count; i < k_maxProtagonists; ++i)
+                s_playerVisCtrls[i].store(0, std::memory_order_relaxed);
+            s_playerCount.store(count, std::memory_order_relaxed);
+
+            {
+                static std::atomic<bool> s_logged{false};
+                if (!s_logged.exchange(true, std::memory_order_relaxed))
+                    DMK::Logger::get_instance().debug(
+                        "Resolve: ws={:#x} am={:#x} user={:#x} count={}",
+                        ws, am, user, count);
+            }
+#ifdef _MSC_VER
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            static std::atomic<bool> s_crashLogged{false};
+            if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
+                DMK::Logger::get_instance().warning("Resolve: SEH caught crash");
+        }
+#endif
+    }
+
     struct AobCandidate
     {
         const char *name;
         const char *pattern;
         ptrdiff_t offsetToHook; // bytes from AOB match to the actual hook point
     };
+
+    using MapLookupFn = uintptr_t(__fastcall *)(uintptr_t map_base, const uint32_t *key);
+
+    static void apply_direct_vis_write() noexcept
+    {
+        if (!s_mapLookupAddr)
+            return;
+
+#ifdef _MSC_VER
+        __try
+        {
+#endif
+            auto lookup = reinterpret_cast<MapLookupFn>(s_mapLookupAddr);
+            const auto n = s_playerCount.load(std::memory_order_relaxed);
+            int modified = 0;
+
+            for (int i = 0; i < n; ++i)
+            {
+                auto vc = s_playerVisCtrls[i].load(std::memory_order_relaxed);
+                if (!vc)
+                    continue;
+
+                auto comp = read_ptr(vc, 0x48);
+                if (!comp)
+                    continue;
+                auto descNode = read_ptr(comp, 0x218);
+                if (!descNode)
+                    continue;
+                auto mapBase = descNode + 0x20;
+
+                for (const auto &[hash, cat] : get_part_map())
+                {
+                    auto entry = lookup(mapBase, &hash);
+                    if (!entry)
+                        continue;
+
+                    auto *visPtr = reinterpret_cast<uint8_t *>(entry + 0x1C);
+                    *visPtr = is_category_hidden(cat) ? 2 : 0;
+                    ++modified;
+                }
+            }
+
+            DMK::Logger::get_instance().trace(
+                "DirectWrite: {} protagonists, {} entries modified",
+                n, modified);
+#ifdef _MSC_VER
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            static std::atomic<bool> s_crashLogged{false};
+            if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
+                DMK::Logger::get_instance().warning("DirectWrite: SEH caught crash");
+        }
+#endif
+    }
 
     static constexpr AobCandidate k_aobCandidates[] = {
         {"P1_DirectSite",
@@ -64,6 +353,10 @@ namespace EquipHide
     /// Core logic — no SEH here so C++ objects (SafetyHookContext&) are fine.
     static void on_vis_check_impl(SafetyHookContext &ctx)
     {
+        if (s_needsDirectWrite.exchange(false, std::memory_order_relaxed) &&
+            !s_fallbackMode.load(std::memory_order_relaxed))
+            apply_direct_vis_write();
+
         auto r10 = ctx.r10;
         if (r10 < 0x10000)
             return;
@@ -82,6 +375,88 @@ namespace EquipHide
         auto r13 = ctx.r13;
         if (r13 < 0x10000)
             return;
+
+        if (s_playerOnly.load(std::memory_order_relaxed))
+        {
+            auto a1 = *reinterpret_cast<uintptr_t *>(ctx.rbp + 0x4F);
+            if (a1 < 0x10000)
+                return;
+
+            if (s_fallbackMode.load(std::memory_order_relaxed))
+            {
+                // d8-based fallback: read actor from vis_ctrl chain and check d8 field
+                auto comp = read_ptr(a1, 0x48);
+                if (comp)
+                {
+                    auto actor = read_ptr(comp, 0x08);
+                    if (actor)
+                    {
+                        auto *d8Ptr = reinterpret_cast<const int32_t *>(actor + 0xD8);
+                        if (DMK::Memory::is_readable(d8Ptr, sizeof(int32_t)) && *d8Ptr >= 2)
+                        {
+                            // Player party member detected — cache a1 into slot array
+                            const auto n = s_playerCount.load(std::memory_order_relaxed);
+                            bool alreadyCached = false;
+                            for (int i = 0; i < n; ++i)
+                            {
+                                if (s_playerVisCtrls[i].load(std::memory_order_relaxed) == a1)
+                                {
+                                    alreadyCached = true;
+                                    break;
+                                }
+                            }
+                            if (!alreadyCached && n < k_maxProtagonists)
+                            {
+                                s_playerVisCtrls[n].store(a1, std::memory_order_relaxed);
+                                s_playerCount.store(n + 1, std::memory_order_relaxed);
+                            }
+                        }
+                    }
+                }
+
+                // Filter using cached slots (same logic as global-chain path)
+                const auto n = s_playerCount.load(std::memory_order_relaxed);
+                if (n > 0)
+                {
+                    bool isPlayer = false;
+                    for (int i = 0; i < n; ++i)
+                    {
+                        if (a1 == s_playerVisCtrls[i].load(std::memory_order_relaxed))
+                        {
+                            isPlayer = true;
+                            break;
+                        }
+                    }
+                    if (!isPlayer)
+                        return;
+                }
+                // n == 0: cache empty, allow all (DefaultHidden still works)
+            }
+            else
+            {
+                auto cnt = s_resolveCounter.fetch_add(1, std::memory_order_relaxed);
+                if (s_playerCount.load(std::memory_order_relaxed) == 0 ||
+                    (cnt % k_resolveInterval) == 0)
+                    resolve_player_vis_ctrls();
+
+                const auto n = s_playerCount.load(std::memory_order_relaxed);
+                if (n > 0)
+                {
+                    bool isPlayer = false;
+                    for (int i = 0; i < n; ++i)
+                    {
+                        if (a1 == s_playerVisCtrls[i].load(std::memory_order_relaxed))
+                        {
+                            isPlayer = true;
+                            break;
+                        }
+                    }
+
+                    if (!isPlayer)
+                        return;
+                }
+            }
+        }
 
         if (is_category_hidden(*cat))
         {
@@ -178,6 +553,15 @@ namespace EquipHide
                 auto& logger = DMK::Logger::get_instance();
                 logger.set_log_level(DMK::Logger::string_to_log_level(val)); }, "Info");
 
+        DMK::Config::register_bool("General", "PlayerOnly", "Player Only", [](bool val)
+                                   { s_playerOnly.store(val, std::memory_order_relaxed); }, true);
+
+        DMK::Config::register_key_combo("General", "ShowAllHotkey", "Show All Hotkey", [](const DMK::Config::KeyComboList &combos)
+                                        { s_showAllCombos = combos; }, "");
+
+        DMK::Config::register_key_combo("General", "HideAllHotkey", "Hide All Hotkey", [](const DMK::Config::KeyComboList &combos)
+                                        { s_hideAllCombos = combos; }, "");
+
         for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
         {
             const auto cat = static_cast<Category>(i);
@@ -186,8 +570,14 @@ namespace EquipHide
             DMK::Config::register_bool(section, "Enabled", section + " Enabled", [i](bool val)
                                        { category_states()[i].enabled.store(val, std::memory_order_relaxed); }, true);
 
-            DMK::Config::register_key_combo(section, "Hotkey", section + " Hotkey", [i](const DMK::Config::KeyComboList &combos)
-                                            { category_states()[i].hotkeyCombos = combos; }, "V");
+            DMK::Config::register_key_combo(section, "ToggleHotkey", section + " Toggle Hotkey", [i](const DMK::Config::KeyComboList &combos)
+                                            { category_states()[i].toggleHotkeyCombos = combos; }, "V");
+
+            DMK::Config::register_key_combo(section, "ShowHotkey", section + " Show Hotkey", [i](const DMK::Config::KeyComboList &combos)
+                                            { category_states()[i].showHotkeyCombos = combos; }, "");
+
+            DMK::Config::register_key_combo(section, "HideHotkey", section + " Hide Hotkey", [i](const DMK::Config::KeyComboList &combos)
+                                            { category_states()[i].hideHotkeyCombos = combos; }, "");
 
             DMK::Config::register_bool(section, "DefaultHidden", section + " Default Hidden", [i](bool val)
                                        { category_states()[i].hidden.store(val, std::memory_order_relaxed); }, false);
@@ -202,13 +592,80 @@ namespace EquipHide
     }
 
     // =========================================================================
+    // Hotkey helpers
+    // =========================================================================
+
+    /// Serialise a KeyComboList into a stable string key for deduplication.
+    static std::string combo_key(const DMK::Config::KeyComboList &combos)
+    {
+        std::string key;
+        for (const auto &combo : combos)
+        {
+            for (const auto &mod : combo.modifiers)
+                key += std::to_string(static_cast<int>(mod.source)) + ":" + std::to_string(mod.code) + "+";
+            for (const auto &k : combo.keys)
+                key += std::to_string(static_cast<int>(k.source)) + ":" + std::to_string(k.code) + ",";
+            key += "|";
+        }
+        return key;
+    }
+
+    /// Trigger direct-write update after visibility state change.
+    static void flush_visibility() noexcept
+    {
+        if (!s_fallbackMode.load(std::memory_order_relaxed))
+        {
+            resolve_player_vis_ctrls();
+            apply_direct_vis_write();
+        }
+        s_needsDirectWrite.store(true, std::memory_order_relaxed);
+    }
+
+    // =========================================================================
     // Hotkey registration — categories sharing the same key toggle together
     // =========================================================================
     static void register_hotkeys()
     {
         auto &inputMgr = DMK::InputManager::get_instance();
         auto &states = category_states();
+        auto &logger = DMK::Logger::get_instance();
 
+        // --- Global Show All / Hide All ---
+        if (!s_showAllCombos.empty())
+        {
+            inputMgr.register_press(
+                "ShowAll",
+                s_showAllCombos,
+                [&logger]()
+                {
+                    auto &st = category_states();
+                    for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
+                        st[i].hidden.store(false, std::memory_order_relaxed);
+
+                    logger.info("Equip hide: all categories VISIBLE");
+                    flush_visibility();
+                });
+            logger.info("Registered hotkey binding 'ShowAll'");
+        }
+
+        if (!s_hideAllCombos.empty())
+        {
+            inputMgr.register_press(
+                "HideAll",
+                s_hideAllCombos,
+                [&logger]()
+                {
+                    auto &st = category_states();
+                    for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
+                        st[i].hidden.store(true, std::memory_order_relaxed);
+
+                    logger.info("Equip hide: all categories HIDDEN");
+                    flush_visibility();
+                });
+            logger.info("Registered hotkey binding 'HideAll'");
+        }
+
+        // --- Per-category toggle (grouped by shared combo) ---
         struct HotkeyGroup
         {
             DMK::Config::KeyComboList combos;
@@ -221,26 +678,14 @@ namespace EquipHide
         {
             if (!states[i].enabled.load(std::memory_order_relaxed))
                 continue;
-            if (states[i].hotkeyCombos.empty())
+            if (states[i].toggleHotkeyCombos.empty())
                 continue;
 
-            std::string key;
-            for (const auto &combo : states[i].hotkeyCombos)
-            {
-                for (const auto &mod : combo.modifiers)
-                    key += std::to_string(static_cast<int>(mod.source)) + ":" + std::to_string(mod.code) + "+";
-                for (const auto &k : combo.keys)
-                    key += std::to_string(static_cast<int>(k.source)) + ":" + std::to_string(k.code) + ",";
-                key += "|";
-            }
-
-            auto &group = groups[key];
+            auto &group = groups[combo_key(states[i].toggleHotkeyCombos)];
             if (group.combos.empty())
-                group.combos = states[i].hotkeyCombos;
+                group.combos = states[i].toggleHotkeyCombos;
             group.categoryIndices.push_back(i);
         }
-
-        auto &logger = DMK::Logger::get_instance();
 
         for (auto &[key, group] : groups)
         {
@@ -268,10 +713,48 @@ namespace EquipHide
                         catNames += category_section(static_cast<Category>(idx));
                     }
                     logger.info("Equip hide toggled [{}]: {}", catNames, newHidden ? "HIDDEN" : "VISIBLE");
+                    flush_visibility();
                 });
 
             logger.info("Registered hotkey binding '{}' for {} categories",
                         bindingName, indices.size());
+        }
+
+        // --- Per-category force show / force hide ---
+        for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
+        {
+            if (!states[i].enabled.load(std::memory_order_relaxed))
+                continue;
+
+            const auto section = std::string(category_section(static_cast<Category>(i)));
+
+            if (!states[i].showHotkeyCombos.empty())
+            {
+                inputMgr.register_press(
+                    "ShowEquip_" + section,
+                    states[i].showHotkeyCombos,
+                    [i, &logger, section]()
+                    {
+                        category_states()[i].hidden.store(false, std::memory_order_relaxed);
+                        logger.info("Equip hide [{}]: VISIBLE", section);
+                        flush_visibility();
+                    });
+                logger.info("Registered hotkey binding 'ShowEquip_{}'", section);
+            }
+
+            if (!states[i].hideHotkeyCombos.empty())
+            {
+                inputMgr.register_press(
+                    "HideEquip_" + section,
+                    states[i].hideHotkeyCombos,
+                    [i, &logger, section]()
+                    {
+                        category_states()[i].hidden.store(true, std::memory_order_relaxed);
+                        logger.info("Equip hide [{}]: HIDDEN", section);
+                        flush_visibility();
+                    });
+                logger.info("Registered hotkey binding 'HideEquip_{}'", section);
+            }
         }
     }
 
@@ -283,6 +766,30 @@ namespace EquipHide
         auto &logger = DMK::Logger::get_instance();
 
         logger.info("=== {} v{} ===", MOD_NAME, MOD_VERSION);
+
+        DMK::Memory::init_cache();
+
+        s_worldSystemPtr = resolve_address(
+            k_worldSystemCandidates, std::size(k_worldSystemCandidates),
+            "WorldSystem");
+
+        s_childActorVtbl = resolve_address(
+            k_childActorVtblCandidates, std::size(k_childActorVtblCandidates),
+            "ChildActorVtbl");
+
+        s_mapLookupAddr = resolve_address(
+            k_mapLookupCandidates, std::size(k_mapLookupCandidates),
+            "MapLookup");
+
+        if (!s_worldSystemPtr || !s_childActorVtbl)
+        {
+            s_fallbackMode.store(true, std::memory_order_relaxed);
+            logger.info("Player identification: d8-based fallback (global chain AOB unavailable)");
+        }
+        else
+        {
+            logger.info("Player identification: global pointer chain");
+        }
 
         load_config();
 


### PR DESCRIPTION
## Summary
  - Add `PlayerOnly` mode to restrict equipment hiding to player characters, using global pointer chain resolution with d8-based fallback
  - Introduce per-category `ShowHotkey`/`HideHotkey` bindings alongside existing toggle, plus global `ShowAllHotkey`/`HideAllHotkey` overrides
  - Implement direct-write visibility updates via map lookup for immediate feedback on hotkey press
  - Rename `Hotkey` config key to `ToggleHotkey` across all categories
  - Update INI template, README, and Nexus description with new configuration options

  ## Test plan
  - [x] Verify `PlayerOnly = true` hides equipment only on the player, not NPCs
  - [x] Verify `PlayerOnly = false` applies to all entities
  - [x] Test `ToggleHotkey`, `ShowHotkey`, `HideHotkey` per-category bindings
  - [x] Test `ShowAllHotkey` / `HideAllHotkey` global overrides
  - [x] Confirm fallback mode activates when global chain AOBs fail
  - [x] Verify direct-write updates equipment visibility immediately on hotkey press