### PR TITLE
fix(equip-hide): reduce micro-stutter, fix config reload and cleanup bugs

### DIFF
--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -11,7 +11,7 @@
 - Weapon categories: One-Hand Weapons, Two-Hand Weapons, Shields, Bows, Special Weapons, Tools, Lanterns
 - Armor categories: Helm, Chest, Legs, Gloves, Boots, Cloak, Shoulder, Mask, Glasses
 - Accessory categories: Earrings, Rings, Necklace, Bags
-- User Presets: 3 custom part groups with independent visibility control (overrides built-in categories)
+- User Presets: 10 custom part groups with independent visibility control (overrides built-in categories)
 - Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
 - [Experimental] BaldFix: runtime hair-visibility fix when helmet/cloak is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 - GlidingFix: prevents hidden equipment from briefly flashing visible during state transitions (e.g. exiting gliding, cutscene transitions)
@@ -230,11 +230,14 @@ ForceShow = true
 
 Safe to leave `false` if you are not using such mods.
 
-## Known Limitations
+## Known Issues
 
+- **Flight cloak parts cause visual artifacts and squished hair** — `CD_Cloak_Flight` and its variants can cause strange visual artifacts and compressed/squished hair when toggling cloak visibility. These parts have been removed from the default Cloak category. You can re-add them in the INI at your own risk (see the comment in the `[Cloak]` section).
+- **Chest/Legs flickering when toggled independently** — Hiding chest while legs are visible, then toggling legs, can cause pants to flicker on/off. This appears to be a limitation of how the game handles layered armor visibility. Workaround: toggle both chest and legs together using the same hotkey, or set your desired default states via `DefaultHidden` and avoid toggling them separately at runtime.
+- **Dagger permanently visible after hiding one-hand weapons** — Daggers may remain visible and clip with swords occupying the same visual slot. This is a known issue and will be addressed in a future update.
 - Toggle may take 1-3 seconds to take effect.
-- After a major game update, AOB patterns may need updating
-- Currently only tested with the Steam version of the game
+- After a major game update, the mod may stop working until a new version is released.
+- Currently only tested with the Steam version of the game.
 
 ## Changelog
 

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -69,6 +69,8 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
+; Tip: If daggers appear permanently visible or clip with swords, remove the
+; four CD_MainWeapon_Dagger_* entries from Parts to restore default behaviour.
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Bola, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_L, CD_MainWeapon_HandCannon, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux
 
 [TwoHandWeapons]
@@ -167,7 +169,11 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-Parts = CD_Cloak, CD_Cloak_Acc, CD_Cloak_Acc_01, CD_Cloak_Acc_02, CD_Cloak_Shoulder, CD_Cloak_Flight, CD_Cloak_Flight_01, CD_Cloak_Flight_02, CD_Cloak_Flight_03
+; Known issue: CD_Cloak_Flight parts cause visual artifacts and squished hair
+; when toggling cloak visibility. Removed from defaults until fixed.
+; To re-enable at your own risk, append to Parts:
+;   CD_Cloak_Flight, CD_Cloak_Flight_01, CD_Cloak_Flight_02, CD_Cloak_Flight_03
+Parts = CD_Cloak, CD_Cloak_Acc, CD_Cloak_Acc_01, CD_Cloak_Acc_02, CD_Cloak_Shoulder
 
 [Shoulder]
 Enabled = false
@@ -254,6 +260,62 @@ DefaultHidden = false
 Parts =
 
 [UserPreset3]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts =
+
+[UserPreset4]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts =
+
+[UserPreset5]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts =
+
+[UserPreset6]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts =
+
+[UserPreset7]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts =
+
+[UserPreset8]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts =
+
+[UserPreset9]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts =
+
+[UserPreset10]
 Enabled = false
 ToggleHotkey =
 ShowHotkey =

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -170,7 +170,7 @@ ShowHotkey =
 HideHotkey =
 DefaultHidden = false
 ; Known issue: CD_Cloak_Flight parts cause visual artifacts and squished hair
