### PR TITLE
fix(equip-hide): resolve thread-safety issues and optimize hot path

### DIFF
--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(CrimsonDesertEquipHide VERSION 0.2.0 LANGUAGES CXX)
+project(CrimsonDesertEquipHide VERSION 0.2.3 LANGUAGES CXX)
 
 # --- Standard and Compiler Options ---
 set(CMAKE_CXX_STANDARD 23)
@@ -50,6 +50,9 @@ else()
         "'git submodule update --init --recursive'")
 endif()
 
+# --- Dev Build Option ---
+option(EQUIPHIDE_DEV_BUILD "Build two-DLL hot-reload configuration for development" OFF)
+
 # --- Source Files ---
 set(COMMON_SOURCES
     src/dllmain.cpp
@@ -66,81 +69,178 @@ set(COMMON_INCLUDE_DIRS
     src
 )
 
-# --- ASI Target (.asi file) ---
-add_library(${PROJECT_NAME}-ASI SHARED ${ASI_SOURCES})
+# --- Game Output Directory (dev builds) ---
+set(GAME_BIN_DIR "D:/Games/SteamLibrary/steamapps/common/Crimson Desert/bin64/plugins")
 
-target_include_directories(${PROJECT_NAME}-ASI PRIVATE ${COMMON_INCLUDE_DIRS})
+if(EQUIPHIDE_DEV_BUILD)
+    # =====================================================================
+    # Dev Build: two-DLL hot-reload (loader + logic)
+    # =====================================================================
+    message(STATUS "DEV BUILD enabled — building loader + logic DLL pair")
 
-target_link_libraries(${PROJECT_NAME}-ASI PRIVATE
-    DetourModKit
-    psapi
-    user32
-    kernel32
-)
+    # --- Loader ASI (thin stub, no DetourModKit) ---
+    add_library(equip_hide_loader SHARED src/dev/loader_main.cpp)
 
-# Set output name and properties for ASI
-set_target_properties(${PROJECT_NAME}-ASI PROPERTIES
-    OUTPUT_NAME "CrimsonDesertEquipHide-temp-asi"
-    SUFFIX ".asi"
-    PREFIX ""
-)
-
-# --- Target-Scoped Release Optimizations ---
-if(MSVC)
-    # /Gy: function-level linking, /Gw: global data optimization.
-    # /O1: favor size (appropriate for an injected DLL).
-    target_compile_options(${PROJECT_NAME}-ASI PRIVATE
-        $<$<CONFIG:Release>:/O1 /Gy /Gw>
+    target_link_libraries(equip_hide_loader PRIVATE
+        kernel32
+        user32
     )
 
-    # /OPT:REF removes unreferenced functions/data; /OPT:ICF folds identical COMDATs.
-    target_link_options(${PROJECT_NAME}-ASI PRIVATE
-        $<$<CONFIG:Release>:/OPT:REF /OPT:ICF>
+    set_target_properties(equip_hide_loader PROPERTIES
+        OUTPUT_NAME "CrimsonDesertEquipHide"
+        SUFFIX ".asi"
+        PREFIX ""
+        RUNTIME_OUTPUT_DIRECTORY "${GAME_BIN_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${GAME_BIN_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${GAME_BIN_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_BIN_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY "${GAME_BIN_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY_DEBUG "${GAME_BIN_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY_RELEASE "${GAME_BIN_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_BIN_DIR}"
     )
-else()
-    # -ffunction-sections/-fdata-sections enable --gc-sections for dead code elimination.
-    # -O2 is set globally via CMAKE_CXX_FLAGS_RELEASE.
-    target_compile_options(${PROJECT_NAME}-ASI PRIVATE
-        $<$<CONFIG:Release>:-ffunction-sections -fdata-sections>
+
+    if(MSVC)
+        target_compile_options(equip_hide_loader PRIVATE /W4)
+    else()
+        target_link_options(equip_hide_loader PRIVATE
+            -static-libgcc
+            -static-libstdc++
+            -static
+        )
+    endif()
+
+    # --- Logic DLL (all mod code) ---
+    add_library(equip_hide_logic SHARED
+        ${COMMON_SOURCES}
+        src/dev/logic_exports.cpp
     )
-    target_link_options(${PROJECT_NAME}-ASI PRIVATE
-        -Wl,--gc-sections
-        -Wl,--exclude-all-symbols
-        -static-libgcc
-        -static-libstdc++
-        -static
 
-        # Strip all symbols in Release to minimize binary size.
-        $<$<CONFIG:Release>:-s>
+    target_include_directories(equip_hide_logic PRIVATE ${COMMON_INCLUDE_DIRS})
+
+    target_compile_definitions(equip_hide_logic PRIVATE EQUIPHIDE_DEV_BUILD)
+
+    target_link_libraries(equip_hide_logic PRIVATE
+        DetourModKit
+        psapi
+        user32
+        kernel32
     )
-endif()
 
-# --- Link-Time Optimization ---
-include(CheckIPOSupported)
-check_ipo_supported(RESULT _ipo_supported LANGUAGES CXX OUTPUT _ipo_error)
+    # Build to staging/ so the linker never conflicts with a game-locked DLL.
+    # The loader copies from staging/ before LoadLibrary.
+    set(GAME_STAGING_DIR "${GAME_BIN_DIR}/staging")
 
-if(_ipo_supported)
+    set_target_properties(equip_hide_logic PROPERTIES
+        OUTPUT_NAME "CrimsonDesertEquipHide_Logic"
+        PREFIX ""
+        RUNTIME_OUTPUT_DIRECTORY "${GAME_STAGING_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${GAME_STAGING_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${GAME_STAGING_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_STAGING_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY "${GAME_STAGING_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY_DEBUG "${GAME_STAGING_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY_RELEASE "${GAME_STAGING_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_STAGING_DIR}"
+        PDB_OUTPUT_DIRECTORY "${GAME_STAGING_DIR}"
+        PDB_OUTPUT_DIRECTORY_DEBUG "${GAME_STAGING_DIR}"
+        PDB_OUTPUT_DIRECTORY_RELEASE "${GAME_STAGING_DIR}"
+        PDB_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_STAGING_DIR}"
+    )
+
+    if(MSVC)
+        target_compile_options(equip_hide_logic PRIVATE /W4 /Zi)
+        target_link_options(equip_hide_logic PRIVATE /DEBUG /OPT:REF /OPT:ICF)
+    else()
+        target_link_options(equip_hide_logic PRIVATE
+            -Wl,--exclude-all-symbols
+            -static-libgcc
+            -static-libstdc++
+            -static
+        )
+    endif()
+
+else() # EQUIPHIDE_DEV_BUILD=OFF
+    # =====================================================================
+    # Production Build: single ASI (unchanged)
+    # =====================================================================
+
+    # --- ASI Target (.asi file) ---
+    add_library(${PROJECT_NAME}-ASI SHARED ${ASI_SOURCES})
+
+    target_include_directories(${PROJECT_NAME}-ASI PRIVATE ${COMMON_INCLUDE_DIRS})
+
+    target_link_libraries(${PROJECT_NAME}-ASI PRIVATE
+        DetourModKit
+        psapi
+        user32
+        kernel32
+    )
+
+    # Set output name and properties for ASI
     set_target_properties(${PROJECT_NAME}-ASI PROPERTIES
-        INTERPROCEDURAL_OPTIMIZATION_RELEASE ON
+        OUTPUT_NAME "CrimsonDesertEquipHide-temp-asi"
+        SUFFIX ".asi"
+        PREFIX ""
     )
-    message(STATUS "LTO enabled for ${PROJECT_NAME}-ASI Release builds")
-else()
-    message(STATUS "LTO not supported for ${PROJECT_NAME}-ASI: ${_ipo_error}")
-endif()
 
-# Post-build steps to rename to desired names
-add_custom_command(TARGET ${PROJECT_NAME}-ASI POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-    $<TARGET_FILE:${PROJECT_NAME}-ASI>
-    ${CMAKE_CURRENT_BINARY_DIR}/CrimsonDesertEquipHide.asi
-    COMMENT "Renaming ASI output to final name"
-)
+    # --- Target-Scoped Release Optimizations ---
+    if(MSVC)
+        # /Gy: function-level linking, /Gw: global data optimization.
+        # /O1: favor size (appropriate for an injected DLL).
+        target_compile_options(${PROJECT_NAME}-ASI PRIVATE
+            $<$<CONFIG:Release>:/O1 /Gy /Gw>
+        )
 
-# --- Build Summary ---
-message(STATUS "---------------------------------------------------------------------")
-message(STATUS "CrimsonDesertEquipHide (${PROJECT_VERSION}) Configuration Summary:")
-message(STATUS "  Generator:                   ${CMAKE_GENERATOR}")
-message(STATUS "  Build Type:                  ${CMAKE_BUILD_TYPE}")
-message(STATUS "  Targets:")
-message(STATUS "    - ${PROJECT_NAME}-ASI      -> CrimsonDesertEquipHide.asi (via post-build copy)")
-message(STATUS "---------------------------------------------------------------------")
+        # /OPT:REF removes unreferenced functions/data; /OPT:ICF folds identical COMDATs.
+        target_link_options(${PROJECT_NAME}-ASI PRIVATE
+            $<$<CONFIG:Release>:/OPT:REF /OPT:ICF>
+        )
+    else()
+        # -ffunction-sections/-fdata-sections enable --gc-sections for dead code elimination.
+        # -O2 is set globally via CMAKE_CXX_FLAGS_RELEASE.
+        target_compile_options(${PROJECT_NAME}-ASI PRIVATE
+            $<$<CONFIG:Release>:-ffunction-sections -fdata-sections>
+        )
+        target_link_options(${PROJECT_NAME}-ASI PRIVATE
+            -Wl,--gc-sections
+            -Wl,--exclude-all-symbols
+            -static-libgcc
+            -static-libstdc++
+            -static
+
+            # Strip all symbols in Release to minimize binary size.
+            $<$<CONFIG:Release>:-s>
+        )
+    endif()
+
+    # --- Link-Time Optimization ---
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT _ipo_supported LANGUAGES CXX OUTPUT _ipo_error)
+
+    if(_ipo_supported)
+        set_target_properties(${PROJECT_NAME}-ASI PROPERTIES
+            INTERPROCEDURAL_OPTIMIZATION_RELEASE ON
+        )
+        message(STATUS "LTO enabled for ${PROJECT_NAME}-ASI Release builds")
+    else()
+        message(STATUS "LTO not supported for ${PROJECT_NAME}-ASI: ${_ipo_error}")
+    endif()
+
+    # Post-build steps to rename to desired names
+    add_custom_command(TARGET ${PROJECT_NAME}-ASI POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE:${PROJECT_NAME}-ASI>
+        ${CMAKE_CURRENT_BINARY_DIR}/CrimsonDesertEquipHide.asi
+        COMMENT "Renaming ASI output to final name"
+    )
+
+    # --- Build Summary ---
+    message(STATUS "---------------------------------------------------------------------")
+    message(STATUS "CrimsonDesertEquipHide (${PROJECT_VERSION}) Configuration Summary:")
+    message(STATUS "  Generator:                   ${CMAKE_GENERATOR}")
+    message(STATUS "  Build Type:                  ${CMAKE_BUILD_TYPE}")
+    message(STATUS "  Targets:")
+    message(STATUS "    - ${PROJECT_NAME}-ASI      -> CrimsonDesertEquipHide.asi (via post-build copy)")
+    message(STATUS "---------------------------------------------------------------------")
+endif() # EQUIPHIDE_DEV_BUILD

--- a/CrimsonDesertEquipHide/CMakePresets.json
+++ b/CrimsonDesertEquipHide/CMakePresets.json
@@ -1,0 +1,74 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 16,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "msvc-release",
+            "displayName": "MSVC Release (single ASI)",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "binaryDir": "${sourceDir}/build/release-msvc",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "mingw-release",
+            "displayName": "MinGW Release (single ASI)",
+            "generator": "MinGW Makefiles",
+            "binaryDir": "${sourceDir}/build/release-mingw",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
+            }
+        },
+        {
+            "name": "msvc-dev",
+            "displayName": "MSVC Dev (hot-reload two-DLL)",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "x64",
+            "binaryDir": "${sourceDir}/build/dev-msvc",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "EQUIPHIDE_DEV_BUILD": "ON"
+            }
+        },
+        {
+            "name": "mingw-dev",
+            "displayName": "MinGW Dev (hot-reload two-DLL)",
+            "generator": "MinGW Makefiles",
+            "binaryDir": "${sourceDir}/build/dev-mingw",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++",
+                "EQUIPHIDE_DEV_BUILD": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "msvc-release",
+            "configurePreset": "msvc-release",
+            "configuration": "Release"
+        },
+        {
+            "name": "mingw-release",
+            "configurePreset": "mingw-release"
+        },
+        {
+            "name": "msvc-dev",
+            "configurePreset": "msvc-dev",
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "mingw-dev",
+            "configurePreset": "mingw-dev"
+        }
+    ]
+}

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -15,17 +15,67 @@
 
 ## Installation
 
