### PR TITLE
fix(categories): update IndexedStringA hash IDs for game v1.01.00

### DIFF
--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -22,179 +22,188 @@ namespace EquipHide
     // Ranges verified via CE runtime breakpoints + string table reads.
     // See .idea/research/equip_hide_v2.md for full mapping.
     //
-    // Game version: 1.00.03
+    // Game version: 1.01.00
     //
     // ---- Complete Part Hash Reference ----
     //
-    // OneHandWeapons (0xADC7 - 0xADDE, 0xB049 - 0xB04A):
-    //   0xADC7  CD_MainWeapon_Sword_R         Sword (Right, drawn)
-    //   0xADC8  CD_MainWeapon_Sword_IN_R      Sword (Right, sheathed)
-    //   0xADC9  CD_MainWeapon_Sword_L         Sword (Left, drawn)
-    //   0xADCA  CD_MainWeapon_Sword_IN_L      Sword (Left, sheathed)
-    //   0xADCB  CD_MainWeapon_Dagger_R        Dagger (Right, drawn)
-    //   0xADCC  CD_MainWeapon_Dagger_IN_R     Dagger (Right, sheathed)
-    //   0xADCD  CD_MainWeapon_Dagger_L        Dagger (Left, drawn)
-    //   0xADCE  CD_MainWeapon_Dagger_IN_L     Dagger (Left, sheathed)
-    //   0xADCF  CD_MainWeapon_Axe_R           Axe (Right)
-    //   0xADD0  CD_MainWeapon_Axe_L           Axe (Left)
-    //   0xADD1  CD_MainWeapon_Mace_R          Mace (Right)
-    //   0xADD2  CD_MainWeapon_Mace_L          Mace (Left)
-    //   0xADD3  CD_MainWeapon_Hammer_R        Hammer (Right)
-    //   0xADD4  CD_MainWeapon_Flail_R         Flail (Right)
-    //   0xADD5  CD_MainWeapon_Wand_R          Wand (Right)
-    //   0xADD6  CD_MainWeapon_Bola            Bola
-    //   0xADD7  CD_MainWeapon_Fist_R          Fist (Right)
-    //   0xADD8  CD_MainWeapon_Fist_L          Fist (Left)
-    //   0xADD9  CD_MainWeapon_HandCannon      Hand Cannon
-    //   0xADDA  CD_MainWeapon_Fist_Hand       Fist (Hand)
-    //   0xADDB  CD_MainWeapon_Fist_Foot       Fist (Foot)
-    //   0xADDC  CD_MainWeapon_Lance           Lance
-    //   0xADDD  CD_MainWeapon_Gauntlet        Gauntlet (Right)
-    //   0xADDE  CD_MainWeapon_Gauntlet_L      Gauntlet (Left)
-    //   0xB049  CD_MainWeapon_Sword_R_Aux     Sword Aux (Right, drawn)
-    //   0xB04A  CD_MainWeapon_Sword_IN_R_Aux  Sword Aux (Right, sheathed)
+    // OneHandWeapons (0xAE03 - 0xAE1A, 0xB085 - 0xB086):
+    //   0xAE03  CD_MainWeapon_Sword_R         Sword (Right, drawn)
+    //   0xAE04  CD_MainWeapon_Sword_IN_R      Sword (Right, sheathed)
+    //   0xAE05  CD_MainWeapon_Sword_L         Sword (Left, drawn)
+    //   0xAE06  CD_MainWeapon_Sword_IN_L      Sword (Left, sheathed)
+    //   0xAE07  CD_MainWeapon_Dagger_R        Dagger (Right, drawn)
+    //   0xAE08  CD_MainWeapon_Dagger_IN_R     Dagger (Right, sheathed)
+    //   0xAE09  CD_MainWeapon_Dagger_L        Dagger (Left, drawn)
+    //   0xAE0A  CD_MainWeapon_Dagger_IN_L     Dagger (Left, sheathed)
+    //   0xAE0B  CD_MainWeapon_Axe_R           Axe (Right)
+    //   0xAE0C  CD_MainWeapon_Axe_L           Axe (Left)
+    //   0xAE0D  CD_MainWeapon_Mace_R          Mace (Right)
+    //   0xAE0E  CD_MainWeapon_Mace_L          Mace (Left)
+    //   0xAE0F  CD_MainWeapon_Hammer_R        Hammer (Right)
+    //   0xAE10  CD_MainWeapon_Flail_R         Flail (Right)
+    //   0xAE11  CD_MainWeapon_Wand_R          Wand (Right)
+    //   0xAE12  CD_MainWeapon_Bola            Bola
+    //   0xAE13  CD_MainWeapon_Fist_R          Fist (Right)
+    //   0xAE14  CD_MainWeapon_Fist_L          Fist (Left)
+    //   0xAE15  CD_MainWeapon_HandCannon      Hand Cannon
+    //   0xAE16  CD_MainWeapon_Fist_Hand       Fist (Hand)
+    //   0xAE17  CD_MainWeapon_Fist_Foot       Fist (Foot)
+    //   0xAE18  CD_MainWeapon_Lance           Lance
+    //   0xAE19  CD_MainWeapon_Gauntlet        Gauntlet (Right)
+    //   0xAE1A  CD_MainWeapon_Gauntlet_L      Gauntlet (Left)
+    //   0xB085  CD_MainWeapon_Sword_R_Aux     Sword Aux (Right, drawn)
+    //   0xB086  CD_MainWeapon_Sword_IN_R_Aux  Sword Aux (Right, sheathed)
     //
