### PR TITLE
feat(equip-hide): equip-change detection for CascadeFix

### DIFF
--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -52,6 +52,7 @@ set(COMMON_SOURCES
     src/visibility_write.cpp
     src/armor_injection.cpp
     src/bald_fix.cpp
+    src/cascade_suppress.cpp
     src/gliding_fix.cpp
     src/background_threads.cpp
     src/input_handler.cpp

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -243,7 +243,7 @@ Safe to leave `false` if you are not using such mods.
 | ------- | --------- | ------------ |
 | **Stuttering or FPS drops** | Some users report performance issues in crowded areas. *Not reproducible on my end.* | Try a different ASI Loader DLL (e.g. `version.dll` instead of `winmm.dll`) |
 | **Flight cloak visual artifacts** | `CD_Cloak_Flight` variants cause artifacts and squished hair. Removed from defaults. | Re-add in INI at your own risk (see `[Cloak]` comment) |
-| **Chest/Legs flickering** | Hiding chest armor can cause pants to flicker | Enable `CascadeFix = true` in INI (experimental). Hiding legs while chest is visible may not stick. |
+| **Chest/Legs flickering** | Hiding chest armor can cause pants to flicker | Enable `CascadeFix = true` in INI (experimental). Some armor (e.g. Bandit Cloth) may show invisible torso or missing upper body parts when hiding chest with legs visible. Reloading a save may briefly show armor during loading. |
 | **Dagger stays visible** | Daggers may remain visible and clip after hiding one-hand weapons | *Will be addressed in a future update* |
 | **Toggle delay** | Visibility changes can take 1-3 seconds | -- |
 | **Game updates** | Major updates may break the mod until a new version is released | -- |

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -59,8 +59,9 @@ BaldFix = true
 GlidingFix = true
 ; [Experimental] Reduces pants flickering when hiding chest armor.
 ; Allows running around bare-chested without pants flashing.
-; Known limitations: hiding legs while chest is visible may not stick,
-; and toggling pants independently may not work correctly.
+; Known limitations: some armor (e.g. Bandit Cloth) may show invisible
+; torso or missing upper body parts when hiding chest with legs visible.
+; Reloading a save may briefly show armor during the loading screen.
 ; Report issues on the mod page.
 CascadeFix = false
 ; When multiple categories share the same ToggleHotkey, this controls

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## BaldFix Rework & CascadeFix
 
-- Added `CascadeFix` option (disabled by default, experimental): reduces pants flickering when hiding chest armor, allowing bare-chested gameplay without visual glitches. Known limitations: hiding legs while chest is visible may not stick, and toggling pants independently may not work correctly.
+- Added `CascadeFix` option (disabled by default, experimental): reduces pants flickering when hiding chest armor, allowing bare-chested gameplay without visual glitches. Some armor (e.g. Bandit Cloth) may show invisible torso or missing upper body parts when hiding chest with legs visible. Reloading a save may briefly show armor during loading.
 - BaldFix reworked: now uses a per-call priority bitmask override instead of permanent state changes, hair-hiding rules are suppressed only for the player context when Helm, Cloak, or Mask is hidden, eliminating NPC hair clipping entirely
 - Improved performance when toggling equipment visibility
 - Reorganized internal code for easier maintenance and future updates

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -199,7 +199,7 @@ In this example, pressing [b]V[/b] would still toggle Shields and Masks, but Hel
 [list]
 [*] [b]Stuttering or FPS drops[/b] - Some users report performance issues in crowded areas. [i]Not reproducible on my end.[/i] [i]Workaround:[/i] try a different ASI Loader DLL (e.g. [b]version.dll[/b] instead of [b]winmm.dll[/b]).
 [*] [b]Flight cloak visual artifacts[/b] - [b]CD_Cloak_Flight[/b] variants cause artifacts and squished hair. Removed from defaults; re-add in INI at your own risk (see [b][Cloak][/b] comment).
-[*] [b]Chest/Legs flickering[/b] - Hiding chest armor can cause pants to flicker. [i]Workaround:[/i] enable [b]CascadeFix = true[/b] in INI (experimental). Hiding legs while chest is visible may not stick.
+[*] [b]Chest/Legs flickering[/b] - Hiding chest armor can cause pants to flicker. [i]Workaround:[/i] enable [b]CascadeFix = true[/b] in INI (experimental). Some armor (e.g. Bandit Cloth) may show invisible torso or missing upper body parts when hiding chest with legs visible. Reloading a save may briefly show armor during loading.
 [*] [b]Dagger stays visible[/b] - Daggers may remain visible and clip after hiding one-hand weapons. [i]Will be addressed in a future update.[/i]
 [*] Toggle may take 1-3 seconds to take effect.
 [*] Major game updates may break the mod until a new version is released.

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -49,21 +49,21 @@ namespace EquipHide
 
     inline constexpr AddrCandidate k_worldSystemCandidates[] = {
         {"WS_P1_SmallFunc",
-         "48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 8B 49 50 E8 ?? ?? ?? ?? 84 C0 0F 94 C0 48 83 C4 28 C3",
+         "48 83 EC 28 48 8B 0D ?? ?? ?? ?? 48 8B 49 ?? E8 ?? ?? ?? ?? 84 C0 0F 94 C0 48 83 C4 28 C3",
          ResolveMode::RipRelative, 7, 11},
 
         {"WS_P2_StructField",
-         "80 B8 49 01 00 00 00 75 ?? 48 8B 05 ?? ?? ?? ?? 48 8B 88 D8 00 00 00",
+         "80 B8 ?? ?? ?? ?? 00 75 ?? 48 8B 05 ?? ?? ?? ?? 48 8B 88 ?? ?? ?? ??",
          ResolveMode::RipRelative, 12, 16},
 
         {"WS_P3_InnerLoad",
-         "48 8B 0D ?? ?? ?? ?? 48 8B 49 50 E8 ?? ?? ?? ?? 84 C0 0F 94 C0",
+         "48 8B 0D ?? ?? ?? ?? 48 8B 49 ?? E8 ?? ?? ?? ?? 84 C0 0F 94 C0",
          ResolveMode::RipRelative, 3, 7},
     };
 
     inline constexpr AddrCandidate k_childActorVtblCandidates[] = {
         {"VT_P1_AllocCtor",
-         "48 8B 55 08 48 89 F1 E8 ?? ?? ?? ?? 90 48 8D 05 ?? ?? ?? ?? 48 89 06 EB ??",
+         "48 8B 55 ?? 48 89 F1 E8 ?? ?? ?? ?? 90 48 8D 05 ?? ?? ?? ?? 48 89 06 EB ??",
          ResolveMode::RipRelative, 16, 20},
 
         {"VT_P2_CtorStore",
@@ -71,7 +71,7 @@ namespace EquipHide
          ResolveMode::RipRelative, 12, 16},
 
         {"VT_P3_WiderCtorStore",
-         "45 31 ED 48 85 F6 74 ?? 48 8B 55 08 48 89 F1 E8 ?? ?? ?? ?? 90 48 8D 05",
+         "45 31 ED 48 85 F6 74 ?? 48 8B 55 ?? 48 89 F1 E8 ?? ?? ?? ?? 90 48 8D 05",
          ResolveMode::RipRelative, 24, 28},
     };
 
@@ -81,11 +81,11 @@ namespace EquipHide
          ResolveMode::Direct, 0, 0},
 
         {"ML_P2_HashBody",
-         "8B 48 58 48 03 D2 44 8B 5C D1 08 41 8B 08 85 C9 74 ?? 33 D2 41 8B C3 F7 F1",
+         "8B 48 ?? 48 03 D2 44 8B 5C D1 ?? 41 8B 08 85 C9 74 ?? 33 D2 41 8B C3 F7 F1",
          ResolveMode::Direct, -0x24, 0},
 
         {"ML_P3_HashLoop",
-         "44 8B CA 33 D2 49 C1 E1 08 4D 03 48 10 45 8B 11 45 85 D2",
+         "44 8B CA 33 D2 49 C1 E1 08 4D 03 48 ?? 45 8B 11 45 85 D2",
          ResolveMode::Direct, -0x3D, 0},
     };
 
