### PR TITLE
feat(equip-hide): coexist with official headgear visibility setting

### DIFF
--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -14,6 +14,7 @@
 - User Presets: 10 custom part groups with independent visibility control (overrides built-in categories)
 - Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
 - IndependentToggle mode: categories sharing a hotkey flip their own state individually, preserving mixed visible/hidden configurations
+- Automatic coexistence with the game's built-in headgear visibility setting (v1.02.00+) — when the in-game setting is anything other than "Show Always", the mod yields Helm, Mask, and Glasses to the official system and only manages the remaining categories. No configuration needed
 - [Experimental] BaldFix: runtime hair-visibility fix when helmet/cloak is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 - GlidingFix: prevents hidden equipment from briefly flashing visible during state transitions (e.g. exiting gliding, cutscene transitions)
 - ForceShow mode for compatibility with mods that alter default equipment visibility via PAZ patching (e.g. character replacers, armor replacers, transmog mods)
@@ -112,6 +113,9 @@ GlidingFix = true
 ; Use true when categories on the same key have different DefaultHidden
 ; values and you want to preserve mixed visible/hidden states.
 IndependentToggle = false
+; Yield Helm/Mask/Glasses to the game's built-in headgear visibility
+; setting when active. Set false to always let the mod control headgear.
+DeferHeadgear = true
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =
@@ -185,9 +189,10 @@ ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 2. **Mid-Hook** - Intercepts the visibility check and forces `Visible=2` (Out-only) for hidden weapon categories
 3. **Inline Hook** - When GlidingFix is enabled, a secondary hook on the PartAddShow function prevents hidden parts from briefly flashing visible during state transitions (e.g. exiting glide)
 4. **Armor Injection** - Armor parts have no vanilla visibility entries, so the mod injects new map entries via the game's own internal functions
-5. **[Experimental] BaldFix Hook** - Hooks the postfix rule evaluator to suppress hair-hiding rules when Helm or Cloak is hidden, keeping hair visible at runtime without PAZ patching. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
-6. **Input Management** - DetourModKit's input system handles keyboard, mouse, and gamepad with modifier key combos
-7. **SEH Protection** - Hook callback is wrapped in structured exception handling (MSVC) to prevent crashes
+5. **Official Headgear Coexistence** - Detects the game's built-in headgear visibility gate byte at startup. When the official system is active, the mod automatically yields Helm, Mask, and Glasses categories to avoid write conflicts on the shared visibility byte
+6. **[Experimental] BaldFix Hook** - Hooks the postfix rule evaluator to suppress hair-hiding rules when Helm or Cloak is hidden, keeping hair visible at runtime without PAZ patching. Defers to the game's own hair handling when headgear is officially managed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
+7. **Input Management** - DetourModKit's input system handles keyboard, mouse, and gamepad with modifier key combos
+8. **SEH Protection** - Hook callback is wrapped in structured exception handling (MSVC) to prevent crashes
 
 ## Troubleshooting
 
