### PR TITLE
fix(equip-hide): rework baldfix with per-call priority bitmask override

### DIFF
--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -185,7 +185,7 @@ ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 2. **Mid-Hook** - Intercepts the visibility check and forces `Visible=2` (Out-only) for hidden weapon categories
 3. **Inline Hook** - When GlidingFix is enabled, a secondary hook on the PartAddShow function prevents hidden parts from briefly flashing visible during state transitions (e.g. exiting glide)
 4. **Armor Injection** - Armor parts have no vanilla visibility entries, so the mod injects new map entries via the game's own internal functions
-5. **[Experimental] BaldFix Hook** - Hooks the postfix rule evaluator to suppress hair-hiding rules when Helm or Cloak is hidden, keeping hair visible at runtime without PAZ patching. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
+5. **[Experimental] BaldFix Hook** - Hooks the postfix rule evaluator and temporarily sets a priority bitmask override on equipped items per-call, making hair-hiding rules see them as inactive so hair stays visible. Only applies to the player context; NPCs are unaffected. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 6. **Input Management** - DetourModKit's input system handles keyboard, mouse, and gamepad with modifier key combos
 7. **SEH Protection** - Hook callback is wrapped in structured exception handling (MSVC) to prevent crashes
 

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -14,7 +14,7 @@
 - User Presets: 10 custom part groups with independent visibility control (overrides built-in categories)
 - Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
 - IndependentToggle mode: categories sharing a hotkey flip their own state individually, preserving mixed visible/hidden configurations
-- [Experimental] BaldFix: runtime hair-visibility fix when helmet/cloak is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
+- BaldFix: runtime hair-visibility fix when helmet/cloak is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 - GlidingFix: prevents hidden equipment from briefly flashing visible during state transitions (e.g. exiting gliding, cutscene transitions)
 - ForceShow mode for compatibility with mods that alter default equipment visibility via PAZ patching (e.g. character replacers, armor replacers, transmog mods)
 - Hot-reload cleanup: visibility bytes restored on DLL unload
@@ -101,7 +101,7 @@ PlayerOnly = true
 ; toggling equipment back to visible still works.
 ; Safe to leave false if you are not using such mods.
 ForceShow = false
-; [Experimental] Prevents baldness when hiding helmets/cloaks
+; Prevents baldness when hiding helmets/cloaks
 ; Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 BaldFix = true
 ; Prevents hidden equipment from briefly flashing during state transitions
@@ -185,7 +185,7 @@ ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 2. **Mid-Hook** - Intercepts the visibility check and forces `Visible=2` (Out-only) for hidden weapon categories
 3. **Inline Hook** - When GlidingFix is enabled, a secondary hook on the PartAddShow function prevents hidden parts from briefly flashing visible during state transitions (e.g. exiting glide)
 4. **Armor Injection** - Armor parts have no vanilla visibility entries, so the mod injects new map entries via the game's own internal functions
-5. **[Experimental] BaldFix Hook** - Hooks the postfix rule evaluator and temporarily sets a priority bitmask override on equipped items per-call, making hair-hiding rules see them as inactive so hair stays visible. Only applies to the player context; NPCs are unaffected. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
+5. **BaldFix Hook** - Hooks the postfix rule evaluator and temporarily sets a priority bitmask override on equipped items per-call, making hair-hiding rules see them as inactive so hair stays visible. Only applies to the player context; NPCs are unaffected. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 6. **Input Management** - DetourModKit's input system handles keyboard, mouse, and gamepad with modifier key combos
 7. **SEH Protection** - Hook callback is wrapped in structured exception handling (MSVC) to prevent crashes
 

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -14,7 +14,7 @@
 - User Presets: 10 custom part groups with independent visibility control (overrides built-in categories)
 - Per-category configuration: enable/disable, toggle/show/hide hotkeys, default hidden state, part list
 - IndependentToggle mode: categories sharing a hotkey flip their own state individually, preserving mixed visible/hidden configurations
-- BaldFix: runtime hair-visibility fix when helmet/cloak is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
+- BaldFix: runtime hair-visibility fix when helmet/cloak/mask is hidden — no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the headgear (show then hide) restores it
 - GlidingFix: prevents hidden equipment from briefly flashing visible during state transitions (e.g. exiting gliding, cutscene transitions)
 - ForceShow mode for compatibility with mods that alter default equipment visibility via PAZ patching (e.g. character replacers, armor replacers, transmog mods)
 - Hot-reload cleanup: visibility bytes restored on DLL unload
@@ -101,7 +101,7 @@ PlayerOnly = true
 ; toggling equipment back to visible still works.
 ; Safe to leave false if you are not using such mods.
 ForceShow = false
-; Prevents baldness when hiding helmets/cloaks
+; Prevents baldness when hiding helmets/cloaks/masks
 ; Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 BaldFix = true
 ; Prevents hidden equipment from briefly flashing during state transitions
@@ -185,7 +185,7 @@ ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 2. **Mid-Hook** - Intercepts the visibility check and forces `Visible=2` (Out-only) for hidden weapon categories
 3. **Inline Hook** - When GlidingFix is enabled, a secondary hook on the PartAddShow function prevents hidden parts from briefly flashing visible during state transitions (e.g. exiting glide)
 4. **Armor Injection** - Armor parts have no vanilla visibility entries, so the mod injects new map entries via the game's own internal functions
-5. **BaldFix Hook** - Hooks the postfix rule evaluator and temporarily sets a priority bitmask override on equipped items per-call, making hair-hiding rules see them as inactive so hair stays visible. Only applies to the player context; NPCs are unaffected. Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
+5. **BaldFix Hook** - Hooks the postfix rule evaluator and temporarily sets a priority bitmask override on equipped items per-call, making hair-hiding rules see them as inactive so hair stays visible. Only applies to the player context; NPCs are unaffected. Hair/beard may occasionally disappear; re-toggling the headgear (show then hide) restores it
 6. **Input Management** - DetourModKit's input system handles keyboard, mouse, and gamepad with modifier key combos
 7. **SEH Protection** - Hook callback is wrapped in structured exception handling (MSVC) to prevent crashes
 

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -48,7 +48,7 @@ PlayerOnly = true
 ; visible still works.
 ; Safe to leave false if you are not using such mods.
 ForceShow = false