@@ -122,12 +122,12 @@ namespace EquipHide
          0},
 
         {"P2_WiderContext",
-         "45 32 C0 48 8B 4D ?? 48 8B 41 38 8B 49 40 48 C1 E1 04 48 03 C8 48 3B C1 74 ?? 41 8B 12",
+         "45 32 C0 48 8B 4D ?? 48 8B 41 ?? 8B 49 ?? 48 C1 E1 04 48 03 C8 48 3B C1 74 ?? 41 8B 12",
          0x36},
 
-        {"P3_ShortCore",
-         "41 0F B6 45 1C 3C 03",
-         0},
+        {"P3_PrecedingGate",
+         "41 B0 01 41 0F B6 45 1C 3C 03 74 ?? 45 84 C0",
+         3},
     };
 
     /**
@@ -143,17 +143,17 @@ namespace EquipHide
      */
     inline constexpr AddrCandidate k_partAddShowCandidates[] = {
         {"PAS_P1_Prologue",
-         "40 55 56 57 41 55 48 83 EC 48 48 8B 79 38",
+         "40 55 56 57 41 55 48 83 EC ?? 48 8B 79 ??",
          ResolveMode::Direct, 0, 0},
 
-        // Post-prologue: sub rsp,48; mov rdi,[rcx+38]; mov r13,r8; mov r9d,[rcx+40]
+        // Post-prologue: sub rsp,??; mov rdi,[rcx+??]; mov r13,r8; mov r9d,[rcx+??]
         {"PAS_P2_PostPrologue",
-         "48 83 EC 48 48 8B 79 38 4D 8B E8 44 8B 49 40",
+         "48 83 EC ?? 48 8B 79 ?? 4D 8B E8 44 8B 49 ??",
          ResolveMode::Direct, -6, 0},
 
-        // SIMD save + shift: movaps [rsp+30],xmm6; shl rax,04; movaps xmm6,xmm3; add rax,rdi
+        // SIMD save + shift: movaps [rsp+??],xmm6; shl rax,04; movaps xmm6,xmm3; add rax,rdi
         {"PAS_P3_SimdBody",
-         "0F 29 74 24 30 48 C1 E0 04 0F 28 F3 48 03 C7",
+         "0F 29 74 24 ?? 48 C1 E0 04 0F 28 F3 48 03 C7",
          ResolveMode::Direct, -0x1B, 0},
     };
 
