### PR TITLE
feat(equip-hide): add ForceShow setting for replacer mod compatibility

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,17 +1,17 @@
 {
   "configurations": [
     {
-      "name": "windows-gcc-x64",
+      "name": "windows-msvc-x64",
       "includePath": [
         "${workspaceFolder}/CrimsonDesertEquipHide/src",
         "${workspaceFolder}/CrimsonDesertEquipHide/external/DetourModKit/include",
         "${workspaceFolder}/**"
       ],
-      "defines": ["_DEBUG", "UNICODE", "_UNICODE"],
-      "compilerPath": "C:/msys64/mingw64/bin/gcc.exe",
-      "cStandard": "c23",
+      "defines": ["_DEBUG", "UNICODE", "_UNICODE", "WIN32", "_WINDOWS"],
+      "compilerPath": "cl.exe",
+      "cStandard": "c17",
       "cppStandard": "c++23",
-      "intelliSenseMode": "windows-gcc-x64"
+      "intelliSenseMode": "windows-msvc-x64"
     }
   ],
   "version": 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -110,13 +110,13 @@
     "ranges": "cpp",
     "syncstream": "cpp"
   },
-  "C_Cpp_Runner.cCompilerPath": "gcc",
-  "C_Cpp_Runner.cppCompilerPath": "g++",
-  "C_Cpp_Runner.debuggerPath": "gdb",
+  "C_Cpp_Runner.cCompilerPath": "cl",
+  "C_Cpp_Runner.cppCompilerPath": "cl",
+  "C_Cpp_Runner.debuggerPath": "vsdbg",
   "C_Cpp_Runner.cStandard": "",
   "C_Cpp_Runner.cppStandard": "",
   "C_Cpp_Runner.msvcBatchPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvarsall.bat",
-  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.useMsvc": true,
   "C_Cpp_Runner.warnings": [
     "-Wall",
     "-Wextra",
@@ -149,10 +149,7 @@
   "C_Cpp_Runner.compilerArgs": [],
   "C_Cpp_Runner.linkerArgs": [],
   "C_Cpp_Runner.includePaths": [],
-  "C_Cpp_Runner.includeSearch": [
-    "*",
-    "**/*"
-  ],
+  "C_Cpp_Runner.includeSearch": ["*", "**/*"],
   "C_Cpp_Runner.excludeSearch": [
     "**/build",
     "**/build/**",

--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -7,19 +7,8 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Override CMake's default -O3 for MinGW Release builds with -O2 for a better
-# code-size/performance tradeoff and to avoid GCC 15 LTO ICEs at -O3.
-if(NOT MSVC)
-    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "" FORCE)
-endif()
-
 # --- Compiler Flags ---
-if(MSVC)
-    add_compile_options(/W4)
-else()
-    # GCC/Clang/MinGW specific flags
-    add_compile_options(-Wall -Wextra)
-endif()
+add_compile_options(/W4)
 
 # --- Windows Definitions ---
 if(WIN32)
@@ -100,15 +89,7 @@ if(EQUIPHIDE_DEV_BUILD)
         LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_BIN_DIR}"
     )
 
-    if(MSVC)
-        target_compile_options(equip_hide_loader PRIVATE /W4)
-    else()
-        target_link_options(equip_hide_loader PRIVATE
-            -static-libgcc
-            -static-libstdc++
-            -static
-        )
-    endif()
+    target_compile_options(equip_hide_loader PRIVATE /W4)
 
     # --- Logic DLL (all mod code) ---
     add_library(equip_hide_logic SHARED
@@ -148,17 +129,8 @@ if(EQUIPHIDE_DEV_BUILD)
         PDB_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_STAGING_DIR}"
     )
 
-    if(MSVC)
-        target_compile_options(equip_hide_logic PRIVATE /W4 /Zi)
-        target_link_options(equip_hide_logic PRIVATE /DEBUG /OPT:REF /OPT:ICF)
-    else()
-        target_link_options(equip_hide_logic PRIVATE
-            -Wl,--exclude-all-symbols
-            -static-libgcc
-            -static-libstdc++
-            -static
-        )
-    endif()
+    target_compile_options(equip_hide_logic PRIVATE /W4 /Zi)
+    target_link_options(equip_hide_logic PRIVATE /DEBUG /OPT:REF /OPT:ICF)
 
 else() # EQUIPHIDE_DEV_BUILD=OFF
     # =====================================================================
