### PR TITLE
feat(live-transmog): add instant apply, slot-scoped apply, and overlay UX improvements

### DIFF
--- a/.github/workflows/release-livetransmog.yml
+++ b/.github/workflows/release-livetransmog.yml
@@ -202,8 +202,8 @@ jobs:
           ### Installation
 
           1. Extract all files to your Crimson Desert `bin64/plugins/` directory
-          2. Edit the INI file to configure your transmog swaps
-          3. Launch the game and press T (default) to toggle transmog
+          2. Launch the game and press **Home** to open the ReShade overlay
+          3. Find the **Transmog** tab, browse armor, and click **Apply All**
 
           ### Note
           This package includes everything you need:

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,10 @@
-## [Title for next release]
+## Instant Apply and Overlay Improvements
 
-- New feature
-- Bug fix
-- Improvement
+- Added **Instant Apply** mode - preview armor in real-time by hovering over items in the picker, no need to click Apply All
+- Clicking an item or toggling a slot checkbox now applies immediately when Instant Apply is on
+- Added **Keep Search Text** option - search field preserves your text between picker opens
+- Added **X** button next to each slot for quick one-click clear
+- Added **navigation buttons** (^/v) in the item picker for browsing without scrolling
+- Changing one armor slot no longer causes all other slots to briefly flicker
+- Unticking a slot then unequipping that armor in the inventory now correctly removes the visual
+- Fixed a bug where clearing a slot could save "Pyeonjeon_Arrow" in the preset file instead of leaving it empty

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -55,6 +55,8 @@ Download the [b]x64[/b] build of [url=https://github.com/ThirteenAG/Ultimate-ASI
 
 [b]How to verify:[/b] After completing Step 3, launch the game once. If no [b]CrimsonDesertLiveTransmog.log[/b] file appears in [b]bin64[/b], the ASI Loader is not loading. Try renaming the DLL to one of the other variants listed above.
 
+[color=#ff6600][b]Note:[/b][/color] If you are using a newer version of Ultimate ASI Loader and the log file is not generated, try the [b]win64[/b] (x64) build from [url=https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/tag/v9.1.0]v9.1.0[/url] instead.
+
 [size=4]Step 3 -Install the mod[/size]
 [list=1]
 [*]Download the latest release from the Files tab
@@ -68,6 +70,7 @@ Launch the game. Press [b]Home[/b] to open ReShade, find the [b]Transmog[/b] tab
 [code]
 <Crimson Desert>/bin64/
 ├── CrimsonDesert.exe                          (Game executable)
+├── dxgi.dll                                   (ReShade)
 ├── winmm.dll                                  (ASI Loader)
 ├── CrimsonDesertLiveTransmog.asi              (This mod)
 ├── CrimsonDesertLiveTransmog.ini              (Configuration)
@@ -186,6 +189,7 @@ If you encounter issues:
 [*]Set [b]LogLevel = Debug[/b] in the INI file
 [*]Check the log file in your game directory ([b]CrimsonDesertLiveTransmog.log[/b])
 [*]For memory pattern errors, the mod needs an update for the current game version
+[*]If the log file is not generated after updating to a newer version of Ultimate ASI Loader, try the [b]win64[/b] (x64) build from [url=https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/tag/v9.1.0]Ultimate ASI Loader v9.1.0[/url] instead
 [/list]
 
 [line]

--- a/CrimsonDesertLiveTransmog/src/overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay.cpp
@@ -24,6 +24,22 @@ namespace Transmog
     static HMODULE s_overlayModule = nullptr;
     static bool s_overlayRegistered = false;
 
+    // Minimum time (ms) the cursor must rest on a picker item before
+    // hover-apply fires. Prevents rapid apply cycles while scrolling.
+    static constexpr int64_t k_hoverDebounceMs = 300;
+
+    // --- Overlay preferences (render-thread only) ---
+
+    // Instant Apply mode: applies transmog immediately on hover, pick,
+    // slot toggle, and clear — no Apply All click needed. Off by default
+    // because each action triggers a tear-down + SlotPopulator cycle.
+    static bool s_autoApply = false;
+
+    // When true, preserve the search text between picker opens so the
+    // user can re-open the same slot and keep browsing where they left
+    // off. Off by default to match legacy behaviour (clear on open).
+    static bool s_keepSearchText = true;
+
     // --- Per-slot UI state ---
 
     struct SlotUIState
@@ -35,8 +51,22 @@ namespace Transmog
         // matches THIS slot. Defaults to ON so the dropdown shows ~350
         // relevant items instead of all 6024.
         bool exactFilter = true;
-        bool hideIncompatible = true;   // hide crash-risk + non-equipment
-        bool hideVariants = false; // hide NPC variants (carrier items)
+        bool hideIncompatible = true; // hide crash-risk + non-equipment
+        bool hideVariants = false;    // hide NPC variants (carrier items)
+        // Hover-apply debounce state. We track which item the cursor is
+        // on and when it first landed there. Apply fires only after the
+        // cursor has settled on the same item for k_hoverDebounceMs,
+        // preventing rapid-fire apply cycles when scrolling the list.
+        uint16_t hoverPendingId = 0;
+        uint16_t hoverAppliedId = 0;
+        int64_t hoverStartMs = 0;
+        // Button-driven navigation index into the visible (filtered)
+        // list. -1 = no highlight. Up/Down buttons move this; Enter
+        // commits the highlighted item. lastVisibleCount stores the
+        // previous frame's visible count for clamping.
+        int navIndex = -1;
+        int lastVisibleCount = 0;
+        bool navMoved{false}; // true only on the frame a nav button was pressed
     };
 
     static SlotUIState s_slotUI[k_slotCount]{};
@@ -72,15 +102,28 @@ namespace Transmog
 
     // Draw a search-filterable picker popup for one slot. Returns true if
     // the user committed a selection this frame (caller is responsible for
-    // persisting it).
-    static bool draw_item_picker_popup(const char *popupId,
+    // persisting it). When autoApply is true, hovering an item starts a
+    // debounce timer; once it expires the slot-scoped apply fires via
+    // manual_apply_slot so only the hovered slot re-equips.
+    [[nodiscard]] static bool draw_item_picker_popup(const char *popupId,
                                        SlotUIState &ui,
                                        TransmogSlot slotCategory,
-                                       uint16_t &targetItemId)
+                                       uint16_t &targetItemId,
+                                       bool autoApply,
+                                       std::size_t slotIdx)
     {
         bool committed = false;
         if (!ImGui::BeginPopup(popupId))
             return false;
+
+        // Reset hover-debounce state on first frame so stale state from
+        // a previous open doesn't suppress or prematurely fire an apply.
+        if (ImGui::IsWindowAppearing())
+        {
+            ui.hoverPendingId = targetItemId;
+            ui.hoverAppliedId = targetItemId;
+            ui.hoverStartMs = 0;
+        }
 
         ImGui::TextDisabled("Item picker");
         ImGui::Separator();
@@ -99,28 +142,70 @@ namespace Transmog
         ImGui::SameLine();
         ImGui::Checkbox("Hide variants", &ui.hideVariants);
 
-        ImGui::SetNextItemWidth(260.0f);
+        ImGui::SetNextItemWidth(200.0f);
         if (ImGui::IsWindowAppearing())
+        {
             ImGui::SetKeyboardFocusHere();
-        ImGui::InputTextWithHint("##search", "search by name...",
-                                 ui.searchBuf, sizeof(ui.searchBuf));
+            ui.navIndex = -1;
+        }
+        const bool searchEdited = ImGui::InputTextWithHint(
+            "##search", "search by name...",
+            ui.searchBuf, sizeof(ui.searchBuf));
+        if (searchEdited)
+            ui.navIndex = 0;
 
         ImGui::SameLine();
         if (ImGui::SmallButton("Clear##search"))
+        {
             ui.searchBuf[0] = '\0';
+            ui.navIndex = 0;
+        }
+
+        // Navigation buttons: move the highlight through the visible
+        // list. Placed next to the search bar so they're always
+        // reachable without scrolling. Enter commits the highlighted
+        // item.
+        ImGui::SameLine();
+        ui.navMoved = false;
+        {
+            const int maxNav = ui.lastVisibleCount - 1;
+            if (ImGui::SmallButton("^##nav_up"))
+            {
+                ui.navIndex = (ui.navIndex > 0) ? ui.navIndex - 1 : 0;
+                ui.navMoved = true;
+            }
+            ImGui::SameLine();
+            if (ImGui::SmallButton("v##nav_down"))
+            {
+                ui.navIndex = (ui.navIndex < maxNav)
+                                  ? ui.navIndex + 1
+                                  : (maxNav >= 0 ? maxNav : 0);
+                ui.navMoved = true;
+            }
+        }
 
         const auto &table = ItemNameTable::instance();
         const auto &entries = table.sorted_entries();
 
-        // Fixed-height scrollable region so the popup doesn't resize per
-        // keystroke as the filter narrows.
         const float rowH = ImGui::GetTextLineHeightWithSpacing();
+
+        // Fixed-height scrollable region so the popup doesn't resize
+        // per keystroke as the filter narrows.
         ImGui::BeginChild("##itemlist",
-                          ImVec2(320.0f, rowH * 14.0f),
+                          ImVec2(340.0f, rowH * 22.0f),
                           true);
 
-        // "None" / clear entry — maps to id 0 so the user can disable a
-        // slot without typing hex.
+        // Increase vertical spacing between items for easier click/hover
+        // targets. Pushed INSIDE BeginChild so the popup-level spacing
+        // stays default — otherwise the popup's own scroll region may
+        // capture mouse wheel events instead of the child.
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                            ImVec2(ImGui::GetStyle().ItemSpacing.x,
+                                   rowH * 0.35f));
+
+        // "None" / clear entry at the top of the scroll region.
+        // Hover-preview shows bare head/body (empty slot) via the
+        // active+none path in apply_single_slot.
         {
             const bool selected = (targetItemId == 0);
             if (ImGui::Selectable("(none -- id 0)##picker_none", selected))
@@ -128,6 +213,14 @@ namespace Transmog
                 targetItemId = 0;
                 committed = true;
                 ImGui::CloseCurrentPopup();
+            }
+            if (selected)
+                ImGui::SetItemDefaultFocus();
+            if (autoApply && ImGui::IsItemHovered() &&
+                ui.hoverPendingId != 0)
+            {
+                ui.hoverPendingId = 0;
+                ui.hoverStartMs = steady_ms();
             }
         }
 