-; [Experimental] Prevents baldness when hiding helmets/cloaks.
+; Prevents baldness when hiding helmets/cloaks.
 ; The game normally hides hair when a helmet is equipped — this fix keeps
 ; hair visible when the mod hides the helmet mesh.
 ; Note: Hair/beard may occasionally disappear; re-toggling the helmet

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -48,7 +48,7 @@ PlayerOnly = true
 ; visible still works.
 ; Safe to leave false if you are not using such mods.
 ForceShow = false
-; Prevents baldness when hiding helmets/cloaks.
+; Prevents baldness when hiding helmets/cloaks/masks.
 ; The game normally hides hair when a helmet is equipped — this fix keeps
 ; hair visible when the mod hides the helmet mesh.
 ; Note: Hair/beard may occasionally disappear; re-toggling the helmet

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
-## Internal Improvements
+## Improvements
 
-- BaldFix now correctly respects the `PlayerOnly` setting; when enabled, hair-hiding suppression only applies to the player character and does not affect NPCs
+- BaldFix reworked: now uses a per-call priority bitmask override instead of permanent state changes, hair-hiding rules are suppressed only for the player context when Helm or Cloak is hidden, eliminating NPC hair clipping entirely
 - Improved performance when toggling equipment visibility
 - Reorganized internal code for easier maintenance and future updates
 - Adopted newer DetourModKit APIs for faster and more reliable pattern scanning

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Improvements
 
-- BaldFix reworked: now uses a per-call priority bitmask override instead of permanent state changes, hair-hiding rules are suppressed only for the player context when Helm or Cloak is hidden, eliminating NPC hair clipping entirely
+- BaldFix reworked: now uses a per-call priority bitmask override instead of permanent state changes, hair-hiding rules are suppressed only for the player context when Helm, Cloak, or Mask is hidden, eliminating NPC hair clipping entirely
 - Improved performance when toggling equipment visibility
 - Reorganized internal code for easier maintenance and future updates
 - Adopted newer DetourModKit APIs for faster and more reliable pattern scanning

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Internal Improvements
 
+- BaldFix now correctly respects the `PlayerOnly` setting; when enabled, hair-hiding suppression only applies to the player character and does not affect NPCs
 - Improved performance when toggling equipment visibility
 - Reorganized internal code for easier maintenance and future updates
 - Adopted newer DetourModKit APIs for faster and more reliable pattern scanning

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -86,7 +86,7 @@ PlayerOnly = true
 ; toggling equipment back to visible still works.
 ; Safe to leave false if you are not using such mods.
 ForceShow = false
-; [Experimental] Prevents baldness when hiding helmets/cloaks
+; Prevents baldness when hiding helmets/cloaks
 ; Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 BaldFix = true
 ; Prevents hidden equipment from briefly flashing during state transitions

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -86,7 +86,7 @@ PlayerOnly = true
 ; toggling equipment back to visible still works.
 ; Safe to leave false if you are not using such mods.
 ForceShow = false
-; Prevents baldness when hiding helmets/cloaks
+; Prevents baldness when hiding helmets/cloaks/masks
 ; Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 BaldFix = true
 ; Prevents hidden equipment from briefly flashing during state transitions

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -179,25 +179,5 @@ namespace EquipHide
          ResolveMode::Direct, -0x6F, 0},
     };
 
-    /**
-     * @brief AOB candidates for sub_1425F0580 — per-actor ConditionalPartPrefab
-     *        context creator / evaluator.
-     *
-     * Called once per actor during postfix rule evaluation.  Stores the actor
-     * descriptor at a1+8 (from *a2) and dispatches condition evaluation,
-     * which eventually calls PostfixEval.  Hooked to set a thread-local
-     * player flag so PostfixEval can discriminate player from NPC.
-     */
-    inline constexpr AddrCandidate k_postfixCtxCreateCandidates[] = {
-        {"PCC_P1_Prologue",
-         "48 89 5C 24 10 48 89 6C 24 18 48 89 74 24 20 48 89 4C 24 08 "
-         "57 41 54 41 55 41 56 41 57 48 83 EC 40 4D 8B F9 45 0F B6 E8",
-         ResolveMode::Direct, 0, 0},
-
-        {"PCC_P2_InnerPrologue",
-         "48 89 4C 24 08 57 41 54 41 55 41 56 41 57 48 83 EC 40 4D 8B F9 "
-         "45 0F B6 E8",
-         ResolveMode::Direct, -0x0F, 0},
-    };
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -179,4 +179,25 @@ namespace EquipHide
          ResolveMode::Direct, -0x6F, 0},
     };
 
+    /**
+     * @brief AOB candidates for sub_1425F0580 — per-actor ConditionalPartPrefab
+     *        context creator / evaluator.
+     *
+     * Called once per actor during postfix rule evaluation.  Stores the actor
+     * descriptor at a1+8 (from *a2) and dispatches condition evaluation,
+     * which eventually calls PostfixEval.  Hooked to set a thread-local
+     * player flag so PostfixEval can discriminate player from NPC.
+     */
+    inline constexpr AddrCandidate k_postfixCtxCreateCandidates[] = {
+        {"PCC_P1_Prologue",
+         "48 89 5C 24 10 48 89 6C 24 18 48 89 74 24 20 48 89 4C 24 08 "
+         "57 41 54 41 55 41 56 41 57 48 83 EC 40 4D 8B F9 45 0F B6 E8",
+         ResolveMode::Direct, 0, 0},
+
+        {"PCC_P2_InnerPrologue",
+         "48 89 4C 24 08 57 41 54 41 55 41 56 41 57 48 83 EC 40 4D 8B F9 "
+         "45 0F B6 E8",
+         ResolveMode::Direct, -0x0F, 0},
+    };
+
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -17,19 +17,19 @@ namespace EquipHide
     /**
      * @brief Hair-hiding suffix check.
      *
-     * ruleObj + 0x18 is a string handle (char**). Double-deref to get char*.
-     * Hair-hiding suffixes: _a, _c, _d, _f, _i, _q, _v
+     * ruleObj+0x18 is a string handle (char**); double-deref for char*.
+     * Hair-hiding suffixes: _a _c _d _f _i _q _v
      */