@@ -185,34 +157,16 @@ else() # EQUIPHIDE_DEV_BUILD=OFF
     )
 
     # --- Target-Scoped Release Optimizations ---
-    if(MSVC)
-        # /Gy: function-level linking, /Gw: global data optimization.
-        # /O1: favor size (appropriate for an injected DLL).
-        target_compile_options(${PROJECT_NAME}-ASI PRIVATE
-            $<$<CONFIG:Release>:/O1 /Gy /Gw>
-        )
+    # /Gy: function-level linking, /Gw: global data optimization.
+    # /O1: favor size (appropriate for an injected DLL).
+    target_compile_options(${PROJECT_NAME}-ASI PRIVATE
+        $<$<CONFIG:Release>:/O1 /Gy /Gw>
+    )
 
-        # /OPT:REF removes unreferenced functions/data; /OPT:ICF folds identical COMDATs.
-        target_link_options(${PROJECT_NAME}-ASI PRIVATE
-            $<$<CONFIG:Release>:/OPT:REF /OPT:ICF>
-        )
-    else()
-        # -ffunction-sections/-fdata-sections enable --gc-sections for dead code elimination.
-        # -O2 is set globally via CMAKE_CXX_FLAGS_RELEASE.
-        target_compile_options(${PROJECT_NAME}-ASI PRIVATE
-            $<$<CONFIG:Release>:-ffunction-sections -fdata-sections>
-        )
-        target_link_options(${PROJECT_NAME}-ASI PRIVATE
-            -Wl,--gc-sections
-            -Wl,--exclude-all-symbols
-            -static-libgcc
-            -static-libstdc++
-            -static
-
-            # Strip all symbols in Release to minimize binary size.
-            $<$<CONFIG:Release>:-s>
-        )
-    endif()
+    # /OPT:REF removes unreferenced functions/data; /OPT:ICF folds identical COMDATs.
+    target_link_options(${PROJECT_NAME}-ASI PRIVATE
+        $<$<CONFIG:Release>:/OPT:REF /OPT:ICF>
+    )
 
     # --- Link-Time Optimization ---
     include(CheckIPOSupported)

--- a/CrimsonDesertEquipHide/CMakePresets.json
+++ b/CrimsonDesertEquipHide/CMakePresets.json
@@ -17,17 +17,6 @@
             }
         },
         {
-            "name": "mingw-release",
-            "displayName": "MinGW Release (single ASI)",
-            "generator": "MinGW Makefiles",
-            "binaryDir": "${sourceDir}/build/release-mingw",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++"
-            }
-        },
-        {
             "name": "msvc-dev",
             "displayName": "MSVC Dev (hot-reload two-DLL)",
             "generator": "Visual Studio 17 2022",
@@ -35,18 +24,6 @@
             "binaryDir": "${sourceDir}/build/dev-msvc",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "EQUIPHIDE_DEV_BUILD": "ON"
-            }
-        },
-        {
-            "name": "mingw-dev",
-            "displayName": "MinGW Dev (hot-reload two-DLL)",
-            "generator": "MinGW Makefiles",
-            "binaryDir": "${sourceDir}/build/dev-mingw",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
                 "EQUIPHIDE_DEV_BUILD": "ON"
             }
         }
@@ -58,17 +35,9 @@
             "configuration": "Release"
         },
         {
-            "name": "mingw-release",
-            "configurePreset": "mingw-release"
-        },
-        {
             "name": "msvc-dev",
             "configurePreset": "msvc-dev",
             "configuration": "RelWithDebInfo"
-        },
-        {
-            "name": "mingw-dev",
-            "configurePreset": "mingw-dev"
         }
     ]
 }

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -87,6 +87,8 @@ The mod is configured via the `CrimsonDesertEquipHide.ini` file:
 LogLevel = Info
 ; Apply only to player characters
 PlayerOnly = true