@@ -195,12 +288,54 @@ namespace Transmog
                 ImGui::PushStyleColor(ImGuiCol_Text,
                                       ImVec4(0.5f, 0.85f, 1.0f, 1.0f));
 
-            const bool selected = (targetItemId == e.id);
-            if (ImGui::Selectable(label, selected))
+            const bool isNavTarget = (shown == ui.navIndex);
+            const bool highlighted =
+                (targetItemId == e.id) || isNavTarget;
+            if (ImGui::Selectable(label, highlighted))
             {
                 targetItemId = e.id;
                 committed = true;
                 ImGui::CloseCurrentPopup();
+            }
+
+            // Scroll the nav-highlighted row into view and handle
+            // Enter to commit.
+            if (isNavTarget)
+            {
+                if (ui.navMoved)
+                    ImGui::SetScrollHereY();
+                if (ImGui::IsKeyPressed(ImGuiKey_Enter) ||
+                    ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))
+                {
+                    targetItemId = e.id;
+                    committed = true;
+                    ImGui::CloseCurrentPopup();
+                }
+                // Feed nav target into hover-apply debounce so
+                // button navigation previews items when auto-apply
+                // is on.
+                if (autoApply && ui.hoverPendingId != e.id)
+                {
+                    ui.hoverPendingId = e.id;
+                    ui.hoverStartMs = steady_ms();
+                }
+            }
+            else if (targetItemId == e.id)
+            {
+                // Scroll to the currently selected item on popup
+                // open so it's visible without manual scrolling.
+                ImGui::SetItemDefaultFocus();
+            }
+
+            // Live preview: record the mouse-hovered item and start
+            // the debounce timer. Sync nav cursor to mouse so the
+            // highlight follows the cursor.
+            if (autoApply && ImGui::IsItemHovered() &&
+                ui.hoverPendingId != e.id)
+            {
+                ui.hoverPendingId = e.id;
+                ui.hoverStartMs = steady_ms();
+                ui.navIndex = shown;
             }
 
             if (crashRisk || usesCarrier)