-; when toggling cloak visibility. Removed from defaults until fixed.
+; when toggling cloak visibility.
 ; To re-enable at your own risk, append to Parts:
 ;   CD_Cloak_Flight, CD_Cloak_Flight_01, CD_Cloak_Flight_02, CD_Cloak_Flight_03
 Parts = CD_Cloak, CD_Cloak_Acc, CD_Cloak_Acc_01, CD_Cloak_Acc_02, CD_Cloak_Shoulder

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,22 @@
-## [Title for next release]
+## Performance & Stability Improvements
 
-- New feature
-- Bug fix
-- Improvement
+### Fixed
+
+- Reduced micro-stuttering caused by frequent memory safety checks in the hot path
+- Fixed game thread stalling when pressing hotkeys during heavy scenes
+- Fixed equipment parts not updating after editing the INI and hot-reloading (dev builds)
+- Fixed shutdown corrupting visibility state of unrelated equipment parts
+- Fixed repeated log entries for already-resolved parts during startup scan
+
+### Changed
+
+- Removed flight cloak parts (CD_Cloak_Flight) from default Cloak category to prevent visual artifacts and squished hair when toggling cloak visibility
+- Unified address format in log output to uppercase hex
+- Added per-part trace logging when toggling visibility (visible at Trace log level)
+- Added category summary after config load (visible at Trace log level)
+
+### Added
+
+- Expanded user presets from 3 to 10 slots
+- Added workaround tip in INI for dagger clipping issue
+- Documented known issues: flight cloak artifacts, chest/legs flickering, dagger clipping

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -14,12 +14,8 @@ This mod allows you to hide equipped gear visually in Crimson Desert using custo
 [*] Weapon categories: One-Hand Weapons, Two-Hand Weapons, Shields, Bows, Special Weapons, Tools, Lanterns
 [*] Armor categories: Helm, Chest, Legs, Gloves, Boots, Cloak, Shoulder, Mask, Glasses
 [*] Accessory categories: Earrings, Rings, Necklace, Bags
-[*] User Presets: 3 custom part groups to combine parts from any category into a single toggle
+[*] User Presets: 10 custom part groups to combine parts from any category into a single toggle
 [*] Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
-[*] [Experimental] BaldFix: runtime hair-visibility fix when helmet/cloak is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
-[*] GlidingFix: prevents hidden equipment from briefly flashing visible during state transitions (e.g. exiting gliding, cutscene transitions)
-[*] ForceShow mode for compatibility with mods that alter default equipment visibility via PAZ patching (e.g. character replacers, armor replacers, transmog mods)
-[*] Hot-reload cleanup: visibility bytes restored on DLL unload
 [*] Fully customizable settings through INI configuration
 [*] Open-source with full transparency
 [/list]
@@ -187,7 +183,7 @@ When a preset is [b]enabled[/b] and contains parts, it takes [b]full control[/b]
 [list]
 [*] Only the preset's own hotkey controls its parts
 [*] Built-in category toggles (e.g. [b]V[/b] for Shields/Helm/Mask) will [b]NOT[/b] affect parts owned by an active preset
-[*] Parts can appear in both a built-in category and a preset — the preset wins when enabled
+[*] Parts can appear in both a built-in category and a preset -the preset wins when enabled
 [*] Set [b]DefaultHidden = true[/b] on a preset if you want its parts hidden on startup
 [/list]
 
@@ -201,10 +197,13 @@ Parts = CD_Helm, CD_Cloak, CD_Shoulder
 
 In this example, pressing [b]V[/b] would still toggle Shields and Masks, but Helm would only respond to [b]F5[/b] because UserPreset1 owns it.
 
-[size=5]Known Limitations[/size]
+[size=5]Known Issues[/size]
 [list]
+[*] [b]Flight cloak parts cause visual artifacts and squished hair[/b] -CD_Cloak_Flight and its variants can cause strange visual artifacts and compressed/squished hair when toggling cloak visibility. These parts have been removed from the default Cloak category. You can re-add them in the INI at your own risk (see the comment in the [Cloak] section).
+[*] [b]Chest/Legs flickering when toggled independently[/b] -Hiding chest while legs are visible, then toggling legs, can cause pants to flicker on/off. Workaround: toggle both chest and legs together using the same hotkey, or set your desired default states via DefaultHidden and avoid toggling them separately at runtime.
+[*] [b]Dagger permanently visible after hiding one-hand weapons[/b] -Daggers may remain visible and clip with swords occupying the same visual slot. Will be addressed in a future update.
 [*] Toggle may take 1-3 seconds to take effect
