### PR TITLE
chore(equip-hide): upgrade DetourModKit to v3.0.0

### DIFF
--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -86,18 +86,32 @@ if(EQUIPHIDE_DEV_BUILD)
         user32
     )
 
+    # Build loader to build dir; post-build tries to copy to game folder.
+    # If the ASI is locked (game running), the copy silently fails.
     set_target_properties(equip_hide_loader PROPERTIES
         OUTPUT_NAME "CrimsonDesertEquipHide"
         SUFFIX ".asi"
         PREFIX ""
-        RUNTIME_OUTPUT_DIRECTORY "${GAME_BIN_DIR}"
-        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${GAME_BIN_DIR}"
-        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${GAME_BIN_DIR}"
-        RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_BIN_DIR}"
-        LIBRARY_OUTPUT_DIRECTORY "${GAME_BIN_DIR}"
-        LIBRARY_OUTPUT_DIRECTORY_DEBUG "${GAME_BIN_DIR}"
-        LIBRARY_OUTPUT_DIRECTORY_RELEASE "${GAME_BIN_DIR}"
-        LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${GAME_BIN_DIR}"
+    )
+
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/deploy_loader.cmake" [=[
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E copy "${SRC_ASI}" "${DST_ASI}"
+    RESULT_VARIABLE rc
+)
+if(rc EQUAL 0)
+    message(STATUS "Loader ASI deployed to plugins/")
+else()
+    message(STATUS "Loader ASI deploy skipped (file locked)")
+endif()
+]=])
+
+    add_custom_command(TARGET equip_hide_loader POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+            -DSRC_ASI=$<TARGET_FILE:equip_hide_loader>
+            -DDST_ASI=${GAME_BIN_DIR}/CrimsonDesertEquipHide.asi
+            -P "${CMAKE_CURRENT_BINARY_DIR}/deploy_loader.cmake"
+        COMMENT "Deploying Loader ASI (skips if locked)"
     )
 
     target_compile_options(equip_hide_loader PRIVATE /W4)

--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.25)
 
 project(CrimsonDesertEquipHide VERSION 0.2.3 LANGUAGES CXX)
 
@@ -24,7 +24,7 @@ endif()
 # --- DetourModKit Dependency ---
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/DetourModKit/CMakeLists.txt")
     message(STATUS "Configuring DetourModKit from: external/DetourModKit")
-    add_subdirectory(external/DetourModKit)
+    add_subdirectory(external/DetourModKit SYSTEM)
 
     # Use the exact target name from DetourModKit
     if(TARGET DetourModKit)
@@ -181,7 +181,7 @@ endif()
     )
 
     target_compile_options(equip_hide_logic PRIVATE /W4 /Zi)
-    target_link_options(equip_hide_logic PRIVATE /DEBUG /OPT:REF /OPT:ICF)
+    target_link_options(equip_hide_logic PRIVATE /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF)
 
 else() # EQUIPHIDE_DEV_BUILD=OFF
     # =====================================================================

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,8 @@
-## [Title for next release]
+## Upgrade to DetourModKit v3.0.0
 
-- New feature
-- Bug fix
-- Improvement
+### Internal
+
+- Upgraded DetourModKit dependency from v2.2.0 to v3.0.0 (std::expected API, typed hook errors, AVX2 scanner, deterministic shutdown)
+- Bumped CMake minimum to 3.25; added SYSTEM subdirectory to suppress dependency header warnings
+- Fixed [[nodiscard]] violation on memory cache initialization
+- Fixed linker warning (LNK4075) from INCREMENTAL/ICF conflict in dev builds

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -304,7 +304,8 @@ namespace EquipHide
         logger.info("Nexus:  {}", MOD_NEXUS);
         logger.debug("Built on " __DATE__ " at " __TIME__);
 
-        DMK::Memory::init_cache();
+        if (!DMK::Memory::init_cache())
+            logger.warning("Memory cache init failed — pointer reads may be slower");
 
         auto &addrs = resolved_addrs();
 


### PR DESCRIPTION
## Summary

- Upgrade DetourModKit submodule from v2.2.0 to v3.0.0 (std::expected API, typed hook errors, AVX2 scanner, deterministic shutdown)
- Bump CMake minimum to 3.25; use `add_subdirectory(... SYSTEM)` to suppress dependency header warnings (C4324)
- Handle `[[nodiscard]]` return from `Memory::init_cache()`
- Fix LNK4075 linker warning (INCREMENTAL/ICF conflict) in dev builds

## Test plan

- [x] `cmake --preset msvc-dev` configures without errors
- [x] `cmake --build --preset msvc-dev` compiles with zero warnings from project code
- [x] In-game: verify hooks install and equipment hiding works as before