@@ -226,7 +361,31 @@ namespace Transmog
             ImGui::TextDisabled("(truncated -- narrow your search)");
         }
 
+        // Clamp nav index to the actual visible count so stale values
+        // from a wider filter don't point past the end of the list.
+        ui.lastVisibleCount = shown;
+        if (ui.navIndex >= shown)
+            ui.navIndex = shown > 0 ? shown - 1 : -1;
+
+        ImGui::PopStyleVar(); // ItemSpacing
         ImGui::EndChild();
+
+        // --- Hover-apply debounce ---
+        // Fire manual_apply_slot() only after the cursor has rested on
+        // the same item for k_hoverDebounceMs. Uses the slot-scoped
+        // apply path so only this slot re-equips — other slots are
+        // untouched and don't flicker.
+        if (autoApply &&
+            ui.hoverPendingId != ui.hoverAppliedId &&
+            ui.hoverStartMs != 0 &&
+            (steady_ms() - ui.hoverStartMs) >= k_hoverDebounceMs)
+        {
+            targetItemId = ui.hoverPendingId;
+            ui.hoverAppliedId = ui.hoverPendingId;
+            flag_enabled().store(true, std::memory_order_relaxed);
+            manual_apply_slot(slotIdx);
+        }
+
         ImGui::EndPopup();
 
         return committed;
@@ -246,7 +405,7 @@ namespace Transmog
     // (targetItemId when active, else 0) differs from what's currently
     // committed to the game. Lets the overlay show a "[PENDING]" badge
     // so users don't close the GUI and lose track of their edits.
-    static bool has_pending_changes() noexcept
+    [[nodiscard]] static bool has_pending_changes() noexcept
     {
         const auto &mappings = slot_mappings();
         const auto &lastIds = last_applied_ids();
@@ -263,7 +422,11 @@ namespace Transmog
     static void draw_overlay(reshade::api::effect_runtime *)
     {
         auto &pm = PresetManager::instance();
-        const bool pending = has_pending_changes();
+        // When auto-apply is on, picks are applied immediately so
+        // there's never a meaningful "pending" state. Suppress the
+        // badge and yellow button tint to reduce visual noise.
+        const bool pending =
+            !s_autoApply && has_pending_changes();
 
         // --- Header ---
 
@@ -299,6 +462,18 @@ namespace Transmog
             else
                 manual_clear();
         }
+
+        ImGui::Checkbox("Instant Apply", &s_autoApply);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Apply changes immediately on hover, "
+                              "pick, toggle, and clear — no Apply All "
+                              "needed");
+
+        ImGui::SameLine();
+        ImGui::Checkbox("Keep Search Text", &s_keepSearchText);
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Preserve the search field when "
+                              "re-opening a slot picker");
 
         // --- Player Only / Character selector ---
         //
@@ -507,9 +682,18 @@ namespace Transmog
                 {
                     for (std::size_t i = 0; i < k_slotCount; ++i)
                         mappings[i].active = allActive;
+                    if (s_autoApply)
+                    {
+                        flag_enabled().store(true,
+                                             std::memory_order_relaxed);
+                        manual_apply();
+                    }
                 }
-                ImGui::SameLine();
-                ImGui::TextDisabled("(pending -- Apply All to commit)");
+                if (!s_autoApply)
+                {
+                    ImGui::SameLine();
+                    ImGui::TextDisabled("(pending -- Apply All to commit)");
+                }
             }
 
             for (std::size_t i = 0; i < k_slotCount; ++i)
@@ -520,7 +704,11 @@ namespace Transmog
 
                 ImGui::PushID(static_cast<int>(i) + 100);
 
-                ImGui::Checkbox(slotLabel, &m.active);
+                if (ImGui::Checkbox(slotLabel, &m.active) && s_autoApply)
+                {
+                    flag_enabled().store(true, std::memory_order_relaxed);
+                    manual_apply_slot(i);
+                }
 
                 ImGui::SameLine(120.0f);
 
@@ -555,12 +743,28 @@ namespace Transmog
                                   m.targetItemId);
 
                     ImGui::SetNextItemWidth(240.0f);
-                    if (ImGui::Button(btnLabel, ImVec2(260.0f, 0.0f)))
+                    if (ImGui::Button(btnLabel, ImVec2(240.0f, 0.0f)))
                     {
                         if (tableReady)
                         {
-                            ui.searchBuf[0] = '\0';
+                            if (!s_keepSearchText)
+                                ui.searchBuf[0] = '\0';
                             ImGui::OpenPopup("##slot_picker");
+                        }
+                    }
+
+                    // Quick-clear button: sets slot to (none) without
+                    // opening the picker. Auto-applies if enabled.
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("X##clr") && m.targetItemId != 0)
+                    {
+                        m.targetItemId = 0;
+                        std::snprintf(ui.hexBuf, sizeof(ui.hexBuf), "0000");
+                        if (s_autoApply)
+                        {
+                            flag_enabled().store(true,
+                                                 std::memory_order_relaxed);
+                            manual_apply_slot(i);
                         }
                     }
 