-    // TwoHandWeapons (0xADDF - 0xADED, 0xAE05, 0xAEEE):
-    //   0xADDF  CD_TwoHandWeapon_Sword        Greatsword
-    //   0xADE0  CD_TwoHandWeapon_Axe          2H Axe
-    //   0xADE1  CD_TwoHandWeapon_Axe_Aux      2H Axe (Auxiliary)
-    //   0xADE2  CD_TwoHandWeapon_Mace         2H Mace
-    //   0xADE3  CD_TwoHandWeapon_WarHammer    War Hammer
-    //   0xADE4  CD_TwoHandWeapon_Hammer       2H Hammer
-    //   0xADE5  CD_TwoHandWeapon_Cannon       Cannon
-    //   0xADE6  CD_TwoHandWeapon_CannonBall   Cannon Ball
-    //   0xADE7  CD_TwoHandWeapon_Thrower      Thrower
-    //   0xADE8  CD_TwoHandWeapon_Spear        Spear
-    //   0xADE9  CD_TwoHandWeapon_Alebard      Halberd
-    //   0xADEA  CD_MainWeapon_Pike            Pike
-    //   0xADEB  CD_TwoHandWeapon_Rod          Rod
-    //   0xADEC  CD_TwoHandWeapon_Flail        2H Flail
-    //   0xADED  CD_TwoHandWeapon_BlowPipe     Blow Pipe
-    //   0xAE05  CD_TwoHandWeapon_Scythe       Scythe
-    //   0xAEEE  CD_TwoHandWeapon_Flag         Flag
+    // TwoHandWeapons (0xAE1B - 0xAE29, 0xAE41, 0xAF2A):
+    //   0xAE1B  CD_TwoHandWeapon_Sword        Greatsword
+    //   0xAE1C  CD_TwoHandWeapon_Axe          2H Axe
+    //   0xAE1D  CD_TwoHandWeapon_Axe_Aux      2H Axe (Auxiliary)
+    //   0xAE1E  CD_TwoHandWeapon_Mace         2H Mace
+    //   0xAE1F  CD_TwoHandWeapon_WarHammer    War Hammer
+    //   0xAE20  CD_TwoHandWeapon_Hammer       2H Hammer
+    //   0xAE21  CD_TwoHandWeapon_Cannon       Cannon
+    //   0xAE22  CD_TwoHandWeapon_CannonBall   Cannon Ball
+    //   0xAE23  CD_TwoHandWeapon_Thrower      Thrower
+    //   0xAE24  CD_TwoHandWeapon_Spear        Spear
+    //   0xAE25  CD_TwoHandWeapon_Alebard      Halberd
+    //   0xAE26  CD_MainWeapon_Pike            Pike
+    //   0xAE27  CD_TwoHandWeapon_Rod          Rod
+    //   0xAE28  CD_TwoHandWeapon_Flail        2H Flail
+    //   0xAE29  CD_TwoHandWeapon_BlowPipe     Blow Pipe
+    //   0xAE41  CD_TwoHandWeapon_Scythe       Scythe
+    //   0xAF2A  CD_TwoHandWeapon_Flag         Flag
     //
-    // Shields (0xADEE - 0xADF0):
-    //   0xADEE  CD_MainWeapon_Shield_L        Shield (Left)
-    //   0xADEF  CD_MainWeapon_Shield_R        Shield (Right)
-    //   0xADF0  CD_MainWeapon_TowerShield_L   Tower Shield (Left)
+    // Shields (0xAE2A - 0xAE2C):
+    //   0xAE2A  CD_MainWeapon_Shield_L        Shield (Left)
+    //   0xAE2B  CD_MainWeapon_Shield_R        Shield (Right)
+    //   0xAE2C  CD_MainWeapon_TowerShield_L   Tower Shield (Left)
     //
     //   NOTE: Only 3 shield slot hashes exist in the IndexedStringA table.
     //   All shields (including unique/legendary like "Shield of Conviction")
     //   must use one of these slots. If a shield doesn't get hidden, it may
     //   render via an alternate VFX/overlay code path (see equip_hide.cpp).
     //
-    // Bows (0xADF1 - 0xADF8, 0xAEEC):
-    //   0xADF1  CD_MainWeapon_Bow             Bow
-    //   0xADF2  CD_MainWeapon_Quiver          Quiver
-    //   0xADF3  CD_MainWeapon_Quiver_Arw      Quiver Arrow (base)
-    //   0xADF4  CD_MainWeapon_Quiver_Arw_01   Quiver Arrow 1
-    //   0xADF5  CD_MainWeapon_Quiver_Arw_02   Quiver Arrow 2
-    //   0xADF6  CD_MainWeapon_Quiver_Arw_03   Quiver Arrow 3
-    //   0xADF7  CD_MainWeapon_Arw             Arrow
-    //   0xADF8  CD_MainWeapon_Arwline         Arrow Line
-    //   0xAEEC  CD_MainWeapon_Arw_IN          Arrow (Sheathed)
+    // Bows (0xAE2D - 0xAE34, 0xAF28):
+    //   0xAE2D  CD_MainWeapon_Bow             Bow
+    //   0xAE2E  CD_MainWeapon_Quiver          Quiver
+    //   0xAE2F  CD_MainWeapon_Quiver_Arw      Quiver Arrow (base)
+    //   0xAE30  CD_MainWeapon_Quiver_Arw_01   Quiver Arrow 1
+    //   0xAE31  CD_MainWeapon_Quiver_Arw_02   Quiver Arrow 2
+    //   0xAE32  CD_MainWeapon_Quiver_Arw_03   Quiver Arrow 3
+    //   0xAE33  CD_MainWeapon_Arw             Arrow
+    //   0xAE34  CD_MainWeapon_Arwline         Arrow Line
+    //   0xAF28  CD_MainWeapon_Arw_IN          Arrow (Sheathed)
     //
