### PR TITLE
feat(live-transmog): add cross-character armor carrier support

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Title for next release]
+## Cross-Character Armor Support & Carrier System Improvements
 
-- New feature
-- Bug fix
-- Improvement
+- NPC armor from other characters (Oongka, etc.) can now be worn by Kliff
+- Items with non-player equip types are automatically detected and handled via the carrier system
+- Carrier hybrid descriptor now includes a self-contained copy of the item's rule and classifier data for improved stability

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -171,6 +171,7 @@ See the full list at the [url=https://github.com/tkhquang/DetourModKit?tab=readm
 
 [list]
 [*][b]Item catalog may be incomplete[/b] -the armor list is filtered to exclude known-broken items. Some wearable items may be missing. If you find one, please report it in the Bugs or Posts tab.
+[*][b]Yann leather armor has quirks[/b] -[b]Yann_Basic_Leather_Armor[/b] may flash briefly when switching presets. Workaround: untick the chest slot, then retick it. Also, Yann leather is a single-mesh outfit that covers both chest and cloak regions -deactivate the Cloak slot when using it to avoid visual conflicts.
 [*][b]NPC armor variants and damaged variants render via carrier[/b] -items tagged [b](carrier)[/b] in the picker use an automatic carrier swap + character-class bypass. Most work; a few may still produce empty slots depending on the item's internal skeleton bindings.
 [*][b]Non-humanoid items crash[/b] -horse tack, pet armor, and wagon gear crash the mesh binder. The "Safe only" filter hides these by default.
 [*][color=#ff0000][b]Wrong-slot or non-equipment items will crash[/b][/color] -selecting a chest piece for the helm slot, or picking non-armor items (dog armor, recipes, seeds, etc.) will crash the game. The safety filters prevent this by default -[b]do not disable them unless you know what you're doing[/b].

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -43,8 +43,8 @@ namespace Transmog
     // offsets (not code) so they cannot be AOB-scanned; if a future patch
     // reshapes the struct the catalog walk will produce an implausible
     // count/ptrArray and bail at the existing sanity checks below.
-    static constexpr std::ptrdiff_t k_iteminfoCountOffset     = 0x08; // dword entry count
-    static constexpr std::ptrdiff_t k_iteminfoPtrArrayOffset  = 0x50; // 80: qword base of descriptor ptr array
+    static constexpr std::ptrdiff_t k_iteminfoCountOffset = 0x08;    // dword entry count
+    static constexpr std::ptrdiff_t k_iteminfoPtrArrayOffset = 0x50; // 80: qword base of descriptor ptr array
 
     // Resolved sentinel, cached after first successful build().
     // 0 means "not yet resolved" — has_variant_meta() falls back to false
@@ -137,15 +137,19 @@ namespace Transmog
     // If a future patch changes the player classifier set, re-run the
     // catalog differential against known-player vs known-mount items.
     static constexpr std::uint16_t k_playerClassifiers[] = {
-        0x0015, 0x0018, 0x0058, 0x02E3, 0x039D,
+        0x0015,
+        0x0018,
+        0x0058,
+        0x02E3,
+        0x039D,
     };
-    static constexpr std::ptrdiff_t k_ruleListPtrOffset    = 0x248;
-    static constexpr std::ptrdiff_t k_ruleListCountOffset  = 0x250;
-    static constexpr std::size_t    k_ruleStride           = 0x38;
-    static constexpr std::ptrdiff_t k_ruleClassPtrOffset   = 0x20;
+    static constexpr std::ptrdiff_t k_ruleListPtrOffset = 0x248;
+    static constexpr std::ptrdiff_t k_ruleListCountOffset = 0x250;
+    static constexpr std::size_t k_ruleStride = 0x38;
+    static constexpr std::ptrdiff_t k_ruleClassPtrOffset = 0x20;
     static constexpr std::ptrdiff_t k_ruleClassCountOffset = 0x28;
-    static constexpr std::uint32_t  k_maxPlausibleRuleCount  = 64;
-    static constexpr std::uint32_t  k_maxPlausibleClassCount = 32;
+    static constexpr std::uint32_t k_maxPlausibleRuleCount = 64;
+    static constexpr std::uint32_t k_maxPlausibleClassCount = 32;
 
     // Returns true if the item at `descPtr` has at least one rule whose
     // classifier array contains a player body-type token. Items with no
@@ -270,7 +274,8 @@ namespace Transmog
     // _Large/_XLarge/_Medium/_Small, _Pancake.
     static void strip_variant_tail(std::string &s) noexcept
     {
-        auto ends_with = [](const std::string &str, const char *suf) {
+        auto ends_with = [](const std::string &str, const char *suf)
+        {
             const auto n = std::strlen(suf);
             if (str.size() < n)
                 return false;
@@ -666,7 +671,7 @@ namespace Transmog
         {
             uint16_t id;
             std::string name;
-            uintptr_t metaPtr;       // 0 on read fault
+            uintptr_t metaPtr; // 0 on read fault
             bool playerCompatible;
         };
         std::vector<ScratchEntry> scratch;
@@ -741,9 +746,9 @@ namespace Transmog
             if (valid == 0 || sentinelCount * 3 < valid)
             {
                 logger.debug("[nametable] variant sentinel not dominant "
-                               "(best=0x{:X} count={}/{}) — disabling "
-                               "variant-meta filter",
-                               resolvedSentinel, sentinelCount, valid);
+                             "(best=0x{:X} count={}/{}) — disabling "
+                             "variant-meta filter",
+                             resolvedSentinel, sentinelCount, valid);
                 resolvedSentinel = 0;
             }
             else
@@ -857,6 +862,31 @@ namespace Transmog
         return it->second != 0;
     }
 
+    bool ItemNameTable::has_npc_equip_type(uint16_t itemId) const noexcept
+    {
+        // Player (Kliff) equip-type u16 at desc+0x42 is 0x0004.
+        // NPC items use 0x0001. Any value != 0x0004 needs the carrier
+        // path so the pipeline sees a Kliff-compatible descriptor.
+        static constexpr std::ptrdiff_t k_equipTypeOffset = 0x42;
+        static constexpr std::uint16_t k_playerEquipType = 0x0004;
+
+        const auto desc = descriptor_of(itemId);
+        if (desc == 0)
+            return false; // can't read — default to direct apply
+
+        __try
+        {
+            const auto eType =
+                *reinterpret_cast<const volatile std::uint16_t *>(
+                    desc + k_equipTypeOffset);
+            return eType != k_playerEquipType;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return false;
+        }
+    }
+
     const std::vector<ItemNameTable::Entry> &
     ItemNameTable::sorted_entries() const
     {
@@ -881,7 +911,8 @@ namespace Transmog
         }
 
         std::sort(m_sortedCache.begin(), m_sortedCache.end(),
-                  [](const Entry &a, const Entry &b) {
+                  [](const Entry &a, const Entry &b)
+                  {
                       // Case-insensitive lexicographic compare so "Kliff"
                       // and "kliff" sort together; items lowercase anyway
                       // but this survives future catalog changes.

--- a/CrimsonDesertLiveTransmog/src/item_name_table.hpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.hpp
@@ -55,13 +55,13 @@ namespace Transmog
          */
         enum class BuildResult
         {
-            Ok,             // Catalog walked successfully, table populated.
-            Deferred,       // Address chain resolved but the iteminfo
-                            // global is still null — retry later on a
-                            // background thread.
-            Fatal,          // Address resolution failed (bounded AOB
-                            // anchor missed, no relative call found, etc).
-                            // Do not retry — address chain is broken.
+            Ok,       // Catalog walked successfully, table populated.
+            Deferred, // Address chain resolved but the iteminfo
+                      // global is still null — retry later on a
+                      // background thread.
+            Fatal,    // Address resolution failed (bounded AOB
+                      // anchor missed, no relative call found, etc).
+                      // Do not retry — address chain is broken.
         };
 
         /**
@@ -131,6 +131,17 @@ namespace Transmog
          * game patch.
          */
         bool is_player_compatible(uint16_t itemId) const;
+
+        /**
+         * @brief True if the item's equip-type u16 at desc+0x42 differs
+         *        from the player's value (0x0004 for Kliff).
+         *
+         * Items with NPC equip-type need the carrier path even when their
+         * classifier array includes player tokens (is_player_compatible).
+         * The equip-type controls downstream VEC processing gates that
+         * reject non-Kliff types.  Live read via descriptor_of().
+         */
+        bool has_npc_equip_type(uint16_t itemId) const noexcept;
 
         bool ready() const noexcept { return !m_idToName.empty(); }
         std::size_t size() const noexcept { return m_idToName.size(); }

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -45,11 +45,11 @@ namespace Transmog
     // equip (which may silently fail for NPC/variant items).
 
     static constexpr const char *k_defaultCarrierNames[] = {
-        "Kliff_PlateArmor_Helm",    // TransmogSlot::Helm
-        "Kliff_PlateArmor_Armor",   // TransmogSlot::Chest
-        "Kliff_PlateArmor_Cloak",   // TransmogSlot::Cloak
-        "Kliff_PlateArmor_Gloves",  // TransmogSlot::Gloves
-        "Kliff_Plate_Boots",        // TransmogSlot::Boots
+        "Kliff_PlateArmor_Helm",   // TransmogSlot::Helm
+        "Kliff_PlateArmor_Armor",  // TransmogSlot::Chest
+        "Kliff_PlateArmor_Cloak",  // TransmogSlot::Cloak
+        "Kliff_PlateArmor_Gloves", // TransmogSlot::Gloves
+        "Kliff_Plate_Boots",       // TransmogSlot::Boots
     };
 
     uint16_t default_carrier_for_slot(TransmogSlot slot)
@@ -70,20 +70,34 @@ namespace Transmog
         if (!table.ready())
             return false;
         return table.has_variant_meta(itemId) ||
-               !table.is_player_compatible(itemId);
+               !table.is_player_compatible(itemId) ||
+               table.has_npc_equip_type(itemId);
     }
 
     // SEH-safe memory helpers (MSVC: __try cannot coexist with C++
     // object unwinding in the same function).
     static uintptr_t read_qword_seh(uintptr_t addr) noexcept
     {
-        __try { return *reinterpret_cast<volatile uintptr_t *>(addr); }
-        __except (EXCEPTION_EXECUTE_HANDLER) { return 0; }
+        __try
+        {
+            return *reinterpret_cast<volatile uintptr_t *>(addr);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return 0;
+        }
     }
     static bool memcpy_seh(void *dst, const void *src, size_t n) noexcept
     {
-        __try { std::memcpy(dst, src, n); return true; }
-        __except (EXCEPTION_EXECUTE_HANDLER) { return false; }
+        __try
+        {
+            std::memcpy(dst, src, n);
+            return true;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return false;
+        }
     }
 
     // Descriptor size. Stride between consecutive descriptors observed
@@ -98,9 +112,13 @@ namespace Transmog
     // +0x042  2B  equip-type u16 (Kliff=4, NPC=1)
     //             SlotPopulator reads *(desc+0x42) for the visual-config
     //             matching loop (sub_14076CAED).
-    struct PatchRange { std::ptrdiff_t off; std::size_t len; };
+    struct PatchRange
+    {
+        std::ptrdiff_t off;
+        std::size_t len;
+    };
     static constexpr PatchRange k_carrierPatches[] = {
-        {0x042, 0x002},  // equip-type u16 (Kliff=4, NPC=1)
+        {0x042, 0x002}, // equip-type u16 (Kliff=4, NPC=1)
     };
 
     // Write the char-class bypass byte unconditionally. No from-check:
@@ -112,7 +130,8 @@ namespace Transmog
             return false;
         const auto byteVal = static_cast<std::byte>(val);
         return DMK::Memory::write_bytes(
-            reinterpret_cast<std::byte *>(addr), &byteVal, 1).has_value();
+                   reinterpret_cast<std::byte *>(addr), &byteVal, 1)
+            .has_value();
     }
 
     // Swaps descriptor pointer, toggles char-class bypass, calls
@@ -162,7 +181,8 @@ namespace Transmog
         if (carrierId == 0 || carrierId == targetId)
         {
             logger.trace("[carrier] carrierId={:#06x} == targetId={:#06x}, "
-                         "direct apply", carrierId, targetId);
+                         "direct apply",
+                         carrierId, targetId);
             apply_transmog(a1, targetId);
             return;
         }
@@ -226,13 +246,15 @@ namespace Transmog
         std::size_t patchedBytes = 0;
         for (const auto &p : k_carrierPatches)
         {
-            if (p.off + p.len > k_descBufSize) continue;
+            if (p.off + p.len > k_descBufSize)
+                continue;
             if (!memcpy_seh(hybrid + p.off,
                             reinterpret_cast<const void *>(carrierDesc + p.off),
                             p.len))
             {
                 logger.warning("[carrier] fault patching carrier field "
-                               "at +{:#x} len={}", p.off, p.len);
+                               "at +{:#x} len={}",
+                               p.off, p.len);
                 VirtualFree(hybrid, 0, MEM_RELEASE);
                 apply_transmog(a1, targetId);
                 return;
@@ -592,7 +614,10 @@ namespace Transmog
             for (std::size_t i = 0; i < k_slotCount; ++i)
             {
                 if (mappings[i].active && mappings[i].targetItemId == 0)
-                { hasActiveNone = true; break; }
+                {
+                    hasActiveNone = true;
+                    break;
+                }
             }
 
             if (!presetChanged && !realChanged && !hasActiveNone)
@@ -653,7 +678,7 @@ namespace Transmog
                 const auto &m = mappings[i];
                 const uint16_t wouldBe =
                     (m.active && m.targetItemId != 0) ? m.targetItemId
-                                                       : uint16_t{0};
+                                                      : uint16_t{0};
                 if (wouldBe != prevIds[i])
                 {
                     slotNeedsWork[i] = true;
@@ -815,7 +840,10 @@ namespace Transmog
                 if (!slotNeedsWork[idx])
                     continue;
                 if (last_applied_carrier_ids()[idx] != 0 && prevIds[idx] != 0)
-                { anyCarrierTearDown = true; break; }
+                {
+                    anyCarrierTearDown = true;
+                    break;
+                }
             }
 
             const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
@@ -908,7 +936,8 @@ namespace Transmog
 
         // Helper: look up a slot's real itemId from the snapshot taken
         // during the tear-down phase.
-        auto lookup_real_id = [&](std::size_t slotIdx) -> std::uint16_t {
+        auto lookup_real_id = [&](std::size_t slotIdx) -> std::uint16_t
+        {
             for (std::size_t k = 0; k < k_tearDownCount; ++k)
             {
                 if (static_cast<std::size_t>(k_tearDownSlots[k].slot) == slotIdx)
@@ -988,7 +1017,9 @@ namespace Transmog
                 postCount =
                     *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
             }
-            __except (EXCEPTION_EXECUTE_HANDLER) {}
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+            }
             logger.trace("[dispatch] post-apply slot={} liveCount={}",
                          i, postCount);
             lastIds[i] = m.targetItemId;
@@ -1096,7 +1127,9 @@ namespace Transmog
                          "ourWrittenCount={}",
                          liveCount, ourWrittenCount);
         }
-        __except (EXCEPTION_EXECUTE_HANDLER) {}
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+        }
 
         // targetMask: slots with a fake mesh to render. activeMask: slots
         // the user explicitly controls.
@@ -1154,7 +1187,8 @@ namespace Transmog
         if (world_system_ptr().load(std::memory_order_acquire))
         {
             auto fresh = resolve_player_component();
-            if (fresh > 0x10000) a1 = fresh;
+            if (fresh > 0x10000)
+                a1 = fresh;
         }
 
         suppress_vec().store(true, std::memory_order_release);
@@ -1166,11 +1200,11 @@ namespace Transmog
             std::uint16_t gameTag;
         };
         static constexpr ClearSlot k_clearSlots[] = {
-            {TransmogSlot::Helm,   0x0003},
-            {TransmogSlot::Chest,  0x0004},
+            {TransmogSlot::Helm, 0x0003},
+            {TransmogSlot::Chest, 0x0004},
             {TransmogSlot::Gloves, 0x0005},
-            {TransmogSlot::Boots,  0x0006},
-            {TransmogSlot::Cloak,  0x0010},
+            {TransmogSlot::Boots, 0x0006},
+            {TransmogSlot::Cloak, 0x0010},
         };
         std::uint16_t prevFakeId[std::size(k_clearSlots)]{};
         for (std::size_t k = 0; k < std::size(k_clearSlots); ++k)


### PR DESCRIPTION
## Summary

- Route NPC armor (Oongka, Ashad, Solas, Demian, etc.) through the carrier path so they render on Kliff
- Detect non-player equip-type (`desc+0x42 != 0x0004`) via new `has_npc_equip_type()` check in `needs_carrier()`
- Self-contained hybrid copies rule entry + classifier array into buffer tail, patches first classifier to Kliff's (0x0028) for async VEC stability
- Update changelog and Nexus page with cross-char support notes and known Yann quirks

## Known Limitations

- Yann leather armor flashes on preset switch (workaround: untick then retick the slot)
- Yann leather chest conflicts with cloak slot (single-mesh item covering both regions)
- Some specialty items (e.g. Oongka_Rocket_Helm) may not render if their mesh resources aren't loaded in the current context