@@ -568,19 +772,23 @@ namespace Transmog
                         draw_item_picker_popup(
                             "##slot_picker", ui,
                             static_cast<TransmogSlot>(i),
-                            m.targetItemId))
+                            m.targetItemId,
+                            s_autoApply, i))
                     {
-                        // Picker commits stay PENDING in slot_mappings.
-                        // The visual does not change until the user
-                        // explicitly clicks Apply All -- no auto-apply.
-                        // This lets users edit all 5 slots and then push
-                        // them as a batch, avoiding flicker and partial
-                        // transmog states.
-                        //
                         // Keep the hex field in sync so toggling back to
                         // manual entry doesn't show a stale value.
                         std::snprintf(ui.hexBuf, sizeof(ui.hexBuf), "%04X",
                                       m.targetItemId);
+
+                        // When auto-apply is on, commit the pick
+                        // immediately so clicking an item behaves the
+                        // same as hovering (instant feedback).
+                        if (s_autoApply)
+                        {
+                            flag_enabled().store(true,
+                                                 std::memory_order_relaxed);
+                            manual_apply_slot(i);
+                        }
 
                         // Focused debug log for "picked but no visual"
                         // cases: prints slot, id, resolved name, and
@@ -589,16 +797,16 @@ namespace Transmog
                         // now deferred -- no longer a live event.
                         {
                             const auto name = (m.targetItemId == 0)
-                                ? std::string("(none)")
-                                : table.name_of(m.targetItemId);
+                                                  ? std::string("(none)")
+                                                  : table.name_of(m.targetItemId);
                             const auto cat =
                                 ItemNameTable::classify_slot(name);
                             const char *catName =
                                 (m.targetItemId == 0)
                                     ? "clear"
-                                    : (cat == static_cast<TransmogSlot>(i))
-                                        ? "slot-match"
-                                        : "slot-MISMATCH";
+                                : (cat == static_cast<TransmogSlot>(i))
+                                    ? "slot-match"
+                                    : "slot-MISMATCH";
                             DMK::Logger::get_instance().info(
                                 "[picker] slot={} id=0x{:04X} name='{}' "
                                 "category={} ({}) -- pending Apply All",

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -413,8 +413,14 @@ namespace Transmog
         {
             p.slots[i].active = mappings[i].active;
             p.slots[i].itemId = mappings[i].targetItemId;
-            if (table.ready())
+            // id 0 means "none" — don't resolve a name for it.
+            // The catalog's entry at index 0 is a real item
+            // (Pyeonjeon_Arrow) and saving that name would cause
+            // the preset to load an unintended item on reresolve.
+            if (table.ready() && mappings[i].targetItemId != 0)
                 p.slots[i].itemName = table.name_of(mappings[i].targetItemId);
+            else
+                p.slots[i].itemName.clear();
         }
         return p;
     }

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -20,6 +20,7 @@ namespace Transmog
     static std::array<bool, k_slotCount> s_realDamaged{};
     static std::array<std::uint16_t, 5> s_lastAppliedRealIds{};
     static std::atomic<bool> s_clearPending{false};
+    static std::atomic<std::size_t> s_pendingSlotIndex{k_slotCount};
     static std::array<std::uint16_t, k_slotCount> s_lastAppliedCarrierIds{};
 
     ResolvedAddresses &resolved_addrs() { return s_resolvedAddrs; }
@@ -41,5 +42,6 @@ namespace Transmog
     std::array<std::uint16_t, 5> &last_applied_real_ids() { return s_lastAppliedRealIds; }
     std::array<std::uint16_t, k_slotCount> &last_applied_carrier_ids() { return s_lastAppliedCarrierIds; }
     std::atomic<bool> &clear_pending() { return s_clearPending; }
+    std::atomic<std::size_t> &pending_slot_index() { return s_pendingSlotIndex; }
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -101,6 +101,14 @@ namespace Transmog
     /// Set by manual_clear, consumed by the worker.
     std::atomic<bool> &clear_pending();
 
+    /// Slot index for single-slot hover-apply. k_slotCount means
+    /// "apply all" (the default). Values 0..4 scope the next
+    /// debounced apply to one slot only, avoiding full-gear flicker.
+    /// Last-writer-wins: if manual_apply (full) and manual_apply_slot
+    /// race before the worker wakes, only the latest store takes
+    /// effect. This is acceptable — the user's most recent action wins.
+    std::atomic<std::size_t> &pending_slot_index();
+
     // --- Hot-path utilities ---
 
     inline int64_t steady_ms() noexcept

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -157,6 +157,24 @@ namespace Transmog
 
         DMK::Logger::get_instance().debug("Manual apply: scheduling (debounced)");
         clear_pending().store(false, std::memory_order_release);
+        // Reset to "all slots" so the worker runs the full path.
+        pending_slot_index().store(k_slotCount, std::memory_order_release);
+        schedule_transmog_ms(k_manualDebounceMs);
+    }
+
+    void manual_apply_slot(std::size_t slotIdx)
+    {
+        if (!is_world_ready())
+        {
+            DMK::Logger::get_instance().debug(
+                "Manual apply slot={}: player not found", slotIdx);
+            return;
+        }
+
+        DMK::Logger::get_instance().debug(
+            "Manual apply slot={}: scheduling (debounced)", slotIdx);
+        clear_pending().store(false, std::memory_order_release);
+        pending_slot_index().store(slotIdx, std::memory_order_release);
         schedule_transmog_ms(k_manualDebounceMs);
     }
 

--- a/CrimsonDesertLiveTransmog/src/transmog.hpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.hpp
@@ -1,11 +1,19 @@
 #pragma once
 
+#include <cstddef>
+
 namespace Transmog
 {
     bool init();
     void shutdown();
 
     void manual_apply();
+
+    /// @brief Schedule a single-slot transmog apply via the debounce worker.
+    /// @param slotIdx TransmogSlot index (0..4). Only this slot is torn
+    ///        down and re-applied; other slots are untouched.
+    void manual_apply_slot(std::size_t slotIdx);
+
     void manual_clear();
     void capture_outfit();
 

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -261,6 +261,242 @@ namespace Transmog
         VirtualFree(hybrid, 0, MEM_RELEASE);
     }
 
+    // ── Single-slot apply ──────────────────────────────────────────────
+    //
+    // Scoped version of apply_all_transmog that only touches ONE slot.
+    // Used by hover-preview to avoid the full tear-down + re-apply of
+    // all 5 slots, which causes visible flicker on unchanged gear.
+    //
+    // Differences from apply_all_transmog:
+    //   - Dispatch cache: only clears entries matching this slot's game
+    //     tag (by walking the 24-byte stride array). Does NOT reset the
+    //     global count to zero — other slots' entries stay valid.
+    //   - Tear-down: Phase A (previous fake) and Phase B (real item)
+    //     scoped to one slot.
+    //   - Apply: single call to apply_transmog or
+    //     apply_transmog_with_carrier.
+    //   - State: only updates lastIds, carrier, suppress for this slot.
+
+    // Game slot tags per TransmogSlot index. Must stay in sync with
+    // k_tearDownSlots inside apply_all_transmog.
+    static constexpr std::uint16_t k_gameSlotTags[k_slotCount] = {
+        0x0003, // Helm
+        0x0004, // Chest
+        0x0010, // Cloak
+        0x0005, // Gloves
+        0x0006, // Boots
+    };
+
+    void apply_single_slot_transmog(__int64 a1, std::size_t slotIdx)
+    {
+        if (slotIdx >= k_slotCount)
+            return;
+
+        auto &logger = DMK::Logger::get_instance();
+        auto &mappings = slot_mappings();
+        auto &lastIds = last_applied_ids();
+        auto &m = mappings[slotIdx];
+
+        if (world_system_ptr().load(std::memory_order_acquire))
+        {
+            auto fresh = resolve_player_component();
+            if (fresh > 0x10000)
+                a1 = fresh;
+        }
+
+        __try
+        {
+            auto actor = *reinterpret_cast<uintptr_t *>(a1 + 8);
+            if (actor < 0x10000)
+            {
+                logger.warning("apply_single_slot: a1 invalid");
+                return;
+            }
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            logger.warning("apply_single_slot: a1 access fault");
+            return;
+        }
+
+        suppress_vec().store(true, std::memory_order_release);
+
+        const uint16_t prevId = lastIds[slotIdx];
+        const uint16_t gameTag = k_gameSlotTags[slotIdx];
+
+        // Compute target: active slot with non-zero id → transmog,
+        // otherwise clear this slot.
+        const uint16_t targetId =
+            (m.active && m.targetItemId != 0) ? m.targetItemId : 0;
+
+        // Early-out: nothing changed for this slot.
+        if (targetId == prevId && targetId != 0)
+        {
+            logger.trace("apply_single_slot: slot={} id={:#06x} unchanged",
+                         slotIdx, targetId);
+            suppress_vec().store(false, std::memory_order_release);
+            return;
+        }
+
+        // --- Scoped dispatch cache clear ---
+        // Walk the 24-byte stride cache and zero subCount only for
+        // entries whose slotNativeId matches our game tag. This leaves
+        // other slots' blobs untouched so VEC doesn't re-dispatch them.
+        __try
+        {
+            const auto count =
+                *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
+            const auto base =
+                *reinterpret_cast<volatile uintptr_t *>(a1 + 0x1B8);
+            if (base > 0x10000)
+            {
+                for (uint32_t e = 0; e < count; ++e)
+                {
+                    const auto entry = base + 24ULL * e;
+                    const auto slotId =
+                        *reinterpret_cast<volatile uint16_t *>(entry);
+                    if (slotId == gameTag)
+                        *reinterpret_cast<volatile uint32_t *>(
+                            entry + 0x10) = 0;
+                }
+            }
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            logger.warning("[dispatch] single-slot cache clear fault");
+            suppress_vec().store(false, std::memory_order_release);
+            return;
+        }
+
+        // --- Tear-down scoped to this slot ---
+        std::uint16_t realId = 0;
+        if (RealPartTearDown::is_ready())
+        {
+            realId = RealPartTearDown::get_real_item_id(
+                reinterpret_cast<void *>(a1), gameTag);
+
+            // Phase A: tear down previous fake.
+            if (prevId != 0 && prevId != realId)
+            {
+                const auto prevCarrier = last_applied_carrier_ids()[slotIdx];
+                const uintptr_t bypassAddr =
+                    resolved_addrs().charClassBypass;
+                bool bypassApplied = false;
+                if (prevCarrier != 0)
+                    bypassApplied =
+                        set_char_class_bypass(bypassAddr, 0xEB);
+
+                if (prevCarrier != 0 &&
+                    prevCarrier != static_cast<uint16_t>(prevId))
+                {
+                    RealPartTearDown::tear_down_by_item_id(
+                        reinterpret_cast<void *>(a1), prevCarrier, gameTag);
+                }
+                RealPartTearDown::tear_down_by_item_id(
+                    reinterpret_cast<void *>(a1),
+                    static_cast<uint16_t>(prevId), gameTag);
+
+                if (bypassApplied)
+                    set_char_class_bypass(bypassAddr, 0x74);
+            }
+
+            // Phase B: tear down real item if fake differs.
+            if (targetId != 0 && targetId != realId)
+            {
+                if (RealPartTearDown::tear_down_real_part(
+                        reinterpret_cast<void *>(a1), gameTag))
+                    real_damaged()[slotIdx] = true;
+            }
+        }
+
+        // --- Apply ---
+        if (targetId != 0)
+        {
+            const auto tmSlot = static_cast<TransmogSlot>(slotIdx);
+            const bool useCarrier = needs_carrier(targetId);
+            const uint16_t carrierId =
+                useCarrier ? default_carrier_for_slot(tmSlot) : 0;
+
+            if (useCarrier && carrierId != 0)
+            {
+                logger.debug("apply_single_slot: slot={} target={:#06x} "
+                             "carrier={:#06x}",
+                             slot_name(tmSlot), targetId, carrierId);
+                apply_transmog_with_carrier(a1, carrierId, targetId);
+            }
+            else
+            {
+                logger.debug("apply_single_slot: slot={} target={:#06x}",
+                             slot_name(tmSlot), targetId);
+                apply_transmog(a1, targetId);
+            }
+
+            lastIds[slotIdx] = targetId;
+            last_applied_carrier_ids()[slotIdx] =
+                (useCarrier && carrierId != 0) ? carrierId : 0;
+            // Phase B set real_damaged when tearing down the real item
+            // for this slot. Now that the fake is successfully applied,
+            // clear it so apply_all_transmog doesn't see stale damage
+            // state for this slot on subsequent cycles.
+            real_damaged()[slotIdx] = false;
+        }
+        else
+        {
+            // Clearing this slot. Two cases:
+            //  - active + none (checkbox ticked, picker = none): user
+            //    wants to show an EMPTY slot (bare head, etc.). Do NOT
+            //    restore the real item — Phase B already tore it down.
+            //  - inactive (!m.active): slot was previously controlled
+            //    by us; restore the real item so it reappears.
+            const bool showEmpty = m.active;
+            if (!showEmpty && (prevId != 0 || real_damaged()[slotIdx]))
+            {
+                if (realId != 0)
+                {
+                    logger.debug("apply_single_slot: slot={} restoring "
+                                 "real {:#06x}",
+                                 slot_name(static_cast<TransmogSlot>(
+                                     slotIdx)),
+                                 realId);
+                    apply_transmog(a1, realId);
+                }
+            }
+            lastIds[slotIdx] = 0;
+            last_applied_carrier_ids()[slotIdx] = 0;
+            // Clear damage flag so the slot is fully released back to
+            // the game. Without this, apply_all_transmog's untick-restore
+            // and slotNeedsWork checks see stale damage state and keep
+            // interfering with an unmanaged slot.
+            real_damaged()[slotIdx] = false;
+        }
+
+        // Update suppress mask for this slot only. Rebuild full mask
+        // from current state rather than toggling one bit, to stay
+        // consistent with apply_all_transmog's mask logic.
+        std::uint32_t suppressMask = 0;
+        for (std::size_t k = 0; k < k_slotCount; ++k)
+        {
+            const auto &sm = mappings[k];
+            if (!sm.active)
+                continue;
+            const std::uint16_t slotReal =
+                RealPartTearDown::is_ready()
+                    ? RealPartTearDown::get_real_item_id(
+                          reinterpret_cast<void *>(a1), k_gameSlotTags[k])
+                    : 0;
+            if (sm.targetItemId != 0 &&
+                static_cast<uint16_t>(sm.targetItemId) == slotReal)
+                continue;
+            suppressMask |= (std::uint32_t{1} << k);
+        }
+        PartShowSuppress::set_mask(suppressMask);
+
+        logger.trace("apply_single_slot: slot={} done, suppress={:#x}",
+                     slotIdx, suppressMask);
+
+        suppress_vec().store(false, std::memory_order_release);
+    }
+
     void apply_all_transmog(__int64 a1)
     {
         auto &logger = DMK::Logger::get_instance();
@@ -323,6 +559,7 @@ namespace Transmog
             }
         }
 
