### PR TITLE
feat(equip-hide): add IndependentToggle for mixed-state shared hotkeys

### DIFF
--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -13,6 +13,7 @@
 - Accessory categories: Earrings, Rings, Necklace, Bags
 - User Presets: 10 custom part groups with independent visibility control (overrides built-in categories)
 - Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
+- IndependentToggle mode: categories sharing a hotkey flip their own state individually, preserving mixed visible/hidden configurations
 - [Experimental] BaldFix: runtime hair-visibility fix when helmet/cloak is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 - GlidingFix: prevents hidden equipment from briefly flashing visible during state transitions (e.g. exiting gliding, cutscene transitions)
 - ForceShow mode for compatibility with mods that alter default equipment visibility via PAZ patching (e.g. character replacers, armor replacers, transmog mods)
@@ -105,6 +106,12 @@ ForceShow = false
 BaldFix = true
 ; Prevents hidden equipment from briefly flashing during state transitions
 GlidingFix = true
+; When multiple categories share the same ToggleHotkey, this controls
+; whether they toggle as a synchronized group (false, default) or each
+; category flips its own state independently (true).
+; Use true when categories on the same key have different DefaultHidden
+; values and you want to preserve mixed visible/hidden states.
+IndependentToggle = false
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -57,6 +57,12 @@ BaldFix = true
 ; Prevents hidden equipment from briefly flashing during state transitions
 ; (e.g. exiting gliding, cutscene transitions). Safe to leave enabled.
 GlidingFix = true
+; When multiple categories share the same ToggleHotkey, this controls
+; whether they toggle as a synchronized group (false, default) or each
+; category flips its own state independently (true).
+; Use true when categories on the same key have different DefaultHidden
+; values and you want to preserve mixed visible/hidden states.
+IndependentToggle = false
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -10,6 +10,7 @@ This mod allows you to hide equipped gear visually in Crimson Desert using custo
 [*]Global show-all / hide-all hotkeys to control every category at once[/*]
 [*][b]User Presets[/b]: 10 custom part groups with independent toggle hotkeys[/*]
 [*]Fully configurable via INI with per-category settings[/*]
+[*][b]IndependentToggle[/b] mode: categories sharing a hotkey flip their own state individually, preserving mixed visible/hidden configurations[/*]
 [*]Open-source with full transparency[/*]
 [/list]
 
@@ -90,6 +91,9 @@ ForceShow = false
 BaldFix = true
 ; Prevents hidden equipment from briefly flashing during state transitions
 GlidingFix = true
+; When categories sharing the same ToggleHotkey have different DefaultHidden
+; values, set to true so each category flips its own state independently.
+IndependentToggle = false
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -41,6 +41,9 @@ namespace EquipHide
         DMK::Config::register_bool("General", "GlidingFix", "Gliding Fix", [](bool val)
                                    { flag_gliding_fix().store(val, std::memory_order_relaxed); }, true);
 
+        DMK::Config::register_bool("General", "IndependentToggle", "Independent Toggle", [](bool val)
+                                   { flag_independent_toggle().store(val, std::memory_order_relaxed); }, false);
+
         DMK::Config::register_key_combo("General", "ShowAllHotkey", "Show All Hotkey", [](const DMK::Config::KeyComboList &combos)
                                         { set_show_all_combos(combos); }, "");
 

--- a/CrimsonDesertEquipHide/src/input_handler.cpp
+++ b/CrimsonDesertEquipHide/src/input_handler.cpp
@@ -136,9 +136,20 @@ namespace EquipHide
                 [indices, &logger]()
                 {
                     auto &st = category_states();
-                    const bool newHidden = !st[indices[0]].hidden.load(std::memory_order_relaxed);
-                    for (auto idx : indices)
-                        st[idx].hidden.store(newHidden, std::memory_order_relaxed);
+
+                    if (flag_independent_toggle().load(std::memory_order_relaxed))
+                    {
+                        for (auto idx : indices)
+                            st[idx].hidden.store(
+                                !st[idx].hidden.load(std::memory_order_relaxed),
+                                std::memory_order_relaxed);
+                    }
+                    else
+                    {
+                        const bool newHidden = !st[indices[0]].hidden.load(std::memory_order_relaxed);
+                        for (auto idx : indices)
+                            st[idx].hidden.store(newHidden, std::memory_order_relaxed);
+                    }
 
                     std::string catNames;
                     for (auto idx : indices)
@@ -146,8 +157,11 @@ namespace EquipHide
                         if (!catNames.empty())
                             catNames += ", ";
                         catNames += category_section(static_cast<Category>(idx));
+                        catNames += st[idx].hidden.load(std::memory_order_relaxed)
+                                        ? "(H)"
+                                        : "(V)";
                     }
-                    logger.info("Equip hide toggled [{}]: {}", catNames, newHidden ? "HIDDEN" : "VISIBLE");
+                    logger.info("Equip hide toggled [{}]", catNames);
                     flush_visibility();
                 });
 

--- a/CrimsonDesertEquipHide/src/shared_state.cpp
+++ b/CrimsonDesertEquipHide/src/shared_state.cpp
@@ -13,6 +13,7 @@ namespace EquipHide
     static std::atomic<bool> s_baldFix{true};
     static std::atomic<bool> s_glidingFix{true};
     static std::atomic<bool> s_fallbackMode{false};
+    static std::atomic<bool> s_independentToggle{false};
 
     static std::atomic<bool> s_shutdownRequested{false};
     static std::atomic<bool> s_deferredScanPending{false};
@@ -30,6 +31,7 @@ namespace EquipHide
     std::atomic<bool> &flag_bald_fix() { return s_baldFix; }
     std::atomic<bool> &flag_gliding_fix() { return s_glidingFix; }
     std::atomic<bool> &flag_fallback_mode() { return s_fallbackMode; }
+    std::atomic<bool> &flag_independent_toggle() { return s_independentToggle; }
 
     std::atomic<bool> &shutdown_requested() { return s_shutdownRequested; }
     std::atomic<bool> &deferred_scan_pending() { return s_deferredScanPending; }

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -50,6 +50,7 @@ namespace EquipHide
     std::atomic<bool> &flag_bald_fix();
     std::atomic<bool> &flag_gliding_fix();
     std::atomic<bool> &flag_fallback_mode();
+    std::atomic<bool> &flag_independent_toggle();
 
     // --- Background thread control ---
     std::atomic<bool> &shutdown_requested();


### PR DESCRIPTION
## Summary

- When multiple categories share the same `ToggleHotkey` with different `DefaultHidden` values, the toggle previously synced all categories to the first category's state, making mixed visible/hidden states impossible
- Adds `IndependentToggle` setting in `[General]`: when `true`, each category in a shared-hotkey group flips its own state independently
- Default `false` preserves existing synchronized behavior

## Changes

- `shared_state.hpp/cpp`: new `flag_independent_toggle()` atomic bool
- `input_handler.cpp`: toggle callback branches on the flag, synchronized (default) vs per-category flip
- `equip_hide.cpp`: register `IndependentToggle` config option
- `CrimsonDesertEquipHide.ini`: added setting with documentation
- `README.md` / `nexus-bbcode.txt`: updated features and config sections