-    static bool is_hair_hiding_rule(__int64 ruleObj)
+    static bool is_hair_hiding_rule(__int64 ruleObj) noexcept
     {
-        auto handleAddr = *reinterpret_cast<uintptr_t *>(ruleObj + 0x18);
+        auto handleAddr = *reinterpret_cast<const uintptr_t *>(ruleObj + 0x18);
         if (handleAddr < 0x10000)
             return false;
-        auto suffixAddr = *reinterpret_cast<uintptr_t *>(handleAddr);
+        auto suffixAddr = *reinterpret_cast<const uintptr_t *>(handleAddr);
         if (suffixAddr < 0x10000)
             return false;
-        const auto *suffix = reinterpret_cast<const char *>(suffixAddr);
 
+        const auto *suffix = reinterpret_cast<const char *>(suffixAddr);
         if (suffix[0] != '_' || suffix[2] != '\0')
             return false;
 
@@ -48,32 +48,57 @@ namespace EquipHide
         }
     }
 
-    static bool should_suppress_hair_hiding(__int64 ruleObj) noexcept
+    /* Player contexts have a populated owner pointer at +0x50 and non-zero
+       item count at +0x60.  NPC contexts are empty (null owner, zero items)
+       so PostfixEval returns 0 for them regardless, but we guard explicitly
+       to avoid suppressing rules for contexts we did not originate. */
+    static bool is_player_context(__int64 context) noexcept
     {
-        __try
-        {
-            if (!is_hair_hiding_rule(ruleObj))
-                return false;
-            return is_category_hidden(Category::Helm) ||
-                   is_category_hidden(Category::Cloak);
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
+        auto ctx = static_cast<uintptr_t>(context);
+        if (*reinterpret_cast<const uintptr_t *>(ctx + 0x50) == 0)
             return false;
-        }
+        if (*reinterpret_cast<const uint32_t *>(ctx + 0x60) == 0)
+            return false;
+        return true;
+    }
+
+    static bool should_suppress_hair_hiding(__int64 ruleObj,
+                                            __int64 context) noexcept
+    {
+        if (!is_hair_hiding_rule(ruleObj))
+            return false;
+
+        if (!is_category_hidden(Category::Helm) &&
+            !is_category_hidden(Category::Cloak))
+            return false;
+
+        /* When PlayerOnly is enabled, only suppress for player contexts.
+           When disabled, suppress for all contexts (player + NPC). */
+        if (flag_player_only().load(std::memory_order_relaxed) &&
+            !is_player_context(context))
+            return false;
+
+        return true;
     }
 
     __int64 __fastcall on_postfix_eval(__int64 ruleObj, __int64 context)
     {
-        if (flag_bald_fix().load(std::memory_order_relaxed) &&
-            should_suppress_hair_hiding(ruleObj))
+        if (flag_bald_fix().load(std::memory_order_relaxed))
         {
-            static std::atomic<bool> s_loggedBaldFix{false};
-            if (!s_loggedBaldFix.exchange(true, std::memory_order_relaxed))
-                DMK::Logger::get_instance().debug(
-                    "BaldFix: suppressed hair-hiding rule (suffix at ruleObj 0x{:X})",
-                    ruleObj);
-            return 0;
+            __try
+            {
+                if (should_suppress_hair_hiding(ruleObj, context))
+                {
+                    static std::atomic<bool> s_logged{false};
+                    if (!s_logged.exchange(true, std::memory_order_relaxed))
+                        DMK::Logger::get_instance().debug(
+                            "BaldFix: suppressed hair-hiding rule");
+                    return 0;
+                }
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+            }
         }
         return s_originalPostfixEval(ruleObj, context);
     }

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -76,7 +76,13 @@ namespace EquipHide
            When disabled, suppress for all contexts (player + NPC). */
         if (flag_player_only().load(std::memory_order_relaxed) &&
             !is_player_context(context))