+; Set to true if equipment stays invisible when toggling to visible
+ForceShow = false
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =
@@ -169,6 +171,17 @@ Common issues:
 
 > **Still stuck?** [Open a GitHub issue](https://github.com/tkhquang/CrimsonDesertTools/issues/new?assignees=&labels=bug&template=bug_report.yaml) and include your INI config, log output, and game version.
 
+## Compatibility with Replacer Mods
+
+Some third-party replacer mods (e.g. "Playing as" character mods) hide weapons or shields by default. If you find that toggling equipment to visible has no effect, set `ForceShow = true` in the `[General]` section of the INI file:
+
+```ini
+[General]
+ForceShow = true
+```
+
+This forces the mod to write a visible value directly, overriding whatever the replacer mod has set. Safe to leave `false` if you are not experiencing visibility issues.
+
 ## Known Limitations
 
 - Toggle may take 1-3 seconds to take effect — the game caches mesh visibility and re-evaluates periodically, not per-frame
@@ -190,30 +203,31 @@ This mod requires:
 
 ### Prerequisites
 
-- [MinGW-w64](https://www.mingw-w64.org/) (GCC 12+) or [Visual Studio 2022](https://visualstudio.microsoft.com/) (MSVC with C++23 support)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/) (MSVC with C++23 support)
 - [CMake](https://cmake.org/) (3.16 or newer)
-- [Ninja](https://ninja-build.org/) (recommended)
 - Git (to fetch submodules)
 
-### Building with MinGW (Recommended)
+### Release Build
 
 ```bash
 git submodule update --init --recursive
 cd CrimsonDesertEquipHide
-cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++
-cmake --build build --config Release --parallel
-```
-
-### Building with MSVC
-
-```bash
-git submodule update --init --recursive
-cd CrimsonDesertEquipHide
-cmake -S . -B build/msvc -G "Visual Studio 17 2022" -A x64
-cmake --build build/msvc --config Release --parallel
+cmake --preset msvc-release
+cmake --build build/release-msvc --config Release --parallel
 ```
 
 The output binary (`CrimsonDesertEquipHide.asi`) will be placed in the build directory.
+
+### Dev Build (Hot-Reload)
+
+The dev build produces a loader ASI + logic DLL pair, allowing you to rebuild and hot-reload the logic DLL without restarting the game.
+
+```bash
+cmake --preset msvc-dev
+cmake --build build/dev-msvc --config RelWithDebInfo --parallel
+```
+
+The loader (`CrimsonDesertEquipHide.asi`) and logic DLL (`CrimsonDesertEquipHide_Logic.dll`) are deployed directly to the game's plugin directory via a post-build step. Press **Numpad 0** in-game to trigger a reload after rebuilding.
 
 ## Credits
 

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -41,6 +41,10 @@
 LogLevel = Info
 ; Apply only to player characters
 PlayerOnly = true
+; Set to true if equipment stays invisible when toggling to visible.
+; This can happen with third-party replacer mods that hide equipment by default.
+; Safe to leave false if you are not experiencing visibility issues.
+ForceShow = false
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,10 @@
-## [Title for next release]
+## Replacer mod compatibility
 
-- New feature
-- Bug fix
-- Improvement
+### Added
+
+- `ForceShow` setting — set to `true` if equipment stays invisible when toggling visible (common with "Playing as" replacer mods)
+
+### Changed
+
+- Updated DetourModKit to latest version
+- Dropped MinGW build support (MSVC only)

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -79,6 +79,8 @@ The mod can be configured by editing the [b]CrimsonDesertEquipHide.ini[/b] file:
 LogLevel = Info
 ; Apply only to player characters
 PlayerOnly = true
+; Set to true if equipment stays invisible when toggling to visible
+ForceShow = false
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =
@@ -140,9 +142,19 @@ ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 
 [b]XInput only:[/b] Xbox controllers work natively. For PS4/PS5/Switch controllers, use an XInput translation layer (e.g. DS4Windows, DualSenseX, BetterJoy) or Steam Input to present your controller as XInput. See [url=https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#gamepad-compatibility]Gamepad Compatibility[/url] for details.
 
+[size=5]Compatibility with Replacer Mods[/size]
+Some third-party replacer mods (e.g. "Playing as" character mods) hide weapons or shields by default. If you find that toggling equipment to visible has no effect, set [b]ForceShow = true[/b] in the [b][General][/b] section of the INI file:
+
+[code]
+[General]
+ForceShow = true
+[/code]
+
+This forces the mod to write a visible value directly, overriding whatever the replacer mod has set. Safe to leave [b]false[/b] if you are not experiencing visibility issues.
+
 [size=5]Known Limitations[/size]
 [list]
-[*] Toggle may take 1-3 seconds to take effect — the game caches mesh visibility and re-evaluates periodically, not per-frame
+[*] Toggle may take 1-3 seconds to take effect
 [*] After a major game update, AOB patterns may need updating
 [*] Currently only tested with the Steam version of the game
 [/list]

--- a/CrimsonDesertEquipHide/src/categories.hpp
+++ b/CrimsonDesertEquipHide/src/categories.hpp
@@ -46,6 +46,11 @@ namespace EquipHide
         return names[idx];
     }
 
+    constexpr uint8_t default_show_value([[maybe_unused]] Category cat)
+    {
+        return 0;
+    }
+
     // =========================================================================
     // Per-category runtime state
     // =========================================================================

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -39,6 +39,7 @@ namespace EquipHide
     // =========================================================================
 
     static std::atomic<bool> s_playerOnly{true};
+    static std::atomic<bool> s_forceShow{false};
 
     static constexpr int k_maxProtagonists = 8;
     static std::atomic<uintptr_t> s_playerVisCtrls[k_maxProtagonists]{};
@@ -48,7 +49,7 @@ namespace EquipHide
 
     static uintptr_t s_worldSystemPtr = 0;
     static uintptr_t s_childActorVtbl = 0;
-    static uintptr_t s_mapLookupAddr  = 0;
+    static uintptr_t s_mapLookupAddr = 0;
 
     static std::atomic<bool> s_needsDirectWrite{false};
 
@@ -87,7 +88,8 @@ namespace EquipHide
     static int64_t steady_ms() noexcept
     {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now().time_since_epoch()).count();
+                   std::chrono::steady_clock::now().time_since_epoch())
+            .count();
     }
 
     static uintptr_t read_ptr(uintptr_t base, ptrdiff_t off) noexcept
@@ -106,7 +108,11 @@ namespace EquipHide
     //   Direct:      target = match_addr + offset
     //   RipRelative: target = match_addr + instrEnd + *(int32*)(match + dispOffset)
     // =========================================================================
-    enum class ResolveMode : uint8_t { Direct, RipRelative };
+    enum class ResolveMode : uint8_t
+    {
+        Direct,
+        RipRelative
+    };
 
     struct AddrCandidate
     {
@@ -254,7 +260,6 @@ namespace EquipHide
     // __try/__except does not conflict with C++ objects in the caller.
     static constexpr std::size_t k_maxStringLen = 64;
 
-#ifdef _MSC_VER
     static std::size_t read_table_entry(uintptr_t tableArray, uint32_t hash,
                                         char *buf, std::size_t bufSize) noexcept
     {
@@ -280,44 +285,17 @@ namespace EquipHide
             return 0;
         }
     }
-#else
-    static std::size_t read_table_entry(uintptr_t tableArray, uint32_t hash,
-                                        char *buf, std::size_t bufSize) noexcept
-    {
-        const auto entryAddr = tableArray + static_cast<uintptr_t>(hash) * 16;
-        if (!DMK::Memory::is_readable(reinterpret_cast<const void *>(entryAddr),
-                                       sizeof(uintptr_t)))
-            return 0;
-
-        const auto strPtr = *reinterpret_cast<const uintptr_t *>(entryAddr);
-        if (strPtr < 0x10000)
-            return 0;
-
-        if (!DMK::Memory::is_readable(reinterpret_cast<const void *>(strPtr), bufSize))
-            return 0;
-
-        const auto *src = reinterpret_cast<const char *>(strPtr);
-        std::size_t len = 0;
-        while (len < bufSize - 1 && src[len] != '\0')
-        {
-            buf[len] = src[len];
-            ++len;
-        }
-        buf[len] = '\0';
-        return len;
-    }
-#endif
 
     static std::unordered_map<std::string, uint32_t> scan_indexed_string_table(
         uintptr_t mapLookupFunc)
     {
-        auto& logger = DMK::Logger::get_instance();
+        auto &logger = DMK::Logger::get_instance();
         std::unordered_map<std::string, uint32_t> nameToHash;
 
         // The MapLookup function contains: mov rax, [rip+disp] at offset +20
         // (opcode 48 8B 05 xx xx xx xx). Extract the RIP-relative displacement.
         const auto ripInstr = mapLookupFunc + 20;
-        const auto* instrBytes = reinterpret_cast<const uint8_t*>(ripInstr);
+        const auto *instrBytes = reinterpret_cast<const uint8_t *>(ripInstr);
 
         // Verify REX.W MOV RAX opcode: 48 8B 05
         if (instrBytes[0] != 0x48 || instrBytes[1] != 0x8B || instrBytes[2] != 0x05)
@@ -334,7 +312,7 @@ namespace EquipHide
         const auto globalPtrAddr = static_cast<uintptr_t>(
             static_cast<int64_t>(instrEnd) + disp);
 
-        const auto globalPtr = *reinterpret_cast<const uintptr_t*>(globalPtrAddr);
+        const auto globalPtr = *reinterpret_cast<const uintptr_t *>(globalPtrAddr);
         if (globalPtr < 0x10000)
         {
             logger.trace("IndexedStringA scan: global pointer not yet initialized ({:#x})",
@@ -342,7 +320,7 @@ namespace EquipHide
             return nameToHash;
         }
 
-        const auto tableArray = *reinterpret_cast<const uintptr_t*>(globalPtr + 0x58);
+        const auto tableArray = *reinterpret_cast<const uintptr_t *>(globalPtr + 0x58);
         if (tableArray < 0x10000)
         {
             logger.warning("IndexedStringA scan: tableArray is null/invalid ({:#x})",
@@ -351,7 +329,7 @@ namespace EquipHide
         }
 
         logger.trace("IndexedStringA scan: globalPtr={:#x} tableArray={:#x}",
-                      globalPtr, tableArray);
+                     globalPtr, tableArray);
 
         const auto t0 = std::chrono::steady_clock::now();
         uint32_t cdEntries = 0;
@@ -379,10 +357,11 @@ namespace EquipHide
         if (!unresolved.empty())
         {
             constexpr uint32_t k_probeRadius = 0x100;
-            for (const auto& [name, fallback] : unresolved)
+            for (const auto &[name, fallback] : unresolved)
             {
                 const uint32_t lo = (fallback > k_probeRadius)
-                                        ? fallback - k_probeRadius : 1;
+                                        ? fallback - k_probeRadius
+                                        : 1;
                 const uint32_t hi = fallback + k_probeRadius;
 
                 for (uint32_t h = lo; h <= hi; ++h)
@@ -396,7 +375,8 @@ namespace EquipHide
                         nameToHash[name] = h;
                         ++probeHits;
                         logger.trace("Outlier probe: {} found at 0x{:X} "
-                                     "(fallback was 0x{:X})", name, h, fallback);
+                                     "(fallback was 0x{:X})",
+                                     name, h, fallback);
                         break;
                     }
                 }
@@ -443,7 +423,7 @@ namespace EquipHide
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
 
         logger.trace("IndexedStringA scan complete: {} CD_ entries ({} range, {} probed) in {}ms",
-                      cdEntries + probeHits, cdEntries, probeHits, ms);
+                     cdEntries + probeHits, cdEntries, probeHits, ms);
 
         return nameToHash;
     }
@@ -466,16 +446,17 @@ namespace EquipHide
         if (!s_worldSystemPtr || !s_childActorVtbl)
             return;
 
-#ifdef _MSC_VER
         __try
         {
-#endif
             auto ws = read_ptr(s_worldSystemPtr, 0);
-            if (!ws) return;
+            if (!ws)
+                return;
             auto am = read_ptr(ws, 0x30);
-            if (!am) return;
+            if (!am)
+                return;
             auto user = read_ptr(am, 0x28);
-            if (!user) return;
+            if (!user)
+                return;
 
             static constexpr ptrdiff_t k_bodyOffsets[] = {
                 0xD0, 0xD8, 0xE0, 0xE8, 0xF0, 0xF8, 0x100, 0x108};
@@ -524,7 +505,6 @@ namespace EquipHide
                         s_startupWriteEnd.store(0, std::memory_order_relaxed);
                 }
             }