@@ -167,17 +167,71 @@ namespace EquipHide
     inline constexpr AddrCandidate k_postfixEvalCandidates[] = {
         {"PFE_P1_PrologueAndBody",
          "48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 41 56 41 57 "
-         "48 83 EC 50 4C 8B FA 48 8B 5A 58 8B 42 60 48 8D 3C C3",
+         "48 83 EC ?? 4C 8B FA 48 8B 5A ?? 8B 42 ?? 48 8D 3C C3",
          ResolveMode::Direct, 0, 0},
 
         {"PFE_P2_UniqueBody",
-         "48 83 EC 50 4C 8B FA 48 8B 5A 58 8B 42 60 48 8D 3C C3 48 3B",
+         "48 83 EC ?? 4C 8B FA 48 8B 5A ?? 8B 42 ?? 48 8D 3C C3 48 3B",
          ResolveMode::Direct, -0x14, 0},
 
         {"PFE_P3_LoopInit",
-         "45 33 F6 44 89 74 24 28 C7 44 24 2C 08 00 00 00 49 8B 5F 58 41 8B 47 60",
+         "45 33 F6 44 89 74 24 ?? C7 44 24 ?? ?? 00 00 00 49 8B 5F ?? 41 8B 47 ??",
          ResolveMode::Direct, -0x6F, 0},
     };
 