-1. Make sure you have an ASI Loader installed for Crimson Desert. If you don't have one, download `version.dll` from the [Ultimate ASI Loader releases](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases) and place it in your Crimson Desert game directory (where the game executable is located).
-2. Download the latest release from the [GitHub Releases page](https://github.com/tkhquang/CrimsonDesertTools/releases)
-3. Extract all files to your Crimson Desert game directory:
+### Step 1: Install an ASI Loader
 
-   ```text
-   <Crimson Desert installation folder>/bin64/
+You need an ASI Loader to load `.asi` mods. If you already have one (e.g. from another mod), skip to Step 2.
+
+Download the **x64** build of [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases) and place one of the following DLLs into your `bin64` folder:
+
+| DLL name       | Notes                                    |
+| -------------- | ---------------------------------------- |
+| `winmm.dll`    | **Recommended** — works for most setups  |
+| `version.dll`  | Alternative if `winmm.dll` conflicts     |
+| `dinput8.dll`  | Another alternative                      |
+
+> **Not working?** If the game launches but no `CrimsonDesertEquipHide.log` file appears in `bin64`, the ASI Loader is not loading. Try renaming the DLL to one of the other variants listed above.
+
+### Step 2: Install the mod
+
+1. Download the latest release from the [GitHub Releases page](https://github.com/tkhquang/CrimsonDesertTools/releases)
+2. Extract `CrimsonDesertEquipHide.asi` and `CrimsonDesertEquipHide.ini` into your `bin64` folder
+
+### Step 3: Launch and play
+
+Launch the game. Press `V` (default) to toggle equipment visibility.
+
+### File placement
+
+```text
+<Crimson Desert>/bin64/
+├── CrimsonDesert.exe              (Game executable)
+├── winmm.dll                      (ASI Loader)
+├── CrimsonDesertEquipHide.asi     (This mod)
+├── CrimsonDesertEquipHide.ini     (This mod's configuration)
+└── ...
+```
+
+### Using with OptiScaler
+
+If you use [OptiScaler](https://github.com/cdozdil/OptiScaler) for frame generation or upscaling, the standard ASI Loader (`version.dll`) will conflict with OptiScaler's own `dxgi.dll`. Follow these steps instead:
+
+1. **Delete** `winmm.dll` (or whichever ASI Loader DLL you placed) from `bin64` — OptiScaler will handle mod loading instead
+2. Open `OptiScaler.ini`, find the `[Plugins]` section, and set:
+
+   ```ini
+   LoadAsiPlugins = true
    ```
 
-   Example: `D:\Games\SteamLibrary\steamapps\common\Crimson Desert\bin64`
+3. Create a `plugins` folder inside `bin64`
+4. Move `CrimsonDesertEquipHide.asi` and `CrimsonDesertEquipHide.ini` into the `plugins` folder
 
-4. Launch the game and use the configured hotkey (default: `V`) to toggle equipment visibility
+```text
+<Crimson Desert>/bin64/
+├── CrimsonDesert.exe
+├── OptiScaler.ini                 (LoadAsiPlugins = true)
+├── dxgi.dll                       (OptiScaler)
+├── plugins/
+│   ├── CrimsonDesertEquipHide.asi
+│   ├── CrimsonDesertEquipHide.ini
+│   └── ...                        (Other ASI mods go here too)
+└── ...
+```
+
+> This applies to any ASI mod, not just this one. If you have other `.asi` mods (e.g. CDSprintHold), move them into the `plugins` folder as well.
 
 ## Configuration
 
@@ -133,7 +183,7 @@ See [CHANGELOG.md](CHANGELOG.md) for a detailed history of updates.
 
 This mod requires:
 
-- [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader) by [**ThirteenAG**](https://github.com/ThirteenAG) – `version.dll` variant required
+- [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader) by [**ThirteenAG**](https://github.com/ThirteenAG) – `winmm.dll` recommended (see [Installation](#installation) for alternatives)
 - [DetourModKit](https://github.com/tkhquang/DetourModKit) – A lightweight C++ toolkit for game modding
 
 ## Building from Source

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,18 @@
-## [Title for next release]
+## Thread safety and hot-path performance improvements
 
-- New feature
-- Bug fix
-- Improvement
+### Fixed
+
+- Fix potential permanent mutex deadlock in `apply_direct_vis_write` on SEH unwind — switched to manual `try_lock`/`unlock`
+- Fix TOCTOU race on player slot caching in d8 fallback path — use `compare_exchange_weak`
+- Fix hotkey toggle causing `apply_direct_vis_write` to run on every subsequent hook call indefinitely
+- Fix silent `catch(...)` swallowing malformed hex IDs in INI parsing — now logs a warning
+
+### Improved
+
+- Avoid `lock xchg` (~25 cycles) on every hook call via load-before-exchange on `s_needsDirectWrite`
+- Background threads now exit cleanly on DLL unload via `s_shutdownRequested` flag
+
+### Added
+
+- CMakePresets.json (msvc-release, mingw-release, msvc-dev, mingw-dev)
+- Dev build two-DLL hot-reload infrastructure (loader stub + logic DLL)

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -19,13 +19,57 @@ This mod allows you to hide equipped gear visually in Crimson Desert using custo
 [/list]
 
 [size=5]Installation[/size]
-1. Make sure you have an ASI Loader installed for Crimson Desert. If you don't have one, download [code]version.dll[/code] from the [url=https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases]Ultimate ASI Loader releases[/url] and place it in your Crimson Desert game directory (where the game executable is located).
 
-2. Extract all files from the archive to your Crimson Desert game directory:
-  [code]<Crimson Desert installation folder>/bin64/[/code]
-  Example: [code]D:\Games\SteamLibrary\steamapps\common\Crimson Desert\bin64[/code]
+[size=4]Step 1: Install an ASI Loader[/size]
+You need an ASI Loader to load [code].asi[/code] mods. If you already have one (e.g. from another mod), skip to Step 2.
 
-3. Launch the game and press V (default) to toggle equipment visibility
+Download the [b]x64[/b] build of [url=https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases]Ultimate ASI Loader[/url] and place one of the following DLLs into your [code]bin64[/code] folder:
+[list]
+[*] [code]winmm.dll[/code] — [b]Recommended[/b], works for most setups
+[*] [code]version.dll[/code] — Alternative if [code]winmm.dll[/code] conflicts
+[*] [code]dinput8.dll[/code] — Another alternative
+[/list]
+
+[b]Not working?[/b] If the game launches but no [code]CrimsonDesertEquipHide.log[/code] file appears in [code]bin64[/code], the ASI Loader is not loading. Try renaming the DLL to one of the other variants listed above.
+
+[size=4]Step 2: Install the mod[/size]
+1. Download the latest release from the files section
+2. Extract [code]CrimsonDesertEquipHide.asi[/code] and [code]CrimsonDesertEquipHide.ini[/code] into your [code]bin64[/code] folder
+
+[size=4]Step 3: Launch and play[/size]
+Launch the game. Press [b]V[/b] (default) to toggle equipment visibility.
+
+[size=4]File placement[/size]
+[code]
+<Crimson Desert>/bin64/
+├── CrimsonDesert.exe              (Game executable)
+├── winmm.dll                      (ASI Loader)
+├── CrimsonDesertEquipHide.asi     (This mod)
+├── CrimsonDesertEquipHide.ini     (This mod's configuration)
+└── ...
+[/code]
+
+[size=4]Using with OptiScaler[/size]
+If you use [url=https://github.com/cdozdil/OptiScaler]OptiScaler[/url] for frame generation or upscaling, the standard ASI Loader ([code]winmm.dll[/code]) will conflict with OptiScaler's own [code]dxgi.dll[/code]. Follow these steps instead:
+
+1. [b]Delete[/b] [code]winmm.dll[/code] (or whichever ASI Loader DLL you placed) from [code]bin64[/code] — OptiScaler will handle mod loading instead
+2. Open [code]OptiScaler.ini[/code], find the [code][Plugins][/code] section, and set [code]LoadAsiPlugins = true[/code]
+3. Create a [code]plugins[/code] folder inside [code]bin64[/code]
+4. Move [code]CrimsonDesertEquipHide.asi[/code] and [code]CrimsonDesertEquipHide.ini[/code] into the [code]plugins[/code] folder
+
+[code]
+<Crimson Desert>/bin64/
+├── CrimsonDesert.exe
+├── OptiScaler.ini                 (LoadAsiPlugins = true)
+├── dxgi.dll                       (OptiScaler)
+├── plugins/
+│   ├── CrimsonDesertEquipHide.asi
+│   ├── CrimsonDesertEquipHide.ini
+│   └── ...                        (Other ASI mods go here too)
+└── ...
+[/code]
+
+This applies to any ASI mod, not just this one. If you have other [code].asi[/code] mods (e.g. CDSprintHold), move them into the [code]plugins[/code] folder as well.
 
 [size=5]Configuration[/size]
 The mod can be configured by editing the CrimsonDesertEquipHide.ini file:

--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -140,7 +140,7 @@ namespace EquipHide
     //   0xAF2B  CD_Tool_Pan                   Pan
     //   0xAF2E  CD_Tool_Trumpet               Trumpet
     //   0xAF6B  CD_Tool_Pipe                  Pipe
-    // 0x12A8B  CD_Tool_Book                  Book (non-deterministic slot)
+    //          CD_Tool_Book                  Book (hash assigned on demand, no stable fallback)
     //
     // Lanterns (0xAE5A - 0xAE5C):
     //   0xAE5A  CD_Tool_Hyperspace_RemoteControl  Remote Control
@@ -325,7 +325,7 @@ namespace EquipHide
         {"CD_Tool_Pan",                 0xAF2B},
         {"CD_Tool_Trumpet",             0xAF2E},
         {"CD_Tool_Pipe",                0xAF6B},
-        {"CD_Tool_Book",                0x12A8B},
+        {"CD_Tool_Book",                0},  // demand-loaded: no stable fallback
         // Lanterns
         {"CD_Tool_Hyperspace_RemoteControl", 0xAE5A},
         {"CD_Lantern",                  0xAE5B},
@@ -387,17 +387,22 @@ namespace EquipHide
                     auto it = s_nameToHash.find(p.name);
                     if (it != s_nameToHash.end())
                     {
-                        if (it->second != p.fallbackHash)
+                        if (p.fallbackHash != 0 && it->second != p.fallbackHash)
                             logger.debug("Hash shifted: {} 0x{:X} -> 0x{:X}",
                                          p.name, p.fallbackHash, it->second);
                         ++resolved;
                     }
-                    else
+                    else if (p.fallbackHash != 0)
                     {
                         logger.warning("Part '{}' not found in runtime table, "
                                        "using fallback 0x{:X}", p.name, p.fallbackHash);
                         s_nameToHash[p.name] = p.fallbackHash;
                         ++fallback;
+                    }
+                    else
+                    {
+                        logger.debug("Part '{}' awaiting runtime resolution "
+                                     "(no fallback)", p.name);
                     }
                 }
                 logger.info("Hash resolution: {}/{} runtime, {} fallback",
@@ -407,7 +412,10 @@ namespace EquipHide
             {
                 logger.info("Using compile-time fallback hashes (pending deferred scan)");
                 for (const auto& p : k_allParts)
-                    s_nameToHash[p.name] = p.fallbackHash;
+                {
+                    if (p.fallbackHash != 0)
+                        s_nameToHash[p.name] = p.fallbackHash;
+                }
             }
             s_nameToHashBuilt = true;
         }
@@ -492,9 +500,33 @@ namespace EquipHide
             auto it = nameMap.find(token);
             if (it != nameMap.end())
             {
+                if (it->second == 0)
+                {
+                    logger.trace("  {} skipped {} (no stable hash)", category_section(cat), token);
+                    continue;
+                }
                 writeMap[it->second] = cat;
-                logger.debug("  {} += {} (0x{:04X})", category_section(cat), token, it->second);
+                logger.trace("  {} += {} (0x{:04X})", category_section(cat), token, it->second);
                 continue;
+            }
+
+            // Check if this is a known part awaiting runtime resolution
+            {
+                bool knownDeferred = false;
+                for (const auto& p : k_allParts)
+                {
+                    if (token == p.name && p.fallbackHash == 0)
+                    {
+                        knownDeferred = true;
+                        break;
+                    }
+                }
+                if (knownDeferred)
+                {
+                    logger.trace("  {} deferred {} (awaiting runtime scan)",
+                                  category_section(cat), token);
+                    continue;
+                }
             }
 
             // Try as hex ID (for advanced users / gap IDs)
@@ -504,10 +536,13 @@ namespace EquipHide
                 {
                     auto id = static_cast<uint32_t>(std::stoul(token.substr(2), nullptr, 16));
                     writeMap[id] = cat;
-                    logger.debug("  {} += 0x{:04X} (raw)", category_section(cat), id);
+                    logger.trace("  {} += 0x{:04X} (raw)", category_section(cat), id);
                     continue;
                 }
-                catch (...) {}
+                catch (...)
+                {
+                    logger.warning("  {} : malformed hex ID '{}'", category_section(cat), token);
+                }
             }
 
             logger.warning("  {} : unknown part '{}'", category_section(cat), token);
@@ -598,8 +633,9 @@ namespace EquipHide
         s_outlierCount.store(outlierCount, std::memory_order_release);
 
         auto& logger = DMK::Logger::get_instance();
-        logger.info("Part lookup built: {} entries across {} categories",
-                     writeMap.size(), CATEGORY_COUNT);
+        const char *verb = s_nameToHashBuilt ? "rebuilt" : "built";
+        logger.info("Part lookup {}: {} entries across {} categories",
+                     verb, writeMap.size(), CATEGORY_COUNT);
         if (!writeMap.empty())
         {
             logger.info("Hash range: 0x{:X} - 0x{:X} ({} outliers)",

--- a/CrimsonDesertEquipHide/src/dev/loader_main.cpp
+++ b/CrimsonDesertEquipHide/src/dev/loader_main.cpp
@@ -1,0 +1,248 @@
+/// Hot-reload loader stub for CrimsonDesertEquipHide development builds.
+/// Loads equip_hide_logic.dll, polls Numpad 0 to unload/reload it in-place.
+/// No DetourModKit dependency — logging via OutputDebugStringA only.
+
+#include <Windows.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+// =========================================================================
+// Constants
+// =========================================================================
+static constexpr const char *k_logicDllName   = "CrimsonDesertEquipHide_Logic.dll";
+static constexpr const char *k_stagingSubdir  = "staging";
+static constexpr const char *k_logPrefix      = "[EquipHideLoader] ";
+static constexpr int         k_pollIntervalMs = 100;
+static constexpr int         k_postShutdownMs = 100;
+static constexpr int         k_preLoadDelayMs = 200;
+static constexpr int         k_vkReload       = VK_NUMPAD0;
+
+// =========================================================================
+// State
+// =========================================================================
+static std::atomic<bool> s_running{false};
+static std::atomic<bool> s_reloading{false};
+static HANDLE            s_thread = nullptr;
+static HMODULE           s_logicDll = nullptr;
+
+using InitFn     = bool(__cdecl *)();
+using ShutdownFn = void(__cdecl *)();
+
+static InitFn     s_fnInit     = nullptr;
+static ShutdownFn s_fnShutdown = nullptr;
+
+// =========================================================================
+// Helpers
+// =========================================================================
+static void log_msg(const char *msg)
+{
+    char buf[512];
+    const int len = snprintf(buf, sizeof(buf), "%s%s\n", k_logPrefix, msg);
+    if (len > 0 && static_cast<size_t>(len) < sizeof(buf))
+        OutputDebugStringA(buf);
+    else
+        OutputDebugStringA("[EquipHideLoader] (message truncated)\n");
+}
+
+static std::string get_loader_dir(HMODULE hSelf)
+{
+    char path[MAX_PATH];
+    GetModuleFileNameA(hSelf, path, MAX_PATH);
+
+    char *lastSlash = std::strrchr(path, '\\');
+    if (lastSlash)
+        *(lastSlash + 1) = '\0';
+
+    return std::string(path);
+}
+
+/// Move a single file from staging to the loader directory.
+/// Silently skips if the source does not exist.
+static void move_staged_file(const std::string &stagingDir,
+                             const std::string &loaderDir,
+                             const char *filename)
+{
+    std::string src = stagingDir + filename;
+    std::string dst = loaderDir + filename;
+
+    if (GetFileAttributesA(src.c_str()) == INVALID_FILE_ATTRIBUTES)
+        return;
+
+    CopyFileA(src.c_str(), dst.c_str(), FALSE);
+    DeleteFileA(src.c_str());
+}
+
+/// Copy the logic DLL (and companion PDB) from the staging directory.
+/// Returns true if the DLL was found and copied successfully.
+static bool copy_from_staging(const std::string &loaderDir)
+{
+    std::string stagingDir = loaderDir + k_stagingSubdir + "\\";
+    std::string stagingDll = stagingDir + k_logicDllName;
+
+    if (GetFileAttributesA(stagingDll.c_str()) == INVALID_FILE_ATTRIBUTES)
+        return false;
+
+    if (!CopyFileA(stagingDll.c_str(), (loaderDir + k_logicDllName).c_str(), FALSE))
+    {
+        log_msg("Failed to copy DLL from staging");
+        return false;
+    }
+    DeleteFileA(stagingDll.c_str());
+
+    // Move companion PDB so staging/ stays clean
+    move_staged_file(stagingDir, loaderDir, "CrimsonDesertEquipHide_Logic.pdb");
+
+    log_msg("Copied logic DLL from staging");
+    return true;
+}
+
+// =========================================================================
+// Logic DLL lifecycle
+// =========================================================================
+static bool load_logic(const std::string &dllPath)
+{
+    s_logicDll = LoadLibraryA(dllPath.c_str());
+    if (!s_logicDll)
+    {
+        char err[128];
+        snprintf(err, sizeof(err), "LoadLibrary failed (error %lu)", GetLastError());
+        log_msg(err);
+        return false;
+    }
+
+    s_fnInit = reinterpret_cast<InitFn>(GetProcAddress(s_logicDll, "Init"));
+    s_fnShutdown = reinterpret_cast<ShutdownFn>(GetProcAddress(s_logicDll, "Shutdown"));
+
+    if (!s_fnInit || !s_fnShutdown)
+    {
+        log_msg("FAILED to resolve Init/Shutdown exports");
+        FreeLibrary(s_logicDll);
+        s_logicDll = nullptr;
+        s_fnInit = nullptr;
+        s_fnShutdown = nullptr;
+        return false;
+    }
+
+    if (!s_fnInit())
+    {
+        log_msg("Init() returned false");
+        FreeLibrary(s_logicDll);
+        s_logicDll = nullptr;
+        s_fnInit = nullptr;
+        s_fnShutdown = nullptr;
+        return false;
+    }
+
+    log_msg("Logic DLL loaded and initialized");
+    return true;
+}
+
+static void unload_logic()
+{
+    if (!s_logicDll)
+        return;
+
+    if (s_fnShutdown)
+        s_fnShutdown();
+
+    // Allow in-flight callbacks to drain
+    Sleep(k_postShutdownMs);
+
+    FreeLibrary(s_logicDll);
+    s_logicDll = nullptr;
+    s_fnInit = nullptr;
+    s_fnShutdown = nullptr;
+
+    log_msg("Logic DLL unloaded");
+}
+
+// =========================================================================
+// Loader thread
+// =========================================================================
+static DWORD WINAPI loader_thread(LPVOID param)
+{
+    HMODULE hSelf = static_cast<HMODULE>(param);
+    std::string loaderDir = get_loader_dir(hSelf);
+    std::string dllPath   = loaderDir + k_logicDllName;
+
+    log_msg("Loader thread started");
+
+    copy_from_staging(loaderDir);
+    load_logic(dllPath);
+
+    bool wasKeyDown = false;
+
+    while (s_running.load(std::memory_order_relaxed))
+    {
+        Sleep(k_pollIntervalMs);
+
+        bool isKeyDown = (GetAsyncKeyState(k_vkReload) & 0x8000) != 0;
+
+        // Trigger on key release (debounce)
+        if (wasKeyDown && !isKeyDown)
+        {
+            if (!s_reloading.exchange(true, std::memory_order_acq_rel))
+            {
+                log_msg("Numpad0 released — reloading logic DLL...");
+
+                unload_logic();
+
+                // Wait for file lock release
+                Sleep(k_preLoadDelayMs);
+
+                copy_from_staging(loaderDir);
+
+                if (!load_logic(dllPath))
+                    log_msg("Reload FAILED — logic DLL not loaded");
+
+                s_reloading.store(false, std::memory_order_release);
+            }
+        }
+
+        wasKeyDown = isKeyDown;
+    }
+
+    unload_logic();
+    log_msg("Loader thread exiting");
+    return 0;
+}
+
+// =========================================================================
+// DllMain
+// =========================================================================
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        DisableThreadLibraryCalls(hModule);
+
+        s_running.store(true, std::memory_order_release);
+        s_thread = CreateThread(nullptr, 0, loader_thread, hModule, 0, nullptr);
+        if (!s_thread)
+        {
+            s_running.store(false, std::memory_order_release);
+            return FALSE;
+        }
+        break;
+
+    case DLL_PROCESS_DETACH:
+        s_running.store(false, std::memory_order_release);
+
+        if (s_thread && lpReserved == nullptr)
+        {
+            WaitForSingleObject(s_thread, 5000);
+            CloseHandle(s_thread);
+            s_thread = nullptr;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return TRUE;
+}

--- a/CrimsonDesertEquipHide/src/dev/logic_exports.cpp
+++ b/CrimsonDesertEquipHide/src/dev/logic_exports.cpp
@@ -1,0 +1,52 @@
+/// Logic DLL entry point for hot-reload dev builds.
+/// Exports Init() and Shutdown() for the loader stub to call.
+
+#include "equip_hide.hpp"
+#include "constants.hpp"
+
+#include <DetourModKit.hpp>
+
+#include <Windows.h>
+
+// =========================================================================
+// Exported lifecycle functions
+// =========================================================================
+extern "C" __declspec(dllexport) bool Init()
+{
+    DMK::Logger::configure("EquipHide", EquipHide::LOG_FILE, "%Y-%m-%d %H:%M:%S");
+    auto &logger = DMK::Logger::get_instance();
+
+    DMK::AsyncLoggerConfig asyncCfg;
+    asyncCfg.overflow_policy = DMK::OverflowPolicy::SyncFallback;
+    logger.enable_async_mode(asyncCfg);
+
+    logger.info("[DEV] Logic DLL Init() called");
+
+    if (!EquipHide::init())
+    {
+        logger.error("Equip hide initialization FAILED.");
+        return false;
+    }
+
+    logger.info("Equip hide initialization complete.");
+    return true;
+}
+
+extern "C" __declspec(dllexport) void Shutdown()
+{
+    auto &logger = DMK::Logger::get_instance();
+    logger.info("[DEV] Logic DLL Shutdown() called");
+
+    EquipHide::shutdown();
+}
+
+// =========================================================================
+// DllMain — minimal, no thread spawning
+// =========================================================================
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID /*lpReserved*/)
+{
+    if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+        DisableThreadLibraryCalls(hModule);
+
+    return TRUE;
+}

--- a/CrimsonDesertEquipHide/src/dllmain.cpp
+++ b/CrimsonDesertEquipHide/src/dllmain.cpp
@@ -1,3 +1,5 @@
+#ifndef EQUIPHIDE_DEV_BUILD
+
 #include "constants.hpp"
 #include "equip_hide.hpp"
 
@@ -108,3 +110,5 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 
     return TRUE;
 }
+
+#endif // !EQUIPHIDE_DEV_BUILD

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -54,7 +55,9 @@ namespace EquipHide
     // Per-address cache of original vis bytes written before the mod overrides them.
     // Keyed by the vis-byte address (entry + 0x1C).  Populated by the direct-write
     // path on first hide; consumed on un-hide to restore the game's natural value.
-    // Only accessed from the direct-write call site (cold path, single-threaded).
+    // Guarded by s_directWriteMtx — accessed from both the hook thread (via the
+    // s_needsDirectWrite flag) and the input thread (via flush_visibility).
+    static std::mutex s_directWriteMtx;
     static std::unordered_map<uintptr_t, uint8_t> s_originalVis;
 
     static DMK::Config::KeyComboList s_showAllCombos;
@@ -63,8 +66,18 @@ namespace EquipHide
     // d8-based fallback: activates when global pointer chain AOBs fail
     static std::atomic<bool> s_fallbackMode{false};
 
+    // Signals all background threads to exit during shutdown.
+    static std::atomic<bool> s_shutdownRequested{false};
+
     // Deferred IndexedStringA scan: set when the table isn't ready at init
     static std::atomic<bool> s_deferredScanPending{false};
+
+    // Lazy re-probe: set when the deferred scan finishes with unresolved parts.
+    // A background thread periodically re-scans until all parts resolve or the
+    // game session ends.  The hook signals the re-probe by writing steady_ms()
+    // into s_lazyProbeSignal, which the thread polls cheaply.
+    static std::atomic<bool> s_lazyProbePending{false};
+    static std::atomic<int64_t> s_lazyProbeSignal{0};
 
     // Startup direct-write enforcement deadline (ms since steady_clock epoch).
     // While active, resolve_player_vis_ctrls() schedules direct writes on
@@ -324,7 +337,7 @@ namespace EquipHide
         const auto globalPtr = *reinterpret_cast<const uintptr_t*>(globalPtrAddr);
         if (globalPtr < 0x10000)
         {
-            logger.debug("IndexedStringA scan: global pointer not yet initialized ({:#x})",
+            logger.trace("IndexedStringA scan: global pointer not yet initialized ({:#x})",
                          globalPtr);
             return nameToHash;
         }
@@ -337,7 +350,7 @@ namespace EquipHide
             return nameToHash;
         }
 
-        logger.debug("IndexedStringA scan: globalPtr={:#x} tableArray={:#x}",
+        logger.trace("IndexedStringA scan: globalPtr={:#x} tableArray={:#x}",
                       globalPtr, tableArray);
 
         const auto t0 = std::chrono::steady_clock::now();
@@ -382,8 +395,44 @@ namespace EquipHide
                     {
                         nameToHash[name] = h;
                         ++probeHits;
-                        logger.debug("Outlier probe: {} found at 0x{:X} "
+                        logger.trace("Outlier probe: {} found at 0x{:X} "
                                      "(fallback was 0x{:X})", name, h, fallback);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Wide scan for parts still unresolved after the targeted probe.
+        // Handles arbitrary hash relocations across game versions by sweeping
+        // the full table outside the main scan range.
+        auto wideUnresolved = get_unresolved_fallbacks(nameToHash);
+        if (!wideUnresolved.empty())
+        {
+            constexpr uint32_t k_wideScanMax = 0x20000;
+            for (uint32_t h = 1; h < k_wideScanMax && !wideUnresolved.empty(); ++h)
+            {
+                if (h >= k_tableScanMin && h <= k_tableScanMax)
+                    continue;
+
+                auto len = read_table_entry(tableArray, h, buf, sizeof(buf));
+                if (len == 0 || len >= k_maxStringLen)
+                    continue;
+                if (buf[0] != 'C' || buf[1] != 'D' || buf[2] != '_')
+                    continue;
+
+                for (auto it = wideUnresolved.begin();
+                     it != wideUnresolved.end(); ++it)
+                {
+                    if (len == it->first.size() &&
+                        std::memcmp(buf, it->first.c_str(), len) == 0)
+                    {
+                        nameToHash[it->first] = h;
+                        ++probeHits;
+                        logger.trace("Wide scan: {} found at 0x{:X} "
+                                     "(fallback was 0x{:X})",
+                                     it->first, h, it->second);
+                        wideUnresolved.erase(it);
                         break;
                     }
                 }
@@ -393,8 +442,8 @@ namespace EquipHide
         const auto t1 = std::chrono::steady_clock::now();
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
 
-        logger.info("IndexedStringA scan complete: {} CD_ entries ({} range, {} probed) in {}ms",
-                     cdEntries + probeHits, cdEntries, probeHits, ms);
+        logger.trace("IndexedStringA scan complete: {} CD_ entries ({} range, {} probed) in {}ms",
+                      cdEntries + probeHits, cdEntries, probeHits, ms);
 
         return nameToHash;
     }
@@ -500,6 +549,12 @@ namespace EquipHide
         if (!s_mapLookupAddr)
             return;
 
+        // Manual lock/unlock instead of unique_lock — MSVC SEH does not run
+        // C++ destructors on unwind under /EHsc, so an RAII lock would stay
+        // held permanently after an SEH-caught fault.
+        if (!s_directWriteMtx.try_lock())
+            return;
+
 #ifdef _MSC_VER
         __try
         {
@@ -562,6 +617,7 @@ namespace EquipHide
                 DMK::Logger::get_instance().warning("DirectWrite: SEH caught crash");
         }
 #endif
+        s_directWriteMtx.unlock();
     }
 
     static constexpr AobCandidate k_aobCandidates[] = {
@@ -595,7 +651,8 @@ namespace EquipHide
 
         for (int attempt = 0; attempt < k_maxScanAttempts; ++attempt)
         {
-            // Wait before retrying (2s, 4s, 6s, ...)
+            if (s_shutdownRequested.load(std::memory_order_relaxed))
+                return;
             if (attempt > 0)
                 std::this_thread::sleep_for(std::chrono::seconds(2 * attempt));
 
@@ -607,6 +664,9 @@ namespace EquipHide
 
             if (unresolved.empty() || attempt == k_maxScanAttempts - 1)
             {
+                const auto totalParts = std::size(get_unresolved_fallbacks({}));
+                const auto fallbackCount = unresolved.size();
+
                 set_runtime_hashes(std::move(runtimeHashes));
                 rebuild_part_lookup();
                 s_deferredScanPending.store(false, std::memory_order_relaxed);
@@ -618,10 +678,18 @@ namespace EquipHide
                                        "using fallback 0x{:X}",
                                        name, attempt + 1, fallback);
                 }
+
+                logger.info("Deferred scan complete: {}/{} runtime, {} fallback "
+                            "({} attempts)",
+                            totalParts - fallbackCount, totalParts,
+                            fallbackCount, attempt + 1);
+
+                if (fallbackCount > 0)
+                    s_lazyProbePending.store(true, std::memory_order_relaxed);
                 return;
             }
 
-            logger.debug("Deferred scan attempt {}: {} parts unresolved, retrying",
+            logger.trace("Deferred scan attempt {}: {} parts unresolved, retrying",
                           attempt + 1, unresolved.size());
         }
 
@@ -637,6 +705,17 @@ namespace EquipHide
         if (!s_mapLookupAddr)
             return;
 
+        // Wait until the game world is loaded before launching — avoids
+        // exhausting retry attempts while idling at the main menu.
+        if (s_worldSystemPtr)
+        {
+            auto ws = read_ptr(s_worldSystemPtr, 0);
+            if (!ws) return;
+            auto am = read_ptr(ws, 0x30);
+            if (!am) return;
+            if (!read_ptr(am, 0x28)) return;
+        }
+
         // Launch once — the flag prevents re-entry
         static std::atomic<bool> s_launched{false};
         if (s_launched.exchange(true, std::memory_order_relaxed))
@@ -645,14 +724,100 @@ namespace EquipHide
         std::thread(deferred_scan_thread).detach();
     }
 
+    // =========================================================================
+    // Lazy re-probe for demand-loaded IndexedStringA entries
+    //
+    // Some entries (e.g. CD_Tool_Book) are only populated by the game when
+    // related content is first accessed.  After the deferred scan finishes
+    // with unresolved parts, this thread sleeps until the hook signals that
+    // enough time has passed, then re-scans.
+    // =========================================================================
+    static constexpr int64_t k_lazyProbeIntervalMs = 60'000;
+
+    static void lazy_probe_thread() noexcept
+    {
+        auto& logger = DMK::Logger::get_instance();
+        int probeCount = 0;
+
+        logger.info("Lazy probe started for demand-loaded parts "
+                    "(interval: {}s)", k_lazyProbeIntervalMs / 1000);
+
+        while (s_lazyProbePending.load(std::memory_order_relaxed))
+        {
+            if (s_shutdownRequested.load(std::memory_order_relaxed))
+                return;
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+
+            auto signal = s_lazyProbeSignal.load(std::memory_order_relaxed);
+            if (signal == 0)
+                continue;
+
+            ++probeCount;
+            logger.trace("Lazy probe #{}: scanning IndexedStringA table", probeCount);
+
+            auto runtimeHashes = scan_indexed_string_table(s_mapLookupAddr);
+            if (runtimeHashes.empty())
+                continue;
+
+            auto unresolved = get_unresolved_fallbacks(runtimeHashes);
+            if (unresolved.empty())
+            {
+                set_runtime_hashes(std::move(runtimeHashes));
+                rebuild_part_lookup();
+                s_lazyProbePending.store(false, std::memory_order_relaxed);
+                logger.info("Lazy probe resolved all remaining parts "
+                            "({} probes)", probeCount);
+                return;
+            }
+
+            logger.trace("Lazy probe #{}: {} parts still unresolved",
+                          probeCount, unresolved.size());
+
+            // Reset signal — hook will set it again after the next interval
+            s_lazyProbeSignal.store(0, std::memory_order_relaxed);
+        }
+    }
+
+    static void launch_lazy_probe() noexcept
+    {
+        if (!s_lazyProbePending.load(std::memory_order_relaxed))
+            return;
+
+        static std::atomic<bool> s_launched{false};
+        if (s_launched.exchange(true, std::memory_order_relaxed))
+            return;
+
+        std::thread(lazy_probe_thread).detach();
+    }
+
     /// Core logic — no SEH here so C++ objects (SafetyHookContext&) are fine.
     static void on_vis_check_impl(SafetyHookContext &ctx)
     {
-        if (s_needsDirectWrite.exchange(false, std::memory_order_relaxed))
+        // Load-before-exchange: avoids a locked xchg (~20-30 cycles) on the
+        // common path where the flag is false.  The benign TOCTOU between the
+        // load and exchange is safe — apply_direct_vis_write has its own mutex.
+        if (s_needsDirectWrite.load(std::memory_order_relaxed) &&
+            s_needsDirectWrite.exchange(false, std::memory_order_relaxed))
             apply_direct_vis_write();
 
         if (s_deferredScanPending.load(std::memory_order_relaxed))
             launch_deferred_scan();
+
+        // Signal the lazy re-probe thread periodically.
+        // Throttled: only check the clock every 4096 hook invocations to
+        // avoid per-call QueryPerformanceCounter overhead on the hot path.
+        if (s_lazyProbePending.load(std::memory_order_relaxed))
+        {
+            launch_lazy_probe();
+            static std::atomic<uint32_t> s_probeCounter{0};
+            if ((s_probeCounter.fetch_add(1, std::memory_order_relaxed) & 0xFFF) == 0)
+            {
+                const auto now = steady_ms();
+                auto prev = s_lazyProbeSignal.load(std::memory_order_relaxed);
+                if (prev == 0 || (now - prev) >= k_lazyProbeIntervalMs)
+                    s_lazyProbeSignal.store(now, std::memory_order_relaxed);
+            }
+        }
 
         auto r10 = ctx.r10;
         if (r10 < 0x10000)
@@ -707,11 +872,17 @@ namespace EquipHide
                             }
                             if (!alreadyCached && n < k_maxProtagonists)
                             {
-                                s_playerVisCtrls[n].store(a1, std::memory_order_relaxed);
-                                s_playerCount.store(n + 1, std::memory_order_relaxed);
+                                // Atomically claim the slot to avoid TOCTOU if
+                                // two hook invocations race on parallel threads.
+                                int expected = n;
+                                if (s_playerCount.compare_exchange_weak(
+                                        expected, n + 1, std::memory_order_relaxed))
+                                {
+                                    s_playerVisCtrls[n].store(a1, std::memory_order_relaxed);
 
-                                if (s_startupWriteEnd.load(std::memory_order_relaxed) > 0)
-                                    s_needsDirectWrite.store(true, std::memory_order_relaxed);
+                                    if (s_startupWriteEnd.load(std::memory_order_relaxed) > 0)
+                                        s_needsDirectWrite.store(true, std::memory_order_relaxed);
+                                }
                             }
                         }
                     }
@@ -919,7 +1090,6 @@ namespace EquipHide
         if (!s_fallbackMode.load(std::memory_order_relaxed))
             resolve_player_vis_ctrls();
         apply_direct_vis_write();
-        s_needsDirectWrite.store(true, std::memory_order_relaxed);
     }
 
     // =========================================================================
@@ -930,6 +1100,11 @@ namespace EquipHide
         auto &inputMgr = DMK::InputManager::get_instance();
         auto &states = category_states();
         auto &logger = DMK::Logger::get_instance();
+
+        int toggleCount = 0;
+        int showCount = 0;
+        int hideCount = 0;
+        int globalCount = 0;
 
         // --- Global Show All / Hide All ---
         if (!s_showAllCombos.empty())
@@ -946,7 +1121,7 @@ namespace EquipHide
                     logger.info("Equip hide: all categories VISIBLE");
                     flush_visibility();
                 });
-            logger.info("Registered hotkey binding 'ShowAll'");
+            ++globalCount;
         }
 
         if (!s_hideAllCombos.empty())
@@ -963,7 +1138,7 @@ namespace EquipHide
                     logger.info("Equip hide: all categories HIDDEN");
                     flush_visibility();
                 });
-            logger.info("Registered hotkey binding 'HideAll'");
+            ++globalCount;
         }
 
         // --- Per-category toggle (grouped by shared combo) ---
@@ -1017,8 +1192,7 @@ namespace EquipHide
                     flush_visibility();
                 });
 
-            logger.info("Registered hotkey binding '{}' for {} categories",
-                        bindingName, indices.size());
+            ++toggleCount;
         }
 
         // --- Per-category force show / force hide ---
@@ -1040,7 +1214,7 @@ namespace EquipHide
                         logger.info("Equip hide [{}]: VISIBLE", section);
                         flush_visibility();
                     });
-                logger.info("Registered hotkey binding 'ShowEquip_{}'", section);
+                ++showCount;
             }
 
             if (!states[i].hideHotkeyCombos.empty())
@@ -1054,9 +1228,14 @@ namespace EquipHide
                         logger.info("Equip hide [{}]: HIDDEN", section);
                         flush_visibility();
                     });
-                logger.info("Registered hotkey binding 'HideEquip_{}'", section);
+                ++hideCount;
             }
         }
+
+        const int total = globalCount + toggleCount + showCount + hideCount;
+        logger.info("Hotkeys registered: {} binding(s) "
+                    "({} toggle, {} show, {} hide, {} global)",
+                    total, toggleCount, showCount, hideCount, globalCount);
     }
 
     // =========================================================================
@@ -1100,6 +1279,8 @@ namespace EquipHide
             auto runtimeHashes = scan_indexed_string_table(s_mapLookupAddr);
             if (!runtimeHashes.empty())
             {
+                logger.info("IndexedStringA scan: {} entries resolved at init",
+                            runtimeHashes.size());
                 set_runtime_hashes(std::move(runtimeHashes));
             }
             else
@@ -1191,6 +1372,8 @@ namespace EquipHide
     void shutdown()
     {
         DMK::Logger::get_instance().info("{} shutting down...", MOD_NAME);
+        s_shutdownRequested.store(true, std::memory_order_relaxed);
+        s_lazyProbePending.store(false, std::memory_order_relaxed);
         DMK_Shutdown();
     }
 


### PR DESCRIPTION
## Summary
- Fix permanent mutex deadlock when MSVC SEH catches a fault in `apply_direct_vis_write` — replaced `unique_lock` with manual `try_lock`/`unlock` that survives SEH unwind under `/EHsc`
- Fix TOCTOU race on `s_playerCount` in d8 fallback caching — use `compare_exchange_weak` to atomically claim slots
- Fix perpetual `s_needsDirectWrite` re-arm in `flush_visibility` that caused `apply_direct_vis_write` to run on every hook invocation after any hotkey toggle
- Optimize hot path: load-before-exchange on `s_needsDirectWrite` avoids `lock xchg` (~25 cycles) on every hook call
- Add `s_shutdownRequested` atomic for clean background thread exit
- Log malformed hex IDs in INI parsing instead of silent `catch(...)`
- Sync CMakeLists.txt project version to 0.2.2
- Add CMakePresets.json and dev build two-DLL hot-reload infrastructure

## Test plan
- [x] Build release presets and verify .asi loads in-game
- [x] Toggle equipment visibility via hotkey — confirm immediate effect and no repeated direct-write spam in log (trace level)
- [x] Verify DefaultHidden=true categories hide on game load
- [x] Dev build: hot-reload via Numpad0 works correctly