+        std::array<bool, k_slotCount> slotNeedsWork{};
         {
             bool presetChanged = false;
             for (std::size_t i = 0; i < k_slotCount; ++i)
@@ -399,7 +636,54 @@ namespace Transmog
                 }
             }
 
-            last_applied_real_ids() = liveRealIds;
+            // Per-slot "needs work" flags. Computed BEFORE overwriting
+            // last_applied_real_ids so we compare against the previous
+            // state. A slot needs tear-down + re-apply if its preset
+            // target changed OR its underlying real item changed.
+            // Unchanged slots are skipped — no tear-down, no cache
+            // clear, no SlotPopulator call — so they don't flicker.
+            //
+            // Unticked slots whose real changes ARE still marked: a
+            // prior restore via SlotPopulator may have left a dispatch
+            // cache entry and scene-graph mesh. The cleanup pass after
+            // the untick-restore loop relies on slotNeedsWork to find
+            // and tear down these stale entries.
+            for (std::size_t i = 0; i < k_slotCount; ++i)
+            {
+                const auto &m = mappings[i];
+                const uint16_t wouldBe =
+                    (m.active && m.targetItemId != 0) ? m.targetItemId
+                                                       : uint16_t{0};
+                if (wouldBe != prevIds[i])
+                {
+                    slotNeedsWork[i] = true;
+                    continue;
+                }
+
+                // Check if the real item changed for this slot.
+                // Unticked slots still need cache cleanup when their
+                // real changes — an earlier restore via SlotPopulator
+                // may have left a dispatch entry that the game's own
+                // unequip flow can't remove.
+                for (std::size_t k = 0; k < 5; ++k)
+                {
+                    if (static_cast<std::size_t>(k_earlyOutSlots[k]) == i &&
+                        liveRealIds[k] != last_applied_real_ids()[k])
+                    {
+                        slotNeedsWork[i] = true;
+                        break;
+                    }
+                }
+                // Active "none" slots always need work for suppress
+                // reinforcement.
+                if (m.active && m.targetItemId == 0)
+                    slotNeedsWork[i] = true;
+            }
+
+            // NOTE: last_applied_real_ids is updated at the END of the
+            // function, after all applies succeed. If we crash mid-apply
+            // (e.g. reload SEH), the old values remain so the next retry
+            // detects the real-armor change and tries again.
         }
 
         // Clear lastIds for slots without a new target.