-#ifdef _MSC_VER
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -532,7 +512,6 @@ namespace EquipHide
             if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
                 DMK::Logger::get_instance().warning("Resolve: SEH caught crash");
         }
-#endif
     }
 
     struct AobCandidate
@@ -555,10 +534,8 @@ namespace EquipHide
         if (!s_directWriteMtx.try_lock())
             return;
 
-#ifdef _MSC_VER
         __try
         {
-#endif
             auto lookup = reinterpret_cast<MapLookupFn>(s_mapLookupAddr);
             const auto n = s_playerCount.load(std::memory_order_relaxed);
             int modified = 0;
@@ -594,11 +571,19 @@ namespace EquipHide
                     }
                     else
                     {
-                        auto it = s_originalVis.find(visAddr);
-                        if (it != s_originalVis.end())
+                        if (s_forceShow.load(std::memory_order_relaxed))
                         {
-                            *visPtr = it->second;
-                            s_originalVis.erase(it);
+                            *visPtr = default_show_value(cat);
+                            s_originalVis.erase(visAddr);
+                        }
+                        else
+                        {
+                            auto it = s_originalVis.find(visAddr);
+                            if (it != s_originalVis.end())
+                            {
+                                *visPtr = it->second;
+                                s_originalVis.erase(it);
+                            }
                         }
                     }
                     ++modified;