-[*] After a major game update, AOB patterns may need updating
+[*] After a major game update, the mod may stop working until a new version is released
 [*] Currently only tested with the Steam version of the game
 [/list]
 

--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -539,6 +539,19 @@ namespace EquipHide
         s_categoryParts[static_cast<std::size_t>(cat)] = partsStr;
 
         auto& logger = DMK::Logger::get_instance();
+        auto& writeMap = s_partMaps[1 - s_activeMap.load(std::memory_order_relaxed)];
+
+        // Clear previous entries for this category so that a second callback
+        // (e.g. INI override after default registration) fully replaces them.
+        const auto bit = category_bit(cat);
+        for (auto it = writeMap.begin(); it != writeMap.end(); )
+        {
+            it->second &= ~bit;
+            if (it->second == 0)
+                it = writeMap.erase(it);
+            else
+                ++it;
+        }
 
         if (partsStr.find_first_not_of(" ,") == std::string::npos)
         {
@@ -548,7 +561,6 @@ namespace EquipHide
         }
 
         const auto& nameMap = name_to_hash_map();
-        auto& writeMap = s_partMaps[1 - s_activeMap.load(std::memory_order_relaxed)];
 
         std::size_t pos = 0;
         while (pos < partsStr.size())

--- a/CrimsonDesertEquipHide/src/categories.hpp
+++ b/CrimsonDesertEquipHide/src/categories.hpp
@@ -43,6 +43,13 @@ namespace EquipHide
         UserPreset1,
         UserPreset2,
         UserPreset3,
+        UserPreset4,
+        UserPreset5,
+        UserPreset6,
+        UserPreset7,
+        UserPreset8,
+        UserPreset9,
+        UserPreset10,
         COUNT
     };
 
@@ -57,7 +64,10 @@ namespace EquipHide
             "Helm", "Chest", "Legs", "Gloves", "Boots",
             "Cloak", "Shoulder", "Mask", "Glasses",
             "Earrings", "Rings", "Necklace", "Bags",
-            "UserPreset1", "UserPreset2", "UserPreset3"};
+            "UserPreset1", "UserPreset2", "UserPreset3",
+            "UserPreset4", "UserPreset5", "UserPreset6",
+            "UserPreset7", "UserPreset8", "UserPreset9",
+            "UserPreset10"};
         static_assert(std::size(names) == CATEGORY_COUNT,
                       "names[] must match Category enum");
         const auto idx = static_cast<std::size_t>(cat);