-    // SpecialWeapons (0xADF9 - 0xAE03):
-    //   0xADF9  CD_MainWeapon_ArwHead         Arrow Head
-    //   0xADFA  CD_MainWeapon_CrossBow        Crossbow
-    //   0xADFB  CD_MainWeapon_Pistol_R        Pistol (Right)
-    //   0xADFC  CD_MainWeapon_Pistol_L        Pistol (Left)
-    //   0xADFD  CD_MainWeapon_Musket          Musket
-    //   0xADFE  CD_MainWeapon_Trap            Trap
-    //   0xADFF  CD_MainWeapon_Bomb            Bomb
-    //   0xAE00  CD_MainWeapon_Fan             Fan
-    //   0xAE01  CD_MainWeapon_ThrownSpear_R   Thrown Spear (Right)
-    //   0xAE02  CD_MainWeapon_ThrownSpear_L   Thrown Spear (Left)
-    //   0xAE03  CD_MainWeapon_Whip_R          Whip (Right)
+    // SpecialWeapons (0xAE35 - 0xAE3F):
+    //   0xAE35  CD_MainWeapon_ArwHead         Arrow Head
+    //   0xAE36  CD_MainWeapon_CrossBow        Crossbow
+    //   0xAE37  CD_MainWeapon_Pistol_R        Pistol (Right)
+    //   0xAE38  CD_MainWeapon_Pistol_L        Pistol (Left)
+    //   0xAE39  CD_MainWeapon_Musket          Musket
+    //   0xAE3A  CD_MainWeapon_Trap            Trap
+    //   0xAE3B  CD_MainWeapon_Bomb            Bomb
+    //   0xAE3C  CD_MainWeapon_Fan             Fan
+    //   0xAE3D  CD_MainWeapon_ThrownSpear_R   Thrown Spear (Right)
+    //   0xAE3E  CD_MainWeapon_ThrownSpear_L   Thrown Spear (Left)
+    //   0xAE3F  CD_MainWeapon_Whip_R          Whip (Right)
     //
-    // Tools (0x0F4E, 0xAE06 - 0xAE1D, 0xAEEF, 0xAEF2, 0xAF2F, 0x12435):
-    //   0x0F4E  CD_Tool_FishingRod             Fishing Rod
-    //   0xAE06  CD_Tool                       Tool (generic)
-    //   0xAE07  CD_Tool_01                    Tool variant
-    //   0xAE08  CD_Tool_02                    Tool variant
-    //   0xAE09  CD_Tool_Axe                   Tool Axe
-    //   0xAE0A  CD_Tool_Hammer                Tool Hammer
-    //   0xAE0B  CD_Tool_Saw                   Tool Saw
-    //   0xAE0C  CD_Tool_Hoe                   Tool Hoe
-    //   0xAE0D  CD_Tool_Broom                 Tool Broom
-    //   0xAE0E  CD_Tool_FarmScythe            Farm Scythe
-    //   0xAE0F  CD_Tool_Hayfork               Hayfork
-    //   0xAE10  CD_Tool_Pickaxe               Pickaxe
-    //   0xAE11  CD_Tool_Rake                  Tool Rake
-    //   0xAE12  CD_Tool_Shovel                Tool Shovel
-    //   0xAE13  CD_Tool_Crutch                Tool Crutch
-    //   0xAE14  CD_Tool_FishingRod_Sub        Fishing Rod (Sub)
-    //   0xAE15  CD_Tool_Shooter               Shooter
-    //   0xAE16  CD_Tool_Flute                 Flute
-    //   0xAE17  CD_Tool_FireCan               Fire Can
-    //   0xAE18  CD_Tool_Cigarette             Cigarette
-    //   0xAE19  CD_Tool_Sprayer               Sprayer
-    //   0xAE1A  CD_Tool_HandDrum              Hand Drum
-    //   0xAE1B  CD_Tool_DrumStick_R           Drum Stick (Right)
-    //   0xAE1C  CD_Tool_DrumStick_L           Drum Stick (Left)
-    //   0xAE1D  CD_Tool_Torch                 Torch
-    //   0xAEEF  CD_Tool_Pan                   Pan
-    //   0xAEF2  CD_Tool_Trumpet               Trumpet
-    //   0xAF2F  CD_Tool_Pipe                  Pipe
-    // 0x12435  CD_Tool_Book                  Book
+    // Tools (0x0F6D, 0xAE42 - 0xAE59, 0xAF2B, 0xAF2E, 0xAF6B, 0x12A79):
+    //   0x0F6D  CD_Tool_FishingRod            Fishing Rod
+    //   0xAE42  CD_Tool                       Tool (generic)
+    //   0xAE43  CD_Tool_01                    Tool variant
+    //   0xAE44  CD_Tool_02                    Tool variant
+    //   0xAE45  CD_Tool_Axe                   Tool Axe
+    //   0xAE46  CD_Tool_Hammer                Tool Hammer
+    //   0xAE47  CD_Tool_Saw                   Tool Saw
+    //   0xAE48  CD_Tool_Hoe                   Tool Hoe
+    //   0xAE49  CD_Tool_Broom                 Tool Broom
+    //   0xAE4A  CD_Tool_FarmScythe            Farm Scythe
+    //   0xAE4B  CD_Tool_Hayfork               Hayfork
+    //   0xAE4C  CD_Tool_Pickaxe               Pickaxe
+    //   0xAE4D  CD_Tool_Rake                  Tool Rake
+    //   0xAE4E  CD_Tool_Shovel                Tool Shovel
+    //   0xAE4F  CD_Tool_Crutch                Tool Crutch
+    //   0xAE50  CD_Tool_FishingRod_Sub        Fishing Rod (Sub)
+    //   0xAE51  CD_Tool_Shooter               Shooter
+    //   0xAE52  CD_Tool_Flute                 Flute
+    //   0xAE53  CD_Tool_FireCan               Fire Can
+    //   0xAE54  CD_Tool_Cigarette             Cigarette
+    //   0xAE55  CD_Tool_Sprayer               Sprayer
+    //   0xAE56  CD_Tool_HandDrum              Hand Drum
+    //   0xAE57  CD_Tool_DrumStick_R           Drum Stick (Right)
+    //   0xAE58  CD_Tool_DrumStick_L           Drum Stick (Left)
+    //   0xAE59  CD_Tool_Torch                 Torch
+    //   0xAF2B  CD_Tool_Pan                   Pan
+    //   0xAF2E  CD_Tool_Trumpet               Trumpet
+    //   0xAF6B  CD_Tool_Pipe                  Pipe
+    // 0x12A79  CD_Tool_Book                  Book
     //