@@ -429,27 +713,47 @@ namespace Transmog
         //      never clears subCount, so the previously queued blob
         //      lingers and gets replayed alongside the new one.
         //
-        // Fix: walk every existing cache entry while count is still
-        // valid and force-clear subCount=0 (defensive, O(n<=16)). Then
-        // zero count so SlotPopulator allocates fresh entries for our
-        // targeted slots. Finally restore count to OUR written count,
-        // not the saved one, so prior-preset entries stay invisible.
-        uint32_t savedCount = 0;
-        uintptr_t dispatchBase = 0;
+        // Fix: only clear subCount for dispatch cache entries whose
+        // slotNativeId matches a slot we are about to re-apply. This
+        // avoids nuking unchanged slots' blobs, which would force the
+        // game to re-dispatch them through VEC and cause visible
+        // flicker on gear that hasn't changed.
+        //
+        // Build a set of game tags that need clearing: any active slot
+        // with a non-zero target, plus any unticked slot that needs
+        // real-item restoration.
+        std::uint16_t clearTags[k_slotCount]{};
+        std::size_t clearTagCount = 0;
+        for (std::size_t i = 0; i < k_slotCount; ++i)
+        {
+            if (slotNeedsWork[i])
+                clearTags[clearTagCount++] = k_gameSlotTags[i];
+        }
+
         __try
         {
-            savedCount = *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
-            dispatchBase = *reinterpret_cast<volatile uintptr_t *>(a1 + 0x1B8);
-
-            if (dispatchBase > 0x10000)
+            const auto count =
+                *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
+            const auto base =
+                *reinterpret_cast<volatile uintptr_t *>(a1 + 0x1B8);
+            if (base > 0x10000)
             {
-                for (uint32_t e = 0; e < savedCount; ++e)
+                for (uint32_t e = 0; e < count; ++e)
                 {
-                    auto entry = dispatchBase + 24ULL * e;
-                    *reinterpret_cast<volatile uint32_t *>(entry + 0x10) = 0;
+                    const auto entry = base + 24ULL * e;
+                    const auto slotId =
+                        *reinterpret_cast<volatile uint16_t *>(entry);
+                    for (std::size_t t = 0; t < clearTagCount; ++t)
+                    {
+                        if (slotId == clearTags[t])
+                        {
+                            *reinterpret_cast<volatile uint32_t *>(
+                                entry + 0x10) = 0;
+                            break;
+                        }
+                    }
                 }
             }
-            *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0) = 0;
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -508,6 +812,8 @@ namespace Transmog
             {
                 const auto idx = static_cast<std::size_t>(
                     k_tearDownSlots[k].slot);
+                if (!slotNeedsWork[idx])
+                    continue;
                 if (last_applied_carrier_ids()[idx] != 0 && prevIds[idx] != 0)
                 { anyCarrierTearDown = true; break; }
             }
