### PR TITLE
feat(equip-hide): add game v1.03.01 support

### DIFF
--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Title for next release]
+## Game v1.03.01 Support
 
-- New feature
-- Bug fix
-- Improvement
+- Added support for Crimson Desert v1.03.01 (the mod still works on v1.02.00)
+- Fixed equipment not hiding after the game update
+- Improved diagnostic logging for easier troubleshooting

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -104,27 +104,55 @@ namespace EquipHide
     };
 
     /**
-     * @brief Hook target: sub_14081D3C0 — PartInOut transition function.
+     * @brief Hook target: PartInOut transition function.
      *
-     * Hook point: movzx eax, byte ptr [r13+1Ch]; cmp al, 3
+     * Hook point: movzx eax, byte ptr [<vis_reg>+1Ch]; cmp al, 3
      *
-     * Register layout at hook point:
+     * Register layout at hook point (v1.03.01):
+     *   R10 = pointer to part hash DWORD (IndexedStringA ID)
+     *   RAX = pointer to PartInOutSocket struct (loaded from [RBP+5Fh])
+     *   R8B = exclusion-list flag
+     *   [RBP+0x67] = a4 (transition type byte, saved from R9B at prologue)
+     *   [RBP+0x4F] = a1 context pointer
+     *
+     * Register layout at hook point (v1.02.00 — legacy):
      *   R10 = pointer to part hash DWORD (IndexedStringA ID)
      *   R13 = pointer to PartInOutSocket struct (Visible byte at +0x1C)
      *   R8B = exclusion-list flag
      *   [RBP+0x67] = a4 (transition type byte, saved from R9B at prologue)
+     *   [RBP+0x4F] = a1 context pointer
      *
      * Cascading AOB patterns (tried in order until one matches).
+     * Pattern names prefixed with "V103_" use the v1.03.01 register layout
+     * where the PartInOut struct pointer is in RAX (not R13).
      */
     inline constexpr AobCandidate k_hookSiteCandidates[] = {
+        // v1.03.01: mov rax,[rbp+5F]; movzx eax,[rax+1C]; cmp al,3; ...
+        {"V103_P1_DirectSite",
+         "48 8B 45 5F 0F B6 40 1C 3C 03 74 ?? 45 84 C0 75 ?? 84 C0",
+         4},
+
+        // v1.03.01: xor r8b,r8b; mov rax,[r13+??]; mov ecx,[r13+??]; shl rcx,4; ...
+        {"V103_P2_WiderContext",
+         "45 32 C0 49 8B 45 ?? 41 8B 4D ?? 48 C1 E1 04 48 03 C8 48 3B C1 74 ?? 41 8B 12",
+         0x30},
+
+        // v1.03.01: mov r8b,1; mov rax,[rbp+5F]; movzx eax,[rax+1C]; cmp al,3; ...
+        {"V103_P3_PrecedingGate",
+         "41 B0 01 48 8B 45 5F 0F B6 40 1C 3C 03 74 ?? 45 84 C0",
+         7},
+
+        // v1.02.00 (legacy): movzx eax,[r13+1C]; cmp al,3; ...
         {"P1_DirectSite",
          "41 0F B6 45 1C 3C 03 74 ?? 45 84 C0 75 ?? 84 C0",
          0},
 
+        // v1.02.00 (legacy): xor r8b,r8b; mov rcx,[rbp+??]; ...
         {"P2_WiderContext",
          "45 32 C0 48 8B 4D ?? 48 8B 41 ?? 8B 49 ?? 48 C1 E1 04 48 03 C8 48 3B C1 74 ?? 41 8B 12",
          0x36},
 
+        // v1.02.00 (legacy): mov r8b,1; movzx eax,[r13+1C]; cmp al,3; ...
         {"P3_PrecedingGate",
          "41 B0 01 41 0F B6 45 1C 3C 03 74 ?? 45 84 C0",
          3},

--- a/CrimsonDesertEquipHide/src/armor_injection.cpp
+++ b/CrimsonDesertEquipHide/src/armor_injection.cpp
@@ -37,12 +37,24 @@ namespace EquipHide
                 return 0;
             auto tablePtr = *reinterpret_cast<const uintptr_t *>(globalPtr + 0x58);
             if (tablePtr < 0x10000)
+            {
+                static std::atomic<bool> s_logOnce{false};
+                if (!s_logOnce.exchange(true, std::memory_order_relaxed))
+                    DMK::Logger::get_instance().warning(
+                        "compute_bucket_key: tablePtr=NULL "
+                        "(globalAddr=0x{:X} globalPtr=0x{:X} +0x58)",
+                        globalAddr, globalPtr);
                 return 0;
+            }
             return *reinterpret_cast<const uint32_t *>(
                 tablePtr + 16ULL * partHash + 8);
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
+            static std::atomic<bool> s_logOnce{false};
+            if (!s_logOnce.exchange(true, std::memory_order_relaxed))
+                DMK::Logger::get_instance().warning(
+                    "compute_bucket_key: SEH fault for hash 0x{:04X}", partHash);
             return 0;
         }
     }