@@ -236,6 +241,34 @@ ForceShow = true
 ```
 
 Safe to leave `false` if you are not using such mods.
+
+## Coexistence with Official Headgear Visibility
+
+Since v1.02.00, Crimson Desert includes a built-in headgear visibility setting (`Options > Game > Show Character Helm`) with modes like "Show Always", "Show on Battle", "Hide on Cutscenes", and "Hide Always". This setting controls Helm, Mask, and Glasses visibility.
+
+When `DeferHeadgear = true` (default), the mod **automatically detects** this setting at runtime:
+
+- **Show Always** (default): The mod manages all categories normally, including Helm, Mask, and Glasses
+- **Any other mode**: The mod yields Helm, Mask, and Glasses to the game's official system and only manages the remaining 17 categories (weapons, shields, cloak, chest, etc.)
+
+The log file will report which mode is active at startup:
+
+```log
+Official headgear visibility: ShowAlways — mod manages all categories
+```
+
+or:
+
+```log
+Official headgear visibility active (mode=3), yielding Helm/Glass/Mask to game
+```
+
+To **always** let the mod control headgear regardless of the game setting, set:
+
+```ini
+[General]
+DeferHeadgear = false
+```
 
 ## Known Issues
 

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -63,6 +63,11 @@ GlidingFix = true
 ; Use true when categories on the same key have different DefaultHidden
 ; values and you want to preserve mixed visible/hidden states.
 IndependentToggle = false
+; When true, the mod yields Helm, Mask, and Glasses to the game's built-in
+; headgear visibility setting (Options > Game > Show Character Helm) if it
+; is set to anything other than "Show Always". Set to false to override
+; the game's setting and let the mod control headgear visibility directly.
+DeferHeadgear = true
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,3 +1,8 @@
+## Compatibility
+
+- Added automatic coexistence with the game's built-in headgear visibility setting (v1.02.00+). When the in-game setting is anything other than "Show Always", the mod yields Helm, Mask, and Glasses categories to the official system and only manages the remaining categories. When "Show Always" is selected, the mod manages all categories as before. Controlled by `DeferHeadgear` in `[General]` (default: true). Set to false to override the game's headgear setting
+- BaldFix now correctly defers to the game's own hair handling when headgear visibility is officially managed
+
 ## Internal Improvements
 
 - Improved performance when toggling equipment visibility

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -11,6 +11,7 @@ This mod allows you to hide equipped gear visually in Crimson Desert using custo
 [*][b]User Presets[/b]: 10 custom part groups with independent toggle hotkeys[/*]
 [*]Fully configurable via INI with per-category settings[/*]
 [*][b]IndependentToggle[/b] mode: categories sharing a hotkey flip their own state individually, preserving mixed visible/hidden configurations[/*]
+[*][b]Official headgear coexistence[/b]: auto-detects the game's built-in headgear visibility setting (v1.02.00+) and yields Helm/Mask/Glasses when the official system is active[/*]
 [*]Open-source with full transparency[/*]
 [/list]
 
@@ -94,6 +95,9 @@ GlidingFix = true
 ; When categories sharing the same ToggleHotkey have different DefaultHidden
 ; values, set to true so each category flips its own state independently.
 IndependentToggle = false
+; Yield Helm/Mask/Glasses to the game's built-in headgear visibility setting
+; when active. Set false to always let the mod control headgear.
+DeferHeadgear = true
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =
@@ -172,6 +176,17 @@ ForceShow = true
 [/code]
 
 Safe to leave [b]false[/b] if you are not using such mods.
+
+[size=5]Coexistence with Official Headgear Visibility[/size]
+Since v1.02.00, Crimson Desert includes a built-in headgear visibility setting ([b]Options > Game > Show Character Helm[/b]) with modes like "Show Always", "Show on Battle", "Hide on Cutscenes", and "Hide Always". This setting controls Helm, Mask, and Glasses visibility.
+
+When [b]DeferHeadgear = true[/b] (default), the mod [b]automatically detects[/b] this setting at runtime:
+[list]
+[*] [b]Show Always[/b] (default): The mod manages all categories normally, including Helm, Mask, and Glasses
+[*] [b]Any other mode[/b]: The mod yields Helm, Mask, and Glasses to the game's official system and only manages the remaining 17 categories (weapons, shields, cloak, chest, etc.)
+[/list]
+
+To always let the mod control headgear regardless of the game setting, set [b]DeferHeadgear = false[/b] in [b][General][/b].
 
 [size=5]User Presets[/size]
 The INI file includes three [b]UserPreset[/b] sections (UserPreset1, UserPreset2, UserPreset3) that let you create custom part groups with independent visibility control.

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -104,6 +104,26 @@ namespace EquipHide
     };
 
     /**
+     * @brief Gate byte for the game's built-in headgear visibility system.
+     *
+     * EnumOptionShowPlayerCharacterHelmType: 0=ShowAlways, 1-3=active modes.
+     * When non-zero, the game's decision function (sub_140771990) manages
+     * Helm/Glass/Mask vis bytes on equip change, combat, and cutscene events.
+     *
+     * Pattern targets the movzx that loads the gate byte, followed by a TLS
+     * slot access — distinctive enough to be unique in the binary.
+     */
+    inline constexpr AddrCandidate k_helmVisGateCandidates[] = {
+        {"HVG_P1_MovzxTls",
+         "0F B6 1D ?? ?? ?? ?? BA ?? 00 00 00 65 48 8B 04 25 58 00 00 00",
+         ResolveMode::RipRelative, 3, 7},
+
+        {"HVG_P2_StoreMovzxTls",
+         "C6 45 ?? 01 0F B6 1D ?? ?? ?? ?? BA ?? 00 00 00",
+         ResolveMode::RipRelative, 7, 11},
+    };
+
+    /**
      * @brief Hook target: sub_14081D3C0 — PartInOut transition function.
      *
      * Hook point: movzx eax, byte ptr [r13+1Ch]; cmp al, 3

--- a/CrimsonDesertEquipHide/src/armor_injection.cpp
+++ b/CrimsonDesertEquipHide/src/armor_injection.cpp
@@ -69,10 +69,14 @@ namespace EquipHide
             int injected = 0;
             int existing_set = 0;
             int skipped_key = 0;
+            const bool officialActive = official_helm_active();
 
-            for (const auto &[hash, mask] : get_part_map())
+            for (const auto &[hash, rawMask] : get_part_map())
             {
-                if (!is_any_category_hidden(mask))
+                auto effectiveMask = rawMask;
+                if (officialActive)
+                    effectiveMask &= ~k_officialManagedMask;
+                if (!is_any_category_hidden(effectiveMask))
                     continue;
 
                 auto existing = lookup(mapBase, &hash);

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -54,6 +54,11 @@ namespace EquipHide
         {
             if (!is_hair_hiding_rule(ruleObj))
                 return false;
+            /* When the game's headgear visibility system is active, it handles
+               its own hair rules for Helm. Only suppress for Cloak (which the
+               official system does not manage). */
+            if (official_helm_active())
+                return is_category_hidden(Category::Cloak);
             return is_category_hidden(Category::Helm) ||
                    is_category_hidden(Category::Cloak);
         }

--- a/CrimsonDesertEquipHide/src/categories.hpp
+++ b/CrimsonDesertEquipHide/src/categories.hpp
@@ -188,6 +188,12 @@ namespace EquipHide
         return CategoryMask{1} << static_cast<uint8_t>(cat);
     }
 
+    /** @brief Bitmask of categories managed by the game's built-in headgear visibility system. */
+    inline constexpr CategoryMask k_officialManagedMask =
+        category_bit(Category::Helm) |
+        category_bit(Category::Mask) |
+        category_bit(Category::Glasses);
+
     /**
      * @brief Classify a part hash into a bitmask of all categories it belongs to.
      * @return 0 if the hash is not tracked.

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -44,6 +44,9 @@ namespace EquipHide
         DMK::Config::register_bool("General", "IndependentToggle", "Independent Toggle", [](bool val)
                                    { flag_independent_toggle().store(val, std::memory_order_relaxed); }, false);
 
+        DMK::Config::register_bool("General", "DeferHeadgear", "Defer Headgear", [](bool val)
+                                   { flag_defer_headgear().store(val, std::memory_order_relaxed); }, true);
+
         DMK::Config::register_key_combo("General", "ShowAllHotkey", "Show All Hotkey", [](const DMK::Config::KeyComboList &combos)
                                         { set_show_all_combos(combos); }, "");
 
@@ -153,7 +156,12 @@ namespace EquipHide
         if (!needs_classification(partHash))
             return;
 
-        const auto mask = classify_part(partHash);
+        auto mask = classify_part(partHash);
+        if (mask == 0)
+            return;
+
+        if (official_helm_active())
+            mask &= ~k_officialManagedMask;
         if (mask == 0)
             return;
 
@@ -243,6 +251,9 @@ namespace EquipHide
             }
         }
 
+        /* Gate byte resolution is deferred until after load_config() reads the
+           DeferHeadgear flag. See the block after load_config() below. */
+
         if (!addrs.worldSystem || !addrs.childActorVtbl)
         {
             flag_fallback_mode().store(true, std::memory_order_relaxed);
@@ -276,6 +287,34 @@ namespace EquipHide
         }
 
         load_config();
+
+        if (flag_defer_headgear().load(std::memory_order_relaxed))
+        {
+            addrs.helmVisGate = resolve_address(
+                k_helmVisGateCandidates, std::size(k_helmVisGateCandidates),
+                "HelmVisGate");
+
+            if (addrs.helmVisGate)
+            {
+                auto gateValue = *reinterpret_cast<const uint8_t *>(addrs.helmVisGate);
+                if (gateValue != 0)
+                    logger.info("Official headgear visibility active (mode={}), "
+                                "yielding Helm/Glass/Mask to game",
+                                gateValue);
+                else
+                    logger.info("Official headgear visibility: ShowAlways "
+                                "— mod manages all categories");
+            }
+            else
+            {
+                logger.info("HelmVisGate not resolved — mod manages all categories");
+            }
+        }
+        else
+        {
+            logger.info("DeferHeadgear disabled — mod manages all categories");
+        }
+
         original_vis_map().reserve(get_part_map().size());
 
         std::vector<CompiledCandidate> compiledCandidates;

--- a/CrimsonDesertEquipHide/src/shared_state.cpp
+++ b/CrimsonDesertEquipHide/src/shared_state.cpp
@@ -14,6 +14,7 @@ namespace EquipHide
     static std::atomic<bool> s_glidingFix{true};
     static std::atomic<bool> s_fallbackMode{false};
     static std::atomic<bool> s_independentToggle{false};
+    static std::atomic<bool> s_deferHeadgear{true};
 
     static std::atomic<bool> s_shutdownRequested{false};
     static std::atomic<bool> s_deferredScanPending{false};
@@ -32,6 +33,7 @@ namespace EquipHide
     std::atomic<bool> &flag_gliding_fix() { return s_glidingFix; }
     std::atomic<bool> &flag_fallback_mode() { return s_fallbackMode; }
     std::atomic<bool> &flag_independent_toggle() { return s_independentToggle; }
+    std::atomic<bool> &flag_defer_headgear() { return s_deferHeadgear; }
 
     std::atomic<bool> &shutdown_requested() { return s_shutdownRequested; }
     std::atomic<bool> &deferred_scan_pending() { return s_deferredScanPending; }

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -20,6 +20,7 @@ namespace EquipHide
         uintptr_t mapLookup = 0;
         uintptr_t mapInsert = 0;
         uintptr_t indexedStringGlobal = 0;
+        uintptr_t helmVisGate = 0;
     };
 
     ResolvedAddresses &resolved_addrs();
@@ -51,6 +52,7 @@ namespace EquipHide
     std::atomic<bool> &flag_gliding_fix();
     std::atomic<bool> &flag_fallback_mode();
     std::atomic<bool> &flag_independent_toggle();
+    std::atomic<bool> &flag_defer_headgear();
 
     // --- Background thread control ---
     std::atomic<bool> &shutdown_requested();
@@ -74,6 +76,21 @@ namespace EquipHide
         return (addr > 0x10000) ? addr : 0;
     }
 
+    /**
+     * @brief Returns true if the game's built-in headgear visibility is active
+     *        AND the mod is configured to defer to it.
+     * @details Flag check first (relaxed atomic, same cache line as other flags)
+     *          to skip the gate byte read entirely when disabled.
+     */
+    inline bool official_helm_active() noexcept
+    {
+        if (!flag_defer_headgear().load(std::memory_order_relaxed))
+            return false;
+        auto addr = resolved_addrs().helmVisGate;
+        return addr != 0 &&
+               *reinterpret_cast<const volatile uint8_t *>(addr) != 0;
+    }
+
     /** @brief Returns true if the part at the given hash pointer is hidden by any category. */
     inline bool check_part_hidden(uint64_t partHashPtr)
     {
@@ -83,6 +100,10 @@ namespace EquipHide
         if (!needs_classification(partHash))
             return false;
         auto mask = classify_part(partHash);
+        if (mask == 0)
+            return false;
+        if (official_helm_active())
+            mask &= ~k_officialManagedMask;
         return mask != 0 && is_any_category_hidden(mask);
     }
 

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -42,7 +42,9 @@ namespace EquipHide
                     continue;
                 auto mapBase = descNode + 0x20;
 
-                for (const auto &[hash, mask] : get_part_map())
+                const bool officialActive = official_helm_active();
+
+                for (const auto &[hash, rawMask] : get_part_map())
                 {
                     auto entry = lookup(mapBase, &hash);
                     if (!entry)
@@ -51,7 +53,24 @@ namespace EquipHide
                     const auto visAddr = entry + 0x1C;
                     auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
 
-                    if (is_any_category_hidden(mask))
+                    auto effectiveMask = rawMask;
+                    if (officialActive)
+                        effectiveMask &= ~k_officialManagedMask;
+
+                    if (effectiveMask == 0)
+                    {
+                        auto it = origVis.find(visAddr);
+                        if (it != origVis.end())
+                        {
+                            const auto restored = (it->second == 2) ? 0 : it->second;
+                            *visPtr = static_cast<uint8_t>(restored);
+                            origVis.erase(it);
+                            ++restoredCount;
+                        }
+                        continue;
+                    }
+
+                    if (is_any_category_hidden(effectiveMask))
                     {
                         if (origVis.find(visAddr) == origVis.end())
                             origVis[visAddr] = *visPtr;


### PR DESCRIPTION
## Summary

- Auto-detect the game's built-in headgear visibility gate byte (v1.02.00+) via AOB scan at startup
- When the official system is active (mode != ShowAlways), yield Helm/Mask/Glasses to avoid vis-byte write conflicts on the shared `PartInOutSocket entry+0x1C`
- New `DeferHeadgear` INI option (default: `true`). When `false`, AOB scan is skipped entirely and the mod manages all categories unconditionally
- BaldFix defers to the game's own hair handling when headgear is officially managed

## Details

Both the mod and the game's official headgear visibility system write to the same byte (`entry+0x1C`). The official system is event-driven (fires on equip change, combat transition, cutscene entry) and only covers Helm, Mask, and Glasses. Without this change, the two systems fight over the vis byte, causing flickering on state transitions.

The implementation adds a single relaxed atomic bool check + volatile byte read to the hot path. Negligible cost compared to the mid-hook overhead itself. When `DeferHeadgear=false`, only the atomic flag load executes (immediate early-out).

## Files changed (12)

**Code (8):** `categories.hpp`, `shared_state.hpp/.cpp`, `aob_resolver.hpp`, `equip_hide.cpp`, `visibility_write.cpp`, `armor_injection.cpp`, `bald_fix.cpp`
**Docs (4):** `README.md`, `nexus-bbcode.txt`, `NEXT_CHANGELOG.md`, `CrimsonDesertEquipHide.ini`

## Test plan

- [ ] Launch with `DeferHeadgear = true` (default) and in-game headgear set to "Show Always". Mod controls Helm/Mask/Glasses normally
- [ ] Change in-game setting to "Hide Always". Mod yields head slots, body/cloak/weapons still work
- [ ] Launch with `DeferHeadgear = false`. Mod controls all categories regardless of game setting
- [ ] Verify BaldFix still works for Cloak hiding when official headgear is active
- [ ] Verify log output reports correct mode at startup