@@ -608,7 +593,6 @@ namespace EquipHide
             DMK::Logger::get_instance().trace(
                 "DirectWrite: {} protagonists, {} entries modified",
                 n, modified);
-#ifdef _MSC_VER
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -616,7 +600,6 @@ namespace EquipHide
             if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
                 DMK::Logger::get_instance().warning("DirectWrite: SEH caught crash");
         }
-#endif
         s_directWriteMtx.unlock();
     }
 
@@ -647,7 +630,7 @@ namespace EquipHide
 
     static void deferred_scan_thread() noexcept
     {
-        auto& logger = DMK::Logger::get_instance();
+        auto &logger = DMK::Logger::get_instance();
 
         for (int attempt = 0; attempt < k_maxScanAttempts; ++attempt)
         {
@@ -673,7 +656,7 @@ namespace EquipHide
 
                 if (!unresolved.empty())
                 {
-                    for (const auto& [name, fallback] : unresolved)
+                    for (const auto &[name, fallback] : unresolved)
                         logger.warning("Part '{}' unresolved after {} scan attempts, "
                                        "using fallback 0x{:X}",
                                        name, attempt + 1, fallback);
@@ -690,11 +673,11 @@ namespace EquipHide
             }
 
             logger.trace("Deferred scan attempt {}: {} parts unresolved, retrying",
-                          attempt + 1, unresolved.size());
+                         attempt + 1, unresolved.size());
         }
 
         logger.warning("IndexedStringA deferred scan exhausted {} attempts",
-                         k_maxScanAttempts);
+                       k_maxScanAttempts);
         s_deferredScanPending.store(false, std::memory_order_relaxed);
     }
 