@@ -197,13 +209,27 @@ namespace EquipHide
             /* Per-player SEH so one bad pointer does not skip the rest. */
             __try
             {
-                auto comp = read_ptr_unsafe(vc, 0x48);
+                // v1.03.01 shifted comp from +0x48 to +0x58.
+                auto comp = read_ptr_unsafe(vc, 0x58);
                 if (!comp)
+                    comp = read_ptr_unsafe(vc, 0x48);
+                if (!comp)
+                {
+                    logger.trace("ArmorInject [{}]: vc=0x{:X} comp=NULL "
+                                 "(+0x58 and +0x48 both null)", i, vc);
                     continue;
+                }
                 auto descNode = read_ptr_unsafe(comp, 0x218);
                 if (!descNode)
+                {
+                    logger.trace("ArmorInject [{}]: vc=0x{:X} comp=0x{:X} "
+                                 "descNode=NULL (+0x218)", i, vc, comp);
                     continue;
+                }
                 auto mapBase = descNode + 0x20;
+                logger.trace("ArmorInject [{}]: vc=0x{:X} comp=0x{:X} "
+                             "descNode=0x{:X} mapBase=0x{:X}",
+                             i, vc, comp, descNode, mapBase);
 
                 int result = inject_armor_entries_for_map(mapBase);
                 if (result >= 0)

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -19,10 +19,16 @@
 
 #include <cstring>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace EquipHide
 {
+    // v1.03.01 changed register allocation: PartInOut struct pointer moved
+    // from R13 to RAX (loaded from [RBP+5Fh]).  Set by init() based on
+    // which AOB pattern matched (V103_ prefix → true).
+    static bool s_partInOutFromRax{false};
+
     // Indexed by truncated part hash; R8B gate-skip lock prevents PartInOut
     // from re-running the transition dispatch after the first vis=2 frame.
     static uint8_t s_hideLocked[0x10000]{};
@@ -200,8 +206,10 @@ namespace EquipHide
         if (mask == 0)
             return;
 
-        auto r13 = ctx.r13;
-        if (r13 < 0x10000)
+        // v1.03.01: PartInOut struct is in RAX (loaded from [rbp+5F] before hook).
+        // v1.02.00: PartInOut struct is in R13 directly.
+        auto partInOut = s_partInOutFromRax ? ctx.rax : ctx.r13;
+        if (partInOut < 0x10000)
             return;
 
         const bool cascadeOn = flag_cascade_fix().load(std::memory_order_relaxed);
@@ -236,7 +244,7 @@ namespace EquipHide
             s_hideLocked[hashIdx] &&
             is_any_category_hidden(mask))
         {
-            auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
+            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x1C);
             if (s_hideLocked[hashIdx] == 2)
             {
                 *visPtr = 0;
@@ -254,7 +262,7 @@ namespace EquipHide
 
         if (is_any_category_hidden(mask))
         {
-            auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
+            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x1C);
             *visPtr = 2;
             if (cascadeOn && isChest)
             {
@@ -271,7 +279,7 @@ namespace EquipHide
 
             if (flag_force_show().load(std::memory_order_relaxed))
             {
-                auto *visPtr = reinterpret_cast<uint8_t *>(r13 + 0x1C);
+                auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x1C);
                 *visPtr = 0;
             }
         }
@@ -402,6 +410,15 @@ namespace EquipHide
         {
             logger.error("No AOB pattern matched. The mod may be outdated for this game version.");
             return false;
+        }
+
+        // v1.03.01 moved PartInOut struct pointer from R13 to RAX
+        // and shifted struct offsets (+0x48 → +0x58). body_to_vis_ctrl
+        // chain is still correct; comp offset fix handles the rest.
+        if (matchedSource && std::string_view(matchedSource->name).starts_with("V103_"))
+        {
+            s_partInOutFromRax = true;
+            logger.info("v1.03.01 layout detected (partInOut via RAX, comp at +0x58)");
         }
 
         auto &hookMgr = DMK::HookManager::get_instance();

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -20,11 +20,24 @@ namespace EquipHide
             return 0;
         auto inner = read_ptr_unsafe(body, 0x68);
         if (!inner)
+        {
+            DMK::Logger::get_instance().trace(
+                "body_to_vis_ctrl: body=0x{:X} inner=NULL (+0x68)", body);
             return 0;
+        }
         auto sub = read_ptr_unsafe(inner, 0x40);
         if (!sub)
+        {
+            DMK::Logger::get_instance().trace(
+                "body_to_vis_ctrl: body=0x{:X} inner=0x{:X} sub=NULL (+0x40)",
+                body, inner);
             return 0;
-        return read_ptr_unsafe(sub, 0xE8);
+        }
+        auto vc = read_ptr_unsafe(sub, 0xE8);
+        DMK::Logger::get_instance().trace(
+            "body_to_vis_ctrl: body=0x{:X} inner=0x{:X} sub=0x{:X} vc=0x{:X}",
+            body, inner, sub, vc);
+        return vc;
     }
 
     void resolve_player_vis_ctrls() noexcept