@@ -74,15 +84,7 @@ namespace EquipHide
     /** @brief Returns true if the category is a user-defined preset. */
     constexpr bool is_user_preset(Category cat)
     {
-        switch (cat)
-        {
-        case Category::UserPreset1:
-        case Category::UserPreset2:
-        case Category::UserPreset3:
-            return true;
-        default:
-            return false;
-        }
+        return cat >= Category::UserPreset1 && cat <= Category::UserPreset10;
     }
 
     /**
@@ -108,12 +110,9 @@ namespace EquipHide
         case Category::Rings:
         case Category::Necklace:
         case Category::Bags:
-        case Category::UserPreset1:
-        case Category::UserPreset2:
-        case Category::UserPreset3:
             return true;
         default:
-            return false;
+            return is_user_preset(cat);
         }
     }
 

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -272,7 +272,7 @@ namespace EquipHide
 
         if (result)
         {
-            logger.info("{} resolved via '{}' at {:#x}", label, matchedName, result);
+            logger.info("{} resolved via '{}' at 0x{:X}", label, matchedName, result);
             return result;
         }
 
@@ -346,7 +346,7 @@ namespace EquipHide
         const auto globalPtr = *reinterpret_cast<const uintptr_t *>(globalPtrAddr);
         if (globalPtr < 0x10000)
         {
-            logger.trace("IndexedStringA scan: global pointer not yet initialized ({:#x})",
+            logger.trace("IndexedStringA scan: global pointer not yet initialized (0x{:X})",
                          globalPtr);
             return nameToHash;
         }
@@ -354,12 +354,12 @@ namespace EquipHide
         const auto tableArray = *reinterpret_cast<const uintptr_t *>(globalPtr + 0x58);
         if (tableArray < 0x10000)
         {
-            logger.warning("IndexedStringA scan: tableArray is null/invalid ({:#x})",
+            logger.warning("IndexedStringA scan: tableArray is null/invalid (0x{:X})",
                            tableArray);
             return nameToHash;
         }
 
-        logger.trace("IndexedStringA scan: globalPtr={:#x} tableArray={:#x}",
+        logger.trace("IndexedStringA scan: globalPtr=0x{:X} tableArray=0x{:X}",
                      globalPtr, tableArray);
 
         const auto t0 = std::chrono::steady_clock::now();
@@ -453,17 +453,18 @@ namespace EquipHide
         return nameToHash;
     }
 
+    /** @brief Traverse body -> vis_ctrl pointer chain. Caller MUST be SEH-protected. */
     static uintptr_t body_to_vis_ctrl(uintptr_t body) noexcept
     {
         if (!body)
             return 0;
-        auto inner = read_ptr(body, 0x68);
+        auto inner = read_ptr_unsafe(body, 0x68);
         if (!inner)
             return 0;
-        auto sub = read_ptr(inner, 0x40);
+        auto sub = read_ptr_unsafe(inner, 0x40);
         if (!sub)
             return 0;
-        return read_ptr(sub, 0xE8);
+        return read_ptr_unsafe(sub, 0xE8);
     }
 
     static void resolve_player_vis_ctrls() noexcept
@@ -473,13 +474,14 @@ namespace EquipHide
 
         __try
         {
-            auto ws = read_ptr(s_worldSystemPtr, 0);
+            /* read_ptr_unsafe: outer __try makes is_readable() redundant. */
+            auto ws = read_ptr_unsafe(s_worldSystemPtr, 0);
             if (!ws)
                 return;
-            auto am = read_ptr(ws, 0x30);
+            auto am = read_ptr_unsafe(ws, 0x30);
             if (!am)
                 return;
-            auto user = read_ptr(am, 0x28);
+            auto user = read_ptr_unsafe(am, 0x28);
             if (!user)
                 return;
 
@@ -492,17 +494,22 @@ namespace EquipHide
                 if (count >= k_maxProtagonists)
                     break;
 
-                auto candidate = read_ptr(user, off);
-                if (!candidate)
-                    continue;
+                /* Per-slot SEH so one bad body pointer does not abort the loop. */
+                __try
+                {
+                    auto candidate = read_ptr_unsafe(user, off);
+                    if (!candidate)
+                        continue;
 
-                auto vt = read_ptr(candidate, 0);
-                if (vt != s_childActorVtbl)
-                    continue;
+                    auto vt = read_ptr_unsafe(candidate, 0);
+                    if (vt != s_childActorVtbl)
+                        continue;
 
-                auto vc = body_to_vis_ctrl(candidate);
-                if (vc)
-                    s_playerVisCtrls[count++] = vc;
+                    auto vc = body_to_vis_ctrl(candidate);
+                    if (vc)
+                        s_playerVisCtrls[count++] = vc;
+                }
+                __except (EXCEPTION_EXECUTE_HANDLER) { }
             }
 
             for (int i = count; i < k_maxProtagonists; ++i)