@@ -527,6 +833,8 @@ namespace Transmog
             {
                 const auto &td = k_tearDownSlots[k];
                 const auto idx = static_cast<std::size_t>(td.slot);
+                if (!slotNeedsWork[idx])
+                    continue;
                 const auto prevId = prevIds[idx];
                 const auto prevCarrier = last_applied_carrier_ids()[idx];
                 if (prevId == 0)
@@ -569,11 +877,13 @@ namespace Transmog
 
             // Phase B: real items for any active slot. Skip slots where
             // the NEW fake itemId matches the real equipped id AND the
-            // real is still intact.
+            // real is still intact. Also skip slots with no work needed.
             for (std::size_t k = 0; k < k_tearDownCount; ++k)
             {
                 const auto &td = k_tearDownSlots[k];
                 const auto idx = static_cast<std::size_t>(td.slot);
+                if (!slotNeedsWork[idx])
+                    continue;
                 auto &m = mappings[idx];
                 if (!m.active)
                     continue;
@@ -611,6 +921,15 @@ namespace Transmog
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
             auto &m = mappings[i];
+            if (!slotNeedsWork[i])
+            {
+                // Unchanged slot: preserve its lastIds entry but don't
+                // re-apply. If it has a live dispatch cache entry the
+                // game keeps rendering it.
+                if (m.active && m.targetItemId != 0)
+                    lastIds[i] = m.targetItemId;
+                continue;
+            }
             if (!m.active || m.targetItemId == 0)
                 continue;
 
@@ -698,25 +1017,84 @@ namespace Transmog
                     apply_transmog(a1, realId);
                     ++ourWrittenCount;
                 }
+                else if (real_damaged()[i])
+                {
+                    // Real item was unequipped (realId=0) but we
+                    // previously restored it via SlotPopulator, which
+                    // left a scene-graph mesh entry. Tear it down so
+                    // the visual actually disappears. The old real ID
+                    // is still in last_applied_real_ids (not yet
+                    // overwritten — moved to end of function).
+                    for (std::size_t k = 0; k < k_tearDownCount; ++k)
+                    {
+                        if (static_cast<std::size_t>(
+                                k_tearDownSlots[k].slot) != i)
+                            continue;
+                        const auto oldReal =
+                            last_applied_real_ids()[k];
+                        if (oldReal != 0)
+                        {
+                            logger.info(
+                                "[dispatch] slot={} unticked + "
+                                "unequipped — tearing down restored "
+                                "mesh {:#06x}",
+                                slot_name(static_cast<TransmogSlot>(i)),
+                                oldReal);
+                            RealPartTearDown::tear_down_by_item_id(
+                                reinterpret_cast<void *>(a1),
+                                oldReal,
+                                k_tearDownSlots[k].gameTag);
+                        }
+                        break;
+                    }
+                }
+                // Clear damage flag so this slot is fully released
+                // back to the game. Without this, future apply cycles
+                // keep treating it as managed.
+                real_damaged()[i] = false;
             }
             if (!m.active || m.targetItemId == 0)
                 last_applied_carrier_ids()[i] = 0;
         }
 