@@ -166,8 +179,11 @@ namespace EquipHide
         if (flag_fallback_mode().load(std::memory_order_relaxed))
         {
             /* Actor type byte: *(*(actor+0x88)+1). Value 1 = local player,
-               3-6 = party members. Same mechanism the headgear visibility system uses. */
-            auto comp = read_ptr_unsafe(a1, 0x48);
+               3-6 = party members. Same mechanism the headgear visibility system uses.
+               v1.03.01 shifted comp from +0x48 to +0x58. */
+            auto comp = read_ptr_unsafe(a1, 0x58);
+            if (!comp)
+                comp = read_ptr_unsafe(a1, 0x48);
             if (comp)
             {
                 auto actor = read_ptr_unsafe(comp, 0x08);
@@ -177,6 +193,14 @@ namespace EquipHide
                     if (typePtr)
                     {
                         auto typeByte = *reinterpret_cast<const uint8_t *>(typePtr + 1);
+                        {
+                            static std::atomic<int> s_fbLog{0};
+                            if (s_fbLog.fetch_add(1, std::memory_order_relaxed) < 5)
+                                DMK::Logger::get_instance().trace(
+                                    "Fallback chain: a1=0x{:X} comp=0x{:X} "
+                                    "actor=0x{:X} typePtr=0x{:X} type={}",
+                                    a1, comp, actor, typePtr, typeByte);
+                        }
                         bool isProtagonist = (typeByte == 1) ||
                                              (typeByte >= 3 && typeByte <= 6);
                         if (isProtagonist)

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -34,12 +34,23 @@ namespace EquipHide
                 if (!vc)
                     continue;
 
-                auto comp = read_ptr_unsafe(vc, 0x48);
+                // v1.03.01 shifted comp from +0x48 to +0x58.
+                auto comp = read_ptr_unsafe(vc, 0x58);
                 if (!comp)
+                    comp = read_ptr_unsafe(vc, 0x48);
+                if (!comp)
+                {
+                    logger.trace("DirectWrite [{}]: vc=0x{:X} comp=NULL "
+                                 "(+0x58 and +0x48 both null)", i, vc);
                     continue;
+                }
                 auto descNode = read_ptr_unsafe(comp, 0x218);
                 if (!descNode)
+                {
+                    logger.trace("DirectWrite [{}]: vc=0x{:X} comp=0x{:X} "
+                                 "descNode=NULL (+0x218)", i, vc, comp);
                     continue;
+                }
                 auto mapBase = descNode + 0x20;
 
                 for (const auto &[hash, mask] : get_part_map())


### PR DESCRIPTION
## Summary

- Add v1.03.01 AOB patterns (V103_ prefix) alongside existing v1.02.00 patterns for backward compatibility
- Fix offset shift: PartInOut struct pointer moved from R13 to RAX, comp offset from +0x48 to +0x58
- Add fallback chain (+0x58 → +0x48) in armor injection, player detection, and visibility write
- Add bounded diagnostic logging for pointer chain failures
- Bump DetourModKit submodule
- Update changelog

## Test plan

- [x] Verify equipment hiding works on game v1.03.01
- [x] Verify all categories (helm, chest, shields, etc.) hide/show correctly
- [x] Verify BaldFix and CascadeFix still function
- [x] Verify no log spam at Info level (trace logs are bounded)