+        {
+            static std::atomic<bool> s_loggedSkip{false};
+            if (!s_loggedSkip.exchange(true, std::memory_order_relaxed))
+                DMK::Logger::get_instance().trace(
+                    "BaldFix: skipped NPC context 0x{:X}", context);
             return false;
+        }
 
         return true;
     }

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -8,11 +8,122 @@
 namespace EquipHide
 {
     static PostfixEvalFn s_originalPostfixEval = nullptr;
+    static PostfixCtxCreateFn s_originalCtxCreate = nullptr;
+
+    /* NPC guard flag.  The PostfixEval context is a shared object reused
+       for every actor — it contains the player's equipment but no actor
+       identity.  The context-create wrapper (sub_1425F0580) positively
+       identifies NPC evaluations and sets this flag.
+       Default is false (not NPC) so PostfixEval suppresses hair-hiding
+       unless we know it's an NPC — safe fallback for code paths that
+       don't go through the context-create wrapper (e.g. equip events). */
+    static thread_local bool t_isNpcEval = false;
+    static DWORD s_mainThreadId = 0;
+
+    /* Player descriptor cache.  Main-thread evaluations are always player;
+       we cache their *a2 descriptor so we can recognize the same player
+       on worker threads (e.g. equip events fire asynchronously). */
+    static constexpr int k_maxCachedDescs = 4;
+    static std::atomic<uintptr_t> s_playerDescs[k_maxCachedDescs]{};
+    static std::atomic<int> s_playerDescCount{0};
 
     void set_postfix_eval_trampoline(PostfixEvalFn original)
     {
         s_originalPostfixEval = original;
     }
+
+    void set_postfix_ctx_create_trampoline(PostfixCtxCreateFn original)
+    {
+        s_originalCtxCreate = original;
+    }
+
+    void set_baldfix_main_thread_id(DWORD id)
+    {
+        s_mainThreadId = id;
+    }
+
+    // ── Context-create hook ─────────────────────────────────────────────
+
+    /* sub_1425F0580 is called once per actor during ConditionalPartPrefab
+       evaluation.  Player evaluations always run on the main game thread;
+       NPC evaluations run on worker threads.  The a2 descriptor is NOT an
+       actor object — its pointer chain doesn't reach the player type byte.
+       Thread identity is the only reliable discriminator available here. */
+
+    static bool is_cached_player_desc(uintptr_t desc) noexcept
+    {
+        const int n = s_playerDescCount.load(std::memory_order_relaxed);
+        for (int i = 0; i < n; ++i)
+        {
+            if (s_playerDescs[i].load(std::memory_order_relaxed) == desc)
+                return true;
+        }
+        return false;
+    }
+
+    static void cache_player_desc(uintptr_t desc) noexcept
+    {
+        if (is_cached_player_desc(desc))
+            return;
+        int n = s_playerDescCount.load(std::memory_order_relaxed);
+        if (n < k_maxCachedDescs)
+        {
+            s_playerDescs[n].store(desc, std::memory_order_relaxed);
+            s_playerDescCount.store(n + 1, std::memory_order_relaxed);
+        }
+    }
+
+    __int64 __fastcall on_postfix_ctx_create(__int64 a1, __int64 *a2,
+                                             char a3, __int64 *a4,
+                                             __int64 *a5)
+    {
+        bool wasNpc = t_isNpcEval;
+
+        uintptr_t desc = 0;
+        __try { desc = *reinterpret_cast<const uintptr_t *>(a2); }
+        __except (EXCEPTION_EXECUTE_HANDLER) {}
+
+        if (GetCurrentThreadId() == s_mainThreadId)
+        {
+            /* Main thread is always the player.  Cache the descriptor
+               so we recognize it on worker threads (equip events). */
+            t_isNpcEval = false;
+            if (desc)
+                cache_player_desc(desc);
+
+            static std::atomic<bool> s_loggedPlayer{false};
+            if (!s_loggedPlayer.exchange(true, std::memory_order_relaxed))
+                DMK::Logger::get_instance().trace(
+                    "BaldFix: player eval on main thread (desc 0x{:X})", desc);
+        }
+        else if (desc && is_cached_player_desc(desc))
+        {
+            /* Worker thread but descriptor matches a cached player. */
+            t_isNpcEval = false;
+
+            static std::atomic<bool> s_loggedWorkerPlayer{false};
+            if (!s_loggedWorkerPlayer.exchange(true, std::memory_order_relaxed))
+                DMK::Logger::get_instance().trace(
+                    "BaldFix: player eval on worker thread (cached desc 0x{:X})", desc);
+        }
+        else
+        {
+            /* Worker thread, unknown descriptor — NPC. */
+            t_isNpcEval = true;
+
+            static std::atomic<bool> s_loggedNpc{false};
+            if (!s_loggedNpc.exchange(true, std::memory_order_relaxed))
+                DMK::Logger::get_instance().trace(
+                    "BaldFix: NPC eval on worker thread (desc 0x{:X})", desc);
+        }
+
+        auto result = s_originalCtxCreate(a1, a2, a3, a4, a5);
+
+        t_isNpcEval = wasNpc;
+        return result;
+    }
+
+    // ── PostfixEval hook ────────────────────────────────────────────────
 
     /**
      * @brief Hair-hiding suffix check.
@@ -48,22 +159,7 @@ namespace EquipHide
         }
     }
 
-    /* Player contexts have a populated owner pointer at +0x50 and non-zero
-       item count at +0x60.  NPC contexts are empty (null owner, zero items)
-       so PostfixEval returns 0 for them regardless, but we guard explicitly
-       to avoid suppressing rules for contexts we did not originate. */
-    static bool is_player_context(__int64 context) noexcept
-    {
-        auto ctx = static_cast<uintptr_t>(context);
-        if (*reinterpret_cast<const uintptr_t *>(ctx + 0x50) == 0)
-            return false;
-        if (*reinterpret_cast<const uint32_t *>(ctx + 0x60) == 0)
-            return false;
-        return true;
-    }
-
-    static bool should_suppress_hair_hiding(__int64 ruleObj,
-                                            __int64 context) noexcept
+    static bool should_suppress_hair_hiding(__int64 ruleObj) noexcept
     {
         if (!is_hair_hiding_rule(ruleObj))
             return false;
@@ -72,15 +168,18 @@ namespace EquipHide
             !is_category_hidden(Category::Cloak))
             return false;
 
-        /* When PlayerOnly is enabled, only suppress for player contexts.
-           When disabled, suppress for all contexts (player + NPC). */
+        /* When PlayerOnly is enabled, skip if positively identified as NPC.
+           The TLS flag is set by the context-create wrapper when the
+           evaluation runs on a worker thread (NPC). Default is false
+           (not NPC) so equip events and other main-thread paths suppress
+           correctly without going through context-create. */
         if (flag_player_only().load(std::memory_order_relaxed) &&
-            !is_player_context(context))
+            t_isNpcEval)
         {
             static std::atomic<bool> s_loggedSkip{false};
             if (!s_loggedSkip.exchange(true, std::memory_order_relaxed))
                 DMK::Logger::get_instance().trace(
-                    "BaldFix: skipped NPC context 0x{:X}", context);
+                    "BaldFix: skipped NPC evaluation");
             return false;
         }
 
