### PR TITLE
feat(live-transmog): add NPC and damaged armor variant support

### DIFF
--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -13,7 +13,8 @@
 - In-game item browser with search-filterable dropdown, auto-categorized by slot (Helm, Chest, Cloak, Gloves, Boots)
 - ReShade overlay GUI for full point-and-click control (Home key)
 - Preset system: save, load, rename, and cycle through multiple transmog presets per character
-- Safety filters: damaged variants, non-player gear (horse tack, pet armor), and wrong-slot items are hidden by default
+- NPC armor variants and damaged variants render via automatic carrier swap
+- Safety filters: non-player gear (horse tack, pet armor) and wrong-slot items are hidden by default
 - Per-slot control: enable/disable transmog independently for each equipment slot
 - Optional hotkeys: all disabled by default, configurable via INI
 - Open-source with full transparency
@@ -156,8 +157,8 @@ See the full list at the [Supported Input Names](https://github.com/tkhquang/Det
 ## Known Limitations
 
 - **Item catalog may be incomplete** - the armor list is filtered to exclude known-broken items. Some wearable items may be missing. Report missing items in the Bugs or Posts tab.
-- **Cross-body-type items don't render** - items from other body types (e.g. Oongka gear on Kliff) appear in the catalog but produce an empty slot. These are not caught by the "Hide variants" filter.
-- **Damaged armor variants don't render** - the "Hide variants" filter catches these by default. Disabling the filter shows them in the picker, but they still won't render in-game.
+- **NPC armor variants and damaged variants render via carrier** — items tagged `(carrier)` in the picker use an automatic carrier swap + character-class bypass to render. Most work; a few may still produce empty slots depending on the item's internal skeleton bindings.
+- **Non-humanoid items crash** — horse tack, pet armor, and wagon gear crash the mesh binder. The "Safe only" filter hides these by default.
 - **Wrong-slot or non-equipment items will crash** - selecting a chest piece for the helm slot, or non-armor items (dog armor, recipes, etc.) crashes the game. Safety filters prevent this by default. Do not disable them unless you know what you are doing.
 - **Dyeing is not supported yet** - transmog items use their default colors.
 - **Special-effect armor may have visual quirks** - armor with particle effects (e.g. Marni Laser Helm) may not render particles correctly. Hair may clip through some helmets. I haven't been able to make these work yet.

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,9 @@
-## [Title for next release]
+## NPC and Damaged Armor Support
 
-- New feature
-- Bug fix
-- Improvement
+- **NPC and damaged armor variants now work** - items previously greyed out or invisible (like Antra, Aant, and other NPC-specific armors) can now be equipped as transmog. The mod automatically handles the conversion behind the scenes.
+- **New item picker badges** - NPC/damaged items show a cyan `(carrier)` tag in the picker so you know they use the new system. Truly incompatible items (horse tack, pet armor) remain red.
+- **New filter: "Hide variants"** - toggle visibility of NPC/damaged items in the picker. Off by default so you can see everything.
+- **"Safe only" filter renamed** - the old "Hide variants" filter is now "Safe only" and only hides items that would crash the game (non-humanoid gear).
+- **Fixed: real armor not hiding on game load** - when slots were set to active with no item selected, real armor would briefly show on load. Fixed.
+- **Fixed: unticking a slot now restores real armor** - previously unticking a slot checkbox could leave the slot empty. Now the real equipped item reappears.
+- **Fixed: switching presets with NPC items** - switching from an NPC preset to a normal preset no longer leaves ghost meshes from the previous preset.

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -18,7 +18,8 @@ Change the visual appearance of your equipped armor [b]in real time[/b] without 
 [*][b]In-game item browser[/b] -searchable dropdown with all armor pieces, auto-categorized by slot (Helm, Chest, Cloak, Gloves, Boots)
 [*][b]ReShade overlay GUI[/b] -full point-and-click control via the ReShade overlay ([b]Home[/b] key). No hotkeys required
 [*][b]Preset system[/b] -save, load, rename, and cycle through multiple transmog presets per character
-[*][b]Safety filters[/b] -items that crash or won't render are filtered out by default (variant metadata, non-player gear, wrong-slot items)
+[*][b]NPC and damaged variants[/b] -NPC armor variants and damaged variants render via automatic carrier swap
+[*][b]Safety filters[/b] -non-player gear (horse tack, pet armor) and wrong-slot items are filtered out by default
 [*][b]Per-slot control[/b] -enable/disable transmog independently for each equipment slot
 [*][b]Optional hotkeys[/b] -all disabled by default; bind any action via INI if you prefer keyboard shortcuts
 [*][url=https://github.com/tkhquang/CrimsonDesertTools]Open-source[/url] with full transparency
@@ -167,8 +168,8 @@ See the full list at the [url=https://github.com/tkhquang/DetourModKit?tab=readm
 
 [list]
 [*][b]Item catalog may be incomplete[/b] -the armor list is filtered to exclude known-broken items. Some wearable items may be missing. If you find one, please report it in the Bugs or Posts tab.
-[*][b]Some listed items cannot be worn[/b] -items from other body types (e.g. Oongka gear on Kliff) appear in the catalog but fail to render. These are NOT caught by the "Hide variants" filter and may look valid in the picker but produce an empty slot.
-[*][b]Damaged armor variants don't render[/b] -the game's internal variant-metadata system blocks damaged gear. The "Hide variants" filter catches these by default. You can disable it to see them in the picker, but they still won't show in-game.
+[*][b]NPC armor variants and damaged variants render via carrier[/b] -items tagged [b](carrier)[/b] in the picker use an automatic carrier swap + character-class bypass. Most work; a few may still produce empty slots depending on the item's internal skeleton bindings.
+[*][b]Non-humanoid items crash[/b] -horse tack, pet armor, and wagon gear crash the mesh binder. The "Safe only" filter hides these by default.
 [*][color=#ff0000][b]Wrong-slot or non-equipment items will crash[/b][/color] -selecting a chest piece for the helm slot, or picking non-armor items (dog armor, recipes, seeds, etc.) will crash the game. The safety filters prevent this by default -[b]do not disable them unless you know what you're doing[/b].
 [*][b]Dyeing is not supported yet[/b] -transmog items use their default colors.
 [*][b]Special effect armor may have visual quirks[/b] -armor with particle effects (e.g. Marni Laser Helm) may not render particles correctly. Hair may clip through some helmets.

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -320,6 +320,58 @@ namespace Transmog
     };
 
     /**
+     * @brief Patch site: CondPrefab evaluator secondary hash check.
+     *
+     * sub_141D5F470 at +0xC8 (0x141D5F538 on v1.02.00): the `jz` that
+     * jumps on character-class hash match. NPC items lack Kliff's class
+     * in their secondary hash array, so this `jz` never fires → evaluator
+     * returns empty → no mesh.
+     *
+     * Toggling this single byte from `0x74` (jz) to `0xEB` (jmp) forces
+     * the match, making the evaluator emit resource names for NPC items.
+     *
+     * The AOB anchors on the surrounding instruction sequence:
+     *   66 45 3B 0C 48   cmp  r9w, [r8+rcx*2]
+     *   74 08             jz   +8              ← PATCH BYTE (offset +5)
+     *   FF C1             inc  ecx
+     *   3B CA             cmp  ecx, edx
+     *   72 F3             jb   loop_top
+     *
+     * The patch byte is at AOB match + 5. Resolution mode is Direct
+     * with offsetToHook = +5 so the resolved address points at the jz.
+     */
+    inline constexpr AddrCandidate k_charClassBypassCandidates[] = {
+        // All patterns wildcard fragile bytes (rel8 jump distances,
+        // struct offsets) and append the trailing `EB` (jmp opcode)
+        // to disambiguate from a structurally identical loop at +0x70
+        // in the same function.
+
+        // P1: mov r8,[rbx+??] + movzx r9d,[rax+??] + inner loop + jmp.
+        // IDA find_bytes verified unique 1-hit at 0x141D5F527.
+        // Patch byte (the jz) is at match + 0x11.
+        {"CCB_P1_MovzxCmpLoop",
+         "4C 8B 43 ?? 44 0F B7 88 ?? ?? 00 00 "
+         "66 45 3B 0C 48 74 ?? FF C1 3B CA 72 ?? EB",
+         ResolveMode::Direct, 0x11, 0},
+
+        // P2: test edx,edx + jz + mov + movzx + cmp+jz + loop + jmp.
+        // IDA find_bytes verified unique 1-hit at 0x141D5F523.
+        // Patch byte is at match + 0x15.
+        {"CCB_P2_TestMovzxCmp",
+         "85 D2 74 ?? 4C 8B 43 ?? 44 0F B7 88 ?? ?? 00 00 "
+         "66 45 3B 0C 48 74 ?? FF C1 3B CA 72 ?? EB",
+         ResolveMode::Direct, 0x15, 0},
+
+        // P3: xor ecx,ecx + test + jz + full inner loop + jmp.
+        // IDA find_bytes verified unique 1-hit at 0x141D5F521.
+        // Deepest anchor, most context. Patch byte at match + 0x17.
+        {"CCB_P3_XorTestCmpLoop",
+         "33 C9 85 D2 74 ?? 4C 8B 43 ?? 44 0F B7 88 ?? ?? 00 00 "
+         "66 45 3B 0C 48 74 ?? FF C1 3B CA 72 ?? EB",
+         ResolveMode::Direct, 0x17, 0},
+    };
+
+    /**
      * @brief Inline hook: PartInOut direct-show bypass (sub_14081DC20).
      *        Copied verbatim from CrimsonDesertEquipHide/aob_resolver.hpp.
      *

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -561,6 +561,43 @@ namespace Transmog
         return cached_chain().itemAccessor;
     }
 
+    ItemNameTable::CatalogInfo ItemNameTable::catalog_info() const noexcept
+    {
+        CatalogInfo info;
+        const auto &chain = cached_chain();
+        if (!chain.resolved)
+            return info;
+        bool ok = false;
+        const uintptr_t globalPtr = read_qword_safe(chain.globalHolder, ok);
+        if (!ok || globalPtr < 0x10000)
+            return info;
+        info.count = read_u32_safe(globalPtr + k_iteminfoCountOffset, ok);
+        if (!ok || info.count == 0 || info.count > k_maxCatalogSize)
+        {
+            info.count = 0;
+            return info;
+        }
+        info.ptrArray = read_qword_safe(
+            globalPtr + k_iteminfoPtrArrayOffset, ok);
+        if (!ok || info.ptrArray < 0x10000)
+        {
+            info.ptrArray = 0;
+            info.count = 0;
+        }
+        return info;
+    }
+
+    uintptr_t ItemNameTable::descriptor_of(uint16_t itemId) const noexcept
+    {
+        const auto ci = catalog_info();
+        if (ci.ptrArray == 0 || itemId >= ci.count)
+            return 0;
+        bool ok = false;
+        const uintptr_t desc = read_qword_safe(
+            ci.ptrArray + static_cast<uint64_t>(itemId) * 8, ok);
+        return (ok && desc > 0x10000) ? desc : 0;
+    }
+
     ItemNameTable::BuildResult ItemNameTable::build(uintptr_t subTranslatorAddr)
     {
         auto &logger = DMK::Logger::get_instance();

--- a/CrimsonDesertLiveTransmog/src/item_name_table.hpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.hpp
@@ -136,6 +136,30 @@ namespace Transmog
         std::size_t size() const noexcept { return m_idToName.size(); }
 
         /**
+         * @brief Read the live descriptor pointer for an item.
+         *
+         * Dereferences the iteminfo global cached during build(), walks
+         * `*(globalPtr + 0x50)` (ptrArray) and returns `ptrArray[itemId*8]`.
+         * Returns 0 on any fault or if the catalog is not yet built.
+         * Thread-safe (reads only; no mutation).
+         */
+        uintptr_t descriptor_of(uint16_t itemId) const noexcept;
+
+        /**
+         * @brief Live ptrArray base and entry count.
+         *
+         * Returns {ptrArray, count}. Either or both may be 0 if the
+         * catalog global is not yet initialized. Callers MUST check
+         * both > 0 before indexing.
+         */
+        struct CatalogInfo
+        {
+            uintptr_t ptrArray = 0;
+            uint32_t count = 0;
+        };
+        CatalogInfo catalog_info() const noexcept;
+
+        /**
          * @brief Address of sub_1402D75D0 (IndexedStringA short->hash
          *        lookup), cached during the build() chain walk.
          *

--- a/CrimsonDesertLiveTransmog/src/overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay.cpp
@@ -35,11 +35,8 @@ namespace Transmog
         // matches THIS slot. Defaults to ON so the dropdown shows ~350
         // relevant items instead of all 6024.
         bool exactFilter = true;
-        // "Hide variants" hides items whose descriptor has a non-sentinel
-        // variant-metadata pointer at +0x3A0. These items failed to render
-        // via runtime transmog on every tested sample, so hiding them by
-        // default prevents users from picking non-functional items.
-        bool hideVariants = true;
+        bool hideIncompatible = true;   // hide crash-risk + non-equipment
+        bool hideVariants = false; // hide NPC variants (carrier items)
     };
 
     static SlotUIState s_slotUI[k_slotCount]{};
@@ -98,16 +95,9 @@ namespace Transmog
         //        picker free of non-functional items.
         ImGui::Checkbox("Exact", &ui.exactFilter);
         ImGui::SameLine();
+        ImGui::Checkbox("Safe only", &ui.hideIncompatible);
+        ImGui::SameLine();
         ImGui::Checkbox("Hide variants", &ui.hideVariants);
-
-        // Disclosure: Hide variants covers (1) the variant-meta pool that
-        // fails to render, and (2) non-player items whose rule classifiers
-        // would crash the mesh binder (horse tack, pet armor). It does NOT
-        // catch body-type-incompatible cases (e.g. Oongka items on Kliff)
-        // that look clean catalog-wise but still fail downstream in the
-        // mesh/skeleton binder. Users may discover those empirically.
-        ImGui::TextDisabled("Hide variants covers won't-render + crash "
-                            "items. Other rendering quirks remain.");
 
         ImGui::SetNextItemWidth(260.0f);
         if (ImGui::IsWindowAppearing())
@@ -152,23 +142,18 @@ namespace Transmog
                 ++filteredByCategory;
                 continue;
             }
-            // "Hide unsafe" covers three distinct failure modes:
-            //   1. hasVariantMeta -- engine-linked variant pool, never
-            //      renders via runtime transmog (mesh/skeleton gate).
-            //   2. !isPlayerCompatible -- rule classifier list has no
-            //      player body-type token, so equipping it crashes the
-            //      mesh binder (horse tack, wagon gear, pet armor).
-            //   3. category == Count -- item has no recognized armor-slot
-            //      suffix (weapons, accessories, consumables, recipes,
-            //      books, seeds, etc). These are not transmog targets.
-            // Default ON so users don't footgun themselves; power users
-            // can disable the filter if they need to inspect the full
-            // catalog.
             const bool nonEquipment =
                 (e.category == TransmogSlot::Count);
-            const bool unsafe =
-                e.hasVariantMeta || !e.isPlayerCompatible || nonEquipment;
-            if (ui.hideVariants && unsafe)
+            const bool incompatible =
+                (!e.isPlayerCompatible && !e.hasVariantMeta) ||
+                nonEquipment;
+            const bool npcVariant = e.hasVariantMeta;
+            if (ui.hideIncompatible && incompatible)
+            {
+                ++filteredByUnsafe;
+                continue;
+            }
+            if (ui.hideVariants && npcVariant)
             {
                 ++filteredByUnsafe;
                 continue;
@@ -178,20 +163,22 @@ namespace Transmog
             if (shown >= k_maxShown)
                 break;
 
-            // Tag unsafe items that slip past the filter with a visible
-            // orange badge so the user sees the warning before clicking.
-            // The label distinguishes the two failure modes:
-            //   - "variant"    -> hasVariantMeta only (won't render)
-            //   - "non-player" -> !isPlayerCompatible only (CRASH RISK)
-            //   - "unsafe"     -> both conditions (CRASH RISK)
+            // Tag items with visible badges:
+            //   - "CRASH RISK"  -> !isPlayerCompatible (red)
+            //   - "carrier"     -> hasVariantMeta, rendered via carrier
+            //                      + char-class bypass (cyan)
             char label[200];
             const char *tag = nullptr;
-            if (e.hasVariantMeta && !e.isPlayerCompatible)
-                tag = "unsafe -- CRASH RISK";
-            else if (!e.isPlayerCompatible)
+            // NPC variant items (hasVariantMeta) are humanoid and now
+            // render via carrier + char-class bypass. True crash risks
+            // are non-player items WITHOUT variant meta (horse tack, etc).
+            const bool usesCarrier = e.hasVariantMeta;
+            const bool crashRisk =
+                !e.isPlayerCompatible && !e.hasVariantMeta;
+            if (crashRisk)
                 tag = "non-player -- CRASH RISK";
-            else if (e.hasVariantMeta)
-                tag = "variant -- may not render";
+            else if (usesCarrier)
+                tag = "carrier";
 
             if (tag)
                 std::snprintf(label, sizeof(label),
@@ -201,13 +188,12 @@ namespace Transmog
                 std::snprintf(label, sizeof(label), "%s  [0x%04X]##picker",
                               e.name.c_str(), e.id);
 
-            const bool crashRisk = !e.isPlayerCompatible;
             if (crashRisk)
                 ImGui::PushStyleColor(ImGuiCol_Text,
                                       ImVec4(1.0f, 0.35f, 0.35f, 1.0f));
-            else if (e.hasVariantMeta)
+            else if (usesCarrier)
                 ImGui::PushStyleColor(ImGuiCol_Text,
-                                      ImVec4(1.0f, 0.55f, 0.35f, 1.0f));
+                                      ImVec4(0.5f, 0.85f, 1.0f, 1.0f));
 
             const bool selected = (targetItemId == e.id);
             if (ImGui::Selectable(label, selected))
@@ -217,7 +203,7 @@ namespace Transmog
                 ImGui::CloseCurrentPopup();
             }
 
-            if (crashRisk || e.hasVariantMeta)
+            if (crashRisk || usesCarrier)
                 ImGui::PopStyleColor();
 
             ++shown;
@@ -228,9 +214,10 @@ namespace Transmog
             if (ui.exactFilter && filteredByCategory > 0)
                 ImGui::TextDisabled("no matches in this category -- "
                                     "uncheck Exact to widen");
-            else if (ui.hideVariants && filteredByUnsafe > 0)
-                ImGui::TextDisabled("no matches -- uncheck Hide variants "
-                                    "to include unsafe items");
+            else if ((ui.hideIncompatible || ui.hideVariants) &&
+                     filteredByUnsafe > 0)
+                ImGui::TextDisabled("no matches -- uncheck filters "
+                                    "to show more items");
             else
                 ImGui::TextDisabled("no matches");
         }

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -20,6 +20,7 @@ namespace Transmog
     static std::array<bool, k_slotCount> s_realDamaged{};
     static std::array<std::uint16_t, 5> s_lastAppliedRealIds{};
     static std::atomic<bool> s_clearPending{false};
+    static std::array<std::uint16_t, k_slotCount> s_lastAppliedCarrierIds{};
 
     ResolvedAddresses &resolved_addrs() { return s_resolvedAddrs; }
     std::array<SlotMapping, k_slotCount> &slot_mappings() { return s_slotMappings; }
@@ -38,6 +39,7 @@ namespace Transmog
     std::atomic<uintptr_t> &world_system_ptr() { return s_worldSystemPtr; }
     std::array<bool, k_slotCount> &real_damaged() { return s_realDamaged; }
     std::array<std::uint16_t, 5> &last_applied_real_ids() { return s_lastAppliedRealIds; }
+    std::array<std::uint16_t, k_slotCount> &last_applied_carrier_ids() { return s_lastAppliedCarrierIds; }
     std::atomic<bool> &clear_pending() { return s_clearPending; }
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -16,6 +16,7 @@ namespace Transmog
         uintptr_t subTranslator        = 0; // sub_14076D950 — anchor for iteminfo item-name table scan
         uintptr_t safeTearDown         = 0; // sub_14075FE60 — scene-graph tear-down used by real_part_tear_down
         uintptr_t indexedStringLookup  = 0; // sub_1402D75D0 — IndexedStringA short->hash; resolved via ItemNameTable chain walk (50+ template siblings prevent direct AOB)
+        uintptr_t charClassBypass      = 0; // 0x141D5F538 — jz byte in CondPrefab evaluator secondary hash check. Toggle 0x74↔0xEB for NPC item support.
     };
 
     ResolvedAddresses &resolved_addrs();
@@ -90,6 +91,11 @@ namespace Transmog
     /// Snapshot of auth-table real itemId per armor slot at last apply.
     /// Compared against live auth state to detect real-armor swaps.
     std::array<std::uint16_t, 5> &last_applied_real_ids();
+
+    /// Carrier itemIds used in the last apply, indexed by TransmogSlot.
+    /// 0 means no carrier was used (direct apply). Used by tear-down
+    /// Phase A to find the correct scene-graph identity.
+    std::array<std::uint16_t, k_slotCount> &last_applied_carrier_ids();
 
     /// When true the debounce worker runs clear instead of apply.
     /// Set by manual_clear, consumed by the worker.

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -342,7 +342,7 @@ namespace Transmog
                     "[nametable] built synchronously at init "
                     "({} entries)",
                     ItemNameTable::instance().size());
-                if (logger.is_enabled(DMK::Logger::LogLevel::Trace))
+                if (logger.is_enabled(DMK::LogLevel::Trace))
                     ItemNameTable::instance().dump_catalog_tsv();
             }
             else if (result == BR::Deferred)
@@ -414,6 +414,40 @@ namespace Transmog
                     "InitSwapEntry AOB scan failed — transmog apply will "
                     "be disabled this session");
             }
+        }
+
+        // CharClassBypass: single-byte patch site in CondPrefab evaluator.
+        // Toggled 0x74↔0xEB around each carrier apply so NPC items
+        // pass the character-class hash check.
+        addrs.charClassBypass = resolve_address(
+            k_charClassBypassCandidates,
+            std::size(k_charClassBypassCandidates),
+            "CharClassBypass");
+        if (addrs.charClassBypass)
+        {
+            // Verify the resolved byte is 0x74 (jz). SEH-isolated via
+            // noinline lambda (C++ objects in parent block unwinding).
+            uint8_t probe = 0;
+            [&]() __declspec(noinline) {
+                __try { probe = *reinterpret_cast<volatile uint8_t *>(addrs.charClassBypass); }
+                __except (EXCEPTION_EXECUTE_HANDLER) { probe = 0; }
+            }();
+            if (probe == 0x74)
+                logger.info("CharClassBypass at 0x{:X} (byte=0x{:02X} OK)",
+                            addrs.charClassBypass, probe);
+            else
+            {
+                logger.warning("CharClassBypass at 0x{:X} byte=0x{:02X} "
+                               "(expected 0x74) -- disabling",
+                               addrs.charClassBypass, probe);
+                addrs.charClassBypass = 0;
+            }
+        }
+        else
+        {
+            logger.warning(
+                "CharClassBypass AOB scan failed -- NPC-variant transmog "
+                "will fall back to direct apply (may not render)");
         }
 
         // --- Load config ---

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -1,4 +1,5 @@
 #include "transmog_apply.hpp"
+#include "item_name_table.hpp"
 #include "part_show_suppress.hpp"
 #include "real_part_tear_down.hpp"
 #include "shared_state.hpp"
@@ -36,6 +37,228 @@ namespace Transmog
         slotPop(a1, reinterpret_cast<unsigned __int16 *>(itemData),
                 reinterpret_cast<__int64>(swapEntry));
         in_transmog().store(false, std::memory_order_relaxed);
+    }
+
+    // ── Default carrier set (Kliff PlateArmor) ──────────────────────────
+    // These are valid Kliff-equippable base items resolved by name at
+    // runtime. If a name fails to resolve, the slot falls back to direct
+    // equip (which may silently fail for NPC/variant items).
+
+    static constexpr const char *k_defaultCarrierNames[] = {
+        "Kliff_PlateArmor_Helm",    // TransmogSlot::Helm
+        "Kliff_PlateArmor_Armor",   // TransmogSlot::Chest
+        "Kliff_PlateArmor_Cloak",   // TransmogSlot::Cloak
+        "Kliff_PlateArmor_Gloves",  // TransmogSlot::Gloves
+        "Kliff_Plate_Boots",        // TransmogSlot::Boots
+    };
+
+    uint16_t default_carrier_for_slot(TransmogSlot slot)
+    {
+        const auto idx = static_cast<std::size_t>(slot);
+        if (idx >= k_slotCount)
+            return 0;
+        const auto &table = ItemNameTable::instance();
+        if (!table.ready())
+            return 0;
+        auto id = table.id_of(k_defaultCarrierNames[idx]);
+        return id.value_or(0);
+    }
+
+    bool needs_carrier(uint16_t itemId)
+    {
+        const auto &table = ItemNameTable::instance();
+        if (!table.ready())
+            return false;
+        return table.has_variant_meta(itemId) ||
+               !table.is_player_compatible(itemId);
+    }
+
+    // SEH-safe memory helpers (MSVC: __try cannot coexist with C++
+    // object unwinding in the same function).
+    static uintptr_t read_qword_seh(uintptr_t addr) noexcept
+    {
+        __try { return *reinterpret_cast<volatile uintptr_t *>(addr); }
+        __except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+    }
+    static bool memcpy_seh(void *dst, const void *src, size_t n) noexcept
+    {
+        __try { std::memcpy(dst, src, n); return true; }
+        __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+    }
+
+    // Descriptor size. Stride between consecutive descriptors observed
+    // in CE: 0x400 (1024). Over-read is fine -- we copy into a private
+    // buffer and only the game's actual reads matter.
+    static constexpr std::size_t k_descBufSize = 0x400;
+
+    // Descriptor offsets read by SlotPopulator for character-context
+    // matching BEFORE visual/mesh data. Must come from the CARRIER so
+    // Kliff's evaluator matches; everything else comes from TARGET.
+    //
+    // +0x042  2B  equip-type u16 (Kliff=4, NPC=1)
+    //             SlotPopulator reads *(desc+0x42) for the visual-config
+    //             matching loop (sub_14076CAED).
+    struct PatchRange { std::ptrdiff_t off; std::size_t len; };
+    static constexpr PatchRange k_carrierPatches[] = {
+        {0x042, 0x002},  // equip-type u16 (Kliff=4, NPC=1)
+    };
+
+    // Write the char-class bypass byte unconditionally. No from-check:
+    // the read-after-write can see stale values when page protection
+    // is restored between enable/restore cycles.
+    static bool set_char_class_bypass(uintptr_t addr, uint8_t val) noexcept
+    {
+        if (!addr)
+            return false;
+        const auto byteVal = static_cast<std::byte>(val);
+        return DMK::Memory::write_bytes(
+            reinterpret_cast<std::byte *>(addr), &byteVal, 1).has_value();
+    }
+
+    // Swaps descriptor pointer, toggles char-class bypass, calls
+    // SlotPopulator, then unconditionally restores both via __finally.
+    //
+    // __finally (not __except): runs cleanup WITHOUT catching the
+    // exception. Game-internal SEH exceptions (lazy loading, page
+    // faults) continue propagating to the game's own handlers.
+    // __except would intercept them and break the game.
+    //
+    // This is critical because apply_transmog faults on early load
+    // attempts (game data not ready). Without __finally, the
+    // descriptor pointer and bypass byte would be left corrupted.
+    static void carrier_swap_and_call(
+        __int64 a1, uint16_t carrierId,
+        uintptr_t carrierSlotAddr, uintptr_t hybridAddr,
+        uintptr_t bypassAddr) noexcept
+    {
+        const auto savedDesc = static_cast<LONG64>(
+            InterlockedExchange64(
+                reinterpret_cast<volatile LONG64 *>(carrierSlotAddr),
+                static_cast<LONG64>(hybridAddr)));
+
+        const bool bypassApplied =
+            set_char_class_bypass(bypassAddr, 0xEB);
+
+        __try
+        {
+            apply_transmog(a1, carrierId);
+        }
+        __finally
+        {
+            if (bypassApplied)
+                set_char_class_bypass(bypassAddr, 0x74);
+
+            InterlockedExchange64(
+                reinterpret_cast<volatile LONG64 *>(carrierSlotAddr),
+                savedDesc);
+        }
+    }
+
+    void apply_transmog_with_carrier(
+        __int64 a1, uint16_t carrierId, uint16_t targetId)
+    {
+        auto &logger = DMK::Logger::get_instance();
+
+        if (carrierId == 0 || carrierId == targetId)
+        {
+            logger.trace("[carrier] carrierId={:#06x} == targetId={:#06x}, "
+                         "direct apply", carrierId, targetId);
+            apply_transmog(a1, targetId);
+            return;
+        }
+
+        const auto &table = ItemNameTable::instance();
+        const auto ci = table.catalog_info();
+        if (ci.ptrArray == 0 || ci.count == 0)
+        {
+            logger.warning("[carrier] catalog not ready, direct fallback");
+            apply_transmog(a1, targetId);
+            return;
+        }
+        if (carrierId >= ci.count || targetId >= ci.count)
+        {
+            logger.warning("[carrier] id out of range: "
+                           "carrier={:#06x} target={:#06x} count={}",
+                           carrierId, targetId, ci.count);
+            apply_transmog(a1, targetId);
+            return;
+        }
+
+        const auto carrierSlotAddr =
+            ci.ptrArray + static_cast<uint64_t>(carrierId) * 8;
+        const uintptr_t targetDesc = read_qword_seh(
+            ci.ptrArray + static_cast<uint64_t>(targetId) * 8);
+        const uintptr_t carrierDesc = read_qword_seh(carrierSlotAddr);
+
+        if (targetDesc < 0x10000 || carrierDesc < 0x10000)
+        {
+            logger.warning("[carrier] bad descriptor: "
+                           "carrier={:#06x}={:#018x} target={:#06x}={:#018x}",
+                           carrierId, carrierDesc, targetId, targetDesc);
+            apply_transmog(a1, targetId);
+            return;
+        }
+
+        // ── Build hybrid descriptor on the heap ─────────────────────────
+        // Must use VirtualAlloc so the address is in the high heap range
+        // (game may reject low stack addresses in pointer sanity checks).
+        // Base = target's visual data. Overlay = carrier's matching fields.
+        auto *hybrid = static_cast<uint8_t *>(
+            VirtualAlloc(nullptr, k_descBufSize,
+                         MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+        if (!hybrid)
+        {
+            logger.warning("[carrier] VirtualAlloc failed for hybrid buffer");
+            apply_transmog(a1, targetId);
+            return;
+        }
+
+        if (!memcpy_seh(hybrid, reinterpret_cast<const void *>(targetDesc),
+                        k_descBufSize))
+        {
+            logger.warning("[carrier] fault copying target descriptor");
+            VirtualFree(hybrid, 0, MEM_RELEASE);
+            apply_transmog(a1, targetId);
+            return;
+        }
+
+        // Overlay carrier fields used for character-context matching.
+        std::size_t patchedBytes = 0;
+        for (const auto &p : k_carrierPatches)
+        {
+            if (p.off + p.len > k_descBufSize) continue;
+            if (!memcpy_seh(hybrid + p.off,
+                            reinterpret_cast<const void *>(carrierDesc + p.off),
+                            p.len))
+            {
+                logger.warning("[carrier] fault patching carrier field "
+                               "at +{:#x} len={}", p.off, p.len);
+                VirtualFree(hybrid, 0, MEM_RELEASE);
+                apply_transmog(a1, targetId);
+                return;
+            }
+            patchedBytes += p.len;
+        }
+
+        const auto hybridAddr = reinterpret_cast<uintptr_t>(hybrid);
+        const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
+
+        logger.trace("[carrier] HYBRID built: {} bytes patched, "
+                     "carrier={:#06x} desc={:#018x}, "
+                     "target={:#06x} desc={:#018x}, hybrid={:#018x}",
+                     patchedBytes,
+                     carrierId, carrierDesc, targetId, targetDesc,
+                     hybridAddr);
+
+        // SEH-isolated: swap descriptor, toggle bypass, call
+        // SlotPopulator, then unconditionally restore both.
+        carrier_swap_and_call(
+            a1, carrierId, carrierSlotAddr, hybridAddr, bypassAddr);
+
+        logger.trace("[carrier] POST: carrier={:#06x} target={:#06x}",
+                     carrierId, targetId);
+
+        VirtualFree(hybrid, 0, MEM_RELEASE);
     }
 
     void apply_all_transmog(__int64 a1)
@@ -124,7 +347,18 @@ namespace Transmog
                 }
             }
 
-            if (!presetChanged && !realChanged)
+            // Check for active "none" slots — these need Phase B
+            // tear-down and suppress reinforcement even when nothing
+            // else changed (the game may re-equip real items after our
+            // initial tear-down during the load sequence).
+            bool hasActiveNone = false;
+            for (std::size_t i = 0; i < k_slotCount; ++i)
+            {
+                if (mappings[i].active && mappings[i].targetItemId == 0)
+                { hasActiveNone = true; break; }
+            }
+
+            if (!presetChanged && !realChanged && !hasActiveNone)
             {
                 logger.trace(
                     "apply_all_transmog: no state change "
@@ -265,26 +499,72 @@ namespace Transmog
             }
 
             // Phase A: previous fakes (from lastIds before this apply).
+            // When the previous apply used a carrier, enable the
+            // char-class bypass so the tear-down can trace the NPC
+            // resource entries in the scene graph (they were loaded
+            // with the bypass active).
+            bool anyCarrierTearDown = false;
+            for (std::size_t k = 0; k < k_tearDownCount; ++k)
+            {
+                const auto idx = static_cast<std::size_t>(
+                    k_tearDownSlots[k].slot);
+                if (last_applied_carrier_ids()[idx] != 0 && prevIds[idx] != 0)
+                { anyCarrierTearDown = true; break; }
+            }
+
+            const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
+            bool bypassForTearDown = false;
+            if (anyCarrierTearDown)
+            {
+                bypassForTearDown =
+                    set_char_class_bypass(bypassAddr, 0xEB);
+                if (bypassForTearDown)
+                    logger.trace("[carrier] charClass bypass ENABLED "
+                                 "for Phase A tear-down");
+            }
+
             for (std::size_t k = 0; k < k_tearDownCount; ++k)
             {
                 const auto &td = k_tearDownSlots[k];
                 const auto idx = static_cast<std::size_t>(td.slot);
                 const auto prevId = prevIds[idx];
+                const auto prevCarrier = last_applied_carrier_ids()[idx];
                 if (prevId == 0)
                     continue;
-                if (static_cast<std::uint16_t>(prevId) == realItemId[k])
+                if (static_cast<std::uint16_t>(prevId) == realItemId[k] &&
+                    prevCarrier == 0)
                 {
                     logger.trace(
                         "[dispatch] tear_down_fake slot={:#06x} itemId={:#06x} "
-                        "skipped (matches real)",
+                        "skipped (matches real, no carrier)",
                         td.gameTag,
                         static_cast<std::uint16_t>(prevId));
                     continue;
+                }
+                if (prevCarrier != 0 &&
+                    prevCarrier != static_cast<std::uint16_t>(prevId))
+                {
+                    logger.trace(
+                        "[dispatch] tear_down_fake slot={:#06x} "
+                        "carrier={:#06x} (then target={:#06x})",
+                        td.gameTag, prevCarrier,
+                        static_cast<std::uint16_t>(prevId));
+                    RealPartTearDown::tear_down_by_item_id(
+                        reinterpret_cast<void *>(a1),
+                        prevCarrier,
+                        td.gameTag);
                 }
                 RealPartTearDown::tear_down_by_item_id(
                     reinterpret_cast<void *>(a1),
                     static_cast<std::uint16_t>(prevId),
                     td.gameTag);
+            }
+
+            if (bypassForTearDown)
+            {
+                set_char_class_bypass(bypassAddr, 0x74);
+                logger.trace("[carrier] charClass bypass RESTORED "
+                             "after Phase A tear-down");
             }
 
             // Phase B: real items for any active slot. Skip slots where
@@ -354,12 +634,35 @@ namespace Transmog
                 continue;
             }
 
-            logger.debug("Transmog APPLY: slot={}, target={:#06x}",
-                         slot_name(static_cast<TransmogSlot>(i)), m.targetItemId);
-            logger.trace("[dispatch] applying slot={} itemId={:#06x}",
-                         i, m.targetItemId);
+            // Decide: direct apply or carrier-assisted apply.
+            const auto tmSlot = static_cast<TransmogSlot>(i);
+            const auto targetId = m.targetItemId;
+            const bool useCarrier = needs_carrier(targetId);
+            const uint16_t carrierId =
+                useCarrier ? default_carrier_for_slot(tmSlot) : 0;
 
-            apply_transmog(a1, m.targetItemId);
+            if (useCarrier && carrierId != 0)
+            {
+                logger.debug("Transmog APPLY (carrier): slot={}, "
+                             "target={:#06x}, carrier={:#06x}",
+                             slot_name(tmSlot), targetId, carrierId);
+                logger.trace("[dispatch] applying slot={} targetId={:#06x} "
+                             "via carrier={:#06x}",
+                             i, targetId, carrierId);
+                apply_transmog_with_carrier(a1, carrierId, targetId);
+            }
+            else
+            {
+                if (useCarrier)
+                    logger.warning("Transmog APPLY: slot={} needs carrier "
+                                   "but none resolved, falling back to direct",
+                                   slot_name(tmSlot));
+                logger.debug("Transmog APPLY: slot={}, target={:#06x}",
+                             slot_name(tmSlot), targetId);
+                logger.trace("[dispatch] applying slot={} itemId={:#06x}",
+                             i, targetId);
+                apply_transmog(a1, targetId);
+            }
             uint32_t postCount = 0;
             __try
             {
@@ -370,7 +673,34 @@ namespace Transmog
             logger.trace("[dispatch] post-apply slot={} liveCount={}",
                          i, postCount);
             lastIds[i] = m.targetItemId;
+            last_applied_carrier_ids()[i] =
+                (useCarrier && carrierId != 0) ? carrierId : 0;
             ++ourWrittenCount;
+        }
+
+        // When a slot's checkbox is UNTICKED (!m.active), it was
+        // previously controlled by us (Phase B tore down the real
+        // item). Restore the real item so it reappears.
+        // "Active + none" (checkbox ticked, dropdown=none) means
+        // "show empty" — do NOT restore.
+        for (std::size_t i = 0; i < k_slotCount; ++i)
+        {
+            const auto &m = mappings[i];
+            if (!m.active && (prevIds[i] != 0 || real_damaged()[i]))
+            {
+                const std::uint16_t realId = lookup_real_id(i);
+                if (realId != 0)
+                {
+                    logger.info("[dispatch] slot={} unticked — "
+                                "restoring real item {:#06x}",
+                                slot_name(static_cast<TransmogSlot>(i)),
+                                realId);
+                    apply_transmog(a1, realId);
+                    ++ourWrittenCount;
+                }
+            }
+            if (!m.active || m.targetItemId == 0)
+                last_applied_carrier_ids()[i] = 0;
         }
 
         // Restore count to OUR writes only — stale entries in the
@@ -465,10 +795,19 @@ namespace Transmog
             prevFakeId[k] = static_cast<std::uint16_t>(lastIds[idx]);
         }
 
-        // Clear lastIds and per-slot damage flags.
+        // Snapshot carrier IDs before clearing.
+        std::uint16_t prevCarrierId[std::size(k_clearSlots)]{};
+        for (std::size_t k = 0; k < std::size(k_clearSlots); ++k)
+        {
+            const auto idx = static_cast<std::size_t>(k_clearSlots[k].slot);
+            prevCarrierId[k] = last_applied_carrier_ids()[idx];
+        }
+
+        // Clear lastIds, carrier IDs, and per-slot damage flags.
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
             lastIds[i] = 0;
+            last_applied_carrier_ids()[i] = 0;
             real_damaged()[i] = false;
         }
 
@@ -478,22 +817,35 @@ namespace Transmog
             for (std::size_t k = 0; k < std::size(k_clearSlots); ++k)
             {
                 const auto fakeId = prevFakeId[k];
+                const auto cId = prevCarrierId[k];
                 if (fakeId == 0)
                     continue;
                 const auto realId = RealPartTearDown::get_real_item_id(
                     reinterpret_cast<void *>(a1), k_clearSlots[k].gameTag);
-                if (realId == fakeId)
+                if (realId == fakeId && cId == 0)
                 {
                     logger.trace(
                         "[clear] orphan-check slot={:#06x} fake={:#06x} "
-                        "skipped (matches real)",
+                        "skipped (matches real, no carrier)",
                         k_clearSlots[k].gameTag, fakeId);
                     continue;
                 }
+                // Tear down carrier identity first if used.
+                if (cId != 0 && cId != fakeId)
+                {
+                    logger.info(
+                        "[clear] tearing carrier slot={:#06x} "
+                        "carrier={:#06x} (real={:#06x})",
+                        k_clearSlots[k].gameTag, cId, realId);
+                    RealPartTearDown::tear_down_by_item_id(
+                        reinterpret_cast<void *>(a1),
+                        cId,
+                        k_clearSlots[k].gameTag);
+                }
                 logger.info(
                     "[clear] tearing orphan fake slot={:#06x} itemId={:#06x} "
-                    "(real={:#06x})",
-                    k_clearSlots[k].gameTag, fakeId, realId);
+                    "(real={:#06x} carrier={:#06x})",
+                    k_clearSlots[k].gameTag, fakeId, realId, cId);
                 RealPartTearDown::tear_down_by_item_id(
                     reinterpret_cast<void *>(a1),
                     fakeId,

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.hpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "shared_state.hpp"
+
 #include <cstdint>
 
 namespace Transmog
@@ -7,6 +9,28 @@ namespace Transmog
     /// Applies transmog by calling SlotPopulator directly with target item.
     /// Builds the 16-byte item data structure and empty swap entry internally.
     void apply_transmog(__int64 a1, std::uint16_t targetId);
+
+    /// Applies transmog using a carrier item to bypass equip gates.
+    ///
+    /// Temporarily swaps the carrier's descriptor pointer in the global
+    /// iteminfo ptrArray to point at the target's descriptor, then calls
+    /// SlotPopulator with the carrier's itemId. The game reads the target's
+    /// visual data (mesh hashes, CondPrefab, etc.) while all equip gates
+    /// see a valid carrier. Restores the original pointer immediately after.
+    ///
+    /// @param carrierId  Valid Kliff-equippable item for the slot
+    /// @param targetId   Item whose visual to display (may be NPC variant)
+    void apply_transmog_with_carrier(
+        __int64 a1, std::uint16_t carrierId, std::uint16_t targetId);
+
+    /// Resolve the default carrier itemId for a given transmog slot.
+    /// Returns 0 if no carrier is needed (item is directly equippable)
+    /// or if the carrier name can't be resolved.
+    std::uint16_t default_carrier_for_slot(TransmogSlot slot);
+
+    /// Returns true if the given item needs a carrier (has variant meta
+    /// or is not player-compatible).
+    bool needs_carrier(std::uint16_t itemId);
 
     /// Full apply pass: two-phase tear-down + SlotPopulator for all active
     /// slots. Updates dispatch cache, suppress mask, and last-applied state.

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -69,7 +69,7 @@ namespace Transmog
                     "[nametable] deferred scan succeeded on attempt {} "
                     "({} entries)",
                     attempt + 1, size);
-                if (logger.is_enabled(DMK::Logger::LogLevel::Trace))
+                if (logger.is_enabled(DMK::LogLevel::Trace))
                     ItemNameTable::instance().dump_catalog_tsv();
 
                 // Re-resolve all loaded preset slots against the now-


### PR DESCRIPTION
## Summary
- NPC armor variants and damaged variants now render via automatic carrier descriptor swap + character-class bypass
- New overlay badges: cyan `(carrier)` for variant items, red for crash-risk items
- Split filters: "Safe only" (hides crash-risk) + "Hide variants" (hides NPC/damaged)
- Fixed: real armor showing on load for active-but-empty slots
- Fixed: unticking a slot now restores the real equipped item
- Fixed: switching from NPC preset leaves no ghost meshes

## Test plan
- [x] Apply NPC variant preset (e.g. Antra helm), visual renders
- [x] Set slot to (none),  NPC mesh removed, slot empty
- [x] Untick slot checkbox, real armor reappears
- [x] Switch between NPC and normal presets, no clipping/ghost
- [x] Game load with active+none slots, real armor stays hidden
- [x] "Safe only" filter hides horse tack/pet armor (red items)
- [x] "Hide variants" filter toggles NPC/damaged items (cyan items)