+
+    /**
+     * @brief Inline hook: VisualEquipChange (sub_14076D520).
+     *
+     * Bottleneck for all visual equipment changes (equip and unequip).
+     * Called from the network handler for TrocTrAddVisualEquipItemAck.
+     *
+     * Signature (x64 __fastcall):
+     *   __int64 sub_14076D520(
+     *       __int64 bodyComp,    // RCX  ClientFrameEventActorComponent*
+     *       int16_t slotId,      // DX   equipment slot
+     *       int16_t itemId,      // R8W  new item (0xFFFF = removing)
+     *       __int64 itemData)    // R9   item data pointer
+     */
+    inline constexpr AddrCandidate k_visualEquipChangeCandidates[] = {
+        {"VEC_P1_FullPrologue",
+         "48 89 5C 24 10 48 89 74 24 20 66 44 89 44 24 18 "
+         "55 57 41 54 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? "
+         "B8 ?? ?? ?? ??",
+         ResolveMode::Direct, 0, 0},
+
+        {"VEC_P2_PushFrame",
+         "55 57 41 54 41 56 41 57 "
+         "48 8D AC 24 E0 EA FF FF B8 20 16 00 00",
+         ResolveMode::Direct, -0x10, 0},
+
+        // Post-alloca register shuffle: sub rsp,rax; mov rsi,r9; movzx ebx,r8w; movzx edi,dx; mov r14,rcx
+        {"VEC_P3_PostAlloca",
+         "48 2B E0 49 8B F1 41 0F B7 D8 0F B7 FA 4C 8B F1",
+         ResolveMode::Direct, -0x2A, 0},
+    };
+
+    /**
+     * @brief Inline hook: VisualEquipSwap (sub_14075BBF0).
+     *
+     * Handles direct item-to-item swaps (bypasses VisualEquipChange).
+     * Both paths converge on sub_14075C420 (EquipChangeDispatch).
+     */
+    inline constexpr AddrCandidate k_visualEquipSwapCandidates[] = {
+        {"VES_P1_FullPrologue",
+         "48 89 5C 24 10 55 56 57 41 54 41 55 41 56 41 57 "
+         "48 8D AC 24 30 ED FF FF B8 D0 13 00 00",
+         ResolveMode::Direct, 0, 0},
+
+        {"VES_P2_PushFrame",
+         "55 56 57 41 54 41 55 41 56 41 57 "
+         "48 8D AC 24 30 ED FF FF B8 D0 13 00 00",
+         ResolveMode::Direct, -5, 0},
+
+        // Post-alloca register shuffle: sub rsp,rax; mov r15,r8; mov r12,rdx; mov rsi,rcx; mov r14,[rcx+??]
+        {"VES_P3_PostAlloca",
+         "48 2B E0 4D 8B F8 4C 8B E2 48 8B F1 4C 8B 71 ??",
+         ResolveMode::Direct, -0x22, 0},
+    };
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/cascade_suppress.cpp
+++ b/CrimsonDesertEquipHide/src/cascade_suppress.cpp
@@ -1,0 +1,58 @@
+#include "cascade_suppress.hpp"
+#include "categories.hpp"
+#include "shared_state.hpp"
+
+#include <DetourModKit.hpp>
+
+#include <Windows.h>
+
+namespace EquipHide
+{
+    static std::atomic<bool> s_equipChangeDetected{false};
+
+    // --- VisualEquipChange hook (equip/unequip) ---
+
+    static VisualEquipChangeFn s_originalVisualEquipChange = nullptr;
+
+    void set_visual_equip_change_trampoline(VisualEquipChangeFn original)
+    {
+        s_originalVisualEquipChange = original;
+    }
+
+    __int64 __fastcall on_visual_equip_change(
+        __int64 bodyComp, int16_t slotId, int16_t itemId, __int64 itemData)
+    {
+        if (flag_cascade_fix().load(std::memory_order_relaxed) &&
+            is_category_hidden(Category::Chest))
+        {
+            s_equipChangeDetected.store(true, std::memory_order_relaxed);
+        }
+        return s_originalVisualEquipChange(bodyComp, slotId, itemId, itemData);
+    }
+
+    // --- VisualEquipSwap hook (direct item-to-item swap) ---
+
+    static VisualEquipSwapFn s_originalVisualEquipSwap = nullptr;
+
+    void set_visual_equip_swap_trampoline(VisualEquipSwapFn original)
+    {
+        s_originalVisualEquipSwap = original;
+    }
+
+    __int64 __fastcall on_visual_equip_swap(
+        __int64 *a1, __int64 *a2, __int64 **a3, __int64 **a4)
+    {
+        if (flag_cascade_fix().load(std::memory_order_relaxed) &&
+            is_category_hidden(Category::Chest))
+        {
+            s_equipChangeDetected.store(true, std::memory_order_relaxed);
+        }
+        return s_originalVisualEquipSwap(a1, a2, a3, a4);
+    }
+
+    bool consume_equip_change() noexcept
+    {
+        return s_equipChangeDetected.exchange(false, std::memory_order_relaxed);
+    }
+
+} // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/cascade_suppress.hpp
+++ b/CrimsonDesertEquipHide/src/cascade_suppress.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+
+namespace EquipHide
+{
+    // --- VisualEquipChange hook (equipment change detection) ---
+
+    using VisualEquipChangeFn = __int64(__fastcall *)(__int64, int16_t, int16_t, __int64);
+
+    __int64 __fastcall on_visual_equip_change(
+        __int64 bodyComp, int16_t slotId, int16_t itemId, __int64 itemData);
+
+    void set_visual_equip_change_trampoline(VisualEquipChangeFn original);
+
+    // --- VisualEquipSwap hook (direct item-to-item swap detection) ---
+
+    using VisualEquipSwapFn = __int64(__fastcall *)(__int64 *, __int64 *, __int64 **, __int64 **);
+
+    __int64 __fastcall on_visual_equip_swap(
+        __int64 *a1, __int64 *a2, __int64 **a3, __int64 **a4);
+
+    void set_visual_equip_swap_trampoline(VisualEquipSwapFn original);
+
+    /** @brief Returns true (once) if a visual equip change was detected. */
+    bool consume_equip_change() noexcept;
+
+} // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -3,6 +3,7 @@
 #include "armor_injection.hpp"
 #include "background_threads.hpp"
 #include "bald_fix.hpp"