@@ -93,7 +192,7 @@ namespace EquipHide
         {
             __try
             {
-                if (should_suppress_hair_hiding(ruleObj, context))
+                if (should_suppress_hair_hiding(ruleObj))
                 {
                     static std::atomic<bool> s_logged{false};
                     if (!s_logged.exchange(true, std::memory_order_relaxed))

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -5,132 +5,31 @@
 
 #include <Windows.h>
 
+#include <cstdint>
+
 namespace EquipHide
 {
     static PostfixEvalFn s_originalPostfixEval = nullptr;
-    static PostfixCtxCreateFn s_originalCtxCreate = nullptr;
-
-    /* NPC guard flag.  The PostfixEval context is a shared object reused
-       for every actor — it contains the player's equipment but no actor
-       identity.  The context-create wrapper (sub_1425F0580) positively
-       identifies NPC evaluations and sets this flag.
-       Default is false (not NPC) so PostfixEval suppresses hair-hiding
-       unless we know it's an NPC — safe fallback for code paths that
-       don't go through the context-create wrapper (e.g. equip events). */
-    static thread_local bool t_isNpcEval = false;
-    static DWORD s_mainThreadId = 0;
-
-    /* Player descriptor cache.  Main-thread evaluations are always player;
-       we cache their *a2 descriptor so we can recognize the same player
-       on worker threads (e.g. equip events fire asynchronously). */
-    static constexpr int k_maxCachedDescs = 4;
-    static std::atomic<uintptr_t> s_playerDescs[k_maxCachedDescs]{};
-    static std::atomic<int> s_playerDescCount{0};
+    static std::atomic<uintptr_t> s_cachedContext{0};
 
     void set_postfix_eval_trampoline(PostfixEvalFn original)
     {
         s_originalPostfixEval = original;
     }
 
-    void set_postfix_ctx_create_trampoline(PostfixCtxCreateFn original)
-    {
-        s_originalCtxCreate = original;
-    }
+    // Priority bitmask layout (item+0x70, DWORD):
+    //   bits 16-22: "priority level exists"
+    //   bits  0-6:  "priority level active"
+    //
+    // Bit 19 = priority 3 exists.  Without bit 3 (active), PostfixEval
+    // sees priority 3 as highest but inactive -> rule doesn't match ->
+    // hair stays visible.  Official HideAlways does the same:
+    // 0x00010001 -> 0x00090001.
 
-    void set_baldfix_main_thread_id(DWORD id)
-    {
-        s_mainThreadId = id;
-    }
+    static constexpr uint32_t k_priorityBit = 0x00080000u; // bit 19
+    static constexpr uint32_t k_activeBit   = 0x00000008u; // bit 3
+    static constexpr int      k_maxItems    = 128;
 
-    // ── Context-create hook ─────────────────────────────────────────────
-
-    /* sub_1425F0580 is called once per actor during ConditionalPartPrefab
-       evaluation.  Player evaluations always run on the main game thread;
-       NPC evaluations run on worker threads.  The a2 descriptor is NOT an
-       actor object — its pointer chain doesn't reach the player type byte.
-       Thread identity is the only reliable discriminator available here. */
-
-    static bool is_cached_player_desc(uintptr_t desc) noexcept
-    {
-        const int n = s_playerDescCount.load(std::memory_order_relaxed);
-        for (int i = 0; i < n; ++i)
-        {
-            if (s_playerDescs[i].load(std::memory_order_relaxed) == desc)
-                return true;
-        }
-        return false;
-    }
-
-    static void cache_player_desc(uintptr_t desc) noexcept
-    {
-        if (is_cached_player_desc(desc))
-            return;
-        int n = s_playerDescCount.load(std::memory_order_relaxed);
-        if (n < k_maxCachedDescs)
-        {
-            s_playerDescs[n].store(desc, std::memory_order_relaxed);
-            s_playerDescCount.store(n + 1, std::memory_order_relaxed);
-        }
-    }
-
-    __int64 __fastcall on_postfix_ctx_create(__int64 a1, __int64 *a2,
-                                             char a3, __int64 *a4,
-                                             __int64 *a5)
-    {
-        bool wasNpc = t_isNpcEval;
-
-        uintptr_t desc = 0;
-        __try { desc = *reinterpret_cast<const uintptr_t *>(a2); }
-        __except (EXCEPTION_EXECUTE_HANDLER) {}
-
-        if (GetCurrentThreadId() == s_mainThreadId)
-        {
-            /* Main thread is always the player.  Cache the descriptor
-               so we recognize it on worker threads (equip events). */
-            t_isNpcEval = false;
-            if (desc)
-                cache_player_desc(desc);
-
-            static std::atomic<bool> s_loggedPlayer{false};
-            if (!s_loggedPlayer.exchange(true, std::memory_order_relaxed))
-                DMK::Logger::get_instance().trace(
-                    "BaldFix: player eval on main thread (desc 0x{:X})", desc);
-        }
-        else if (desc && is_cached_player_desc(desc))
-        {
-            /* Worker thread but descriptor matches a cached player. */
-            t_isNpcEval = false;
-
-            static std::atomic<bool> s_loggedWorkerPlayer{false};
-            if (!s_loggedWorkerPlayer.exchange(true, std::memory_order_relaxed))
-                DMK::Logger::get_instance().trace(
-                    "BaldFix: player eval on worker thread (cached desc 0x{:X})", desc);
-        }
-        else
-        {
-            /* Worker thread, unknown descriptor — NPC. */
-            t_isNpcEval = true;
-
-            static std::atomic<bool> s_loggedNpc{false};
-            if (!s_loggedNpc.exchange(true, std::memory_order_relaxed))
-                DMK::Logger::get_instance().trace(
-                    "BaldFix: NPC eval on worker thread (desc 0x{:X})", desc);
-        }
-
-        auto result = s_originalCtxCreate(a1, a2, a3, a4, a5);
-
-        t_isNpcEval = wasNpc;
-        return result;
-    }
-
-    // ── PostfixEval hook ────────────────────────────────────────────────
-
-    /**
-     * @brief Hair-hiding suffix check.
-     *
-     * ruleObj+0x18 is a string handle (char**); double-deref for char*.
-     * Hair-hiding suffixes: _a _c _d _f _i _q _v
-     */
     static bool is_hair_hiding_rule(__int64 ruleObj) noexcept
     {
         auto handleAddr = *reinterpret_cast<const uintptr_t *>(ruleObj + 0x18);
@@ -159,31 +58,50 @@ namespace EquipHide
         }
     }
 
-    static bool should_suppress_hair_hiding(__int64 ruleObj) noexcept
+    /* Temporarily set bit 19 on active items for one PostfixEval call,
+       then restore.  Only called for hair-hiding rules on the player
+       context, so other rules and NPC contexts are unaffected. */
+    static __int64 eval_with_priority_override(
+        __int64 ruleObj, __int64 context) noexcept
     {
-        if (!is_hair_hiding_rule(ruleObj))
-            return false;
+        auto itemsPtr = *reinterpret_cast<uintptr_t *>(context + 0x58);
+        auto itemCount = *reinterpret_cast<uint32_t *>(context + 0x60);
 
-        if (!is_category_hidden(Category::Helm) &&
-            !is_category_hidden(Category::Cloak))
-            return false;
+        if (itemsPtr < 0x10000 || itemCount == 0 || itemCount > k_maxItems)
+            return s_originalPostfixEval(ruleObj, context);
 
-        /* When PlayerOnly is enabled, skip if positively identified as NPC.
-           The TLS flag is set by the context-create wrapper when the
-           evaluation runs on a worker thread (NPC). Default is false
-           (not NPC) so equip events and other main-thread paths suppress
-           correctly without going through context-create. */
-        if (flag_player_only().load(std::memory_order_relaxed) &&
-            t_isNpcEval)
+        uintptr_t patchedItems[k_maxItems];
+        uint32_t  originalValues[k_maxItems];
+        int       patchCount = 0;
+
+        auto *itemArray = reinterpret_cast<uintptr_t *>(itemsPtr);
+
+        for (uint32_t i = 0; i < itemCount; ++i)
         {
-            static std::atomic<bool> s_loggedSkip{false};
-            if (!s_loggedSkip.exchange(true, std::memory_order_relaxed))
-                DMK::Logger::get_instance().trace(
-                    "BaldFix: skipped NPC evaluation");
-            return false;
+            auto item = itemArray[i];
+            if (item < 0x10000)
+                continue;
+            if (*reinterpret_cast<uint8_t *>(item + 0x88) == 0)
+                continue;
+
+            auto *bm = reinterpret_cast<uint32_t *>(item + 0x70);
+            uint32_t val = *bm;
+
+            if (val & k_priorityBit)
+                continue;
+
+            *bm = (val | k_priorityBit) & ~k_activeBit;
+            patchedItems[patchCount] = item;
+            originalValues[patchCount] = val;
+            ++patchCount;
         }
 
-        return true;
+        __int64 result = s_originalPostfixEval(ruleObj, context);
+
+        for (int i = 0; i < patchCount; ++i)
+            *reinterpret_cast<uint32_t *>(patchedItems[i] + 0x70) = originalValues[i];
+
+        return result;
     }
 
     __int64 __fastcall on_postfix_eval(__int64 ruleObj, __int64 context)
@@ -192,13 +110,35 @@ namespace EquipHide
         {
             __try
             {
-                if (should_suppress_hair_hiding(ruleObj))
+                auto ctx = static_cast<uintptr_t>(context);
+
+                /* Cache the player context on first populated call. */
+                if (s_cachedContext.load(std::memory_order_relaxed) == 0 &&
+                    ctx > 0x10000)
+                {
+                    auto cnt = *reinterpret_cast<const uint32_t *>(ctx + 0x60);
+                    if (cnt > 0)
+                    {
+                        s_cachedContext.store(ctx, std::memory_order_relaxed);
+                        DMK::Logger::get_instance().debug(
+                            "BaldFix: cached context 0x{:X} ({} items)",
+                            ctx, cnt);
+                    }
+                }
+
+                /* Only override for the player context + hair-hiding rules
+                   + helm/cloak hidden.  NPC contexts have different addresses
+                   and are never matched. */
+                if (ctx == s_cachedContext.load(std::memory_order_relaxed) &&
+                    is_hair_hiding_rule(ruleObj) &&
+                    (is_category_hidden(Category::Helm) ||
+                     is_category_hidden(Category::Cloak)))
                 {
                     static std::atomic<bool> s_logged{false};
                     if (!s_logged.exchange(true, std::memory_order_relaxed))
                         DMK::Logger::get_instance().debug(
-                            "BaldFix: suppressed hair-hiding rule");
-                    return 0;
+                            "BaldFix: priority override active");
+                    return eval_with_priority_override(ruleObj, context);
                 }
             }
             __except (EXCEPTION_EXECUTE_HANDLER)

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -58,9 +58,24 @@ namespace EquipHide
         }
     }
 
-    /* Temporarily set bit 19 on active items for one PostfixEval call,
-       then restore.  Only called for hair-hiding rules on the player
-       context, so other rules and NPC contexts are unaffected. */
+    /* Build a bitmask of hidden head-covering categories for per-item
+       filtering.  Only items belonging to a hidden category get the
+       priority override — items for shown categories keep their original
+       bitmask so PostfixEval still hides hair/beard under them. */
+    static CategoryMask hidden_headgear_mask() noexcept
+    {
+        CategoryMask mask = 0;
+        if (is_category_hidden(Category::Helm))  mask |= category_bit(Category::Helm);
+        if (is_category_hidden(Category::Cloak)) mask |= category_bit(Category::Cloak);
+        if (is_category_hidden(Category::Mask))  mask |= category_bit(Category::Mask);
+        return mask;
+    }
+
+    /* Temporarily set bit 19 on items whose category is hidden, call
+       the original PostfixEval, then restore.  Only items belonging to
+       a hidden headgear category are overridden — e.g. hiding Mask only
+       overrides Mask items (beard stays visible) while Helm items keep
+       their bitmask (hair hidden under helmet as normal). */
     static __int64 eval_with_priority_override(
         __int64 ruleObj, __int64 context) noexcept
     {
@@ -69,6 +84,8 @@ namespace EquipHide
 
         if (itemsPtr < 0x10000 || itemCount == 0 || itemCount > k_maxItems)
             return s_originalPostfixEval(ruleObj, context);
+
+        auto hiddenMask = hidden_headgear_mask();
 
         uintptr_t patchedItems[k_maxItems];
         uint32_t  originalValues[k_maxItems];
@@ -82,6 +99,15 @@ namespace EquipHide
             if (item < 0x10000)
                 continue;
             if (*reinterpret_cast<uint8_t *>(item + 0x88) == 0)
+                continue;
+
+            /* Only override items whose part hash belongs to a hidden
+               head-covering category. */
+            auto partHash = *reinterpret_cast<uint32_t *>(item + 0x48);
+            if (!needs_classification(partHash))
+                continue;
+            auto partCat = classify_part(partHash);
+            if ((partCat & hiddenMask) == 0)
                 continue;
 
             auto *bm = reinterpret_cast<uint32_t *>(item + 0x70);
@@ -127,12 +153,14 @@ namespace EquipHide
                 }
 
                 /* Only override for the player context + hair-hiding rules
-                   + helm/cloak hidden.  NPC contexts have different addresses
-                   and are never matched. */
+                   + any head-covering gear hidden.  Per-item category
+                   filtering ensures only items for hidden categories are
+                   overridden.  NPC contexts have different addresses. */
                 if (ctx == s_cachedContext.load(std::memory_order_relaxed) &&
                     is_hair_hiding_rule(ruleObj) &&
                     (is_category_hidden(Category::Helm) ||
-                     is_category_hidden(Category::Cloak)))
+                     is_category_hidden(Category::Cloak) ||
+                     is_category_hidden(Category::Mask)))
                 {
                     static std::atomic<bool> s_logged{false};
                     if (!s_logged.exchange(true, std::memory_order_relaxed))

--- a/CrimsonDesertEquipHide/src/bald_fix.hpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.hpp
@@ -7,8 +7,8 @@ namespace EquipHide
     /**
      * @brief Postfix rule evaluator hook callback.
      * @details Temporarily overrides item priority bitmasks so PostfixEval
-     *          treats helmet items as inactive, preventing hair-hiding when
-     *          Helm/Cloak is hidden.  Only applies to the player context.
+     *          treats head-covering items as inactive, preventing hair-hiding
+     *          when Helm/Cloak/Mask is hidden.  Only applies to the player context.
      */
     using PostfixEvalFn = __int64(__fastcall *)(__int64, __int64);
 

--- a/CrimsonDesertEquipHide/src/bald_fix.hpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.hpp
@@ -6,7 +6,8 @@ namespace EquipHide
 {
     /**
      * @brief Postfix rule evaluator hook callback.
-     * @details Suppresses hair-hiding rules when Helm/Cloak is hidden to prevent baldness.
+     * @details Suppresses hair-hiding rules when Helm/Cloak is hidden to
+     *          prevent baldness.  Respects the PlayerOnly flag.
      */
     using PostfixEvalFn = __int64(__fastcall *)(__int64, __int64);
 

--- a/CrimsonDesertEquipHide/src/bald_fix.hpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.hpp
@@ -4,34 +4,9 @@
 
 namespace EquipHide
 {
-    /**
-     * @brief Postfix rule evaluator hook callback.
-     * @details Suppresses hair-hiding rules when Helm/Cloak is hidden to
-     *          prevent baldness.  Respects the PlayerOnly flag via a
-     *          thread-local actor identity set by the context-create hook.
-     */
     using PostfixEvalFn = __int64(__fastcall *)(__int64, __int64);
 
     __int64 __fastcall on_postfix_eval(__int64 ruleObj, __int64 context);
     void set_postfix_eval_trampoline(PostfixEvalFn original);
-
-    /**
-     * @brief Per-actor context creator wrapper.
-     * @details Sets a thread-local player flag around the original call so
-     *          PostfixEval can discriminate player from NPC evaluations.
-     *          The PostfixEval context is shared between all actors — the
-     *          only per-actor identity lives in this function's parameters.
-     */
-    using PostfixCtxCreateFn = __int64(__fastcall *)(__int64, __int64 *,
-                                                     char, __int64 *,
-                                                     __int64 *);
-
-    __int64 __fastcall on_postfix_ctx_create(__int64 a1, __int64 *a2,
-                                             char a3, __int64 *a4,
-                                             __int64 *a5);
-    void set_postfix_ctx_create_trampoline(PostfixCtxCreateFn original);
-
-    /** @brief Cache the main game thread ID for player/NPC discrimination. */
-    void set_baldfix_main_thread_id(unsigned long id);
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/bald_fix.hpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.hpp
@@ -4,9 +4,17 @@
 
 namespace EquipHide
 {
+    /**
+     * @brief Postfix rule evaluator hook callback.
+     * @details Temporarily overrides item priority bitmasks so PostfixEval
+     *          treats helmet items as inactive, preventing hair-hiding when
+     *          Helm/Cloak is hidden.  Only applies to the player context.
+     */
     using PostfixEvalFn = __int64(__fastcall *)(__int64, __int64);
 
     __int64 __fastcall on_postfix_eval(__int64 ruleObj, __int64 context);
+
+    /** @brief Store the original function trampoline after hook installation. */
     void set_postfix_eval_trampoline(PostfixEvalFn original);
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/bald_fix.hpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.hpp
@@ -7,13 +7,31 @@ namespace EquipHide
     /**
      * @brief Postfix rule evaluator hook callback.
      * @details Suppresses hair-hiding rules when Helm/Cloak is hidden to
-     *          prevent baldness.  Respects the PlayerOnly flag.
+     *          prevent baldness.  Respects the PlayerOnly flag via a
+     *          thread-local actor identity set by the context-create hook.
      */
     using PostfixEvalFn = __int64(__fastcall *)(__int64, __int64);
 
     __int64 __fastcall on_postfix_eval(__int64 ruleObj, __int64 context);
-
-    /** @brief Store the original function trampoline after hook installation. */
     void set_postfix_eval_trampoline(PostfixEvalFn original);
+
+    /**
+     * @brief Per-actor context creator wrapper.
+     * @details Sets a thread-local player flag around the original call so
+     *          PostfixEval can discriminate player from NPC evaluations.
+     *          The PostfixEval context is shared between all actors — the
+     *          only per-actor identity lives in this function's parameters.
+     */
+    using PostfixCtxCreateFn = __int64(__fastcall *)(__int64, __int64 *,
+                                                     char, __int64 *,
+                                                     __int64 *);
+
+    __int64 __fastcall on_postfix_ctx_create(__int64 a1, __int64 *a2,
+                                             char a3, __int64 *a4,
+                                             __int64 *a5);
+    void set_postfix_ctx_create_trampoline(PostfixCtxCreateFn original);
+
+    /** @brief Cache the main game thread ID for player/NPC discrimination. */
+    void set_baldfix_main_thread_id(unsigned long id);
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -347,11 +347,12 @@ namespace EquipHide
             }
         }
 
-        // Prevents baldness when hiding helmets/cloaks by suppressing
-        // the game's postfix rules that hide hair based on equipped gear.
+        // Prevents baldness when hiding helmets/cloaks.  The hook temporarily
+        // sets bit 19 in item+0x70 bitmasks per-call so PostfixEval sees
+        // inactive priority and hair-hiding rules don't match.  Player
+        // context is cached on first populated call; NPC contexts never match.
         if (flag_bald_fix().load(std::memory_order_relaxed))
         {
-            set_baldfix_main_thread_id(GetCurrentThreadId());
             auto postfixEvalAddr = resolve_address(
                 k_postfixEvalCandidates, std::size(k_postfixEvalCandidates),
                 "PostfixEval");
@@ -367,7 +368,7 @@ namespace EquipHide
                 if (result.has_value())
                 {
                     set_postfix_eval_trampoline(trampoline);
-                    logger.info("PostfixEval inline hook installed at 0x{:X}",
+                    logger.info("PostfixEval inline hook installed at 0x{:X} — bald fix active",
                                 postfixEvalAddr);
                 }
                 else
@@ -378,39 +379,6 @@ namespace EquipHide
             {
                 logger.warning("PostfixEval AOB scan failed — bald fix disabled");
             }
-
-            // Per-actor context wrapper: sets a TLS player flag around the
-            // PostfixEval dispatch so we only suppress hair-hiding for the
-            // player, not NPCs sharing the same evaluation context.
-            auto ctxCreateAddr = resolve_address(
-                k_postfixCtxCreateCandidates,
-                std::size(k_postfixCtxCreateCandidates),
-                "PostfixCtxCreate");
-
-            if (ctxCreateAddr)
-            {
-                PostfixCtxCreateFn trampoline = nullptr;
-                auto result = hookMgr.create_inline_hook(
-                    "PostfixCtxCreate", ctxCreateAddr,
-                    reinterpret_cast<void *>(on_postfix_ctx_create),
-                    reinterpret_cast<void **>(&trampoline));
-
-                if (result.has_value())
-                {
-                    set_postfix_ctx_create_trampoline(trampoline);
-                    logger.info("PostfixCtxCreate inline hook installed at 0x{:X}",
-                                ctxCreateAddr);
-                }
-                else
-                    logger.warning("PostfixCtxCreate hook failed: {} — NPC hair discrimination unavailable",
-                                   DetourModKit::Hook::error_to_string(result.error()));
-            }
-            else
-            {
-                logger.warning("PostfixCtxCreate AOB scan failed — NPC hair discrimination unavailable");
-            }
-
-            logger.info("Bald fix active");
         }
         else
         {

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -351,6 +351,7 @@ namespace EquipHide
         // the game's postfix rules that hide hair based on equipped gear.
         if (flag_bald_fix().load(std::memory_order_relaxed))
         {
+            set_baldfix_main_thread_id(GetCurrentThreadId());
             auto postfixEvalAddr = resolve_address(
                 k_postfixEvalCandidates, std::size(k_postfixEvalCandidates),
                 "PostfixEval");
@@ -366,7 +367,7 @@ namespace EquipHide
                 if (result.has_value())
                 {
                     set_postfix_eval_trampoline(trampoline);
-                    logger.info("PostfixEval inline hook installed at 0x{:X} — bald fix active",
+                    logger.info("PostfixEval inline hook installed at 0x{:X}",
                                 postfixEvalAddr);
                 }
                 else
@@ -377,6 +378,39 @@ namespace EquipHide
             {
                 logger.warning("PostfixEval AOB scan failed — bald fix disabled");
             }
+
+            // Per-actor context wrapper: sets a TLS player flag around the
+            // PostfixEval dispatch so we only suppress hair-hiding for the
+            // player, not NPCs sharing the same evaluation context.
+            auto ctxCreateAddr = resolve_address(
+                k_postfixCtxCreateCandidates,
+                std::size(k_postfixCtxCreateCandidates),
+                "PostfixCtxCreate");
+
+            if (ctxCreateAddr)
+            {
+                PostfixCtxCreateFn trampoline = nullptr;
+                auto result = hookMgr.create_inline_hook(
+                    "PostfixCtxCreate", ctxCreateAddr,
+                    reinterpret_cast<void *>(on_postfix_ctx_create),
+                    reinterpret_cast<void **>(&trampoline));
+
+                if (result.has_value())
+                {
+                    set_postfix_ctx_create_trampoline(trampoline);
+                    logger.info("PostfixCtxCreate inline hook installed at 0x{:X}",
+                                ctxCreateAddr);
+                }
+                else
+                    logger.warning("PostfixCtxCreate hook failed: {} — NPC hair discrimination unavailable",
+                                   DetourModKit::Hook::error_to_string(result.error()));
+            }
+            else
+            {
+                logger.warning("PostfixCtxCreate AOB scan failed — NPC hair discrimination unavailable");
+            }
+
+            logger.info("Bald fix active");
         }
         else
         {


### PR DESCRIPTION
## Summary

- Replaced return-0 PostfixEval suppression with the official HideAlways mechanism: temporarily sets bit 19 in item+0x70 bitmasks during hair-hiding rule evaluation
- Per-item category filtering via classify_part() ensures only items belonging to hidden headgear categories (Helm/Cloak/Mask) are overridden
- Player context address cached on first populated PostfixEval call; NPC contexts have different addresses and are never matched
- Bitmasks restored immediately after each call; non-hair rules and items for shown categories are unaffected
- Added Mask support: hiding mask alone keeps beard visible without affecting helmet hair-hiding
- Removed [Experimental] tag from BaldFix
- Removed abandoned approaches: gate-byte override, TLS thread-ID, permanent item+0x70, ctx-create hook

## Verified

- Helm hidden only: hair visible, beard hidden under mask
- Mask hidden only: beard visible, hair hidden under helmet
- Both hidden: hair and beard visible
- Re-equip while hidden: no baldness
- NPCs with hoods/helmets: hair correctly hidden, no clipping
- Both protagonists share the same PostfixEval context