-        // Restore count to OUR writes only — stale entries in the
-        // range [ourWrittenCount .. savedCount) remain allocated
-        // (no leak) but are invisible to SlotPopulator's count-limited
-        // linear search.
+        // Cleanup pass: tear down stale scene-graph meshes left by a
+        // prior restore via SlotPopulator. This handles the case where
+        // apply_single_slot restored the real item (creating a scene
+        // graph entry), then the user unequipped in the game inventory.
+        // The untick-restore block above doesn't catch this because
+        // apply_single_slot already cleared prevIds and real_damaged.
+        // We detect it here via slotNeedsWork + unticked + real=0 +
+        // old real in last_applied_real_ids (not yet overwritten).
+        for (std::size_t k = 0; k < k_tearDownCount; ++k)
+        {
+            const auto &td = k_tearDownSlots[k];
+            const auto idx = static_cast<std::size_t>(td.slot);
+            if (!slotNeedsWork[idx])
+                continue;
+            if (mappings[idx].active)
+                continue;
+            if (realItemId[k] != 0)
+                continue;
+            const auto oldReal = last_applied_real_ids()[k];
+            if (oldReal == 0)
+                continue;
+            logger.info("[dispatch] slot={} cleanup — tearing down "
+                        "stale restore mesh {:#06x}",
+                        slot_name(td.slot), oldReal);
+            RealPartTearDown::tear_down_by_item_id(
+                reinterpret_cast<void *>(a1), oldReal, td.gameTag);
+        }
+
+        // Count was NOT zeroed — unchanged slots' entries are still
+        // live with their original subCount. Log the final state for
+        // diagnostics.
         __try
         {
             uint32_t liveCount =
                 *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
-            logger.trace("[dispatch] liveCount={} ourWrittenCount={}",
+            logger.trace("[dispatch] post-apply liveCount={} "
+                         "ourWrittenCount={}",
                          liveCount, ourWrittenCount);
-
-            uint32_t finalCount =
-                (liveCount > ourWrittenCount) ? liveCount : ourWrittenCount;
-            *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0) = finalCount;
         }
         __except (EXCEPTION_EXECUTE_HANDLER) {}
 
@@ -758,6 +1136,12 @@ namespace Transmog
             targetMask, activeMask, suppressMask);
 
         PartShowSuppress::set_mask(static_cast<uint32_t>(suppressMask));
+
+        // Commit the real-armor snapshot AFTER all applies succeed.
+        // If the function crashed (SEH during reload), this line is
+        // never reached and the next retry correctly detects the
+        // real-armor change.
+        last_applied_real_ids() = liveRealIds;
 
         suppress_vec().store(false, std::memory_order_release);
     }

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.hpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.hpp
@@ -32,6 +32,11 @@ namespace Transmog
     /// or is not player-compatible).
     bool needs_carrier(std::uint16_t itemId);
 
+    /// Single-slot apply: tears down and re-applies only the given slot.
+    /// Used by hover-preview to avoid full-gear flicker. Only clears
+    /// dispatch cache entries matching this slot's game tag.
+    void apply_single_slot_transmog(__int64 a1, std::size_t slotIdx);
+
     /// Full apply pass: two-phase tear-down + SlotPopulator for all active
     /// slots. Updates dispatch cache, suppress mask, and last-applied state.
     void apply_all_transmog(__int64 a1);

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -205,12 +205,23 @@ namespace Transmog
         if (a1 <= 0x10000)
             return;
 
+        // Consume the single-slot index. k_slotCount means "all slots".
+        const auto slotIdx =
+            pending_slot_index().exchange(k_slotCount,
+                                          std::memory_order_acq_rel);
+
         __try
         {
             if (do_clear)
             {
                 clear_all_transmog(a1);
                 logger.debug("Transmog cleared (debounced)");
+            }
+            else if (slotIdx < k_slotCount)
+            {
+                apply_single_slot_transmog(a1, slotIdx);
+                logger.debug("Transmog applied slot={} (debounced)",
+                             slotIdx);
             }
             else
             {
@@ -348,6 +359,22 @@ namespace Transmog
                             static_cast<uint64_t>(comp));
                 prevComp = comp;
                 player_a1().store(comp, std::memory_order_release);
+
+                // Reset cached apply state so the early-out in
+                // apply_all_transmog doesn't suppress the re-apply.
+                // The scene graph is fresh after reload — old fake
+                // meshes are gone even though the IDs haven't changed.
+                //
+                // Held under s_applyCvMtx to prevent racing with an
+                // in-flight apply on the worker thread, which reads
+                // and writes these same non-atomic arrays.
+                {
+                    std::lock_guard<std::mutex> lk(s_applyCvMtx);
+                    last_applied_ids().fill(0);
+                    last_applied_real_ids().fill(0);
+                    last_applied_carrier_ids().fill(0);
+                    real_damaged().fill(false);
+                }
 
                 if (!flag_enabled().load(std::memory_order_relaxed))
                     continue;


### PR DESCRIPTION
## Summary

- **Instant Apply mode** - new overlay checkbox; hover-previews items with 300ms debounce, click-applies immediately, slot toggles/clear take effect instantly without Apply All
- **Single-slot apply** - `apply_single_slot_transmog` tears down and re-applies only the changed slot; other slots are untouched (no flicker)
- **Slot-scoped dispatch cache** - `apply_all_transmog` only clears cache entries and runs tear-down for slots that actually changed (preset or real armor)
- **Reload crash safety** - `last_applied_real_ids` committed at end of function; load-detect resets cached state under worker mutex
- **Stale restore cleanup** - unticking a slot then unequipping in inventory now properly tears down the restored mesh from the scene graph
- **Overlay UX** - nav buttons (^/v) for list browsing, per-slot X clear button, keep-search-text option, increased item spacing, pending badge hidden in instant mode
- **Preset fix** - itemId 0 no longer saves as "Pyeonjeon_Arrow" (catalog index 0 collision)