@@ -521,36 +528,40 @@ namespace EquipHide
                 static std::atomic<bool> s_logged{false};
                 if (!s_logged.exchange(true, std::memory_order_relaxed))
                     DMK::Logger::get_instance().debug(
-                        "Resolve: ws={:#x} am={:#x} user={:#x} count={}",
+                        "Resolve: ws=0x{:X} am=0x{:X} user=0x{:X} count={}",
                         ws, am, user, count);
             }
             if (count > 0)
             {
-                s_directWriteMtx.lock();
-                bool changed = (count != s_prevCount);
-                if (!changed)
+                /* Non-blocking: skip if the input thread holds the mutex;
+                   the next resolve cycle will catch any change. */
+                if (s_directWriteMtx.try_lock())
                 {
-                    for (int j = 0; j < count; ++j)
+                    bool changed = (count != s_prevCount);
+                    if (!changed)
                     {
-                        if (s_playerVisCtrls[j].load(std::memory_order_relaxed) != s_prevVisCtrls[j])
+                        for (int j = 0; j < count; ++j)
                         {
-                            changed = true;
-                            break;
+                            if (s_playerVisCtrls[j].load(std::memory_order_relaxed) != s_prevVisCtrls[j])
+                            {
+                                changed = true;
+                                break;
+                            }
                         }
                     }
+                    if (changed)
+                    {
+                        s_prevCount = count;
+                        for (int j = 0; j < count; ++j)
+                            s_prevVisCtrls[j] = s_playerVisCtrls[j].load(std::memory_order_relaxed);
+                        for (int j = 0; j < k_maxProtagonists; ++j)
+                            s_armorInjected[j].store(false, std::memory_order_relaxed);
+                        s_needsDirectWrite.store(true, std::memory_order_relaxed);
+                        DMK::Logger::get_instance().debug(
+                            "Player set changed — scheduling injection + direct write");
+                    }
+                    s_directWriteMtx.unlock();
                 }
-                if (changed)
-                {
-                    s_prevCount = count;
-                    for (int j = 0; j < count; ++j)
-                        s_prevVisCtrls[j] = s_playerVisCtrls[j].load(std::memory_order_relaxed);
-                    for (int j = 0; j < k_maxProtagonists; ++j)
-                        s_armorInjected[j].store(false, std::memory_order_relaxed);
-                    s_needsDirectWrite.store(true, std::memory_order_relaxed);
-                    DMK::Logger::get_instance().debug(
-                        "Player set changed — scheduling injection + direct write");
-                }
-                s_directWriteMtx.unlock();
             }
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
@@ -581,6 +592,7 @@ namespace EquipHide
 
         __try
         {
+            auto &logger = DMK::Logger::get_instance();
             auto lookup = reinterpret_cast<MapLookupFn>(s_mapLookupAddr);
             const auto n = s_playerCount.load(std::memory_order_relaxed);
             int hiddenCount = 0;
@@ -592,10 +604,10 @@ namespace EquipHide
                 if (!vc)
                     continue;
 
-                auto comp = read_ptr(vc, 0x48);
+                auto comp = read_ptr_unsafe(vc, 0x48);
                 if (!comp)
                     continue;
-                auto descNode = read_ptr(comp, 0x218);
+                auto descNode = read_ptr_unsafe(comp, 0x218);
                 if (!descNode)
                     continue;
                 auto mapBase = descNode + 0x20;
@@ -615,13 +627,18 @@ namespace EquipHide
                             s_originalVis[visAddr] = *visPtr;
                         *visPtr = 2;
                         ++hiddenCount;
+                        logger.trace("  [{}] 0x{:04X} hidden (vis=2)",
+                                     i, hash);
                     }
                     else
                     {
                         auto it = s_originalVis.find(visAddr);
                         if (it != s_originalVis.end())
                         {
-                            *visPtr = (it->second == 2) ? 0 : it->second;
+                            const auto restored = (it->second == 2) ? 0 : it->second;
+                            *visPtr = static_cast<uint8_t>(restored);
+                            logger.trace("  [{}] 0x{:04X} restored (vis={})",
+                                         i, hash, restored);
                             s_originalVis.erase(it);
                             ++restoredCount;
                         }
@@ -629,14 +646,15 @@ namespace EquipHide
                         {
                             *visPtr = 0;
                             ++restoredCount;
+                            logger.trace("  [{}] 0x{:04X} force-shown (vis=0)",
+                                         i, hash);
                         }
                     }
                 }
             }
 
-            DMK::Logger::get_instance().trace(
-                "DirectWrite: {} protagonists, {} hidden, {} restored",
-                n, hiddenCount, restoredCount);
+            logger.trace("DirectWrite: {} protagonists, {} hidden, {} restored",
+                        n, hiddenCount, restoredCount);
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -814,20 +832,25 @@ namespace EquipHide
             if (!vc)
                 continue;
 