-    // Lanterns (0xAE1E - 0xAE20):
-    //   0xAE1E  CD_Tool_Hyperspace_RemoteControl  Remote Control
-    //   0xAE1F  CD_Lantern                        Lantern
-    //   0xAE20  CD_Lantern_Ring                   Lantern Ring
+    // Lanterns (0xAE5A - 0xAE5C):
+    //   0xAE5A  CD_Tool_Hyperspace_RemoteControl  Remote Control
+    //   0xAE5B  CD_Lantern                        Lantern
+    //   0xAE5C  CD_Lantern_Ring                   Lantern Ring
     //
     // NOT classified (system / accessories / mount / excluded):
-    //   0xAD55  CD_Horse_Hair                 Horse Hair
-    //   0xAD5B  CD_Helm                       Helm
-    //   0xAD5C  CD_Helm_Acc                   Helm Accessory
-    //   0xAD5D  CD_Helm_Acc_01                Helm Accessory 1
-    //   0xAD5E  CD_Helm_Acc_02                Helm Accessory 2
-    //   0xAD5F  CD_Helm_Small                 Helm (Small)
-    //   0xAD60  CD_Helm_Visione_Belt          Helm Visione Belt
-    //   0xAD8C  CD_Ring_R                     Accessory (ring R)
-    //   0xAD8D  CD_Ring_L                     Accessory (ring L)
-    //   0xAD8E  CD_Glasses                    Accessory (glasses)
-    //   0xAD8F  CD_Earring_L                  Accessory (earring L)
-    //   0xAD90  CD_Earring_R                  Accessory (earring R)
-    //   0xAD91  CD_Necklace                   Accessory (necklace)
-    //   0xADA3  CD_Abyss_Wing                 Abyss Wing
-    //   0xADA4  CD_Abyss_Wing_01              Abyss Wing 1
-    //   0xADA5  CD_Abyss_Wing_02              Abyss Wing 2
-    //   0xADA6  CD_Abyss_Wing_03              Abyss Wing 3
-    //   0xADA7  CD_Abyss_Glider               Abyss Glider
-    //   0xADA8  CD_Abyss_Glider_01            Abyss Glider 1
-    //   0xADA9  CD_Abyss_Glider_02            Abyss Glider 2
-    //   0xADAA  CD_Abyss_WingSuit             Abyss WingSuit
-    //   0xADAB  CD_Abyss_WingSuit_01          Abyss WingSuit 1
-    //   0xADAC  CD_Abyss_WingSuit_02          Abyss WingSuit 2
-    //   0xADB1  CD_Wrist_BindingRope          Binding Rope
-    //   0xADB2  CD_HyperspacePlug             Hyperspace Plug
-    //   0xADB3  CD_AbyssGauntlet              Abyss Gauntlet
-    //   0xADB4  CD_AbyssController            Abyss Controller
-    //   0xADB5  CD_Abyss_Gauntlet             Abyss Gauntlet (variant)
-    //   0xADB6  CD_Abyss_Gauntlet_01          Abyss Gauntlet 1
-    //   0xADB7  CD_Abyss_Gauntlet_02          Abyss Gauntlet 2
-    //   0xADB8  CD_Helm_Flight                Flight Helmet
-    //   0xADB9  CD_Saddle                     Saddle
-    //   0xADBA  CD_Saddle_Hook                Saddle Hook
-    //   0xADBB  CD_Saddle_Belt                Saddle Belt
-    //   0xADBC  CD_Armor_Halterbind           Armor Halterbind
-    //   0xADBD  CD_Halterbind                 Halterbind
-    //   0xADBF  CD_HorseShoe                  Horse Shoe
-    //   0xADC0  CD_HorseHel                   Horse Helmet
-    //   0xADC1  CD_HorseArmor                 Horse Armor
-    //   0xADC2  CD_HorseArmor_01              Horse Armor 1
-    //   0xADC3  CD_HorsePack                  Horse Pack
-    //   0xADC4  CD_HorsePack_01               Horse Pack 1
-    //   0xADC5  CD_Parachute                  Parachute
-    //   0xADC6  CD_WagonWheel                 Wagon Wheel
-    //   0xAE04  CD_PartHider                  System (never hide)
-    //   0xAE21  CD_Wagon_Lantern_R            Wagon Lantern R (excluded)
-    //   0xAE22  CD_Wagon_Lantern_L            Wagon Lantern L (excluded)
-    //   0xAE23  CD_Wagon_Lantern_Ring         Wagon Lantern Ring (excluded)
-    //   0xAE24  CD_LandSpider_Shell           Land Spider Shell
-    //   0xAE25  CD_LandSpider_Shell_01        Land Spider Shell 1
-    //   0xAEF0  CD_MainWeapon_Parachute       Parachute (weapon slot)
+    //   0xAD91  CD_Horse_Hair                 Horse Hair
+    //   0xAD97  CD_Helm                       Helm
+    //   0xAD98  CD_Helm_Acc                   Helm Accessory
+    //   0xAD99  CD_Helm_Acc_01                Helm Accessory 1
+    //   0xAD9A  CD_Helm_Acc_02                Helm Accessory 2
+    //   0xAD9B  CD_Helm_Small                 Helm (Small)
+    //   0xAD9C  CD_Helm_Visione_Belt          Helm Visione Belt
+    //   0xADBE  CD_Bag                        Bag
+    //   0xADBF  CD_Bag_Rocket                 Bag Rocket
+    //   0xADC0  CD_Bag_For_Dock               Bag For Dock
+    //   0xADC1  CD_Bag_Belt_For_Dock          Bag Belt For Dock
+    //   0xADC3  CD_Bag_Small                  Bag Small
+    //   0xADC4  CD_Bag_Acc                    Bag Accessory
+    //   0xADC5  CD_Bag_Belt                   Bag Belt
+    //   0xADC6  CD_Bag_Lantern                Bag Lantern
+    //   0xADC7  CD_Bag_Rack                   Bag Rack
+    //   0xADC8  CD_Ring_R                     Accessory (ring R)
+    //   0xADC9  CD_Ring_L                     Accessory (ring L)
+    //   0xADCA  CD_Glasses                    Accessory (glasses)
+    //   0xADCB  CD_Earring_L                  Accessory (earring L)
+    //   0xADCC  CD_Earring_R                  Accessory (earring R)
+    //   0xADCD  CD_Necklace                   Accessory (necklace)
+    //   0xADDF  CD_Abyss_Wing                 Abyss Wing
+    //   0xADE0  CD_Abyss_Wing_01              Abyss Wing 1
+    //   0xADE1  CD_Abyss_Wing_02              Abyss Wing 2
+    //   0xADE2  CD_Abyss_Wing_03              Abyss Wing 3
+    //   0xADE3  CD_Abyss_Glider               Abyss Glider
+    //   0xADE4  CD_Abyss_Glider_01            Abyss Glider 1
+    //   0xADE5  CD_Abyss_Glider_02            Abyss Glider 2
+    //   0xADE6  CD_Abyss_WingSuit             Abyss WingSuit
+    //   0xADE7  CD_Abyss_WingSuit_01          Abyss WingSuit 1
+    //   0xADE8  CD_Abyss_WingSuit_02          Abyss WingSuit 2
+    //   0xADED  CD_Wrist_BindingRope          Binding Rope
+    //   0xADEE  CD_HyperspacePlug             Hyperspace Plug
+    //   0xADEF  CD_AbyssGauntlet              Abyss Gauntlet
+    //   0xADF0  CD_AbyssController            Abyss Controller
+    //   0xADF1  CD_Abyss_Gauntlet             Abyss Gauntlet (variant)
+    //   0xADF2  CD_Abyss_Gauntlet_01          Abyss Gauntlet 1
+    //   0xADF3  CD_Abyss_Gauntlet_02          Abyss Gauntlet 2
+    //   0xADF4  CD_Helm_Flight                Flight Helmet
+    //   0xADF5  CD_Saddle                     Saddle
+    //   0xADF6  CD_Saddle_Hook                Saddle Hook
+    //   0xADF7  CD_Saddle_Belt                Saddle Belt
+    //   0xADF8  CD_Armor_Halterbind           Armor Halterbind
+    //   0xADF9  CD_Halterbind                 Halterbind
+    //   0xADFB  CD_HorseShoe                  Horse Shoe
+    //   0xADFC  CD_HorseHel                   Horse Helmet
+    //   0xADFD  CD_HorseArmor                 Horse Armor
+    //   0xADFE  CD_HorseArmor_01              Horse Armor 1
+    //   0xADFF  CD_HorsePack                  Horse Pack
+    //   0xAE00  CD_HorsePack_01               Horse Pack 1
+    //   0xAE01  CD_Parachute                  Parachute
+    //   0xAE02  CD_WagonWheel                 Wagon Wheel
+    //   0xAE40  CD_PartHider                  System (never hide)
+    //   0xAE5D  CD_Wagon_Lantern_R            Wagon Lantern R (excluded)
+    //   0xAE5E  CD_Wagon_Lantern_L            Wagon Lantern L (excluded)
+    //   0xAE5F  CD_Wagon_Lantern_Ring         Wagon Lantern Ring (excluded)
+    //   0xAE60  CD_LandSpider_Shell           Land Spider Shell
+    //   0xAE61  CD_LandSpider_Shell_01        Land Spider Shell 1
+    //   0xAF2C  CD_MainWeapon_Parachute       Parachute (weapon slot)
     //
     // =========================================================================
     // =========================================================================