@@ -710,10 +693,13 @@ namespace EquipHide
         if (s_worldSystemPtr)
         {
             auto ws = read_ptr(s_worldSystemPtr, 0);
-            if (!ws) return;
+            if (!ws)
+                return;
             auto am = read_ptr(ws, 0x30);
-            if (!am) return;
-            if (!read_ptr(am, 0x28)) return;
+            if (!am)
+                return;
+            if (!read_ptr(am, 0x28))
+                return;
         }
 
         // Launch once — the flag prevents re-entry
@@ -736,11 +722,12 @@ namespace EquipHide
 
     static void lazy_probe_thread() noexcept
     {
-        auto& logger = DMK::Logger::get_instance();
+        auto &logger = DMK::Logger::get_instance();
         int probeCount = 0;
 
         logger.info("Lazy probe started for demand-loaded parts "
-                    "(interval: {}s)", k_lazyProbeIntervalMs / 1000);
+                    "(interval: {}s)",
+                    k_lazyProbeIntervalMs / 1000);
 
         while (s_lazyProbePending.load(std::memory_order_relaxed))
         {
@@ -766,12 +753,13 @@ namespace EquipHide
                 rebuild_part_lookup();
                 s_lazyProbePending.store(false, std::memory_order_relaxed);
                 logger.info("Lazy probe resolved all remaining parts "
-                            "({} probes)", probeCount);
+                            "({} probes)",
+                            probeCount);
                 return;
             }
 
             logger.trace("Lazy probe #{}: {} parts still unresolved",
-                          probeCount, unresolved.size());
+                         probeCount, unresolved.size());
 
             // Reset signal — hook will set it again after the next interval
             s_lazyProbeSignal.store(0, std::memory_order_relaxed);