-            auto comp = read_ptr(vc, 0x48);
-            if (!comp)
-                continue;
-            auto descNode = read_ptr(comp, 0x218);
-            if (!descNode)
-                continue;
-            auto mapBase = descNode + 0x20;
-
-            int result = inject_armor_entries_for_map(mapBase);
-            if (result >= 0)
+            /* Per-player SEH so one bad pointer does not skip the rest. */
+            __try
             {
-                s_armorInjected[i].store(true, std::memory_order_relaxed);
-                totalInjected += result;
+                auto comp = read_ptr_unsafe(vc, 0x48);
+                if (!comp)
+                    continue;
+                auto descNode = read_ptr_unsafe(comp, 0x218);
+                if (!descNode)
+                    continue;
+                auto mapBase = descNode + 0x20;
+
+                int result = inject_armor_entries_for_map(mapBase);
+                if (result >= 0)
+                {
+                    s_armorInjected[i].store(true, std::memory_order_relaxed);
+                    totalInjected += result;
+                }
             }
+            __except (EXCEPTION_EXECUTE_HANDLER) { }
         }
 
         if (totalInjected > 0)
@@ -1429,6 +1452,38 @@ namespace EquipHide
         DMK::Config::load(INI_FILE);
         DMK::Config::log_all();
         build_part_lookup();
+
+        {
+            auto &logger = DMK::Logger::get_instance();
+            if (logger.get_log_level() <= DMK::LogLevel::Trace)
+            {
+                const auto &states = category_states();
+                const auto &partMap = get_part_map();
+
+                for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
+                {
+                    const auto cat = static_cast<Category>(i);
+                    const auto bit = category_bit(cat);
+                    int count = 0;
+                    for (const auto &[hash, mask] : partMap)
+                    {
+                        if (mask & bit)
+                            ++count;
+                    }
+
+                    const bool enabled = states[i].enabled.load(std::memory_order_relaxed);
+                    const bool hidden = states[i].hidden.load(std::memory_order_relaxed);
+
+                    if (!enabled)
+                        logger.trace("Category {}: disabled ({} parts registered)",
+                                     category_section(cat), count);
+                    else
+                        logger.trace("Category {}: enabled, default={} ({} parts)",
+                                     category_section(cat),
+                                     hidden ? "hidden" : "visible", count);
+                }
+            }
+        }
     }
 
     // --- Hotkey helpers ---
@@ -1637,7 +1692,7 @@ namespace EquipHide
                 std::memcpy(&disp, instrBytes + 3, sizeof(int32_t));
                 s_indexedStringGlobalAddr = static_cast<uintptr_t>(
                     static_cast<int64_t>(ripInstr + 7) + disp);
-                logger.info("IndexedStringA global resolved at {:#x}",
+                logger.info("IndexedStringA global resolved at 0x{:X}",
                             s_indexedStringGlobalAddr);
             }
             else