+#include "cascade_suppress.hpp"
 #include "categories.hpp"
 #include "constants.hpp"
 #include "gliding_fix.hpp"
@@ -22,9 +23,18 @@
 
 namespace EquipHide
 {
-    // Indexed by truncated part hash; vis=3 lock prevents PartInOut re-running
-    // the transition dispatch after the first vis=2 frame (cascade workaround).
+    // Indexed by truncated part hash; R8B gate-skip lock prevents PartInOut
+    // from re-running the transition dispatch after the first vis=2 frame.
     static uint8_t s_hideLocked[0x10000]{};
+
+    // Brief guard window after any hotkey toggle.  Prevents cascade from
+    // other armor slots (shield/helm) from briefly hiding legs.
+    static std::atomic<int> s_flushGuard{0};
+
+    static constexpr CategoryMask k_cascadeBodyMask =
+        category_bit(Category::Legs) |
+        category_bit(Category::Gloves) |
+        category_bit(Category::Boots);
 
     // --- Config ---
     static void load_config()
@@ -132,8 +142,33 @@ namespace EquipHide
         if (needs_direct_write().load(std::memory_order_relaxed) &&
             needs_direct_write().exchange(false, std::memory_order_relaxed))
         {
+            // Clear stale locks on vis ctrl change (save load, zone
+            // transition) so chest gets a fresh first-frame transition.
+            if (flag_cascade_fix().load(std::memory_order_relaxed))
+                std::memset(s_hideLocked, 0, sizeof(s_hideLocked));
+
             inject_armor_entries();
             apply_direct_vis_write();
+        }
+
+        // Equipment change re-sync with debounce (CascadeFix only).
+        if (flag_cascade_fix().load(std::memory_order_relaxed))
+        {
+            static int64_t s_equipPending = 0;
+            if (consume_equip_change())
+                s_equipPending = steady_ms();
+
+            if (s_equipPending > 0)
+            {
+                static uint32_t s_debTick = 0;
+                if ((++s_debTick & 0x3F) == 0 &&
+                    (steady_ms() - s_equipPending) > 500)
+                {
+                    for (int i = 0; i < 0x10000; ++i)
+                        if (s_hideLocked[i] == 1) s_hideLocked[i] = 2;
+                    s_equipPending = 0;
+                }
+            }
         }
 
         if (deferred_scan_pending().load(std::memory_order_relaxed))
@@ -171,15 +206,45 @@ namespace EquipHide
 
         const bool cascadeOn = flag_cascade_fix().load(std::memory_order_relaxed);
         const auto hashIdx = static_cast<uint16_t>(partHash);
+        const bool isChest = (mask & category_bit(Category::Chest)) != 0;
 
-        // Apply vis=3 lock BEFORE player filter so stale MapNodes from
-        // previous vis_ctrl owners can't slip through and un-hide parts.
-        if (cascadeOn &&
+        // Protect legs from cascade during the brief window after a
+        // hotkey toggle (e.g. shield show/hide triggers a re-evaluation
+        // that would otherwise flash the pants).
+        if (cascadeOn)
+        {
+            auto guard = s_flushGuard.load(std::memory_order_relaxed);
+            if (guard > 0 &&
+                s_flushGuard.compare_exchange_strong(
+                    guard, guard - 1, std::memory_order_relaxed))
+            {
+                if ((mask & k_cascadeBodyMask) != 0 &&
+                    !is_any_category_hidden(mask) &&
+                    is_category_hidden(Category::Chest))
+                {
+                    ctx.r8 = 1;
+                    return;
+                }
+            }
+        }
+
+        // Chest lock state machine (BEFORE player filter):
+        //   0 = unlocked -- first frame, let gate pass
+        //   1 = locked   -- R8B=1, skip gate
+        //   2 = re-equip -- force vis=0 (In, recreate scene nodes)
+        if (cascadeOn && isChest &&
             s_hideLocked[hashIdx] &&
             is_any_category_hidden(mask))
         {
             auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
-            *visPtr = 3;
+            if (s_hideLocked[hashIdx] == 2)
+            {
+                *visPtr = 0;
+                s_hideLocked[hashIdx] = 0;
+                return;
+            }
+            *visPtr = 2;
+            ctx.r8 = 1;
             return;
         }
 
@@ -190,26 +255,19 @@ namespace EquipHide
         if (is_any_category_hidden(mask))
         {
             auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
-            if (cascadeOn && s_hideLocked[hashIdx])
+            *visPtr = 2;
+            if (cascadeOn && isChest)
             {
-                *visPtr = 3; // lock: PartInOut skips all processing
-            }
-            else
-            {
-                *visPtr = 2; // first frame: transition Out
-                if (cascadeOn)
+                if (s_hideLocked[hashIdx])
+                    ctx.r8 = 1; // gate skip on locked frames
+                else
                     s_hideLocked[hashIdx] = 1;
             }
         }
         else
         {
-            if (cascadeOn)
-            {
+            if (cascadeOn && isChest)
                 s_hideLocked[hashIdx] = 0;
-                auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
-                if (*visPtr == 3)
-                    *visPtr = 0; // restore from lock
-            }
 
             if (flag_force_show().load(std::memory_order_relaxed))
             {
@@ -427,6 +485,58 @@ namespace EquipHide
             logger.info("BaldFix disabled in config — hair-hiding rules will apply normally");
         }
 
+        // Equipment change detection for CascadeFix re-sync.
+        // Clears the R8B gate-skip locks when chest armor is changed
+        // so the new gear gets a fresh Out transition.
+        if (flag_cascade_fix().load(std::memory_order_relaxed))
+        {
+            auto vecAddr = resolve_address(
+                k_visualEquipChangeCandidates,
+                std::size(k_visualEquipChangeCandidates),
+                "VisualEquipChange");
+
+            if (vecAddr)
+            {
+                VisualEquipChangeFn trampoline = nullptr;
+                auto result = hookMgr.create_inline_hook(
+                    "VisualEquipChange", vecAddr,
+                    reinterpret_cast<void *>(on_visual_equip_change),
+                    reinterpret_cast<void **>(&trampoline));
+
+                if (result.has_value())
+                {
+                    set_visual_equip_change_trampoline(trampoline);
+                    logger.info("VisualEquipChange hook installed at 0x{:X}", vecAddr);
+                }
+                else
+                    logger.warning("VisualEquipChange hook failed: {}",
+                                   DetourModKit::Hook::error_to_string(result.error()));
+            }
+
+            auto vesAddr = resolve_address(
+                k_visualEquipSwapCandidates,
+                std::size(k_visualEquipSwapCandidates),
+                "VisualEquipSwap");
+
+            if (vesAddr)
+            {
+                VisualEquipSwapFn trampoline = nullptr;
+                auto result = hookMgr.create_inline_hook(
+                    "VisualEquipSwap", vesAddr,
+                    reinterpret_cast<void *>(on_visual_equip_swap),
+                    reinterpret_cast<void **>(&trampoline));
+
+                if (result.has_value())
+                {
+                    set_visual_equip_swap_trampoline(trampoline);
+                    logger.info("VisualEquipSwap hook installed at 0x{:X}", vesAddr);
+                }
+                else
+                    logger.warning("VisualEquipSwap hook failed: {}",
+                                   DetourModKit::Hook::error_to_string(result.error()));
+            }
+        }
+
         register_hotkeys();
 
         auto &inputMgr = DMK::InputManager::get_instance();
@@ -440,6 +550,11 @@ namespace EquipHide
         return true;
     }
 
+    void arm_flush_guard() noexcept
+    {
+        if (flag_cascade_fix().load(std::memory_order_relaxed))
+            s_flushGuard.store(500, std::memory_order_relaxed);
+    }
 
     void shutdown()
     {

--- a/CrimsonDesertEquipHide/src/equip_hide.hpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.hpp
@@ -8,4 +8,7 @@ namespace EquipHide
     /** @brief Tear down hooks and restore any patched bytes. */
     void shutdown();
 
+    /** @brief Arm the post-toggle cascade guard for body parts. */
+    void arm_flush_guard() noexcept;
+
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/input_handler.cpp
+++ b/CrimsonDesertEquipHide/src/input_handler.cpp
@@ -1,6 +1,7 @@
 #include "input_handler.hpp"
 #include "armor_injection.hpp"
 #include "categories.hpp"
+#include "equip_hide.hpp"
 #include "player_detection.hpp"
 #include "shared_state.hpp"
 #include "visibility_write.hpp"
@@ -42,6 +43,7 @@ namespace EquipHide
 
     void flush_visibility() noexcept
     {
+        arm_flush_guard();
         update_hidden_mask();
 
         if (!flag_fallback_mode().load(std::memory_order_relaxed))

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -24,7 +24,6 @@ namespace EquipHide
             auto lookup = reinterpret_cast<MapLookupFn>(addrs.mapLookup);
             auto &ps = player_state();
             auto &origVis = original_vis_map();
-            const bool cascadeOn = flag_cascade_fix().load(std::memory_order_relaxed);
             const auto n = ps.count.load(std::memory_order_relaxed);
             int hiddenCount = 0;
             int restoredCount = 0;
@@ -56,10 +55,7 @@ namespace EquipHide
                     {
                         if (origVis.find(visAddr) == origVis.end())
                             origVis[visAddr] = *visPtr;
-                        // Don't overwrite vis=3 lock -- cascade workaround
-                        // already holds this part in the skipped state.
-                        if (!(cascadeOn && *visPtr == 3))
-                            *visPtr = 2;
+                        *visPtr = 2;
                         ++hiddenCount;
                         logger.trace("  [{}] 0x{:04X} hidden (vis=2)",
                                      i, hash);


### PR DESCRIPTION
## Summary

- Hook `VisualEquipChange` and `VisualEquipSwap` to detect armor changes at runtime, triggering a re-sync of chest hide locks so new gear gets a fresh Out transition
- Replace the `vis=3` lock mechanism with an R8B gate-skip state machine (`0`=unlocked, `1`=locked, `2`=re-equip force-In) to eliminate chest/legs flicker without stale lock artifacts
- Add a post-toggle flush guard that briefly protects body-part slots (legs, gloves, boots) from cascade re-evaluation after hotkey presses
- Widen AOB patterns across all signature sets for better cross-version resilience
- Update known-issues docs: remove "legs may not stick" limitation, document Bandit Cloth edge case and save-reload flash

## Test plan

- [x] Verify chest hide works without pants flicker (default armor + Bandit Cloth)
- [x] Change chest armor while hidden → confirm new armor gets hidden after ~500ms debounce
- [x] Toggle shield/helm hotkey while chest is hidden → legs should not flash
- [x] Save/reload with chest hidden → armor briefly visible during load, then re-hides
- [x] Verify `CascadeFix = false` (default) still works as before with no regressions
