### PR TITLE
fix(visibility): cache and restore original vis bytes on un-hide

### DIFF
--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -15,3 +15,6 @@
 ### Fixed
 
 - Fix equipment hide not working on game v1.01.00 — the patch inserted ~60 new entries into the IndexedStringA table, shifting all 98 equipment part hash IDs
+- Fix DefaultHidden intermittently not applying on cold boot — added 60-second startup direct-write enforcement that proactively writes visibility bytes after init, covering the race where the game processes initial equipment visibility before the hook is installed or the PlayerOnly filter has transitional pointer data
+- Direct-write visibility updates now work in d8-based fallback mode, improving hotkey responsiveness when the global pointer chain is unavailable
+- Fix toggling a category to visible forcing all its parts to always-show (vis=0) — the direct-write path now caches each part's original vis byte before overriding and restores it on un-hide, preserving the game's per-part-type render routing (vis=0 for shields rendered through the PartInOut path, vis=3 for weapons rendered by the animation system). This fixes daggers/knives becoming permanently visible after any hide/show toggle cycle

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -51,6 +51,12 @@ namespace EquipHide
 
     static std::atomic<bool> s_needsDirectWrite{false};
 
+    // Per-address cache of original vis bytes written before the mod overrides them.
+    // Keyed by the vis-byte address (entry + 0x1C).  Populated by the direct-write
+    // path on first hide; consumed on un-hide to restore the game's natural value.
+    // Only accessed from the direct-write call site (cold path, single-threaded).
+    static std::unordered_map<uintptr_t, uint8_t> s_originalVis;
+
     static DMK::Config::KeyComboList s_showAllCombos;
     static DMK::Config::KeyComboList s_hideAllCombos;
 
@@ -59,6 +65,17 @@ namespace EquipHide
 
     // Deferred IndexedStringA scan: set when the table isn't ready at init
     static std::atomic<bool> s_deferredScanPending{false};
+
+    // Startup direct-write enforcement deadline (ms since steady_clock epoch).
+    // While active, resolve_player_vis_ctrls() schedules direct writes on
+    // success to proactively enforce DefaultHidden during game loading.
+    static std::atomic<int64_t> s_startupWriteEnd{0};
+
+    static int64_t steady_ms() noexcept
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()).count();
+    }
 
     static uintptr_t read_ptr(uintptr_t base, ptrdiff_t off) noexcept
     {
@@ -444,6 +461,20 @@ namespace EquipHide
                         "Resolve: ws={:#x} am={:#x} user={:#x} count={}",
                         ws, am, user, count);
             }
+            // Startup enforcement: after resolve succeeds, schedule a
+            // direct write so DefaultHidden takes effect even when the
+            // passive hook path missed the initial visibility setup or
+            // the PlayerOnly filter has transitional pointer data.
+            {
+                auto end = s_startupWriteEnd.load(std::memory_order_relaxed);
+                if (end > 0 && count > 0)
+                {
+                    if (steady_ms() < end)
+                        s_needsDirectWrite.store(true, std::memory_order_relaxed);
+                    else
+                        s_startupWriteEnd.store(0, std::memory_order_relaxed);
+                }
+            }
 #ifdef _MSC_VER
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
@@ -497,8 +528,24 @@ namespace EquipHide
                     if (!entry)
                         continue;
 
-                    auto *visPtr = reinterpret_cast<uint8_t *>(entry + 0x1C);
-                    *visPtr = is_category_hidden(cat) ? 2 : 0;
+                    const auto visAddr = entry + 0x1C;
+                    auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
+
+                    if (is_category_hidden(cat))
+                    {
+                        if (s_originalVis.find(visAddr) == s_originalVis.end())
+                            s_originalVis[visAddr] = *visPtr;
+                        *visPtr = 2;
+                    }
+                    else
+                    {
+                        auto it = s_originalVis.find(visAddr);
+                        if (it != s_originalVis.end())
+                        {
+                            *visPtr = it->second;
+                            s_originalVis.erase(it);
+                        }
+                    }
                     ++modified;
                 }
             }
@@ -601,8 +648,7 @@ namespace EquipHide
     /// Core logic — no SEH here so C++ objects (SafetyHookContext&) are fine.
     static void on_vis_check_impl(SafetyHookContext &ctx)
     {
-        if (s_needsDirectWrite.exchange(false, std::memory_order_relaxed) &&
-            !s_fallbackMode.load(std::memory_order_relaxed))
+        if (s_needsDirectWrite.exchange(false, std::memory_order_relaxed))
             apply_direct_vis_write();
 
         if (s_deferredScanPending.load(std::memory_order_relaxed))
@@ -663,6 +709,9 @@ namespace EquipHide
                             {
                                 s_playerVisCtrls[n].store(a1, std::memory_order_relaxed);
                                 s_playerCount.store(n + 1, std::memory_order_relaxed);
+
+                                if (s_startupWriteEnd.load(std::memory_order_relaxed) > 0)
+                                    s_needsDirectWrite.store(true, std::memory_order_relaxed);
                             }
                         }
                     }
@@ -715,7 +764,7 @@ namespace EquipHide
         if (is_category_hidden(*cat))
         {
             auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
-            *visPtr = 2; // Force Out-only visibility
+            *visPtr = 2;
         }
     }
 
@@ -868,10 +917,8 @@ namespace EquipHide
     static void flush_visibility() noexcept
     {
         if (!s_fallbackMode.load(std::memory_order_relaxed))
-        {
             resolve_player_vis_ctrls();
-            apply_direct_vis_write();
-        }
+        apply_direct_vis_write();
         s_needsDirectWrite.store(true, std::memory_order_relaxed);
     }
 
@@ -1115,6 +1162,27 @@ namespace EquipHide
 
         auto &inputMgr = DMK::InputManager::get_instance();
         inputMgr.start();
+
+        // Schedule startup direct-write enforcement if any category starts hidden.
+        // Covers the race where the game processes initial equipment visibility
+        // before the hook is installed, or the PlayerOnly filter has transitional
+        // pointer data during game loading.
+        {
+            bool anyDefaultHidden = false;
+            for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
+            {
+                if (category_states()[i].hidden.load(std::memory_order_relaxed))
+                {
+                    anyDefaultHidden = true;
+                    break;
+                }
+            }
+            if (anyDefaultHidden)
+            {
+                s_startupWriteEnd.store(steady_ms() + 60000, std::memory_order_relaxed);
+                logger.debug("Startup direct-write enforcement scheduled (60s)");
+            }
+        }
 
         logger.info("Equip hide system initialized");
         return true;


### PR DESCRIPTION
## Summary

- Fixed a bug where toggling equipment categories back to "visible" force-wrote `vis=0` (Always Render) to all parts, breaking weapons (`vis=3`, animation-driven) and making daggers/knives permanently visible after any hide/show cycle
- `apply_direct_vis_write` now caches each part's original vis byte before overriding, and restores it when the category is un-hidden
- Hook hot path simplified: writes `vis=2` only when hiding, no-op otherwise (zero overhead when not hidden)

## Test plan

- [x] Hide a weapon category (e.g. shields), confirm parts disappear
- [x] Un-hide the same category, confirm parts reappear with correct rendering behavior (shields via PartInOut, weapons via animation)
- [x] Equip a dagger/knife, hide then un-hide its category, confirm it does NOT stay permanently visible
- [x] Verify no performance regression in the hook hot path when all categories are visible