@@ -209,110 +218,110 @@ namespace EquipHide
     // clang-format off
     static constexpr NamedPart k_allParts[] = {
         // 1H Weapons
-        {"CD_MainWeapon_Sword_R",       0xADC7},
-        {"CD_MainWeapon_Sword_IN_R",    0xADC8},
-        {"CD_MainWeapon_Sword_L",       0xADC9},
-        {"CD_MainWeapon_Sword_IN_L",    0xADCA},
-        {"CD_MainWeapon_Dagger_R",      0xADCB},
-        {"CD_MainWeapon_Dagger_IN_R",   0xADCC},
-        {"CD_MainWeapon_Dagger_L",      0xADCD},
-        {"CD_MainWeapon_Dagger_IN_L",   0xADCE},
-        {"CD_MainWeapon_Axe_R",         0xADCF},
-        {"CD_MainWeapon_Axe_L",         0xADD0},
-        {"CD_MainWeapon_Mace_R",        0xADD1},
-        {"CD_MainWeapon_Mace_L",        0xADD2},
-        {"CD_MainWeapon_Hammer_R",      0xADD3},
-        {"CD_MainWeapon_Flail_R",       0xADD4},
-        {"CD_MainWeapon_Wand_R",        0xADD5},
-        {"CD_MainWeapon_Bola",          0xADD6},
-        {"CD_MainWeapon_Fist_R",        0xADD7},
-        {"CD_MainWeapon_Fist_L",        0xADD8},
-        {"CD_MainWeapon_HandCannon",    0xADD9},
-        {"CD_MainWeapon_Fist_Hand",     0xADDA},
-        {"CD_MainWeapon_Fist_Foot",     0xADDB},
-        {"CD_MainWeapon_Lance",         0xADDC},
-        {"CD_MainWeapon_Gauntlet",      0xADDD},
-        {"CD_MainWeapon_Gauntlet_L",    0xADDE},
-        {"CD_MainWeapon_Sword_R_Aux",   0xB049},
-        {"CD_MainWeapon_Sword_IN_R_Aux",0xB04A},
+        {"CD_MainWeapon_Sword_R",       0xAE03},
+        {"CD_MainWeapon_Sword_IN_R",    0xAE04},
+        {"CD_MainWeapon_Sword_L",       0xAE05},
+        {"CD_MainWeapon_Sword_IN_L",    0xAE06},
+        {"CD_MainWeapon_Dagger_R",      0xAE07},
+        {"CD_MainWeapon_Dagger_IN_R",   0xAE08},
+        {"CD_MainWeapon_Dagger_L",      0xAE09},
+        {"CD_MainWeapon_Dagger_IN_L",   0xAE0A},
+        {"CD_MainWeapon_Axe_R",         0xAE0B},
+        {"CD_MainWeapon_Axe_L",         0xAE0C},
+        {"CD_MainWeapon_Mace_R",        0xAE0D},
+        {"CD_MainWeapon_Mace_L",        0xAE0E},
+        {"CD_MainWeapon_Hammer_R",      0xAE0F},
+        {"CD_MainWeapon_Flail_R",       0xAE10},
+        {"CD_MainWeapon_Wand_R",        0xAE11},
+        {"CD_MainWeapon_Bola",          0xAE12},
+        {"CD_MainWeapon_Fist_R",        0xAE13},
+        {"CD_MainWeapon_Fist_L",        0xAE14},
+        {"CD_MainWeapon_HandCannon",    0xAE15},
+        {"CD_MainWeapon_Fist_Hand",     0xAE16},
+        {"CD_MainWeapon_Fist_Foot",     0xAE17},
+        {"CD_MainWeapon_Lance",         0xAE18},
+        {"CD_MainWeapon_Gauntlet",      0xAE19},
+        {"CD_MainWeapon_Gauntlet_L",    0xAE1A},
+        {"CD_MainWeapon_Sword_R_Aux",   0xB085},
+        {"CD_MainWeapon_Sword_IN_R_Aux",0xB086},
         // 2H Weapons
-        {"CD_TwoHandWeapon_Sword",      0xADDF},
-        {"CD_TwoHandWeapon_Axe",        0xADE0},
-        {"CD_TwoHandWeapon_Axe_Aux",    0xADE1},
-        {"CD_TwoHandWeapon_Mace",       0xADE2},
-        {"CD_TwoHandWeapon_WarHammer",  0xADE3},
-        {"CD_TwoHandWeapon_Hammer",     0xADE4},
-        {"CD_TwoHandWeapon_Cannon",     0xADE5},
-        {"CD_TwoHandWeapon_CannonBall", 0xADE6},
-        {"CD_TwoHandWeapon_Thrower",    0xADE7},
-        {"CD_TwoHandWeapon_Spear",      0xADE8},
-        {"CD_TwoHandWeapon_Alebard",    0xADE9},
-        {"CD_MainWeapon_Pike",          0xADEA},
-        {"CD_TwoHandWeapon_Rod",        0xADEB},
-        {"CD_TwoHandWeapon_Flail",      0xADEC},
-        {"CD_TwoHandWeapon_BlowPipe",   0xADED},
-        {"CD_TwoHandWeapon_Scythe",     0xAE05},
-        {"CD_TwoHandWeapon_Flag",       0xAEEE},
+        {"CD_TwoHandWeapon_Sword",      0xAE1B},
+        {"CD_TwoHandWeapon_Axe",        0xAE1C},
+        {"CD_TwoHandWeapon_Axe_Aux",    0xAE1D},
+        {"CD_TwoHandWeapon_Mace",       0xAE1E},
+        {"CD_TwoHandWeapon_WarHammer",  0xAE1F},
+        {"CD_TwoHandWeapon_Hammer",     0xAE20},
+        {"CD_TwoHandWeapon_Cannon",     0xAE21},
+        {"CD_TwoHandWeapon_CannonBall", 0xAE22},
+        {"CD_TwoHandWeapon_Thrower",    0xAE23},
+        {"CD_TwoHandWeapon_Spear",      0xAE24},
+        {"CD_TwoHandWeapon_Alebard",    0xAE25},
+        {"CD_MainWeapon_Pike",          0xAE26},
+        {"CD_TwoHandWeapon_Rod",        0xAE27},
+        {"CD_TwoHandWeapon_Flail",      0xAE28},
+        {"CD_TwoHandWeapon_BlowPipe",   0xAE29},
+        {"CD_TwoHandWeapon_Scythe",     0xAE41},
+        {"CD_TwoHandWeapon_Flag",       0xAF2A},
         // Shields
-        {"CD_MainWeapon_Shield_L",      0xADEE},
-        {"CD_MainWeapon_Shield_R",      0xADEF},
-        {"CD_MainWeapon_TowerShield_L", 0xADF0},
+        {"CD_MainWeapon_Shield_L",      0xAE2A},
+        {"CD_MainWeapon_Shield_R",      0xAE2B},
+        {"CD_MainWeapon_TowerShield_L", 0xAE2C},
         // Bows / Arrows
-        {"CD_MainWeapon_Bow",           0xADF1},
-        {"CD_MainWeapon_Quiver",        0xADF2},
-        {"CD_MainWeapon_Quiver_Arw",    0xADF3},
-        {"CD_MainWeapon_Quiver_Arw_01", 0xADF4},
-        {"CD_MainWeapon_Quiver_Arw_02", 0xADF5},
-        {"CD_MainWeapon_Quiver_Arw_03", 0xADF6},
-        {"CD_MainWeapon_Arw",           0xADF7},
-        {"CD_MainWeapon_Arwline",       0xADF8},
-        {"CD_MainWeapon_Arw_IN",        0xAEEC},
+        {"CD_MainWeapon_Bow",           0xAE2D},
+        {"CD_MainWeapon_Quiver",        0xAE2E},
+        {"CD_MainWeapon_Quiver_Arw",    0xAE2F},
+        {"CD_MainWeapon_Quiver_Arw_01", 0xAE30},
+        {"CD_MainWeapon_Quiver_Arw_02", 0xAE31},
+        {"CD_MainWeapon_Quiver_Arw_03", 0xAE32},
+        {"CD_MainWeapon_Arw",           0xAE33},
+        {"CD_MainWeapon_Arwline",       0xAE34},
+        {"CD_MainWeapon_Arw_IN",        0xAF28},
         // Special / Ranged
-        {"CD_MainWeapon_ArwHead",       0xADF9},
-        {"CD_MainWeapon_CrossBow",      0xADFA},
-        {"CD_MainWeapon_Pistol_R",      0xADFB},
-        {"CD_MainWeapon_Pistol_L",      0xADFC},
-        {"CD_MainWeapon_Musket",        0xADFD},
-        {"CD_MainWeapon_Trap",          0xADFE},
-        {"CD_MainWeapon_Bomb",          0xADFF},
-        {"CD_MainWeapon_Fan",           0xAE00},
-        {"CD_MainWeapon_ThrownSpear_R", 0xAE01},
-        {"CD_MainWeapon_ThrownSpear_L", 0xAE02},
-        {"CD_MainWeapon_Whip_R",        0xAE03},
+        {"CD_MainWeapon_ArwHead",       0xAE35},
+        {"CD_MainWeapon_CrossBow",      0xAE36},
+        {"CD_MainWeapon_Pistol_R",      0xAE37},
+        {"CD_MainWeapon_Pistol_L",      0xAE38},
+        {"CD_MainWeapon_Musket",        0xAE39},
+        {"CD_MainWeapon_Trap",          0xAE3A},
+        {"CD_MainWeapon_Bomb",          0xAE3B},
+        {"CD_MainWeapon_Fan",           0xAE3C},
+        {"CD_MainWeapon_ThrownSpear_R", 0xAE3D},
+        {"CD_MainWeapon_ThrownSpear_L", 0xAE3E},
+        {"CD_MainWeapon_Whip_R",        0xAE3F},
         // Tools
-        {"CD_Tool_FishingRod",          0x0F4E},
-        {"CD_Tool",                     0xAE06},
-        {"CD_Tool_01",                  0xAE07},
-        {"CD_Tool_02",                  0xAE08},
-        {"CD_Tool_Axe",                 0xAE09},
-        {"CD_Tool_Hammer",              0xAE0A},
-        {"CD_Tool_Saw",                 0xAE0B},
-        {"CD_Tool_Hoe",                 0xAE0C},
-        {"CD_Tool_Broom",               0xAE0D},
-        {"CD_Tool_FarmScythe",          0xAE0E},
-        {"CD_Tool_Hayfork",             0xAE0F},
-        {"CD_Tool_Pickaxe",             0xAE10},
-        {"CD_Tool_Rake",                0xAE11},
-        {"CD_Tool_Shovel",              0xAE12},
-        {"CD_Tool_Crutch",              0xAE13},
-        {"CD_Tool_FishingRod_Sub",      0xAE14},
-        {"CD_Tool_Shooter",             0xAE15},
-        {"CD_Tool_Flute",               0xAE16},
-        {"CD_Tool_FireCan",             0xAE17},
-        {"CD_Tool_Cigarette",           0xAE18},
-        {"CD_Tool_Sprayer",             0xAE19},
-        {"CD_Tool_HandDrum",            0xAE1A},
-        {"CD_Tool_DrumStick_R",         0xAE1B},
-        {"CD_Tool_DrumStick_L",         0xAE1C},
-        {"CD_Tool_Torch",               0xAE1D},
-        {"CD_Tool_Pan",                 0xAEEF},
-        {"CD_Tool_Trumpet",             0xAEF2},
-        {"CD_Tool_Pipe",                0xAF2F},
-        {"CD_Tool_Book",                0x12435},
+        {"CD_Tool_FishingRod",          0x0F6D},
+        {"CD_Tool",                     0xAE42},
+        {"CD_Tool_01",                  0xAE43},
+        {"CD_Tool_02",                  0xAE44},
+        {"CD_Tool_Axe",                 0xAE45},
+        {"CD_Tool_Hammer",              0xAE46},
+        {"CD_Tool_Saw",                 0xAE47},
+        {"CD_Tool_Hoe",                 0xAE48},
+        {"CD_Tool_Broom",               0xAE49},
+        {"CD_Tool_FarmScythe",          0xAE4A},
+        {"CD_Tool_Hayfork",             0xAE4B},
+        {"CD_Tool_Pickaxe",             0xAE4C},
+        {"CD_Tool_Rake",                0xAE4D},
+        {"CD_Tool_Shovel",              0xAE4E},
+        {"CD_Tool_Crutch",              0xAE4F},
+        {"CD_Tool_FishingRod_Sub",      0xAE50},
+        {"CD_Tool_Shooter",             0xAE51},
+        {"CD_Tool_Flute",               0xAE52},
+        {"CD_Tool_FireCan",             0xAE53},
+        {"CD_Tool_Cigarette",           0xAE54},
+        {"CD_Tool_Sprayer",             0xAE55},
+        {"CD_Tool_HandDrum",            0xAE56},
+        {"CD_Tool_DrumStick_R",         0xAE57},
+        {"CD_Tool_DrumStick_L",         0xAE58},
+        {"CD_Tool_Torch",               0xAE59},
+        {"CD_Tool_Pan",                 0xAF2B},
+        {"CD_Tool_Trumpet",             0xAF2E},
+        {"CD_Tool_Pipe",                0xAF6B},
+        {"CD_Tool_Book",                0x12A79},
         // Lanterns
-        {"CD_Tool_Hyperspace_RemoteControl", 0xAE1E},
-        {"CD_Lantern",                  0xAE1F},
-        {"CD_Lantern_Ring",             0xAE20},
+        {"CD_Tool_Hyperspace_RemoteControl", 0xAE5A},
+        {"CD_Lantern",                  0xAE5B},
+        {"CD_Lantern_Ring",             0xAE5C},
     };
     // clang-format on
 

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -364,8 +364,8 @@ namespace EquipHide
         auto partHash = *reinterpret_cast<const uint32_t *>(r10);
 
         // Quick range check before map lookup — skip obviously out-of-range hashes.