@@ -1792,62 +1847,26 @@ namespace EquipHide
 
     /**
      * @brief Undo all visibility modifications before unload.
-     * @details Injected armor entries get vis=3 (skip) so the game ignores
-     *          the malformed entries (zero socket bones). Modified weapon
-     *          entries get their original vis bytes restored.
+     * @details Restores only entries tracked in s_originalVis. Unmodified
+     *          entries (including injected zero-bone armor entries) are left as-is.
      */
     static void cleanup_vis_bytes() noexcept
     {
-        if (!s_mapLookupAddr)
-            return;
         s_directWriteMtx.lock();
 
         __try
         {
-            auto lookup = reinterpret_cast<MapLookupFn>(s_mapLookupAddr);
-            const auto n = s_playerCount.load(std::memory_order_relaxed);
-
             int restoredCount = 0;
-            int skipCount = 0;
-
-            for (int i = 0; i < n; ++i)
+            for (const auto &[visAddr, origVis] : s_originalVis)
             {
-                auto vc = s_playerVisCtrls[i].load(std::memory_order_relaxed);
-                if (!vc)
-                    continue;
-                auto comp = read_ptr(vc, 0x48);
-                if (!comp)
-                    continue;
-                auto descNode = read_ptr(comp, 0x218);
-                if (!descNode)
-                    continue;
-                auto mapBase = descNode + 0x20;
-
-                for (const auto &[hash, mask] : get_part_map())
-                {
-                    auto entry = lookup(mapBase, &hash);
-                    if (!entry)
-                        continue;
-
-                    auto *visPtr = reinterpret_cast<uint8_t *>(entry + 0x1C);
-
-                    auto it = s_originalVis.find(reinterpret_cast<uintptr_t>(visPtr));
-                    if (it != s_originalVis.end())
-                    {
-                        *visPtr = it->second;
-                        ++restoredCount;
-                    }
-                    else
-                    {
-                        *visPtr = 3;
-                        ++skipCount;
-                    }
-                }
+                auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
+                *visPtr = origVis;
+                ++restoredCount;
             }
             s_originalVis.clear();
+
             DMK::Logger::get_instance().debug(
-                "Cleanup: {} vis bytes restored, {} set to skip",
-                restoredCount, skipCount);
+                "Cleanup: {} vis bytes restored", restoredCount);
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -400,11 +400,13 @@ namespace EquipHide
 
                     if (std::memcmp(buf, name.c_str(), len) == 0)
                     {
+                        const bool isNew = (nameToHash.find(name) == nameToHash.end());
                         nameToHash[name] = h;
                         ++probeHits;
-                        logger.trace("Outlier probe: {} found at 0x{:X} "
-                                     "(fallback was 0x{:X})",
-                                     name, h, fallback);
+                        if (isNew)
+                            logger.trace("Outlier probe: {} found at 0x{:X} "
+                                         "(fallback was 0x{:X})",
+                                         name, h, fallback);
                         break;
                     }
                 }
@@ -432,11 +434,13 @@ namespace EquipHide
                     if (len == it->first.size() &&
                         std::memcmp(buf, it->first.c_str(), len) == 0)
                     {
+                        const bool isNew = (nameToHash.find(it->first) == nameToHash.end());
                         nameToHash[it->first] = h;
                         ++probeHits;
-                        logger.trace("Wide scan: {} found at 0x{:X} "
-                                     "(fallback was 0x{:X})",
-                                     it->first, h, it->second);
+                        if (isNew)
+                            logger.trace("Wide scan: {} found at 0x{:X} "
+                                         "(fallback was 0x{:X})",
+                                         it->first, h, it->second);
                         wideUnresolved.erase(it);
                         break;
                     }


### PR DESCRIPTION
## Summary

- **Performance**: Replace `read_ptr()` with `read_ptr_unsafe()` in SEH-protected hot paths, eliminating ~36 redundant VirtualQuery cache lookups per resolve cycle. Change blocking `mutex::lock()` to `try_lock()` in `resolve_player_vis_ctrls` to prevent game thread stalling on input thread contention.
- **Bug fix**: `cleanup_vis_bytes()` was corrupting vanilla vis entries with `vis=3` on shutdown, breaking state after hot-reload.
- **Bug fix**: `register_parts()` was additive — INI overrides after default registration left stale entries in the part map (e.g. removing parts from INI had no effect after reload).
- **Bug fix**: `is_armor_category()` switch had a fallthrough bug where armor cases fell through to `default` (dead code, no runtime impact).
- **Feature**: Expand user presets from 3 to 10.
- **Docs**: Remove flight cloak parts from default `[Cloak]` (causes visual artifacts and squished hair). Document known issues (chest/legs flicker, dagger clipping). Add dagger workaround tip in INI. Unify hex log format to uppercase.
- **Logging**: Add per-part trace logging in DirectWrite and category summary after config load.

## Test plan

- [x] Hot-reload (Numpad0): confirm INI changes take effect, no stale parts
- [x] Hot-reload: remove a part from INI, reload, verify it's no longer tracked
- [x] Toggle cloak with flight parts removed: no visual artifacts
- [x] Toggle hide-all / show-all: verify correct restore
- [x] Verify TRACE log shows per-part visibility decisions on hotkey press