@@ -829,8 +817,7 @@ namespace EquipHide
         // Bounds cover the contiguous block; outliers are checked separately.
         const auto rangeMin = hash_range_min();
         const auto rangeMax = hash_range_max();
-        if (rangeMin != 0 && (partHash < rangeMin || partHash > rangeMax)
-            && !is_outlier_hash(partHash))
+        if (rangeMin != 0 && (partHash < rangeMin || partHash > rangeMax) && !is_outlier_hash(partHash))
             return;
 
         const auto cat = classify_part(partHash);
@@ -937,12 +924,16 @@ namespace EquipHide
             auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
             *visPtr = 2;
         }
+        else if (s_forceShow.load(std::memory_order_relaxed))
+        {
+            auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
+            *visPtr = default_show_value(*cat);
+        }
     }
 
     /// SEH wrapper — catches access violations if mod is outdated and
     /// register layout has changed.  Separate function because MSVC SEH
     /// cannot coexist with C++ destructors in the same frame.
-#ifdef _MSC_VER
     static int seh_filter(unsigned int /*code*/) { return EXCEPTION_EXECUTE_HANDLER; }
 
     static void on_vis_check(SafetyHookContext &ctx)
@@ -956,15 +947,6 @@ namespace EquipHide
             // Silently swallow — mod is likely outdated, don't crash the game
         }
     }
-#else
-    // MinGW/GCC does not support MSVC-style SEH (__try/__except).
-    // Fall back to an unprotected call — the pointer checks in
-    // on_vis_check_impl already guard against the most common faults.
-    static void on_vis_check(SafetyHookContext &ctx)
-    {
-        on_vis_check_impl(ctx);
-    }
-#endif
 
     // =========================================================================
     // AOB scan with unpack retry
@@ -1029,6 +1011,9 @@ namespace EquipHide
 
         DMK::Config::register_bool("General", "PlayerOnly", "Player Only", [](bool val)
                                    { s_playerOnly.store(val, std::memory_order_relaxed); }, true);
+
+        DMK::Config::register_bool("General", "ForceShow", "Force Show", [](bool val)
+                                   { s_forceShow.store(val, std::memory_order_relaxed); }, false);
 
         DMK::Config::register_key_combo("General", "ShowAllHotkey", "Show All Hotkey", [](const DMK::Config::KeyComboList &combos)
                                         { s_showAllCombos = combos; }, "");


### PR DESCRIPTION
## Summary

- Add `ForceShow` INI setting in `[General]` to fix equipment staying invisible when using third-party replacer mods (e.g. "Playing as" character mods) that hide weapons/shields by default
- Drop MinGW build support — MSVC only going forward
- Update DetourModKit to latest version
- Switch VS Code IntelliSense from GCC to MSVC

## Context

Since v0.2.2, the direct-write path caches the original vis byte and restores it on un-hide. Replacer mods that pre-set vis=2 (hidden) cause the cached "original" to also be 2, so restoring it keeps equipment hidden. `ForceShow = true` bypasses the cache and force-writes a visible value.

## Test plan

- [x] Verify default behavior unchanged (`ForceShow = false`)
- [x] Verify `ForceShow = true` makes equipment visible with a replacer mod active
- [x] Verify hide/show toggle cycle works correctly with `ForceShow = true`
- [x] Verify MSVC release build produces working ASI