-        // Equipment part hashes span 0xAD00-0xBFFF with outliers at 0x0F4E and 0x12435.
-        if (partHash != 0x0F4E && partHash != 0x12435 && (partHash < 0xAD00 || partHash > 0xBFFF))
+        // Equipment part hashes span 0xAE03-0xBFFF with outliers at 0x0F6D and 0x12A79.
+        if (partHash != 0x0F6D && partHash != 0x12A79 && (partHash < 0xAE03 || partHash > 0xBFFF))
             return;
 
         const auto cat = classify_part(partHash);


### PR DESCRIPTION
## Summary
- Update all 98 equipment part hash IDs in `k_allParts` to match game v1.01.00
- Update range filter in `on_vis_check_impl` (`0xAE03-0xBFFF`, outliers `0x0F6D`, `0x12A79`)
- Update complete hash reference comments in categories.cpp

The v1.01.00 patch inserted ~60 new entries (CD_Bag_*, accessories) into the IndexedStringA table, shifting all equipment hash IDs upward. This caused only tools and 2H weapons to appear to hide (their old hash slots accidentally overlapped with new weapon IDs).

## Test plan
- [x] Launch game with updated ASI
- [x] Verify Hide All (Numpad8) hides all categories
- [x] Verify Show All (Numpad7) restores all categories
- [x] Verify per-category hotkeys work (Lanterns toggle, Bows show/hide)
- [x] Verify PlayerOnly mode still filters correctly
