### PR TITLE
feat(live-transmog): add display names and improve item picker UI

### DIFF
--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -157,6 +157,7 @@ See the full list at the [Supported Input Names](https://github.com/tkhquang/Det
 ## Known Limitations
 
 - **Item catalog may be incomplete** - the armor list is filtered to exclude known-broken items. Some wearable items may be missing. Report missing items in the Bugs or Posts tab.
+- **Silverwolf Leather Armor** and some other armor seems to have combined with cloak. If you apply it and it disappears right afterwards, you should try setting the cloak slot and armor slot to none, save, then reapply the armor again.
 - **NPC armor variants and damaged variants render via carrier** — items tagged `(carrier)` in the picker use an automatic carrier swap + character-class bypass to render. Most work; a few may still produce empty slots depending on the item's internal skeleton bindings.
 - **Non-humanoid items crash** — horse tack, pet armor, and wagon gear crash the mesh binder. The "Safe only" filter hides these by default.
 - **Wrong-slot or non-equipment items will crash** - selecting a chest piece for the helm slot, or non-armor items (dog armor, recipes, etc.) crashes the game. Safety filters prevent this by default. Do not disable them unless you know what you are doing.

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_display_names.tsv
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_display_names.tsv
@@ -1,0 +1,6022 @@
+Aant_PlateArmor_Helm	Awrain Plate Helm
+Abacus	Abacus
+Abidon_Fabric_Helm	Pailunese Hat
+Abidon_Fabric_Helm_T5_QA	Abidon Fabric Helm T5 QA
+Abyss_Artifact	Abyss Artifact
+Abyss_InfiniteStat_Hp30	Vitality of the Abyss
+Abyss_InfiniteStat_Mp2	Spirit of the Abyss
+Abyss_InfiniteStat_Sp3	Breath of the Abyss
+Abyss_Surreal_Human_Fabric_Boots	Rabbit Cloth Boots
+Abyss_Surreal_Human_Leather_Armor	Rabbit Leather Coat
+Abyss_Surreal_Human_Leather_Helm	Rabbit Leather Mask
+Abyss_Surreal_Wolf_Leather_Armor	Jester Leather Coat
+Abyss_Surreal_Wolf_Leather_Cloak	Jester Leather Cloak
+Abyss_Surreal_Wolf_Leather_Gloves	Jester Leather Gloves
+Abyss_Surreal_Wolf_Leather_Helm	Jester Leather Mask
+Abyss_Surreal_Wolf_Necklace	Surreal Necklace
+AbyssGear_Epistle	White Crow's Letter
+AbyssReward_Desert_OneHandMace	Desert Hammer
+AbyssReward_Dragon_TwoHandGiantHammer	Aeserion Greathammer
+AbyssReward_Drake_Metal_OneHandShield	Drake Shield
+AbyssReward_EastWitch_Ring	Witch's Ring
+AbyssReward_HolyEcho_OneHandBow	Divine Echoes Bow
+AbyssReward_Kutum_TowerShield	Kutum Shield
+AbyssReward_MarniMusket	Marni Musket
+AbyssReward_Mysterm_OneHandSword	Sword of the Lord
+AbyssReward_Peltree_OneHandSword	Peltree Sword
+AbyssReward_Reeddevil_OneHandSword	Hollow Visage
+AbyssReward_Skull_Knight_TwoHandSword	Frozen Anguish
+AbyssReward_Titan_TwoHandSpear	Reckoning
+AbyssReward_WhiteHorn_Ring	White Horn's Ring
+AbyssRuinsCreatureCore	Abyss Cell
+AbyssStone_Seed	Abyssal Seed
+Acembel_Leather_Gloves	Essembel Leather Gloves
+Acid_Spider_Poison	Acidic Spider Venom
+Acorn	Acorn
+Acquirs_Wood_OneHandShield	Rising Arrow Shield
+Adeion_Leather_Boots	Adeion Leather Boots
+Adeion_Leather_Gloves	Adeion Leather Gloves
+Aequor_OneHandMusket	Delesyian Musket
+Aggro_Backpack	Sonic Resonator
+Ahns_Fabric_Armor	Annis Cloth Armor
+Ahntutan_Fabric_Armor	Antutan Cloth Armor
+Air_OneHandCannon	Air Blaster
+Ajure_Leather_Armor	Ajure Leather Armor
+Akesti_Leather_Boots	Agstree Leather Boots
+Aklas_Fabric_Armor	Acklass Cloth Armor
+Albert_PlateArmor_Armor	Albert Plate Armor
+Alchemist_Key	Engraved Key
+Alchemist_Key_Proto	Shabby Wooden Key
+Ald_Leather_Armor	Auld Leather Armor
+Aldwin_Leather_Gloves	Aldwin Leather Gloves
+Alida_OneHandShotgun	Dewhaven Shotgun
+Alida_Restraint_OneHandPistol	Shadow of the Past Pistol
+Allbit_Leather_Boots	Alvitt Leather Boots
+Alpein_Fabric_Armor	Alphen Cloth Armor
+Alsace_Fabric_Armor	Alsace Cloth Armor
+Alustin_Journal_Book_I	Archive Record: Ch. 1
+Alustin_Journal_Book_II	Archive Record: Ch. 2
+Alustin_Journal_Book_III	Archive Record: Ch. 3
+Alustin_Journal_Book_IV	Archive Record: Ch. 4
+Alustin_Journal_Book_V	Archive Record: Ch. 5
+Alustin_Journal_Book_VI	Archive Record: Final Chapter
+Ama	Flax
+Amanas_ChainMail_Armor	Amanas Chain Mail
+Amanta_PlateArmor_Armor	Amanta Plate Armor
+Amantia_ChainMail_Armor	Amantia Chain Mail
+Amundule_Fabric_Armor	Amundule Cloth Armor
+Anamorphic_Book	Constellation Research Journal
+Anamorphic_PlateArmor_Helm	Constellation Helm
+Ancient_Fabric_Armor	Primus's Cloth Armor
+Ancient_Fabric_Armor_I	Priscus's Cloth Armor
+Ancient_Fabric_Armor_II	Praevus's Cloth Armor
+Ancient_People_Earring	Ancient Earring
+Ancient_People_Necklace	Ancient's Necklace
+Ancient_People_Ring	Ancient Ring
+Ancient_Shield	Ancient Shield
+Andaran_Leather_Boots	Andaran Leather Boots
+Andre_ChainMail_Armor	Andre Chain Mail
+Andria_Leather_Gloves	Andria Leather Gloves
+Angry_Wave_Ring_Drill	Furious Waves Gauntlet
+Animal_Bone	Small Bone
+Ankara_Fabric_Armor	Ancara Cloth Armor
+Ankrian_Fabric_Armor	Ankrian Cloth Armor
+Anruditz_Leather_Armor	Anderitz Leather Armor
+Anruditz_Leather_Boots	Anderitz Leather Boots
+Anti_Caliburn_Picket	Anti-Caliburn Signboard
+Anti_Demeniss_Crail_PlateArmor_Armor	Anti-Crail Plate Armor
+Anti_Demeniss_Mueo_PlateArmor_Armor	Anti-Meyer Plate Armor
+Antika_Leather_Armor	Antika Leather Armor
+Antony_PlateArmor_Armor	Antoni Plate Armor
+Antony_PlateArmor_Helm	Antoni Plate Helm
+Antra_PlateArmor_Helm	Antra Plate Helm
+Antuka_ChainMail_Armor	Antuka Chain Mail
+Antum_PlateArmor_Armor	Antum Plate Armor
+Antumbra_DarkDeacon_Earring	Oath of Darkness
+Antumbra_DarkDeacon_Necklace	Relic of Darkness
+Antumbra_DarkDeacon_Ring	Mark of Darkness
+Antumbra_Fabric_Armor	Antumbra Cloth Armor
+Antumbra_King_Ring	Seal of Pitch-Black Darkness
+Antumbra_Leather_Boots	Antumbra Leather Boots
+Antumbra_Leather_Gloves	Ator's Will Leather Gloves
+Antumbra_Leather_Gloves_I	Antumbra Leather Gloves
+Anvil_Fort_Secret_Document	The Seal of House Serkis
+Apenzel_OneHandRapier	Fallen Kingdom's Rapier
+Apothecary_BackPack_I	Apothecary's Pack
+Apothecary_BackPack_II	Apothecary's Pack
+Apple	Apple
+Apple_BackPack	Apple Pack
+AppleTree_Seed	Apple Seed
+Arandhal_Fabric_Armor	Arandhal Cloth Armor
+Arcalu_PlateArmor_Armor	Arcalu Plate Armor
+Archaia_OneHandMace	Spine of the Earth
+Archen_Leather_Gloves	Archen Leather Gloves
+Archran_Fabric_Armor	Akran Cloth Armor
+Archria_ChainMail_Armor	Acria Chain Mail
+Archria_Fabric_Armor	Acria Cloth Armor
+Archria_OneHandSword	Acria Sword
+Archrika_OneHandSword	Legionary's Gladius
+Archsyan_OneHandMace	Odeck Wooden Club Mace
+Arcria_Leather_Gloves	Acria Leather Gloves
+Arcti_Leather_Gloves	Arsen Leather Gloves
+Arctotus_Leather_Armor	Acrodus Leather Armor
+Ardeah_Leather_Armor	Ardia Leather Armor
+Ardoratte_Leather_Armor_I	Adoratt Leather Armor
+Arendyer_Leather_Boots	Arrenya Leather Boots
+Argatah_Fabric_Helm	Agatha Cloth Cap
+Argatah_Leather_Helm	Agatha Leather Helm
+Argatah_OneHandMusket	Pailunese Musket
+Argatah_PlateArmor_Gloves	Agatha's Plate Gloves
+Argen_OneHandMace	Lanford Hammer
+Arghai_Fabric_Armor	Arghai Cloth Armor
+Arghai_Leather_Boots	Arghai Leather Boots
+Arghai_PlateArmor_Helm	The Faceless's Plate Helm
+Argtisan_TwoHandSpear	Cog Destroyer Spear
+Ariete_OneHandRapier	Fallen Noble's Rapier
+Arkhan_Fabric_Armor	Leddic Cloth Armor
+Arkhan_PlateArmor_Armor	Arkhan Plate Armor
+Arkhan_PlateArmor_Gloves	Arkhan Plate Gloves
+Arqus_Leather_Armor	Arqus Leather Armor
+Arrow	Arrow
+Arrow_Flag_I	Small Blinding Arrows Banner Pike
+Arrow_Flag_II	Medium Blinding Arrows Banner Pike
+Arrow_Technique_Instructor_Leather_Armor	Arrow Skill Instructor Armor
+Arsard_TwoHandedWarHammer	Bekker Warhammer
+Arti_Leather_Gloves	Arti Leather Gloves
+Artiree_Fabric_Helm	Artiree Cloth Cap
+Artisan_Leather_Armor	Arteyan Leather Armor
+Artisan_Thorn_OneHandTowerShield	Thorny Warspike Large Shield
+Artnan_Fabric_Armor	Atnan Cloth Armor
+Arven_Giant_TwoHandGiantBastard	Arben Greatsword
+Ashad_PlateArmor_Armor	Ashad Plate Armor
+Ashad_PlateArmor_Boots	Ashad Plate Boots
+Ashad_PlateArmor_Cloak	Ashad Plate Cloak
+Ashad_PlateArmor_Gloves	Ashad Plate Gloves
+Ashad_PlateArmor_Helm	Ashad Plate Helm
+Ashiteu_Fabric_Gloves	Ashtu Cloth Gloves
+Aslan_ChainMail_Armor	Aslan Chain Mail
+Asparagus	Asparagus
+Aspherd_PlateArmor_Helm	Ashford Plate Helm
+Astia_Fabric_Gloves	Astia Cloth Gloves
+Astin_PlateArmor_Helm	Austin Plate Helm
+Astti_Fabric_Gloves	Asty Cloth Gloves
+Atanti_Leather_Boots	Lauques Leather Boots
+Ataram_Fabric_Helm	Ataram Cloth Cap
+Aurellian_Leather_Boots	Aurelian Leather Boots
+Aurellian_OneHandBow	Tardik Bow
+Aurio_OneHandDagger	Pailunese Riteblade
+Auron_Fabric_Armor	Auron Cloth Armor
+Austia_Leather_Armor	Oustia Leather Armor
+Austphelt_Fabric_Armor	Austfeld Cloth Armor
+Austphelt_Leather_Gloves	Austfeld Leather Gloves
+Avignon_Fabric_Armor	Avignon Cloth Armor
+Awaken_Caliburn_TwoHandSword	Twisted Verdict
+Badran_Leather_Boots	Badran Leather Boots
+Badran_Leather_Gloves	Badran Leather Gloves
+Baidan_Fabric_Helm	Baidan Cloth Headband
+Bailao_Fabric_Armor	Bailao Cloth Armor
+Bainian_Leather_Boots	Blackwing Leather Boots
+Bainian_Leather_Boots_T5_QA	Bainian Leather Boots T5 QA
+Baked_Egg	Smoked Egg
+Baked_Egg_Large	Satisfying Smoked Eggs
+Baked_Egg_Medium	Filling Smoked Eggs
+Baked_Egg_XLarge	Hearty Smoked Eggs
+Bakrao_Fabric_Armor	Barclao Cloth Armor
+Baku_Leather_Boots	Baku Leather Boots
+Balder_Leather_Armor	Bettert Leather Armor
+Balderinne_Fabric_Armor	Baldrin Cloth Armor
+Balindean_Leather_Armor	Baladean Leather Armor
+Balindeuri_Leather_Gloves	Bandellure Leather Gloves
+Ballet_Leather_Gloves	Barre Leather Gloves
+Balthazar_BackPack	Wyvernflames Captain's Pack
+Baltimer_Leather_Armor	Baltimier Leather Armor
+Balton_OneHandMace	Balton Hammer
+Bamboo_TwoHandSpear	Bamboo Spear
+Banana_Bread	Fruit Bread
+Bandit_Leather_Boots	Bandit's Leather Greaves
+Bandit_Leather_Boots_II	Bandit's Leather Greaves
+Bandit_Leather_Gloves_I	Bandit Leather Gloves
+Bandit_Leather_Gloves_II	Orc Bandit's Leather Gloves
+Bandit_Leather_Gloves_III	Bandit's Scale Leather Gloves
+Baraccuro_Fabric_Armor	Baraccuro Cloth Armor
+Baraoh_Fabric_Armor	Barrow Cloth Armor
+Baras_Fabric_Armor	Baras Cloth Armor
+Baratan_ChainMail_Armor	Baratan Chain Mail
+Baratum_Fabric_Armor	Baratum Cloth Armor
+Barbarian_Leather_Boots_II	Barbarian Leather Greaves
+Barbarian_Leather_Gloves_I	Barbarian Leather Gloves
+Barbaros_Leather_Armor	Barbaros Leather Armor
+Barbaroy_Fabric_Armor	Barbaroy Cloth Armor
+Barbaroy_Leather_Armor	Barbaroy Leather Armor
+Barch_Fabric_Armor	Barch Cloth Armor
+Barcy_Fabric_Armor	Barcy Cloth Armor
+Baredin_OneHandBow	Tommasoan Bow
+Bareuan_Fabric_Armor	Barian Cloth Armor
+Barioca_Leather_Armor	Baorica Leather Armor
+Barisoka_Leather_Armor	Varsoka Leather Armor
+Baritum_Fabric_Armor	Baritum Cloth Armor
+Barley	Barley
+Barndid_Fabric_Armor	Bandide Cloth Armor
+Barnia_ChainMail_Boots	Varnian Chain Boots
+Barnia_Fabric_Armor	Varnia Cloth Armor
+Barnia_Fabric_Helm	Varnia Cloth Cap
+barnia_Flag_I	Small Varnian Banner Pike
+barnia_Flag_II	Medium Varnian Banner Pike
+Barnia_Leather_Gloves	Varnian Leather Gloves
+Barnia_Soldier_General_Fabric_Armor	Varnian Guard Captain's Cloth Armor
+Barnia_Soldier_General_Fabric_Cloak	Varnian Guard Captain's Cloth Cloak
+Barnia_Soldier_General_PlateArmor_Helm	Varnian Guard Captain's Plate Helm
+Barrette_Fabric_Boots	Barrette Cloth Boots
+Barrette_Leather_Armor	Barrette Leather Armor
+Bastion_OneHandMace	Mace of Ambition
+Bastion_OneHandShield	Black Sun
+Bastion_PlateArmor_Armor	Bastier Armor
+Batangka_Leather_Armor	Batangka Leather Armor
+BattleSticky_FlowerBomb	Sticky Flower Bomb
+BattleStickyBomb	Sticky Bomb
+Battmen_Fabric_Armor	Bartmun Cloth Armor
+Batz_OneHandDagger	Kylus Dagger
+Batz_Plate_Boots	Batz Plate Boots
+Batz_PlateArmor_Gloves	Batz Plate Gloves
+Batz_PlateArmor_Gloves_I	Batz Plate Gloves I
+Bayur_Fabric_Armor	The Faceless's Cloth Armor
+Bayur_Leather_Boots	Bayer Leather Boots
+Bayur_PlateArmor_Helm	Bayer Plate Helm
+Bean	Beans
+Bear_BackPack	Bear Pack
+Bear_Bile	Bear's Gallbladder
+Bear_Chief_Leather_Helm	Boss Bear Hat
+Bear_Leather	Thick Hide
+Bear_Leather_cloak	Bear Hide Cloak
+Beastman_ChainMail_Gloves	Beastman Chain Gloves
+Beastman_Leather_Armor	Beastman Leather Armor
+Beastman_PlateArmor_Helm	Beastman Bone Helmet
+Beastman_TwoHandSword	Savage Longsword
+Becur_PlateArmor_Armor	Bekur Plate Armor
+Beef_Bone_Soup	Meat Stew
+Beef_Bone_Soup_Large	Satisfying Meat Stew
+Beef_Bone_Soup_Medium	Filling Meat Stew
+Beef_Bone_Soup_XLarge	Hearty Meat Stew
+Beekeeping_BackPack	Beekeeper's Pack
+Beer	Beer
+BeggarLeader_FindPotion	Plague Remedy
+Begill_Leather_Armor	Begill Leather Armor
+Begill_Leather_Boots	Begill Leather Boots
+Begonia	Begonia
+Bekker_OneHandAxe	Bekker Axe
+Bekker_OneHandSword	Alabaster Curved Sword
+Bell_BackPack	Bell Pack
+Bell_Flower	Lily of the Valley
+Bellac_HorseArmor_Helm	Velok Champron
+Bellaon_OneHandMace	Bekker Hammer
+Beltran_PlateArmor_Helm	Beltran Plate Helm
+Belui_Leather_Boots	Belui Leather Boots
+Belui_PlateArmor_Gloves	Belui Plate Gloves
+Belui_PlateArmor_Helm	Belui Plate Helm
+Benberry_Leather_Boots	Benberry Leather Boots
+Benne_Leather_Armor	Benne Leather Armor
+Beoneck_Fabric_Helm	Beoneck Cloth Cap
+Beoneck_Leather_Helm	Black Bears' Leather Helm
+Beoratte_Fabric_Armor	Beralt Cloth Armor
+Berenzard_Leather_Armor	Berenzard Leather Armor
+Bergam_OneHandMace	Rogue's Mace
+Berin_PlateArmor_Helm	Berin Plate Helm
+Berkei_HorseArmor_Armor	Berkei Barding
+Berkei_HorseArmor_Helm	Berkei Champron
+Berkei_HorseArmor_Saddle	Berkei Saddle
+Berkei_HorseArmor_Stirrup	Berkei Stirrups
+Berker_Leather_Armor	Berker Leather Armor
+Berkhia_Fabric_Armor	Berkhia Cloth Armor
+Berkhia_Leather_Gloves	Berkhia Leather Gloves
+Berkhia_OneHandBow	Twilight Messengers' Bow
+Berkhia_OneHandTowerShield	Thalwynd Large Shield
+Berlublean_Leather_Armor	Berblin Leather Armor
+Bernold_Leather_Armor	Bennault Leather Armor
+Berry_Juice	Fruit Juice
+Bessenette_Fabric_Armor	Besnet Cloth Armor
+Bessenette_Leather_Boots	Bessett Leather Boots
+Bessenette_PlateArmor_Gloves	Bessett Plate Gloves
+Bessenette_PlateArmor_Helm	Besnet Plate Helm
+Bethel_Leather_Boots	Bethel Leather Boots
+Betty_Leather_Boots	Beattie Leather Boots
+Betty_Leather_Gloves	Bettie Leather Gloves
+Beverly_PlateArmor_Armor	Beverly Plate Armor
+Bhetert_TwoHandAxe	Fan-Blade Greataxe
+Bhran_TwoHandAxe	Tardik Greataxe
+Bicornio_PlateArmor_Helm	Biconio Plate Helm
+Bierny_Leather_Armor	Vierni Leather Armor
+Big_Horn_Tiger_OneHandAxe	Silverwolf Axe
+Bildain_Leather_Armor_I	Vildyne Leather Armor
+Bilibili_Earring	Blue Scout Earring
+Bilibili_Fabric_Armor	Blue Scout Armor
+Bilibili_Fabric_Cloak	Blue Scout Cloak
+Bilibili_HorseArmor_Helm	Blue Scout Champron
+Bilibili_HorseArmor_Saddle	Blue Scout Saddle
+Bilibili_HorseArmor_Stirrup	Blue Scout Stirrups
+Bilibili_Lantern	Blue Scout Lantern
+Bilibili_Leather_Helm	Blue Scout Hat
+Bilibili_Necklace	Blue Scout Necklace
+Bilibili_OneHandShield	Blue Scout Shield
+Bilibili_Ring	Blue Scout Ring
+Binden_Leather_Armor	Binden Leather Armor
+Binder_PlateArmor_Helm	Binder's Plate Helm
+Bird_Meat	Lean Bird Meat
+Birdish_Leather_Armor	Verdesh Leather Armor
+Birdish_Leather_Gloves	Verdesh Leather Gloves
+Biryghton_Leather_Gloves	Viraiton Leather Gloves
+Biryghton_OneHandMace	Wells Mace
+Bismuth_CannonBall_Errant	Crude Bismuth Cannonball
+Bismuth_TwoHandCannon_I	Bismuth Cannon
+Bismuth_TwoHandSpear	Bismuth Spear
+BismuthOre	Bismuth Ore
+Black_Horse_Report	Sighting of Rokade
+Black_Lion_Earring	Black Lion Earring
+Blackbear_Flag_I	Small Black Bears Banner Pike
+Blackbear_Flag_II	Medium Black Bears Banner Pike
+Blackbear_Flag_IV	Black Bears Banner Pike with Tassel
+BlackBear_Leather_Gloves	Black Bear Leather Gloves
+Blackberry	Blackberry
+Blackburn_PlateArmor_Armor	Blackburn Plate Armor
+BlackOath_OneHandShield	Black Oath Shield
+Blady_ChainMail_Armor	Blandry Chain Mail
+Blank_Book	Empty Book
+Bleann_Leather_Armor	Blin Leather Armor
+Bleed_Alchemist_Fabric_Armor_I	Bleed Alchemist's Cloth Armor
+Bleed_Bandits_Fabric_Armor	Bleed Officer's Cloth Armor
+Bleed_Bandits_Fabric_Cloak_II	Bleed Officer's Cloth Cloak
+Bleed_Bandits_Leather_Armor	Bleed Officer's Leather Armor
+Bleed_Bandits_Leather_Gloves	Bleed Officer's Leather Gloves
+Bleed_Bomb_BackPack	Bleed Bandits' Alchemy Explosive Pack
+Bleed_Flag_II	Small Bleed Bandits Banner Pike
+Bleed_Flag_III	Medium Bleed Bandits Banner Pike
+Bloatte_Leather_Armor	Blaine Leather Armor
+BloodyFarmhouse_Book	Quarry Manager's Log
+Blowin_Leather_Armor	Bleawin Leather Armor
+Blueberry	Blueberry
+BlueStone	Azurite
+Blyan_Leather_Gloves	Blyne Leather Bracers
+BoardPaperBundle	Posters
+Boboten_Leather_Boots	Bourveten Leather Boots
+Bodin_PlateArmor_Armor	Bodin Plate Armor
+Bohen_Leather_Gloves	Boggen Leather Gloves
+BoiledPork	Boiled Meat
+BoiledPork_Large	Satisfying Boiled Meat
+BoiledPork_Medium	Filling Boiled Meat
+BoiledPork_XLarge	Hearty Boiled Meat
+Bolson_Leather_Gloves	Bolson Leather Gloves
+Bolton_PlateArmor_Armor	Bolton Plate Armor
+Bolton_PlateArmor_Cloak	Bolton Plate Cloak
+Bolton_PlateArmor_Helm	Keredeg Plate Helm
+Bolzers_Leather_Armor	Bolzers Leather Armor
+Bomb_Arrow	Explosive Arrow
+Bomb_Smoke	Smoke Bomb
+BombSpider_CannonBall	Mine Spider Cannonball
+BoneCollectorWagon_Book	Skull Collector's Journal
+Book_Battle_ATT_Alfonso	Spear Manual of House Alfonso, Vol. 2
+Book_Battle_DEF_Alfonso	Spear Manual of House Alfonso, Vol. 1
+Book_Battle_EXP_Alfonso	Spear Manual of House Alfonso, Vol. 3
+Book_Beighen_Diary	Journal
+Book_DrugFactory	Equipment Manual
+Book_FruitofGreed	Investigative Log: Harvest of Greed
+Book_GoldleafGuildhouse_Clue	Horse Hire Ledger
+Book_GoldleafGuildhouse_Clue_I	Empty Ledger
+Book_Grace_Diary_Journal	Count Grace's Journal
+Book_Hernand_story	Tales of Sunset Valley
+Book_HyperSpace	Old Research Journal
+Book_Investigation_GoldleafGuildhouse	Investigative Log: Extinguish the Flames
+Book_Investigation_Log	Investigative Log: Shadows in the Village
+Book_Misappropriation_Log	Investigative Log: Ambition in the Ruins
+Book_RedfoxTradePost_Questioning	Investigative Log: Broken Silence
+Book_ScholarLibrary_Knowledge_Knowledge_PlateArmor_Helm	The Knowledge Helm
+Book_TruthontheSand	Investigative Log: Truth on the Sands
+Book_WeightOfKnowledge	Investigative Log: The Weight of Knowledge
+Bopet_PlateArmor_Helm	Bobfett Plate Helm
+Borman_Fabric_Armor	Borman Cloth Armor
+Borsehir_Fabric_Armor	Borsehir Cloth Armor
+Boss_Hyena_Skevald_Report	Sighting of Skevald, the Carrion King
+Boss_Ludvig_Awakening_Leahter_Armor	Awakened Jackal's Leather Armor
+Boss_Ludvig_Awakening_Leather_Boots	Awakened Jackal's Leather Boots
+Boss_Reward_AutomatedIncome	Golden Piggy Bank
+Boss_Reward_BigMoney	Plunderer's Gold Chest
+Boss_Reward_BountyReduction	Shadow Contract
+Boss_Reward_CatFishMap	Voyages of Sir Catfish
+Boss_Reward_DelesyianNode	REN-X Surveillance Record
+Boss_Reward_DragonParts	Golden Star's Component
+Boss_Reward_Efficiency	Golden Beer
+Boss_Reward_FishMap	Mossy Secret Map
+Boss_Reward_GoldVeinMap	Gold Vein Map
+Boss_Reward_Graymanes	Seal of Devotion
+Boss_Reward_KnowledgeOverview	Memory of Ancient Nature
+Boss_Reward_KweidenContribution	Trace of the Thunder God
+Boss_Reward_KweidenNode	Eye of the Sky
+Boss_Reward_LargeStone	Secret of the Abandoned Mine
+Boss_Reward_LargeWood	Wrecked Keglord
+Boss_Reward_MasterThief	Shadow Gloves
+Boss_Reward_MerchantKing_GoldleafGuildhouse	Seal of Greed - Goldleaf Merchant Guild
+Boss_Reward_MerchantKing_SaltroadTradePost	Seal of Greed - Saltroad Trading Post
+Boss_Reward_MerchantKing_SilvermoonTroll	Seal of Greed - Silvermoon Trade Group
+Boss_Reward_MiraculousRecovery	Bloodstained Blessing
+Boss_Reward_Npc01Intimacy	Mysterious Gift
+Boss_Reward_QuickLearner	Sage's Eye
+Boss_Reward_ReturnCamp	Memory of a Fallen Kingdom
+Boss_Reward_StatsCrime	Chalice of Corruption
+Boss_Reward_StatsMp	T'rukan's Fighting Spirit
+Boss_Reward_StatsStamina	Dark Red Goblet
+Boss_Reward_SummonMerchant	Hologram Projector
+Boss_Reward_Supercarrot	Giant Brown Sugar Cube
+Boss_Reward_SuperSkill	Blessing of the Immortal
+Boss_Reward_SuperWeapon	Axe of the Apocalypse
+Boss_Reward_Survivors	The Ivory Messenger
+Boss_Reward_Tracker	Leebur's Soul
+BountyHunter_Fabric_Armor	Bounty Hunter's Cloth Armor
+BountyHunter_Fabric_Armor_I	Bounty Hunter's Cloth Armor
+BountyHunter_Fabric_Armor_II	Bounty Hunter's Cloth Armor
+BountyHunter_Fabric_Armor_III	Bounty Hunter's Cloth Armor
+BountyHunter_Fabric_Armor_IV	Bounty Hunter's Cloth Armor
+BountyHunter_Fabric_Armor_V	Bounty Hunter's Cloth Armor
+BountyHunter_Fabric_Armor_VI	Bounty Hunter's Cloth Armor
+BountyHunter_Fabric_Boots_I	Bounty Hunter's Cloth Boots
+BountyHunter_Fabric_Gloves_I	Bounty Hunter's Cloth Gloves
+BountyHunter_Fabric_Helm_I	Bounty Hunter's Cloth Cap
+BountyHunter_Fabric_Helm_II	Bounty Hunter's Cloth Cap
+BountyHunter_Leather_Armor	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_I	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_II	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_III	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_IV	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_V	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_VI	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_VII	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Armor_VIII	Bounty Hunter's Leather Armor
+BountyHunter_Leather_Boots	Bounty Hunter's Leather Boots
+BountyHunter_Leather_Boots_I	Strapped Bounty Hunter's Leather Boots
+BountyHunter_Leather_Gloves	Ringed Leather Gloves
+BountyHunter_Leather_Gloves_I	Tough Hunter's Leather Gloves
+BountyHunter_Leather_Gloves_II	Thick Hunter's Leather Gloves
+BountyHunter_Leather_Helm_I	Bounty Hunter's Scale Helm
+BountyHunter_Leather_Helm_II	Bounty Hunter's Leather Helm
+BountyHunter_Plate_Armor	Bounty Hunter's Plate Armor
+BountyHunter_Plate_Armor_I	Bounty Hunter's Plate Armor
+BountyHunter_Plate_Armor_II	Bounty Hunter's Plate Armor
+BountyHunter_Plate_Armor_III	Bounty Hunter's Plate Armor
+BountyHunter_Plate_Boots	Bounty Hunter's Plate Boots
+BountyHunter_PlateArmor_Gloves_I	Bounty Hunter's Plate Gloves
+BountyHunter_PlateArmor_Helm	Horned Bounty Hunter's Plate Helm
+BountyHunter_PlateArmor_Helm_I	Bounty Hunter's Plate Helm
+BountyHunter_PlateArmor_Helm_II	Crow Bounty Plate Helm
+Bourgogne_OneHandMace	Sorcerer's Massage Stick
+Braised_Fish	Braised Fish
+Braised_Fish_Large	Satisfying Braised Fish
+Braised_Fish_Medium	Filling Braised Fish
+Braised_Fish_Vegetable	Braised Fish and Vegetables
+Braised_Fish_Vegetable_Large	Satisfying Braised Fish and Vegetables
+Braised_Fish_Vegetable_Medium	Filling Braised Fish and Vegetables
+Braised_Fish_Vegetable_XLarge	Hearty Braised Fish and Vegetables
+Braised_Fish_XLarge	Hearty Braised Fish
+Braised_Meat	Braised Meat
+Braised_Meat_Fish	Braised Meat and Fish
+Braised_Meat_Fish_Large	Satisfying Braised Meat and Fish
+Braised_Meat_Fish_Medium	Filling Braised Meat and Fish
+Braised_Meat_Fish_XLarge	Hearty Braised Meat and Fish
+Braised_Meat_Large	Satisfying Braised Meat
+Braised_Meat_Medium	Filling Braised Meat
+Braised_Meat_Vegetable	Braised Ribs
+Braised_Meat_Vegetable_Large	Satisfying Braised Ribs
+Braised_Meat_Vegetable_Medium	Filling Braised Ribs
+Braised_Meat_Vegetable_XLarge	Hearty Braised Ribs
+Braised_Meat_XLarge	Hearty Braised Meat
+Braised_Vegetable	Pickled Vegetables
+Braised_Vegetable_Large	Satisfying Pickled Vegetables
+Braised_Vegetable_Medium	Filling Pickled Vegetables
+Braised_Vegetable_XLarge	Hearty Pickled Vegetables
+Branik_HorseArmor_Saddle	Branique Saddle
+Braxen_PlateArmor_Helm	Condemner's Plate Helm
+Bread	Bread
+Brejin_PlateArmor_Armor	Brejin Plate Armor
+Brejin_PlateArmor_Armor_I	Brejin Plate Armor
+Brimstone_Bomb	Brimstone Bomb
+Brimstone_Leather_Helm	Black Bear Gas Mask
+Brimstone_Leather_Helm_I	Demenissian Soldiers' Brimstone Gas Mask
+Brimstone_Leather_Helm_II	Demeniss Brimstone Gas Mask
+Brina_PlateArmor_Armor	Brina Plate Armor
+Brittle_Leather_Gloves	Bristel Leather Gloves
+Brizzle_Leather_Armor	Breitzle Leather Armor
+Brogue_Leather_Armor	Brogue Leather Armor
+Bromarty_Leather_Armor	Brometi Leather Armor
+Brudandi_TwoHandAxe	Kylus Greataxe
+Buchanan_Fabric_Armor	Buchanan Cloth Armor
+BucketHeavy	Heavy Bucket
+Buckwheat	Buckwheat
+Bulga_Leather_Armor	Bulga Leather Armor
+Bullet	Bullet
+Bunce_Leather_Gloves	Bunce Leather Gloves
+Burimen_PlateArmor_Armor	Breemen Plate Armor
+burrowingtoad	Burrowing Toad
+Bydan_Fabric_Gloves	Baidan Cloth Gloves
+ByeorSeungja_Chongtong_TwoHandCannon_I	Gamma Barrel Cannon
+Cabbage	Cabbage
+CabinDeathMystery_Book	Journal at the Cabin
+Cacao	Cacao
+cacao_Seed	Cacao Seed
+Cacheco_Leather_Boots	Catcheta Leather Boots
+Cadwallon_ChainMail_Helm	Kadallon Chain Coif
+Cadwallon_Leather_Boots	Kadallon's Leather Boots
+Cadwallon_Leather_Gloves	Kadallon Leather Gloves
+Cage_BackPack	Birdcage Pack
+Caisro_Leather_Boots	Cassrow Leather Boots
+Caliburn_Engineer_Fabric_Armor	Caliburn's Combat Engineer Cloth Armor
+Caliburn_Engineer_Fabric_Armor_I	Caliburn's Combat Engineer Cloth Armor
+Caliburn_Engineer_Fabric_Armor_II	Caliburn's Combat Engineer Cloth Armor
+Caliburn_Engineer_Fabric_Armor_III	Caliburn's Combat Engineer Cloth Armor
+Caliburn_Engineer_Fabric_Armor_IV	Caliburn's Combat Engineer Cloth Armor
+Caliburn_Engineer_Leather_Gloves	Caliburn's Combat Engineer Leather Gloves
+Caliburn_Flag	Small Caliburn's Banner Pike
+Caliburn_Flag_I	Small Caliburn's Banner Pike
+Caliburn_Flag_II	Medium Caliburn's Banner Pike
+Caliburn_Plate_Boots	Caliburn's Plate Boots
+Caliburn_PlateArmor_Armor	Caliburn's Plate Armor
+Caliburn_PlateArmor_Gloves	Caliburn's Plate Gloves
+Caliburn_Report	Investigative Report
+Caliburn_Tolerance_OneHandPistol	Caliburn's Mercy Pistol
+Caliburn_TwoHandSword	Righteous Verdict
+Calio_Leather_Gloves	Calio's Leather Gloves
+Calio_Leather_Gloves_I	Calio's Leather Gloves
+Calio_PlateArmor_Helm	Calio Plate Helm
+Calis_Fabric_Armor	Calis Cloth Armor
+Calphade_Contribution_Flag	Calphadean Contribution Banner Pike
+Calphade_Flag_I	Small Calphadean Banner Pike
+Calphade_Flag_II	Medium Calphadean Banner Pike
+Calpris_Fabric_Helm	Calprise Cloth Cap
+Calto_Leather_Armor	Calto Leather Armor
+Caltrop_Bomb	Caltrop Explosive
+Camantti_Leather_Boots	Camantti Leather Boots
+Camouflage_Boar_Cloak	Boar Cloak
+Camouflage_Boar_Leather_Gloves	Boar Camouflage Leather Gloves
+Camouflage_Bull_Cloak	Cow Cloak
+Camouflage_Reindeer_Cloak	Reindeer Cloak
+Camouflage_Wolf_Cloak	Wolf Cloak
+Campbell_Leather_Gloves	Keimbel Leather Gloves
+Campo_Leather_Armor	Campo Leather Armor
+CannonBall	Small Cannonball
+Canta_PlateArmor_Armor	Canta Plate Armor
+Canta_PlateArmor_Cloak	Canta Plate Cloak
+Cantarts_Leather_Armor	Cantars Leather Armor
+Cantina_ChainMail_Armor	Cantina Chain Mail
+Cantu_Leather_Boots	Cantu Leather Boots
+Canusti_PlateArmor_Armor	Canusti Plate Armor
+Canusti_PlateArmor_Armor_I	Canusti Plate Armor
+CapitalPatrol_OneHandShield	City Guard's Shield
+Carcon_Leather_Boots	Carcon Leather Boots
+Card_Vision_Helm	Deceiver's Fedora
+Cardion_Leather_Boots	Bolton Leather Boots
+Carious_Leather_Armor	Karius Leather Armor
+Carix_Leather_Gloves	Cains Leather Gloves
+Carphalen_Leather_Armor	Carphalen Leather Armor
+Carpinne_Leather_Armor	Carpine Leather Armor
+Carrot	Carrot
+Carta_Leather_Gloves	Carta Leather Gloves
+Carta_PlateArmor_Armor	Carta Plate Armor
+Carta_PlateArmor_Helm	Carta Plate Helm
+Carta_Plated_Boots	Carta Plate Boots
+Carton_PlateArmor_Armor	Garten Plate Armor
+Casa_Fabric_Armor	Kassa Cloth Armor
+Casanta_Leather_Boots	Kassantra Leather Boots
+Casco_Leather_Boots	Cosgrove Leather Boots
+Casinian_PlateArmor_Helm	Casinian Plate Helm
+Cateine_Leather_Boots	Cateine Leather Boots
+Catfish_Helm	Catfish Plate Helm
+Caviden_Leather_Gloves	Caviden Leather Gloves
+Caviden_Wood_OneHandShield	Sydmon Kite Shield
+Cebro_Fabric_Gloves	Serbello Cloth Gloves
+Cecilia_Kokes_OneHandMace	Acorn Mace
+centipede	Centipede
+Ceremonial_OneHandDagger	Ator's Finger
+Cernos_HorseArmor_Armor	Cernos Barding
+Ceruon_PlateArmor_Armor	Cerruan Plate Armor
+Cetry_Fabric_Gloves	Setri Cloth Gloves
+CharacterCustomize_Damian_DefultHair	Damiane's Basic Hair Ticket
+CharacterCustomize_Damian_TieHair	Damiane's Ponytail Ticket
+CharacterCustomize_Kliff_Aging	Kliff Aging Appearance Change Coupon
+CharacterCustomize_Kliff_Deaging	Kliff Youthful Appearance Change Coupon
+CharacterCustomize_Kliff_Neck_Scar	Kliff's Neck Scar Change Coupon
+CharacterCustomize_Oongka_Arm_Aging	Oongka's Arms Aging Appearance Change Coupon
+Charphnir_OneHandDagger	Alabaster Dagger
+Chart_Leather_Gloves	Chent Leather Gloves
+Chartian_Fabric_Helm	Dark Ringleader's Cloth Helm
+Chaya_seed	Chaya Seed
+Checia_PlateArmor_Helm	Chelcia Plate Helm
+Checia_PlateArmor_Helm_I	Wells Elite Plate Helm
+Cheese	Cheese
+Chelcia_Plate_Boots	Chelcia Plate Boots
+Chelti_Leather_Boots	Chanti Leather Boots
+Cheon_Leather_Armor	Chayten Leather Armor
+Cheonja_Chongtong_TwoHandCannon_I	Alpha Barrel Cannon
+Cherke_Leather_Armor	Cherke Leather Armor
+Chickadee	False Hellebore
+Chicken_Helm	Herald of Six O'Clock
+Chicken_Meat	Bird Meat
+Chijar_Fabric_Armor	Chizhar Cloth Armor
+Chijar_Fabric_Boots	Chizhar Cloth Boots
+Chijar_Fabric_Gloves	Chizhar Cloth Gloves
+Chile_Leather_Armor	Cherlay Leather Armor
+Chile_Leather_Boots	Cherlay Leather Boots
+Chile_Leather_Gloves	Cherlay Leather Gloves
+Chocolate_Factory_BackPack	Gearmelt Confectionery Pack
+Ciburn_Leather_Gloves	Sivern Leather Gloves
+Cigar_Leather_Boots	Seiger Leather Boots
+Cigar_OneHandSword	Grey Wolf's Sword
+Cigrymon_Plate_Boots	Sigremon Plate Boots
+Cigrymon_TwoHandAxe	Sigremon Greataxe
+Cilantro_Leather_Boots	Sillau Leather Boots
+CircusMachine_Sphere	Circus Machine Sphere
+Claire_Leather_Gloves	Claire Leather Gloves
+ClaireHill_Leather_Boots	Clarille Leather Boots
+Clays_Leather_Boots	Clays Leather Boots
+Clays_Leather_Boots_I	Desert Clays Leather Boots
+Clays_Leather_Boots_II	Large Clays Leather Boots
+Clays_Leather_Boots_III	Wetlands Clays Leather Boots
+Clays_Leather_Boots_IV	Gilded Clays Leather Boots
+Clout	Cloth Piece
+Coby_Leather_Armor_I	Coby Leather Armor
+Cocotar_Fabric_Armor	Cocotar Cloth Armor
+Coffee	Coffee Cherry
+Coffee_Seed	Coffee Cherry Seed
+Cog	Cogwheel
+Cog_Pack	Cogwheel
+Colatte_Leather_Armor	Colatte Leather Armor
+Colbern_Leather_Boots	Colbern Leather Boots
+Colbill_Leather_Armor_I	Colbill Leather Armor
+Collection_gemstone_lamp_0001	Icy White Processed Crystal
+Collection_gemstone_lamp_0001_index01	Twilight Processed Crystal
+Collection_gemstone_lamp_0001_index02	Lilac Processed Crystal
+Collection_gemstone_lamp_0002	Icy White Crystal
+Collection_gemstone_lamp_0002_index01	Twilight Crystal
+Collection_gemstone_lamp_0002_index02	Lilac Crystal
+Collection_Lamp_Candle_0001	Icy White Glass Lamp
+Collection_Lamp_Candle_0001_index01	Twilight Glass Lamp
+Collection_Lamp_Candle_0001_index02	Lilac Glass Lamp
+Collection_Lamp_Candle_0002	Icy White Pavilion Glass Lamp
+Collection_Lamp_Candle_0002_index01	Twilight Pavilion Glass Lamp
+Collection_Lamp_Candle_0002_index02	Lilac Pavilion Glass Lamp
+Collection_Lamp_Candle_0003	Icy White Watchtower Glass Lamp
+Collection_Lamp_Candle_0003_index01	Twilight Watchtower Glass Lamp
+Collection_Lamp_Candle_0003_index02	Lilac Watchtower Glass Lamp
+Collection_Lamp_Candle_0004	Icy White Hexagonal Lamp
+Collection_Lamp_Candle_0004_index01	Twilight Hexagonal Lamp
+Collection_Lamp_Candle_0004_index02	Lilac Hexagonal Lamp
+Collection_Prop_Bismuthornament_0001	Broken Bismuth Ornament
+Collection_Prop_Bismuthornament_0002	Angular Bismuth Ornament
+Collection_Prop_Bismuthornament_0003	Round Bismuth Ornament
+Collection_Prop_Bottle_0001	Blue-Green Glass Water Bottle
+Collection_Prop_Bottle_0002	Wooden Container
+Collection_Prop_Bottle_0003	Portable Wooden Container
+Collection_Prop_Bottle_0004	Blue Round Water Bottle
+Collection_Prop_Bottle_0005	Ceramic Container
+Collection_Prop_Bottle_0006	Short-Necked Ceramic Container
+Collection_Prop_Bottle_0007	Liquor Bottle
+Collection_Prop_Bottle_0008	Sturdy Clay Container
+Collection_Prop_Bottle_0009	Tin Water Bottle
+Collection_Prop_Bottle_0010	Round Blue Container
+Collection_Prop_Bottle_0011	Round Blue Container
+Collection_Prop_Bottle_0012	Slim Indigo Glass Bottle
+Collection_Prop_Bottle_0013	Gourd Bottle
+Collection_Prop_Bottle_0014	Pale Blue Container
+Collection_Prop_Bottle_0015	Waterskin
+Collection_Prop_Bottle_0016	Portable Blue Water Bottle
+Collection_Prop_Bottle_0017	Water Bottle for Patients
+Collection_Prop_Bottle_0018	White-Handled Water Bottle
+Collection_Prop_Bottle_0019	Purple-Handled Water Bottle
+Collection_Prop_Bottle_0020	Iron Distiller
+Collection_Prop_Bottle_0021	Rusty Iron Water Bottle
+Collection_Prop_Bottle_0022	Copper Water Bottle
+Collection_Prop_Bottle_0023	Brass Container
+Collection_Prop_Bottle_0024	Clay Container
+Collection_Prop_Bottle_0025	Iron Container
+Collection_Prop_Bottle_0026	Decorative Iron Water Bottle
+Collection_Prop_Bottle_0027	Decorative Brass Water Bottle
+Collection_Prop_Bottle_0028	Two-Handled Iron Water Bottle
+Collection_Prop_Bottle_0029	Old Two-Handled Iron Water Bottle
+Collection_Prop_Bottle_0030	Two-Handled Brass Container
+Collection_Prop_Bottle_0031	Water Bottle of the Agonized
+Collection_Prop_Bottle_0032	Distiller
+Collection_Prop_Bottle_0033	Blue Jar-Shaped Water Bottle
+Collection_Prop_Bottle_0034	White Jar-Shaped Water Bottle
+Collection_Prop_Bottle_0035	Green Jar-Shaped Water Bottle
+Collection_Prop_Bottle_0036	Long Crimson Water Bottle
+Collection_Prop_Bottle_0037	Long White Water Bottle
+Collection_Prop_Bottle_0038	Long Yellow Water Bottle
+Collection_Prop_Bottle_0039	Long Blue Water Bottle
+Collection_Prop_Bottle_0040	Silver-Decorated Water Bottle
+Collection_Prop_Bottle_0041	Wide-Mouthed Water Bottle
+Collection_Prop_Bottle_0042	Small Pot for Boiling
+Collection_Prop_Bottle_0043	Blue-Glazed Container
+Collection_Prop_Bottle_0044	Black Ceramic Water Bottle
+Collection_Prop_Bottle_0045	Travel Flask
+Collection_Prop_Bottle_0046	Yellow-Glazed Water Bottle
+Collection_Prop_Bottle_0047	Light Green-Glazed Water Bottle
+Collection_Prop_Bottle_0048	Clay-Handled Water Bottle
+Collection_Prop_Bottle_0049	Indigo Bottle
+Collection_Prop_Bottle_0050	Wide-Bottomed Water Bottle
+Collection_Prop_Bottle_0051	Decorative Water Bottle with Lid
+Collection_Prop_Bottle_0052	Glazed Clay Water Bottle
+Collection_Prop_Bottle_0053	Large Water Bottle
+Collection_Prop_Bottle_0054	Leather Strap Gourd Bottle
+Collection_Prop_Bottle_0055	Plaid Gourd Bottle
+Collection_Prop_Bowl_0001	Bread Plate
+Collection_Prop_Bowl_0002	Deep Bowl
+Collection_Prop_Bowl_0003	Storage Bowl
+Collection_Prop_Bowl_0004	Wide Bowl
+Collection_Prop_Bowl_0005	Nut Bowl
+Collection_Prop_Bowl_0006	Grain Bowl
+Collection_Prop_Bowl_0007	Large Grain Bowl
+Collection_Prop_Bowl_0008	Cheese Plate
+Collection_Prop_Bowl_0011	Small Mortar Bowl
+Collection_Prop_Bowl_0012	Herb Mortar Bowl
+Collection_Prop_Bowl_0013	Damaged Bowl
+Collection_Prop_Bowl_0014	Iron Bowl
+Collection_Prop_Bowl_0015	Golden Bowl
+Collection_Prop_Bowl_0016	Red Spice Bowl
+Collection_Prop_Bowl_0017	Green Spice Bowl
+Collection_Prop_Bowl_0018	Blue Spice Bowl
+Collection_Prop_Bowl_0019	Ashen Spice Bowl
+Collection_Prop_Bowl_0020	Glazed Mortar
+Collection_Prop_Bowl_0021	Glazed Bowl
+Collection_Prop_Bowl_0022	Stacked Glazed Bowls
+Collection_Prop_Bowl_0023	Wooden Beaker
+Collection_Prop_Bowl_0024	Oak Beaker
+Collection_Prop_Bowl_0025	Two-Handled Bronze Cup
+Collection_Prop_Bowl_0026	Pot
+Collection_Prop_Bowl_0027	Ceremonial Bowl
+Collection_Prop_Candle_0001	Twin Candles
+Collection_Prop_Candle_0002	Candle
+Collection_Prop_Candle_0003	Plain Candle
+Collection_Prop_Candle_0004	Five-Candle Candelabra
+Collection_Prop_Candle_0005	Copper Candlestick
+Collection_Prop_Candle_0006	Three-Candle Candelabra
+Collection_Prop_Candle_0007	Iron Cup Candle
+Collection_Prop_Candle_0008	Iron Candle
+Collection_Prop_Candle_0009	Tripod Candle
+Collection_Prop_Candle_0010	Four-Candle Candelabra
+Collection_Prop_Candle_0011	Tarnished Four Candle Candelabra
+Collection_Prop_Ceramic_0001	Blue Patterned Ceramic
+Collection_Prop_Ceramic_0002	Slim Celadon Bottle
+Collection_Prop_Ceramic_0003	Freshly Fired Celadon Vase
+Collection_Prop_Ceramic_0004	Medicine Ceramic Jar
+Collection_Prop_Ceramic_0005	Multipurpose Jar
+Collection_Prop_Ceramic_0006	Medicine Jar
+Collection_Prop_Ceramic_0007	Round Jar
+Collection_Prop_Ceramic_0008	Worn Two-Handled Jar
+Collection_Prop_Ceramic_0009	Shiny Ceramic Vase
+Collection_Prop_Ceramic_0010	Gray Two-Handled Jar
+Collection_Prop_Ceramic_0011	Brown Two-Handled Jar
+Collection_Prop_Ceramic_0012	Red One-Handled Jar
+Collection_Prop_Ceramic_0013	Gray Jar
+Collection_Prop_Ceramic_0014	Ocher Jar
+Collection_Prop_Ceramic_0015	Small Storage Jar
+Collection_Prop_Ceramic_0016	Large Medicine Jar
+Collection_Prop_Ceramic_0017	Cylindrical Jar
+Collection_Prop_Ceramic_0018	Ornate Tree Pattern Vase
+Collection_Prop_Ceramic_0019	Water Pot
+Collection_Prop_Ceramic_0020	Grain Jar
+Collection_Prop_Ceramic_0024	Gilded Slim Bottle
+Collection_Prop_Ceramic_0025	Water Jug
+Collection_Prop_Ceramic_0026	Wide White Jar
+Collection_Prop_Ceramic_0027	Wide Jar
+Collection_Prop_Ceramic_0028	Dark Brown Jar
+Collection_Prop_Ceramic_0029	Silver Carafe
+Collection_Prop_Ceramic_0030	Golden Carafe
+Collection_Prop_Ceramic_0031	Storage Jar
+Collection_Prop_Ceramic_0032	Gilded Vase
+Collection_Prop_Ceramic_0045	Silver Water Pot
+Collection_Prop_Ceramic_0046	Long-Necked Silver Jar
+Collection_Prop_Ceramic_0047	Ornate Silver Conical Jar
+Collection_Prop_Ceramic_0050	Cylindrical Ocher Jar
+Collection_Prop_Ceramic_0051	Cylindrical Clay Jar
+Collection_Prop_Ceramic_0052	Old Round Jar
+Collection_Prop_Ceramic_0053	Brown Round Jar
+Collection_Prop_Ceramic_0054	Old Water Pot
+Collection_Prop_Ceramic_0055	Light Brown Water Pot
+Collection_Prop_Chest_0001	Strongbox
+Collection_Prop_Chest_0002	Document Storage
+Collection_Prop_Chest_0003	Sturdy Wooden Box
+Collection_Prop_Chest_0004	Wooden Box
+Collection_Prop_Chest_0005	Engraved Wooden Box
+Collection_Prop_Chest_0006	Iron-Adorned Storage
+Collection_Prop_Chest_0007	Jewelry Storage
+Collection_Prop_Chest_0008	Jewel Box
+Collection_Prop_Chest_0009	Multipurpose Wooden Box
+Collection_Prop_Chest_0010	Cylindrical Wooden Box
+Collection_Prop_Cup_0001	Golden Goblet
+Collection_Prop_Cup_0002	Silver Goblet
+Collection_Prop_Cup_0003	Bronze Goblet
+Collection_Prop_Cup_0004	Wooden Mug
+Collection_Prop_Cup_0005	Brass Goblet
+Collection_Prop_Cup_0006	Sturdy Wooden Beer Mug
+Collection_Prop_Cup_0007	Worn Wooden Beer Mug
+Collection_Prop_Cup_0008	Old Wooden Beer Mug
+Collection_Prop_Cup_0009	Decorative Silver Mug
+Collection_Prop_Cup_0010	Decorative Brass Goblet
+Collection_Prop_Cup_0011	Large Decorative Goblet
+Collection_Prop_Cup_0012	Worn Decorative Silver Mug
+Collection_Prop_Cup_0013	Large Multipurpose Vessel
+Collection_Prop_Cup_0014	Fine Gold Goblet
+Collection_Prop_Cup_0015	Artisan's Metal Goblet
+Collection_Prop_Cup_0016	Ornate Gold Goblet
+Collection_Prop_Cup_0017	Plain Wooden Beer Mug
+Collection_Prop_Doll_0001	Simple Dress Doll
+Collection_Prop_Doll_0002	Fine Blue Bonnet Doll
+Collection_Prop_Doll_0003	Simple Brown Bonnet Doll
+Collection_Prop_Doll_0004	Beige Bandana Doll
+Collection_Prop_Doll_0005	Brown Dress Doll
+Collection_Prop_Doll_0006	Doll Wearing Brown Bonnet
+Collection_Prop_Doll_0007	Fine Dress Doll
+Collection_Prop_Dyewater_0001	Bright Red Dye
+Collection_Prop_Dyewater_0002	Rich Red Dye
+Collection_Prop_Dyewater_0003	Red Dye
+Collection_Prop_Dyewater_0004	Dark Red Dye
+Collection_Prop_Dyewater_0005	Deep Red Dye
+Collection_Prop_Dyewater_0006	Bright Violet Dye
+Collection_Prop_Dyewater_0007	Rich Violet Dye
+Collection_Prop_Dyewater_0008	Violet Dye
+Collection_Prop_Dyewater_0009	Dark Violet Dye
+Collection_Prop_Dyewater_0010	Deep Violet Dye
+Collection_Prop_Dyewater_0011	Bright Purple Dye
+Collection_Prop_Dyewater_0012	Rich Purple Dye
+Collection_Prop_Dyewater_0013	Purple Dye
+Collection_Prop_Dyewater_0014	Dark Purple Dye
+Collection_Prop_Dyewater_0015	Deep Purple Dye
+Collection_Prop_Dyewater_0016	Bright Blue Dye
+Collection_Prop_Dyewater_0017	Rich Blue Dye
+Collection_Prop_Dyewater_0018	Blue Dye
+Collection_Prop_Dyewater_0019	Dark Blue Dye
+Collection_Prop_Dyewater_0020	Deep Blue Dye
+Collection_Prop_Dyewater_0021	Bright Sky Blue Dye
+Collection_Prop_Dyewater_0022	Rich Sky Blue Dye
+Collection_Prop_Dyewater_0023	Sky Blue Dye
+Collection_Prop_Dyewater_0024	Dark Sky Blue Dye
+Collection_Prop_Dyewater_0025	Deep Sky Blue Dye
+Collection_Prop_Dyewater_0026	Bright Teal Dye
+Collection_Prop_Dyewater_0027	Rich Teal Dye
+Collection_Prop_Dyewater_0028	Teal Dye
+Collection_Prop_Dyewater_0029	Dark Teal Dye
+Collection_Prop_Dyewater_0030	Deep Teal Dye
+Collection_Prop_Dyewater_0031	Bright Green Dye
+Collection_Prop_Dyewater_0032	Rich Green Dye
+Collection_Prop_Dyewater_0033	Green Dye
+Collection_Prop_Dyewater_0034	Dark Green Dye
+Collection_Prop_Dyewater_0035	Deep Green Dye
+Collection_Prop_Dyewater_0036	Bright Spring Green Dye
+Collection_Prop_Dyewater_0037	Rich Spring Green Dye
+Collection_Prop_Dyewater_0038	Spring Green Dye
+Collection_Prop_Dyewater_0039	Dark Spring Green Dye
+Collection_Prop_Dyewater_0040	Deep Spring Green Dye
+Collection_Prop_Dyewater_0041	Bright Yellow Dye
+Collection_Prop_Dyewater_0042	Rich Yellow Dye
+Collection_Prop_Dyewater_0043	Yellow Dye
+Collection_Prop_Dyewater_0044	Dark Yellow Dye
+Collection_Prop_Dyewater_0045	Deep Yellow Dye
+Collection_Prop_Dyewater_0046	Bright Orange Dye
+Collection_Prop_Dyewater_0047	Rich Orange Dye
+Collection_Prop_Dyewater_0048	Orange Dye
+Collection_Prop_Dyewater_0049	Dark Orange Dye
+Collection_Prop_Dyewater_0050	Deep Orange Dye
+Collection_Prop_Dyewater_Grey_0001	Pure White Dye
+Collection_Prop_Dyewater_Grey_0002	Bright Grey Dye
+Collection_Prop_Dyewater_Grey_0003	Silver Grey Dye
+Collection_Prop_Dyewater_Grey_0004	Medium Grey Dye
+Collection_Prop_Dyewater_Grey_0005	Grey Dye
+Collection_Prop_Dyewater_Grey_0006	Shadow Grey Dye
+Collection_Prop_Dyewater_Grey_0007	Cloud Grey Dye
+Collection_Prop_Dyewater_Grey_0008	Deep Grey Dye
+Collection_Prop_Dyewater_Grey_0009	Dark Grey Dye
+Collection_Prop_Dyewater_Grey_0010	Black Dye
+Collection_Prop_FlowerPot_0001	Flower Basket
+Collection_Prop_FlowerPot_0002	Flower Basket
+Collection_Prop_FlowerPot_0003	Daisy Flower Basket
+Collection_Prop_FlowerPot_0004	Yellow Blue-Eyed Grass Basket
+Collection_Prop_FlowerPot_0005	Red Rose Flower Pot
+Collection_Prop_FlowerPot_0006	Yellow Rose Flower Pot
+Collection_Prop_FlowerPot_0007	Ornamental Plant Pot
+Collection_Prop_FlowerPot_0008	Colorful Gerbera Pot
+Collection_Prop_FlowerPot_0009	Violet Flower Pot
+Collection_Prop_FlowerPot_0010	Purple Gerbera Flower Pot
+Collection_Prop_FlowerPot_0011	Dark Brown Gerbera Flower Pot
+Collection_Prop_FlowerPot_0012	Light Brown Gerbera Flower Pot
+Collection_Prop_FlowerPot_0013	Flower-Shaped Marigold Pot
+Collection_Prop_FlowerPot_0014	Chalice Flower Pot
+Collection_Prop_FlowerPot_0015	White Flower-Shaped Marigold Pot
+Collection_Prop_FlowerPot_0020	Leafy Pot
+Collection_Prop_FlowerPot_0023	Purple Cactus Pot
+Collection_Prop_FlowerPot_0025	Purple Flower-Shaped Cactus Pot
+Collection_Prop_FlowerPot_0027	Chalice Bush Pot
+Collection_Prop_FlowerPot_0029	Flower-Decorated Cactus Pot
+Collection_Prop_FlowerPot_0031	Small Plant Pot
+Collection_Prop_FlowerPot_0032	Red Flower Pot
+Collection_Prop_Glasscraft_0003	Unicorn Glass Art
+Collection_Prop_Glasscraft_0004	Dolphin Glass Art
+Collection_Prop_Glasscraft_0005	Humpback Whale Glass Art
+Collection_Prop_Picture_0001	Study - Fields of Color
+Collection_Prop_Picture_0002	Study - Poverty Amidst Plenty
+Collection_Prop_Picture_0003	Study - Golden Lands
+Collection_Prop_Picture_0004	Acclaimed - Idle Hands
+Collection_Prop_Picture_0005	Acclaimed - Abundance
+Collection_Prop_Picture_0006	Acclaimed - Prelude to War
+Collection_Prop_Picture_0007	Notable - Poverty Amidst Plenty
+Collection_Prop_Picture_0008	Masterpiece - Poverty Amidst Plenty
+Collection_Prop_Picture_0009	Study - Hiding the Evidence
+Collection_Prop_Picture_0010	Study - Hernand Castle
+Collection_Prop_Picture_0011	Study - Saint Grein
+Collection_Prop_Picture_0012	Study - The Blessed Queen
+Collection_Prop_Picture_0013	Magnum Opus - Saint Bartali
+Collection_Prop_Picture_0014	Notable - Saint Reventine
+Collection_Prop_Picture_0015	Notable - Nameless
+Collection_Prop_Picture_0016	Replica - Idle Hands
+Collection_Prop_Picture_0017	Replica - Prelude to War
+Collection_Prop_Picture_0018	Notable - Those Who Celebrate the Harvest Festival
+Collection_Prop_Picture_0019	Notable - Those Headed to the Chapel
+Collection_Prop_Picture_0020	Acclaimed - Silence of Dawn
+Collection_Prop_Picture_0021	Masterpiece - Silence of Dawn
+Collection_Prop_Picture_0022	Study - Delesyia
+Collection_Prop_Picture_0023	Notable - Glory of Days Past
+Collection_Prop_Picture_0024	Study - Eghod the Great
+Collection_Prop_Picture_0025	Notable - Duel Between Rivals
+Collection_Prop_Picture_0026	Acclaimed - Golden Lands
+Collection_Prop_Picture_0027	Notable - Duel - Echoes of the Battlefield
+Collection_Prop_Picture_0028	Notable - Execution
+Collection_Prop_Picture_0029	Notable - Fields of Color
+Collection_Prop_Picture_0030	Acclaimed - Poverty Amidst Plenty
+Collection_Prop_Picture_0031	Study - The Cat and the Bird
+Collection_Prop_Picture_0032	Study - Blooming Rabbit
+Collection_Prop_Picture_0033	Study - The Rat's Roll
+Collection_Prop_Picture_0034	Acclaimed - Bighorn Sheep
+Collection_Prop_Picture_0035	Masterpiece - Bighorn Sheep
+Collection_Prop_Picture_0036	Acclaimed - The Lamb
+Collection_Prop_Picture_0037	Acclaimed - Gatekeeper of Death
+Collection_Prop_Picture_0038	Masterpiece - Gatekeeper of Death
+Collection_Prop_Picture_0039	Acclaimed - Dawnbreak
+Collection_Prop_Picture_0040	Masterpiece - Dawnbreak
+Collection_Prop_Picture_0041	Acclaimed - A Dairy Cow
+Collection_Prop_Picture_0042	Masterpiece - A Dairy Cow
+Collection_Prop_Picture_0043	Acclaimed - Man's Best Friend
+Collection_Prop_Picture_0044	Masterpiece - Man's Best Friend
+Collection_Prop_Picture_0045	Acclaimed - Lion's Majesty
+Collection_Prop_Picture_0046	Study - A Sheep with Horns
+Collection_Prop_Picture_0047	Study - The Hound
+Collection_Prop_Picture_0048	Masterpiece - King of Death
+Collection_Prop_Picture_0049	Study - Red Bighorn Sheep
+Collection_Prop_Picture_0050	Notable - King of Hens
+Collection_Prop_Picture_0051	Magnum Opus - Priest of Bulls
+Collection_Prop_Picture_0052	Magnum Opus - The Tiger General
+Collection_Prop_Picture_0053	Notable - Winged Fox
+Collection_Prop_Picture_0054	Study - My Beloved Steed
+Collection_Prop_Picture_0055	Study - Bighorn Sheep
+Collection_Prop_Picture_0056	Notable - The Fox
+Collection_Prop_Picture_0057	Notable - Snowfield Fox
+Collection_Prop_Picture_0058	Masterpiece - Crown Prince Edward Thorel
+Collection_Prop_Picture_0059	Notable - Marni's Portrait
+Collection_Prop_Picture_0060	Study - Dignified Genius
+Collection_Prop_Picture_0061	Study - Marni's Room
+Collection_Prop_Picture_0062	Acclaimed - Fields of Color
+Collection_Prop_Picture_0063	Notable - Golden Lands
+Collection_Prop_Picture_0064	Notable - Nameless
+Collection_Prop_Picture_0065	Replica - Poverty Amidst Plenty
+Collection_Prop_Picture_0066	Study - Emptiness
+Collection_Prop_Picture_0067	Study - Gathering Genius
+Collection_Prop_Picture_0068	Study - Discovering Genius
+Collection_Prop_Picture_0069	Study - Contemplative Genius
+Collection_Prop_Plate_0001	Large Wooden Plate
+Collection_Prop_Plate_0002	Bright Wooden Plate
+Collection_Prop_Plate_0003	Concave Wooden Plate
+Collection_Prop_Plate_0004	Sturdy Wooden Plate
+Collection_Prop_Plate_0006	Deep Wooden Plate
+Collection_Prop_Plate_0007	Soft Wooden Plate
+Collection_Prop_Plate_0008	Dark Wooden Plate
+Collection_Prop_Plate_0009	Thinly Carved Wooden Plate
+Collection_Prop_Plate_0010	Brass Bowl
+Collection_Prop_Plate_0011	Ritual Copper Plate
+Collection_Prop_Plate_0012	Square Tray
+Collection_Prop_Plate_0013	Decorative Plate
+Collection_Prop_Plate_0014	Ceramic Bowl
+Collection_Prop_Plate_0015	Fruit Bowl
+Collection_Prop_Plate_0016	Deep Iron Plate
+Collection_Prop_Plate_0017	Wide Iron Plate
+Collection_Prop_Plate_0018	Round Iron Plate
+Collection_Prop_Plate_0019	Decorative Iron Plate
+Collection_Prop_Statue_0001	Woman Holding a Water Bottle
+Collection_Prop_Statue_0003	Priest in a Mask
+Collection_Prop_Tool_0001	Cast Iron Pan
+Collection_Prop_Tool_0002	Pot
+Collection_Prop_Tool_0003	Gilded Mirror
+Collection_Prop_Tool_0004	Teapot
+Collection_Prop_Tool_0005	Iron Basin
+Collection_Prop_Tool_0006	Hourglass
+Collection_Prop_Tool_0007	Ornate Magnifying Glass
+Collection_Prop_Tool_0008	Magnifying Glass
+Collection_Prop_Tool_0009	Scales
+Collection_Prop_Tool_0010	Pile of Clothing Materials
+Collection_Prop_Tool_0011	Pile of Cloth
+Collection_Prop_Trophy_0001	Trophy - All-Out Duel
+Collection_Prop_Trophy_0002	Trophy - Unarmed Duel
+Collection_Prop_Trophy_0003	Trophy - Wrestling Match
+Collection_Prop_Trophy_0004	Trophy - Spear Duel
+Collection_Prop_Trophy_0005	Trophy - Sword Duel
+Collection_Prop_viewingstone_0001	Blue Dragon Scale Decorative Stone
+Collection_Prop_viewingstone_0002	Ancient's Decorative Stone
+Collection_Prop_viewingstone_0003	Red Fire Decorative Stone
+Collection_Prop_WeaponBox_0001	Firearms Box
+Collection_Prop_WeaponBox_0002	Swords Box
+Collection_Prop_WeaponBox_0003	Weapons Box
+Colossus_Boots	Giant's Boots
+Commander_PlateArmor_Gloves	Dulone Plate Gloves
+Common_Flag_I	Double-Sided Banner Pike
+Common_Flag_II	Small Banner Pike
+Conally_Fabric_Armor	Conally Cloth Armor
+Concerta_Leather_Gloves	Conchetta Leather Gloves
+Condola	Contola
+Continuous_Supply_Bullet	Replenishing Bullets
+Continuous_Supply_CannonBall	Replenishing Cannonballs
+Contra_Leather_Gloves	Contra Leather Gloves
+Contribution_Delesyian	Delesyian Contribution
+Contribution_Demenissian	Demenissian Contribution
+Contribution_Graymane	Greymane Contribution
+Contribution_Hernandian	Hernandian Contribution
+Contribution_Pailunese	Pailunese Contribution
+Contribution_Tashkalpan	Tashkalp Contribution
+Cooking_Oil	Cooking Oil
+Copper_Pack	Modest Copper Pouch
+CopperOre	Copper Ore
+Corey_Fabric_Armor	Corey Cloth Armor
+Corn	Corn
+Corn_seed	Corn Seed
+Corvo_PlateArmor_Armor	Icewing Plate Armor
+Corvo_PlateArmor_Cloak	Icewing Plate Cloak
+Corvo_PlateArmor_Gloves	Icewing Plate Gloves
+Corvo_PlateArmor_Gloves_II	Corvo Plate Gloves
+Cotton	Cotton
+cotton_BackPack	Cotton Pack
+Cournantry_Fabric_Armor	Conentry Cloth Armor
+Cournantry_Leather_Boots	Conentry Leather Boots
+Cradbahn_Leather_Armor	Cradbahn Leather Armor
+Crafting_Blizzard_Necklace	Blizzard Crystal Necklace
+Crafting_WhiteHorn_OneHandShield	Frostbone Shield
+CraftingRecipe_Demian_Leather_Armor_V	Elegant Carmine Armor Blueprint
+CraftingRecipe_Demian_Leather_Cloak_I	Elegant Carmine Cloak Blueprint
+CraftingRecipe_Demian_PlateArmor_Gloves_VI	Elegant Carmine Gloves Blueprint
+CraftingRecipe_Demian_PlateArmor_Helm_XIII	Elegant Carmine Helm Blueprint
+CraftingRecipe_Demian_Pure_White_Plate_Boots_II	Fluttering Radiance Plate Boots
+CraftingRecipe_Dragon_Weapon	Aeserion Gear Blueprint
+CraftingRecipe_Kuku_Golden999K	Kuku Communicative Pack Blueprint
+CraftingRecipe_Kuku_Pot_Arms_Book	Kuku Gear Special Blueprint
+CraftingRecipe_Kuku_Pot_Backpack_Book	Kuku Pack Special Blueprint
+CraftingRecipe_Kuku_Pot_Book	Kuku Pot Special Blueprint
+CraftingRecipe_Kuku_Pot_Machine_Book	Kuku Robot Special Blueprint
+CraftingRecipe_Kuku_Pot_Spear_Book	Kuku Spear Special Blueprint
+CraftingRecipe_Oongka_PlateArmor_Armor_III	Belkandor Armor Blueprint
+CraftingRecipe_Oongka_PlateArmor_Boots_III	Belkandor Boots Blueprint
+CraftingRecipe_Oongka_PlateArmor_Cloak_III	Belkandor Cloak Blueprint
+CraftingRecipe_Oongka_PlateArmor_Gloves_III	Belkandor Gloves Blueprint
+CraftingRecipe_Oongka_PlateArmor_Helm_III	Belkandor Helm Blueprint
+Crail_PlateArmor_Armor	Crail Plate Armor
+Crail_PlateArmor_Armor_I	Crail Plate Armor
+Criminal_DropItem	Note with a Suspicious Symbol
+Criminal_Urga_Book	Ursula's Journal
+CrimsonFlame_OneHandShield	Blazing Shield
+Crocodile_Skin	Sturdy Hide
+Croden_Leather_Armor	Croden Leather Armor
+Croton	Croton
+Croton_Red	Red Croton
+Crow_Bell	Bells
+Crow_Bomb	Crow Bomb
+Crow_Charm	Talisman
+Crow_PlateArmor_Helm	Crow Plate Helm
+Crow_Thurible	Censer
+CrowMan_PlateArmor_Helm	Blackwing Mask
+Crude_Devil_Mask	Crude Devil Mask
+Crudell_OneHandAxe	Timberham Axe
+Crudil_Leather_Boots	Crudil Leather Boots
+Crudil_PlateArmor_Helm	Crudil Plate Helm
+Cruedil_Leather_Gloves	Crudil Leather Gloves
+Crutch	Crutch
+Cucumber	Cucumber
+Cueman_Fabric_Armor	Quandan Cloth Armor
+Cuenantta_Fabric_Armor	Qunanta Cloth Armor
+Cuetain_Fabric_Armor	Qutin Cloth Armor
+Cuthbertson_Leather_Armor	Cuthbertson Leather Armor
+Cuzerchin_Leather_Armor	Churrchen Leather Armor
+Cyton_Leather_Armor	Cyton Leather Armor
+Dadnion_PlateArmor_Armor	Dardnion Plate Armor
+Daeil_Band	Axiom Bracelet
+Daibeads_Leather_Armor	Davis Leather Armor
+dain_Leather_Gloves	Dane Leather Bands
+Daine_Leather_Boots	Daine Leather Boots
+Dakahbern_Fabric_Armor	Dahkavan Cloth Armor
+Dallaban_Leather_Gloves	Dallaban Leather Gloves
+Dallabici_PlateArmor_Armor	Demeniss Honor Armor
+Dallabici_PlateArmor_Armor_I	Dalbich Plate Armor
+Dalton_Leather_Gloves	Dalton Leather Gloves
+Damian_Daeil_Band	Damiane's Axiom Bracelet
+Damian_Demeniss_Elite_Uniform_Leather_Armor	Demenissian Elite Uniform Leather Armor
+Damian_Demeniss_Elite_Uniform_Leather_Boots	Demeniss Elite Uniform Leather Boots
+Damian_Demeniss_Uniform_Leather_Armor	Demenissian Uniform Leather Armor
+Damian_Demeniss_Uniform_Leather_Boots	Demenissian Uniform Leather Boots
+Damian_Demeniss_Uniform_Leather_Cloak	Demenissian Uniform Leather Cloak
+Damian_Demeniss_Uniform_Leather_Gloves	Demenissian Uniform Leather Gloves
+Damian_OneHandPistol	Spencer Pistol
+Damian_OneHandShield	Demenissian Gold-Decorated Shield
+Damian_OneHandShield_IV	Demenissian Silver-Decorated Shield
+Damian_OneHandShield_VI	Artisan's Ornamented Shield
+Damian_OneHandShield_VII	Shield of Radiance
+Damian_OneHandShield_VIII	Golden Kerria Shield
+DamianOnly_Leather_Boots_II	Low-heeled Leather Boots
+DamianOnly_Leather_Boots_III	White Bloodwind Leather Boots
+DamianOnly_Leather_Boots_IV	Autumn Banquet Leather Boots
+DamianOnly_Leather_Boots_V	Official Knight's Leather Boots
+DamianOnly_Leather_Boots_VI	Wanderer of Faith Leather Boots
+DamianOnly_Leather_Boots_VII	Leather Boots of Earth's Honor
+Danda_ChainMail_Armor	Danda Chain Mail
+Danda_Fabric_Helm	Danda Cloth Cap
+Danda_Leather_Gloves	Danda Leather Gloves
+Danekoche_Leather_Boots	Dannoche Leather Boots
+Danid_PlateArmor_Helm	Deland Plate Helm
+Daraz_Fabric_Armor	Daraz Cloth Armor
+Darbaran_Leather_Armor	Darbaran Leather Armor
+Dark_King_Fabric_Armor	Antumbra Cloth Armor
+Dark_King_Metal_OneHandShield	Mirror of Night
+Dark_King_Plate_Boots	Antumbra Plate Boots
+DarkLeader_OneHandDagger	Dagger of Dark Pursuit
+DarkLeader_TwoHandGiantSpear	Thorn of Dark Pursuit
+DarkLeader_TwoHandSword	Vessel of Dark Pursuit
+DarkLeader_TwoHandWarHammer	Guidance of Dark Pursuit
+DarknessKing_PlateArmor_Armor	Plate Armor of the Shadows
+DarknessKing_PlateArmor_Boots	Plate Boots of the Shadows
+DarknessKing_PlateArmor_Cloak	Plate Cloak of the Shadows
+DarknessKing_PlateArmor_Gloves	Plate Gloves of the Shadows
+DarknessKing_PlateArmor_Helm	Plate Helm of the Shadows
+DarknessKing_TwoHandAlebard	Vow of the Dead King
+Darman_Leather_Boots	Darman Leather Boots
+Darren_ChainMail_Armor	Darren Chain Mail
+Darren_Fabric_Armor	Darren Cloth Armor
+Darren_Leather_Gloves	Darren Leather Gloves
+Dart	Dart
+Dartus_Leather_Armor	Dartus Leather Armor
+Dasasola_Leather_Armor	Dasala Leather Armor
+David_Leather_Boots	Daveed Leather Boots
+David_Leather_Gloves	Daveed Leather Gloves
+David_Leather_Helm	Daveed Leather Helm
+Daymonicon_Leather_Armor	Deimon Leather Armor
+Dayseorun_Leather_Armor	Derrison Leather Armor
+Dayseorun_Leather_Gloves	Derrison Leather Gloves
+Deactived_Abyss_Artifact	Faded Abyss Artifact
+Dealinger_Fabric_Armor	Dillinger Cloth Armor
+Dealinger_OneHandTowerShield	Mass-Produced Large Rekel Shield
+Deboros_Leather_Armor	Deboros Leather Armor
+Decoy_Human_I	Fake Silver Pouch
+Deekz_Fabric_Armor	Diggs Cloth Armor
+Deer_Antler	Long Horn
+Deer_King_Follower_Cloak_I	Yrkabel Cloth Cloak
+Deer_King_Follower_Leather_Armor	Staglord Acolyte's Leather Armor
+Deer_King_Follower_Leather_Armor_II	Staglord Acolyte's Leather Armor
+Deer_King_Follower_Leather_Armor_III	Staglord Acolyte's Leather Armor
+Deer_King_Follower_Leather_Armor_IV	Staglord Acolyte's Leather Armor
+Deer_King_Follower_Leather_Armor_V	Staglord Acolyte's Leather Armor
+Deer_King_Follower_Leather_Armor_VI	Yrkabel Leather Armor
+Deer_King_Follower_Leather_Helm	Deer Hat
+Deer_King_Leather_Helm	Leather Helm of the Fallen Kingdom
+Deer_King_Leather_Helm_T4_QA	Deer King Leather Helm T4 QA
+Deer_King_Metal_OneHandShield	Staglord's Shield
+Deer_King_OneHandSword	Survivor's Solitude
+Deer_Leather	Short Hair Hide
+Deer_Porter_BackPack	Deer Pack
+DeerAntler_Fruit_Tea	Antler Tea
+DeerAntler_Soup	Longhorn Soup
+DeerAntler_Soup_Large	Satisfying Longhorn Soup
+DeerAntler_Soup_Medium	Filling Longhorn Soup
+DeerAntler_Soup_XLarge	Hearty Longhorn Soup
+deerking_Flag_I	Small Staglord Banner Pike
+deerking_Flag_II	Medium Staglord Banner Pike
+DeerKing_Lantern	Fancy Flame-Patterned Lantern
+Deerking_Leather_Armor	Leather Armor of the Fallen Kingdom
+Deerking_Leather_Armor_T4_QA	Deerking Leather Armor T4 QA
+Deerking_Leather_Cloak	Leather Cloak of the Fallen Kingdom
+Deerking_Plate_Boots	Plate Boots of the Fallen Kingdom
+Deerking_PlateArmor_Gloves	Plate Gloves of the Fallen Kingdom
+Deernil_Leather_Gloves	Delinell's Leather Gloves
+Deernil_Leather_Gloves_I	Delinell's Leather Gloves
+Deerprice_Leather_Armor	Dyrfrith Leather Armor
+Deerprice_Leather_Boots	Dyrfrith Leather Boots
+Deet_Leather_Boots	Deint Leather Boots
+Defelde_Leather_Gloves	Dimfeld Leather Gloves
+Degah_Fabric_Armor	Dega Cloth Armor
+Deidre_Leather_Boots	Deidre Leather Boots
+Dein_OneHandShotgun	Dane Shotgun
+Dekcher_Leather_Armor	Dekter Leather Armor
+Dekcher_Leather_Boots	Dreiger Leather Boots
+Dekcher_Leather_Helm	Dekter Leather Helm
+Del_Prison_Room_Key	Delesyia Prison Key
+Delegation_Leather_Helm	Delegation Leather Hat
+Delesian_Friend_Boss_TwoHandSword	Delesyian Longsword
+Delesian_Friend_PlateArmor_Armor	Armor of Loyal Friendship
+Delesian_Friend_PlateArmor_Cloak	Cloak of Loyal Friendship
+Delesian_HorseArmor_Armor	Delesyian Barding
+Delesian_HorseArmor_Helm	Delesyian Champron
+Delesian_HorseArmor_Saddle	Delesyian Saddle
+Delesian_HorseArmor_Stirrup	Delesyian Stirrups
+Delesian_Soldier_General_Fabric_Cloak	Delesyian Guard Captain's Cloth Cloak
+Delesian_Soldier_General_PlateArmor_Armor	Delesyian Guard Captain's Armor
+Delesian_Soldier_HorseArmor_Armor	Delesyian Soldier's Cloth Barding
+Delesyian_Cloak	Delesyian Noble's Cloak
+Delesyian_Contribution_Flag	Delesyian Contribution Banner Pike
+Delesyian_Crown	Delesyian Crown
+Delesyian_Flag	Small Delesyian Banner Pike
+Delesyian_Nobility_Degree_I	Delesyian Signet
+Delfrid_Leather_Armor	Delfreid Leather Armor
+Delicy_Leather_Gloves	Delise Leather Gloves
+Dellesian_Flag_I	Small Delesyian Banner Pike
+Dellesian_Flag_II	Medium Delesyian Banner Pike
+Dellian_Leather_Armor	Dellian Leather Armor
+Delmar_HorseArmor_Saddle	Delmar Saddle
+Delonde_OneHandAxe	Delonde Axe
+Delphi_Leather_Boots	Delphi Leather Boots
+Delphoir_OneHandRapier	Lambert Rapier
+Deltlin_Leather_Armor	Deltin Leather Armor
+Demeniss_Chainsaw	Demenissian Chainsaw
+Demeniss_Cloak	Demenissian Noble's Cloak
+Demeniss_Contribution_Flag	Demenissian Contribution Banner Pike
+Demeniss_Cross_Necklace	Demeniss Cathedral Necklace
+Demeniss_Cross_Ring	Demeniss Cathedral Ring
+Demeniss_Crown	Demenissian Crown
+Demeniss_Earring	Demeniss Earring
+Demeniss_Flag	Small Demenissian Banner Pike
+Demeniss_Flag_II	Small Demenissian Banner Pike
+Demeniss_Flag_III	Medium Demenissian Banner Pike
+Demeniss_Guard_Shield	Demeniss Royal Guard Shield
+Demeniss_HorseArmor_Armor	Demenissian Barding
+Demeniss_HorseArmor_Helm	Demenissian Champron
+Demeniss_HorseArmor_Saddle	Demenissian Saddle
+Demeniss_HorseArmor_Stirrup	Demenissian Stirrups
+Demeniss_Nobility_Degree_I	Demenissian Signet
+Demeniss_PlateArmor_Armor	Chelcia Plate Armor
+Demeniss_PlateArmor_Cloak	Chelcia Plate Cloak
+Demeniss_Revolutionary_Paper_I	Demenissian Rebel's Secret Letter
+Demeniss_Soldier_HorseArmor_Armor	Demenissian Soldier's Cloth Barding
+Demeniss_Soldier_Kitee_Metal_OneHandShield_I	Demenissian Shield of Valor
+Demeniss_Soldier_Kitee_Metal_OneHandShield_II	Demenissian Shield of Loyalty
+Demeniss_Soldier_Kitee_Metal_OneHandShield_III	Demenissian Shield of Obedience
+Demeniss_Soldier_OneHandTowerShield	Demenissian Soldier's Large Shield
+demenissnobility_Flag_I	Small Demenissian Noble's Banner
+demenissnobility_Flag_II	Small Demenissian Noble's Banner
+demenissnobility_Flag_III	Small Demenissian Noble's Banner
+demenissnobility_Flag_IV	Medium Demenissian Noble's Banner Pike
+demenissnobility_Flag_V	Medium Demenissian Noble's Banner Pike
+demenissnobility_Flag_VI	Medium Demenissian Noble's Banner Pike
+Demian_Earring_I	Light of the Battlefield Earring
+Demian_Fabric_Armor	Demian Fabric Armor
+Demian_Fabric_Cloak_I	Light of the Battlefield Cloth Cloak
+Demian_Fabric_Cloak_II	White Bloodwind Cloth Cloak
+Demian_Fabric_Cloak_III	Autumn Banquet Cloth Cloak
+Demian_Fabric_Cloak_IV	Official Knight's Cloth Cloak
+Demian_Fabric_Cloak_V	Demian Fabric Cloak V
+Demian_Greyfur_Fabric_Cloak	Grey Wolf Cloth Cloak
+Demian_Leather_Armor	Leather Armor of Earth's Honor
+Demian_Leather_Armor_III	White Bloodwind Leather Armor
+Demian_Leather_Armor_IV	Autumn Banquet Leather Armor
+Demian_Leather_Armor_V	Elegant Carmine Leather Armor
+Demian_Leather_Armor_VI	Wanderer of Faith Leather Armor
+Demian_Leather_Cloak	Leather Cloak of Earth's Honor
+Demian_Leather_Cloak_I	Elegant Carmine Leather Cloak
+Demian_Leather_Cloak_II	Wanderer of Faith Leather Cloak
+Demian_Leather_Gloves_I	Official Knight's Leather Gloves
+Demian_Leather_Gloves_II	Leather Gloves of Earth's Honor
+Demian_Leather_Gloves_III	Autumn Banquet Leather Gloves
+Demian_Leather_Gloves_IV	Wanderer of Faith Leather Gloves
+Demian_OneHandRapier	White Wind Rapier
+Demian_Plate_Boots_III	Goldlight Plate Boots
+Demian_Plate_Boots_IV	Elegant Carmine Plate Boots
+Demian_Plate_Boots_V	Executioner of Darkness Plate Boots
+Demian_Plate_Boots_VI	Light of the Battlefield Plate Boots
+Demian_PlateArmor_Armor_II	Light of the Battlefield Plate Armor
+Demian_PlateArmor_Armor_VI	Official Knight's Plate Armor
+Demian_PlateArmor_Cloak_III	Goldlight Plate Cloak
+Demian_PlateArmor_Cloak_V	Executioner of Darkness Plate Cloak
+Demian_PlateArmor_Gloves_I	Fluttering Radiance Plate Gloves
+Demian_PlateArmor_Gloves_II	Light of the Battlefield Plate Gloves
+Demian_PlateArmor_Gloves_III	White Bloodwind Plate Gloves
+Demian_PlateArmor_Gloves_IV	Goldlight Plate Gloves
+Demian_PlateArmor_Gloves_V	Executioner of Darkness Plate Gloves
+Demian_PlateArmor_Gloves_VI	Elegant Carmine Plate Gloves
+Demian_PlateArmor_Helm_I	White Bloodwind Plate Helm
+Demian_PlateArmor_Helm_IV	Goldlight Plate Helm
+Demian_PlateArmor_Helm_V	Wanderer of Faith's Plate Helm
+Demian_PlateArmor_Helm_VI	Autumn Banquet Plate Helm
+Demian_PlateArmor_Helm_VII	Official Knight's Plate Helm
+Demian_PlateArmor_Helm_VIII	Light of the Battlefield Plate Helm
+Demian_PlateArmor_Helm_XI	Executioner of Darkness Plate Helm
+Demian_PlateArmor_Helm_XIII	Elegant Carmine Plate Helm
+Demian_Pure_White_Plate_Boots_I	Radiant Plate Boots
+Demian_Pure_White_Plate_Boots_II	Fluttering Radiance Plate Boots
+Demian_Skirt_Fabric_Armor	Demian Skirt Fabric Armor
+Dendi_PlateArmor_Armor	Dundree Plate Armor
+Dendi_PlateArmor_Armor_I	Dundree Plate Armor
+Dendrobium_Flower	Dendrobium Orchid
+Denill_Fabric_Armor	Denill Cloth Armor
+Denmore_Fabric_Armor	Denmore Cloth Armor
+Deole_Fabric_Helm	Dwelle Cloth Cap
+Deole_Leather_Boots	Dwelle Leather Boots
+Deole_Leather_Gloves	Dwelle Leather Gloves
+Derbid_Wood_OneHandShield	Tardik Shield
+Derish_Fabric_Helm	Drish Cloth Cap
+Dernat_Fabric_Armor	Dernat Cloth Armor
+Dernat_PlateArmor_Helm	Dernat Plate Helm
+Derovidine_Leather_Armor	Dellovian Leather Armor
+Derrison_Fabric_Gloves	Derrison Cloth Gloves
+Desert_Abyss_Wraith_OneHandShield	Twisted Thorns
+Desert_BackPack_I	Desert Pack
+Desert_Harrier_Leather_Armor	Helms Leather Armor
+Desert_Harrier_Leather_Boots_I	Helms Leather Boots
+Desert_Harrier_Leather_Boots_II	Helms Leather Boots
+Desert_Harrier_PlateArmor_Armor_I	Desert Marauder's Plate Armor
+Desert_Harrier_PlateArmor_Armor_II	Desert Marauder's Plate Armor
+Desert_Harrier_PlateArmor_Armor_III	Desert Marauder's Plate Armor
+Desert_Harrier_PlateArmor_Cloak_I	Desert Marauder's Cloak
+Desert_Harrier_PlateArmor_Gloves	Helms Plate Gloves
+Desert_Harrier_PlateArmor_Helm_II	Helms Rhinoceros Beetle Helm
+Desert_Harrier_PlateArmor_Helm_III	Helms Stag Beetle Helm
+Desert_Harrier_PlateArmor_Helm_IV	Helms Beetle Helm
+Desert_Harrier_PlateArmor_Helm_V	Helms Hornet Helm
+Desert_Harrier_PlateArmor_Helm_VI	Helms Bull Helm
+Desert_Harrier_PlateArmor_Helm_VII	Helms Bull Helm
+Desert_HorseArmor_Armor	Sahareum Barding
+Desert_HorseArmor_Helm	Sahareum Champron
+Desert_HorseArmor_Saddle	Sahareum Saddle
+Desert_HorseArmor_Stirrup	Sahareum Stirrups
+Desert_Watermelon	Desert Melon
+Deshret_Ceremonial_TwoHandedWarHammer	Ceremonial Warhammer
+Deshret_Fabric_Armor	Deshret Cloth Armor
+Deshret_Leather_Armor	Ziggurat Leather Armor
+Deshret_Leather_Boots	Deshret Leather Boots
+Deshret_Soldier_Fabric_Armor	Deshret Cloth Armor
+Detail_Gold_Necklace	Finely Crafted Gold Necklace
+Detail_Gold_Ring	Finely Crafted Gold Ring
+Dev_Growth_Ring_I	Dev Growth Ring I
+Dev_Growth_Ring_II	Dev Growth Ring II
+Dev_Growth_Ring_III	Dev Growth Ring III
+Dev_Growth_Ring_IV	Dev Growth Ring IV
+Dev_Growth_Ring_IX	Dev Growth Ring IX
+Dev_Growth_Ring_V	Dev Growth Ring V
+Dev_Growth_Ring_VI	Dev Growth Ring VI
+Dev_Growth_Ring_VII	Dev Growth Ring VII
+Dev_Growth_Ring_VIII	Dev Growth Ring VIII
+Dev_Growth_Ring_X	Dev Growth Ring X
+Dev_QA_demtodel_run	[QA] Profiling (Demeniss-Delesyia 20)
+Dev_QA_demtodel_walk	[QA] Profiling (Demeniss-Delesyia 2.5)
+Dev_QA_demtovar_run	[QA] Profiling (Demeniss-Varnia 20)
+Dev_QA_demtovar_walk	[QA] Profiling (Demeniss-Varnia 2.5)
+Dev_QA_her_loop	[QA] Repeated movement within Hernand (Speed 15)
+Dev_QA_hertopail_run	[QA] Profiling (Hernand-Pailune 20)
+Dev_QA_hertopail_walk	[QA] Profiling (Hernand-Pailune 2.5)
+Dev_QA0	[QA] Profiling (Hernand)
+Dev_QA1	[QA] Profiling (Hernand-Demeniss 60)
+Dev_QA2	[QA] Profiling (Hernand-Demeniss 20)
+Dev_QA3	[QA] Profiling (Hernand-Demeniss 2.5)
+Dev_Red_Dragon_HorseArmor_Armor	Dev Red Dragon HorseArmor Armor
+Dev_Red_Dragon_HorseArmor_Helm	Dev Red Dragon HorseArmor Helm
+Dev_Red_Dragon_HorseArmor_Saddle	Dev Red Dragon HorseArmor Saddle
+Dev_Red_Dragon_HorseArmor_Stirrup	Dev Red Dragon HorseArmor Stirrup
+Dev_Red_Dragon_Kliff_Leather_Armor	Dev Red Dragon Kliff Leather Armor
+Dev_Red_Dragon_Oongka_Leather_Armor	Dev Red Dragon Oongka Leather Armor
+Dev_Red_Dragon_Ring_Def_HP	Dev Red Dragon Ring Def HP
+Dev_Red_Dragon_Ring_Immune	Dev Red Dragon Ring Immune
+Dev_Red_Dragon_Ring_MP_Stamina	Dev Red Dragon Ring MP Stamina
+Dev_Red_Dragon_Ring_Str_HP	Dev Red Dragon Ring Str HP
+Dev_Red_Dragon_Yann_Leather_Armor	Dev Red Dragon Yann Leather Armor
+Dev_Specialty_Crudell_OneHandAxe	Dev Specialty Crudell OneHandAxe
+Dev_Speed_Ring	Dev Speed Ring
+Devarn_Fabric_Armor	Dvalin Cloth Armor
+Devidhe_Fabric_Helm	Duvidet Hoops
+Devinenne_PlateArmor_Gloves	Devinine Plate Gloves
+Devinion_PlateArmor_Helm	Devins Plate Helm
+Dewhaven_Flag_I	Small Dewhaven Banner Pike
+Dewhaven_Flag_II	Medium Dewhaven Banner Pike
+Dewhaven_PlateArmor_Helm	Dewhaven Standard Plate Helm
+Diamond	Diamond
+Diancia_OneHandAxe	Kylus Axe
+Dicari_Fabric_Helm	Dicari Laurel Headband
+Dicrian_PlateArmor_Helm	Digren Plate Helm
+Diencia_Fabric_Boots	Diencia Cloth Boots
+Diencia_TwoHandAlebard	Lambert Halberd
+Diencia_TwoHandAxe	Iris Greataxe
+Diencia_TwoHandedWarHammer	Arlem Warhammer
+diereuben_Leather_Gloves	Dirrebin Leather Gloves
+Dikkahn_Fabric_Helm	Deccain Cloth Headband
+Diknanteu_Fabric_Armor	Decanteau Cloth Armor
+Dimfeld_Leather_Boots	Driseld Leather Boots
+Dimfeld_Leather_Helm	Dimfeld Leather Helm
+Dimfeld_PlateArmor_Gloves	Dimfeld Plate Gloves
+Dimphelt_Wood_OneHandShield	Dewhaven Shield
+Dinon_Leather_Armor	Dannon Leather Armor
+Dioburn_Leather_Boots	Diovern Leather Boots
+Dior_Fabric_Armor	Deorre Cloth Armor
+Diorness_Leather_Armor	Dorness Leather Armor
+Diorness_Leather_Boots	Ferman Leather Boots
+Dirmall_Leather_Armor	Dremel Leather Armor
+Discao_PlateArmor_Helm_I	Descao Plate Helm
+Discao_PlateArmor_Helm_II	Blacksteel Descao Plate Helm
+Diskio_Leather_Gloves	Deskio Leather Gloves
+Diskio_Metal_OneHandShield	Sydmon Round Shield
+Ditter_Fabric_Armor	Ditter Cloth Armor
+Diver_Steel_Drill	Diver's Machine Knuckledrill
+Dohahn_Fabric_Armor	Dohann Cloth Armor
+Dollette_Fabric_Armor	Dollette Cloth Armor
+Dolters_Leather_Boots	Dolters Leather Boots
+Donaf_Leather_Boots	Donaff Leather Boots
+Dongdegobi_Fabric_Armor	Dondegobi Cloth Armor
+Dongdegobi_Leather_Gloves	Dondegobi Leather Gloves
+Dongdegobi_PlateArmor_Helm	Dondegobi Plate Helm
+Douglas_Leather_Armor	Blackwing Leather Armor
+Douglas_Leather_Armor_T5_QA	Douglas Leather Armor T5 QA
+Douglas_Leather_Cloak	Blackwing Leather Cloak
+Douglas_Leather_Gloves	Blackwing Leather Gloves
+Douglas_Leather_Gloves_T5_QA	Douglas Leather Gloves T5 QA
+Doventry_Leather_Armor	Doventry Leather Armor
+Dowsampton_Leather_Armor	Dowsampton Leather Armor
+Dragon_Armor_01	Abyssal Dragon Armor
+Dragon_Armor_Material	Abyssal Fusion
+Dragon_Knight_Archer_PlateArmor_Gloves	Dragon Knight Archer's Plate Gloves
+Dragon_Knight_ChainMail_Armor	Dragon Knight Chain Mail
+Dragon_Knight_Commander_ChainMail_Armor	Dragon Flame Armor
+Dragon_Knight_Commander_ChainMail_Cloak	Dragon Flame Cloak
+Dragon_Knight_Commander_PlateArmor_Helm	Dragon Flame Helm
+Dragon_Knight_PlateArmor_Helm	Dragon Knight's Helm
+Dragon_Knight_Warrior_PlateArmor_Armor	Dragon Knight Warrior's Plate Armor
+Dragon_Knight_Warrior_PlateArmor_Gloves	Dragon Knight Warrior's Plate Gloves
+Dragon_OneHandBow	Aeserion Bow
+Dragon_OneHandDagger	Aeserion Dagger
+Dragon_OneHandMace	Aeserion Mace
+Dragon_Slayer_Leather_Boots	Flame Knight's Leather Boots
+Dragon_Slayer_Ohyoon_PlateArmor_Helm	Cassius Morten's Plate Helm
+Dragon_TwoHandAlebard	Aeserion Halberd
+Dragon_TwoHandAxe	Aeserion Greataxe
+Dragon_TwoHandedWarHammer	Aeserion Warhammer
+Dragon_TwoHandSword	Aeserion Longsword
+dragonkiller_Flag_I	Small Flame Knights Banner Pike
+dragonkiller_Flag_II	Medium Flame Knights Banner Pike
+DragonSlayerLeader_OneHandCannon	Wyvern Blaster
+Draiga_PlateArmor_Gloves	Draiga Plate Gloves
+Drakhan_OneHandMace	Drakhan Hammer
+Dreenah_Fabric_Helm	Drina Cloth Cap
+Drheebahn_Leather_Armor	Dreban Leather Armor
+Dria_PlateArmor_Helm	Drea Plate Helm
+Drimnarrow_Fabric_Armor	Drimrow Cloth Armor
+Drivon_ChainMail_Armor	Drivon Chain Mail
+Drone_Backpack	Sandwatcher Watcher Pack
+Drottesel_Leather_Armor	Drossel Leather Armor
+Drug_Leather_Helm	Scarlet Blades Gas Mask
+Drug_Leather_Helm_I	Bleed Bandits' Gas Mask
+Drug_Leather_Helm_II	Bleed Bandits' Makeshift Gas Mask
+Drumard_Leather_Gloves	Drumard Leather Gloves
+Drumfin_Fabric_Armor	Drumfin Cloth Armor
+Drunk_BlackBears_Elite_Leather_Armor	Black Bear Officer's Leather Armor
+Drunk_BlackBears_Elite_Leather_Gloves	Black Bear Officer's Leather Gloves
+Drunk_BlackBears_Flag	Small Black Bears Banner Pike
+Drunk_BlackBears_Leather_Armor	Black Bear Leather Armor
+Drunk_BlackBears_Leather_Boots	Black Bear Leather Boots
+Drunk_BlackBears_Leather_Gloves	Black Bear Leather Gloves
+Drunk_BlackBears_TwoHandedWarHamme	Roar of the Black Bear
+Dublin_Leather_Boots	Derting Leather Boots
+Ducca_Leather_Armor	Ducca Leather Armor
+Duebell_Leather_Armor	Duvelle Leather Armor
+Dueblone_Plated_Boots	Dulone Plate Boots
+Duemeniss_Fabric_Armor	Dumenis Cloth Armor
+Duemeniss_Leather_Boots	Dumas Leather Boots
+Duemeniss_Plate_Boots	Dumenis Plate Boots
+Duemeniss_Plate_Boots_I	Blacksteel Dumenis Plate Boots
+Duemeniss_Plate_Boots_II	Dumenis Plate Boots II
+Duemeniss_PlateArmor_Gloves	Dumenis Plate Gloves
+Duemeniss_PlateArmor_Helm	Demenissian Soldier Plate Helm
+Duemeniss_PlateArmor_Helm_I	Dumenis Plate Helm
+Dueroin_Fabric_Gloves	Duroin Cloth Gloves
+Duilker_Fabric_Armor	Dwelker Cloth Armor
+Dukesan_OneHandDagger	Delesyian Dagger
+Dukris_Fabric_Helm	Ducriss Conical Cap
+Duncan_Leather_Armor	Dunqane Leather Armor
+Dunfermline_PlateArmor_Armor	Dunverline Plate Armor
+Dunfermline_PlateArmor_Armor_I	Dunverline Plate Armor
+Dunion_ChainMail_Armor	Dunion Chain Mail
+Dunion_Leather_Gloves	Dunion Leather Gloves
+Dunion_PlateArmor_Armor	Dunion Plate Armor
+Dunis_Leather_Gloves	Dherri Leather Gloves
+Duratti_PlateArmor_Helm	Schtump Plate Helm
+Durion_ChainMail_Armor	Durain Chain Mail
+Durion_OneHandDagger	Crow Brothers Dagger
+Duroar_PlateArmor_Armor	Dreer Plate Armor
+Duroar_PlateArmor_Armor_I	Dreer Plate Armor
+Dursus_Leather_Armor	Dursus Leather Armor
+Dutian_ChainMail_Armor	Dutian Chain Mail
+Dutinaan_ChainMail_Armor	Dutinan Chain Mail
+Dutinion_PlateArmor_Armor	Dutinion Plate Armor
+Dutrat_Leather_Boots	Dutrat Leather Boots
+Dutyluon_PlateArmor_Armor	Dutiron Plate Armor
+Dux_Leather_Armor	Dux Leather Armor
+Duzje_Fabric_Armor	Duizeh Cloth Armor
+Dwarf_Necklace	Dwarf Necklace
+Dweyi_Leather_Armor	Dewey Leather Armor
+Dylanka_Fabric_Armor	Dilanka Cloth Armor
+Dyran_Fabric_Armor	Dyran Cloth Armor
+Dyrania_Fabric_Armor	Direnya Cloth Armor
+Dyrill_Leather_Armor	Dyrel Leather Armor
+Earring_Tier1_I	Worn Earring
+Earring_Tier2_I	Faded Earring
+Earring_Tier3_I	Green Coral Reef Earring
+EasternWanderer_OneHandShield	Eastern Wanderer's Shield
+Ebenezer_Leather_Gloves	Ebenezer Leather Gloves
+Eccanta_PlateArmor_Armor	Eccanta Plate Armor
+Echebern_Fabric_Armor	Echebern Cloth Armor
+Eclan_PlateArmor_Armor	Eclaon Plate Armor
+Eclis_PlateArmor_Armor	Egliss Plate Armor
+Eclman_PlateArmor_Armor	Ekklemen Plate Armor
+Ecyrune_Fabric_Armor	Eshrun Cloth Armor
+Edzel_PlateArmor_Armor	Edzel Plate Armor
+Edzel_PlateArmor_Armor_I	Edzel Plate Armor
+Eestyon_TwoHandHammer	Golden Dragon's Claw
+Egg	Egg
+Ehshian_Leather_Boots	Eshian Leather Boots
+Ehshian_OneHandSword	Fallen Kingdom's Sword
+Einz_Leather_Armor	Einz Leather Armor
+Eirun_PlateArmor_Armor	Aeron Plate Armor
+Ekeny_Fabric_Boots	Eckney Cloth Boots
+Elai_Leather_Armor	Eli's Attire
+Elderberry	Elderberry
+Eldruan_Leather_Gloves	Eldruan Leather Gloves
+Eleven_Leather_Gloves	Eplern Leather Gloves
+Elish_Leather_Boots	Elish Leather Boots
+Ellachic_Leather_Gloves	Elashe Leather Gloves
+Elliot_Leather_Armor	Elliot Leather Armor
+Elsiguo_Leather_Gloves	Ellisco Leather Bracers
+Emil_PlateArmor_Armor	Emil Plate Armor
+EMP_BackPack	Disruptor
+EMP_TwoHandSpear	Disruptor Spear
+Empty_BackPack	Empty Pack
+Empty_Bottle	Empty Bottle
+Endnion_PlateArmor_Armor	Endnion Plate Armor
+Endoron_Leather_Boots	Endoron Leather Boots
+Endour_PlateArmor_Helm	Goldbranch Plate Crown
+Enge_Leather_Armor	Enge Leather Armor
+EngineerWorkLog_Book	An Engineer's Work Log
+Enratte_PlateArmor_Helm	Enratte Plate Helm
+Enratte_PlateArmor_Helm_I	Large Enratte Plate Helm
+Ensete_seed	Enset Seed
+EntHunter_Leather_Armor	Shadowleaf Leather Armor
+EntHunter_Leather_Cloak	Shadowleaf Leather Cloak
+EntHunter_OneHandBow	Shadowleaf Bow
+Entom_PlateArmor_Armor	Entom Plate Armor
+Entrian_Fabric_Armor	Attrean Cloth Armor
+Entuka_Fabric_Armor	Entuka Cloth Armor
+Entura_PlateArmor_Helm	Icewing Plate Helm
+Enus_PlateArmor_Armor	Enus Plate Armor
+Ephesus_Fabric_Armor	Esbeth Cloth Armor
+Epistle	Mysterious Letter
+Equip_Broom	Broom
+Equip_Drum	Small Drum
+Equip_Felling_Axe	Logging Axe
+Equip_Felling_Axe_I	Fine Logging Axe
+Equip_Felling_Axe_II	Olvald's Logging Axe
+Equip_Hoe	Hoe
+Equip_Iron_Chain	Pitchfork
+Equip_Large_Agricultural_Sickle	Large Farming Scythe
+Equip_Large_Agricultural_Sickle_1	Large Farming Rake Scythe
+Equip_Magic_Scythe	Magic Scythe
+Equip_Pickaxe	Pickaxe
+Equip_Pickaxe_I	Fine Pickaxe
+Equip_Pickaxe_II	Bernor's Pickaxe
+Equip_Rake	Rake
+Equip_Saw	Saw
+Equip_Shovel	Shovel
+Equip_Stick	Walking Cane
+Equip_TriRake	Wooden Pitchfork
+Equip_Trumpet	Trumpet
+Equip_WoodRake	Wooden Rake
+Equip_Work_Hammer	Mallet
+Erday_Leather_Armor	Erday Leather Armor
+Erin_Fabric_Helm	Eryn Cloth Cap
+Erkeney_Fabric_Armor	Eckney Cloth Armor
+Erkeney_OneHandAxe	Lanford Axe
+Ernst_ChainMail_Armor	Ernst Chain Mail
+Erphy_Leather_Boots	Erphy Leather Boots
+Esahah_Leather_Boots	Esha Leather Boots
+Esahah_Leather_Gloves	Esha Leather Gloves
+Esirun_Leather_Armor	Eshrun Leather Armor
+Esleague_Leather_Armor	Islekk Leather Armor
+Estir_Leather_Boots	Estelle Leather Boots
+Euler_OneHandRapier	Elenore Rapier
+Eustis_Leather_Boots	Eustice Leather Boots
+Evanizer_Leather_Boots	Ebenezer Leather Boots
+Ewen_Fabric_Armor	Ewen Cloth Armor
+Faded_Necklace	Tarnished Necklace
+Faded_Ring	Tarnished Ring
+Faience_Fabric_Armor	Faians Cloth Armor
+Falcone_OneHandPistol	Falconne Pistol
+Falstaff_Fabric_Helm	Falstaff Cloth Helm
+Fang	Fang
+Farmer_BackPack_I	Farmer's Pack
+Farmer_BackPack_II	Farmer's Pack
+FarmSlot_Expansion_1	Small Livestock Capacity Increase
+FarmSlot_Expansion_2	Medium Livestock Capacity Increase
+FarmSlot_Expansion_3	Large Livestock Capacity Increase
+Feather	Feather
+Feather_Pen	Feather Pen
+Fennel	Fennel
+Fertilizer_Sprayer_BackPack	Fertilizer Sprayer
+Fiburrou_TwoHandedWarHammer	Iris Warhammer
+FieldBattle_BackPack_I	Field Pack
+FieldBattle_BackPack_II	Field Pack
+FieldBattle_BackPack_III	Field Pack
+Figs	Fig
+Figs_Seed	Fig Seed
+Fine_Stone	Fine Stone
+Fine_Wood	Fine Timber
+Finraysen_Leather_Armor	Finneron Leather Armor
+Fiore_Fabric_Armor	Fiore Cloth Armor
+Fiore_Fabric_Helm	Fiore Cloth Cap
+Fiore_Leather_Boots	Fiore Leather Boots
+Fire_Arrow	Fire Arrow
+Fire_Bomb	Bomb
+Fire_Boots	Fire Walk Boots
+Fire_staff_spear_TwoHandSpear	Flame Spear
+FireFly_Lantern	Firefly Lantern
+First_Artifact	The First Artifact
+Fish_BackPack_I	Angler's Pack
+Fish_BackPack_II	Angler's Pack
+Fish_Bulgogi	Pan-Fried Marinated Fish
+Fish_Bulgogi_Large	Satisfying Pan-Fried Marinated Fish
+Fish_Bulgogi_Medium	Filling Pan-Fried Marinated Fish
+Fish_Bulgogi_XLarge	Hearty Pan-Fried Marinated Fish
+Fish_Fruit_Porridge	Steamed Fish
+Fish_Fruit_Porridge_Large	Satisfying Steamed Fish
+Fish_Fruit_Porridge_Medium	Filling Steamed Fish
+Fish_Fruit_Porridge_XLarge	Hearty Steamed Fish
+Fish_Porridge	Fish Porridge
+Fish_Porridge_Large	Satisfying Fish Porridge
+Fish_Porridge_Medium	Filling Fish Porridge
+Fish_Porridge_XLarge	Hearty Fish Porridge
+Fish_Sanjeok	Fish Skewers
+Fish_Sanjeok_Large	Satisfying Fish Skewers
+Fish_Sanjeok_Medium	Filling Fish Skewers
+Fish_Sanjeok_XLarge	Hearty Fish Skewers
+Fish_Soup	Mixed Stew
+Fish_Soup_Large	Satisfying Mixed Stew
+Fish_Soup_Medium	Filling Mixed Stew
+Fish_Soup_XLarge	Hearty Mixed Stew
+Fish_Stew	Fish Stew
+Fish_Stew_Large	Satisfying Fish Stew
+Fish_Stew_Medium	Filling Fish Stew
+Fish_Stew_XLarge	Hearty Fish Stew
+Fish_Vegetable_Porridge	Vegetable and Seafood Porridge
+Fish_Vegetable_Porridge_Large	Satisfying Vegetable and Seafood Porridge
+Fish_Vegetable_Porridge_Medium	Filling Vegetable and Seafood Porridge
+Fish_Vegetable_Porridge_XLarge	Hearty Vegetable and Seafood Porridge
+FishingRod	Fishing Rod
+FishingRod_II	Fine Fishing Rod
+FishingRod_III	Pororin Fishing Rod
+Flame_Knights_PlateArmor_Helm	Flame Knight's Plate Helm
+Flame_Knights_PlateArmor_Helm_I	Flame Knight's Plate Helm
+Flame_staff_spear_TwoHandSpear	Blazing Spear
+Flame_SwordMan_PlateArmor_Gloves	Flame Swordsman Plate Gloves
+Flame_SwordMan_TwoHandHammer	Greathammer of Fire
+FlameThrower	Electromagnetic Flamespitter
+FlatBasket	Wide Basket
+Flolin_BackPack	Pororin Pack
+Flolin_BackPack_FlowerDrone_I	Florindale Flower Bomb Pack
+Flolin_BackPack_II	Florindale Empty Pack
+Flordanus_Leather_Armor	Flordanus Leather Armor
+Florin_Fabric_Cloak	Pororin Cloth Cloak
+Florin_Fabric_Helm	Pororin Petal Hat
+Flynn_PlateArmor_Helm	Flynn Plate Helm
+Folorin_Earring	Flower Petal Earring
+Fontergear_OneHandMace	Bonepit Mace
+Fontine_Leather_Armor	Fontine Leather Armor
+Food_BaliOgluChub	Small Minnow
+Food_Bass_I	Bass
+Food_Bass_II	Yellow Bass
+Food_Benjari	Threeline Grunt
+Food_Beyaz	Small Rasbora
+Food_Blackbrow_Bleak	Small Blackbrow Bleak
+Food_BlackSeaBream	Blackhead Seabream
+Food_BlueCrab	Blue Crab
+Food_Burbot	Burbot
+Food_Carp	Carp
+Food_Catfish	Catfish
+Food_Coelacanth	Coelacanth
+Food_CookFailed	Mysterious Dish
+Food_Crayfish	Crayfish
+Food_Crucian_Carp	Crucian Carp
+Food_Cuvier	Saw-Edged Perch
+Food_Dover_Sole	Red Tonguesole
+Food_Dried_Fish	Dried Fish
+Food_DrinkFailed	Mysterious Liquid
+Food_Eel	Freshwater Eel
+Food_Fish_Meat	Fish Fillet
+Food_GiantMudfish	Giant Pond Loach
+Food_GiantRedSeaBream	Giant Red Seabream
+Food_GoldCarp	Golden Carp
+Food_Golden_Coelacanth	Golden Coelacanth
+Food_GoldTenchi	Golden Tench
+Food_HexeFish	Hexe Earthen Fish
+Food_Lenok	Lenok
+Food_LightCrotch	Anglerfish
+Food_LightningEel	Electric Eel
+Food_Mackerel	Mackerel
+Food_Marlin	Striped Marlin
+Food_MechanicFish	Clockwork Fish
+Food_Mudfish	Pond Loach
+Food_Perch	Perch
+Food_Pikefish	Northern Pike
+Food_Red_Seabream	Red Seabream
+Food_Red_Snapper	Opaleye
+Food_RedSnapper	Crimson Opaleye
+Food_Ricefish	Ricefish
+Food_river_Crab	Freshwater Crab
+Food_Rock_Bream	Barred Knifejaw
+Food_Sailfish	Sailfish
+Food_Salmon	Salmon
+Food_Sammy	Small Gudgeon
+Food_Schneider	Small Spirlin
+Food_Seahorse	Seahorse
+Food_SevenStarShark	Broadnose Sevengill Shark
+Food_Shrimp	Shrimp
+Food_Sockeye_Salmon	Sockeye Salmon
+Food_SpatulaSturgeon	Paddlefish
+Food_Squid	Squid
+Food_Ssogari	Leopard Perch
+Food_Starfish	Starfish
+Food_Sturgeon	Sturgeon
+Food_Tenchi	Tench
+Food_Trout	Trout
+Forest_Fairy_Leather_Armor	Forest Fae Armor
+ForestFairy_TwoHandedWarHammer	Shadowleaf Soul Branch
+Forgotten_General_TwoHandAlebard	Awakened Spirit
+Formosa_Leather_Armor	Formosa Leather Armor
+Fort_Flag_02	Small Halberd of Carnage's Banner Pike
+Fort_Flag_03	Medium Halberd of Carnage's Banner Pike
+fort_Flag_I	Small Dusksongs Banner Pike
+fort_Flag_II	Small Faceless Banner Pike
+fort_Flag_III	Small Twilight Messengers Banner Pike
+fort_Flag_IV	Medium Dusksongs Banner Pike
+fort_Flag_V	Medium Faceless Banner Pike
+fort_Flag_VI	Medium Twilight Messengers Banner Pike
+FortMoru_Key	Fort Anvil Key
+FoxBean_Flower	Dunbaria
+Freshly_Grilled_Bird	Grilled Bird Meat
+Freshly_Grilled_Bird_Large	Satisfying Grilled Bird Meat
+Freshly_Grilled_Bird_Medium	Filling Grilled Bird Meat
+Freshly_Grilled_Bird_XLarge	Hearty Grilled Bird Meat
+Freshly_Grilled_Crab	Grilled Pincers
+Freshly_Grilled_Crab_Large	Satisfying Grilled Pincers
+Freshly_Grilled_Crab_Medium	Filling Grilled Pincers
+Freshly_Grilled_Crab_XLarge	Hearty Grilled Pincers
+Freshly_Grilled_Squid	Grilled Seafood
+Freshly_Grilled_Squid_Large	Satisfying Grilled Seafood
+Freshly_Grilled_Squid_Medium	Filling Grilled Seafood
+Freshly_Grilled_Squid_XLarge	Hearty Grilled Seafood
+Fri_PlateArmor_Armor	Prix Plate Armor
+Friendly_Legendary_Animal_Book	Black Lion Observation Log
+Friendly_Legendary_Hunter	The Legendary Hunter's Whereabouts
+Frinyl_PlateArmor_Helm	Ferenna Plate Helm
+frog	Poison Frog
+FrontierMilitia_OneHandShield	Flame Knights Shield
+Fruit_Porridge	Fruit Punch
+Fruit_Porridge_Large	Satisfying Fruit Punch
+Fruit_Porridge_Medium	Filling Fruit Punch
+Fruit_Porridge_XLarge	Hearty Fruit Punch
+Fruit_Wine	Wine
+FruitTea	Fruit Tea
+Full_Course_of_Braised_Fish	Assorted Braised Fish
+Full_Course_of_Braised_Fish_Large	Satisfying Assorted Braised Fish
+Full_Course_of_Braised_Fish_Medium	Filling Assorted Braised Fish
+Full_Course_of_Braised_Fish_XLarge	Hearty Assorted Braised Fish
+Furniture_BackPack	Carpenter's Pack
+Gadget_Fabric_Helm	Tech Hat
+Gadget_Gloves	Tech Gloves
+Gadherish_Fabric_Armor	Gadereich Cloth Armor
+Gadherish_Fabric_Gloves	Gadereich Cloth Gloves
+Gadherish_Fabric_Helm	Gadereich Cloth Cap
+Gael_Fabric_Armor	Gael Cloth Armor
+Gaeljude_Plate_Boots	Golden Greed Plate Boots
+Gaeljude_PlateArmor_Gloves	Golden Greed Plate Gloves
+Gahlatain_OneHandAxe	Ring of the Earth
+Gaimeon_Leather_Gloves	Gaiman Leather Gloves
+Gainarre_OneHandAxe	Leofric Double-Headed Axe
+Gainik_Leather_Boots	Gannech Leather Boots
+Galanta_Leather_Armor	Galanta Leather Armor
+Galbon_ChainMail_Armor	Galbon Chain Mail
+Gallabay_Leather_Armor	Gallabay Leather Armor
+Gallophelt_Leather_Boots	Silverwolf Leather Boots
+Gallophelt_PlateArmor_Gloves	Geloufeld Plate Gloves
+Galustin_Leather_Armor	Galustin Leather Armor
+Gamelot_Plate_Boots	Sahazhad Plate Boots
+GantryCrane_Big_Key	Crane Control Room Key
+Gardbedeff_Fabric_Armor	Gardeiff Cloth Armor
+Garff_Fabric_Armor	Gaph Cloth Armor
+Garlic	Garlic
+Gas_Mask_Helm_I	Brimstone Gas Mask
+Gatin_Leather_Boots	Gatin Leather Boots
+Gaurah_Fabric_Helm	Gaurra Cloth Cap
+Gaut_Fabric_Armor	Gaut Cloth Armor
+Gaut_Fabric_Boots	Gaut Cloth Boots
+Gaut_Leather_Armor	Gaut Leather Armor
+Gelhouke_OneHandTowerShield	The Laughing Marionette Shield
+Georg_Leather_Armor	Gorg Leather Armor
+Gerano_Leather_Armor	Gerano Leather Armor
+Germion_PlateArmor_Armor	Jerrinmarne Plate Armor
+Ghaltain_Fabric_Helm	Ghaltain Cloth Cap
+Ghost_TwohandSword	Invisible Longsword
+Giant_Copper_Drill	Copper Knuckledrill
+Giant_ReiGhis_TwoHandGiantAxe	Gorthak Greataxe
+Giant_Warriors_TwoHandGiantAxe	Patterned Stone Greataxe
+GiantBallista_Book	Pailunese Guard's Journal
+Gias_Leather_Armor	Giath's Leather Armor
+Gias_OneHandSword	Savage Sawblade
+Gilded_OneHandShield	Gilded Shield
+Gilded_OneHandTowerShield	Large Gilded Shield
+gimmick_tool_kinetic_barbell_0001	Kinetic Counterweight
+gimmick_tool_kinetic_barbell_0002	Kinetic Knight
+gimmick_tool_kinetic_boat_0001	Kinetic Boat
+gimmick_tool_kinetic_circle_0001	Kinetic Circle
+gimmick_tool_kinetic_dolphin_0001	Kinetic Dolphin Family
+gimmick_tool_kinetic_dolphin_0002	Kinetic Dolphin
+Ginseng_Seed	Wild Ginseng Seed
+Girrin_PlateArmor_Armor	Guilan Plate Armor
+Gladiator_Fabric_Armor	Gladiator's Cloth Armor
+Gladiator_Fabric_Armor_I	Gladiator's Cloth Armor
+Gladiator_Fabric_Armor_II	Gladiator's Cloth Armor
+Gladiator_Fabric_Armor_III	Gladiator's Cloth Armor
+Gladiator_Fabric_Boots	Gladiator Cloth Boots
+Gladiator_Fabric_Gloves_I	Gladiator Cloth Gloves
+Gladiator_Leather_Armor	Gladiator Leather Armor
+Gladiator_Leather_Boots	Troll Gladiator's Leather Boots
+Gladiator_Leather_Boots_II	Gladiator's Leather Boots
+Gladiator_Plate_Boots	Gladiator Plate Boots
+Gladiator_PlateArmor_Gloves_I	Gladiator Plate Gloves
+Gladiator_Stigma_TwoHandSpear	Slave Gladiator Branding Spear
+Glaville_Leather_Armor	Glaville Leather Armor
+Glosope_Leather_Armor	Glosope Leather Armor
+Glow_Fruit	Shineberry
+GlowFlower_Seed	Luminous Seed
+Goat_Horn_Potion	Mysterious Elixir
+Gobialthai_Fabric_Armor	Gobialta Cloth Armor
+Gobialthai_Leather_Gloves	Gobialta Leather Gloves
+Goblin_Boss_OneHandSword	Lightningblade of Greed
+Goblin_Director_House_Key	Overseer's House Key
+Goblin_Fight_PlateArmor_Gloves	Goblin Dueling Plate Gloves
+Goblin_Merchant_Fabric_Armor_V	Goldleaves' Cloth Armor
+Goblin_Merchant_Fabric_Armor_���	Goldleaves' Cloth Armor
+Goblin_Merchant_Fabric_Armor_���	Goldleaves' Cloth Armor
+Goblin_Merchant_Fabric_Armor_���	Nibrak Cloth Armor
+Goblin_Merchant_Fabric_Cloak_���	Goldleaves' Cloth Cloak
+Goblin_Merchant_Fabric_Cloak_���	Goldleaves' Cloth Cloak
+Goblin_Merchant_Fabric_Helm	Goldleaf Soldier Cloth Headband
+Goblin_Merchant_PlateArmor_Gloves_I	Goblin Merchant Guild's Plate Gloves
+Goblin_Merchant_Soldier_Leather_Boots	Goldleaves' Short Leather Boots
+Goblin_Merchant_Soldier_Leather_Boots_I	Goldleaves' Leather Boots
+Goblin_Merchant_Soldier_Leather_Helm_I	Goldleaves' Cone Leather Helm
+Goblin_Merchant_Soldier_Leather_Helm_II	Goldleaves' Leather Helm
+Goblin_Pot	Goldleaf Censer
+Goblin_Pumpkin_Helm_I	Goblin Pumpkin Helm
+Godhehart_ChainMail_Gloves	Goldheart Chain Gloves
+Gohol_Leather_Boots	Gohol Leather Boots
+Gold_Apple	Golden Apple
+Gold_Armor_OneHandShield	Golden Shield
+Gold_Plating_Lantern	Shroud Lantern
+GoldArmor_OneHandSword	Sword of Greed
+GoldBar	Gold Bar
+Golden_OneHandSword	Golden Sword
+Golden_PlateArmor_Armor	Golden Greed Plate Armor
+Golden_PlateArmor_Cloak	Golden Greed Plate Cloak
+Golden_PlateArmor_Helm	Golden Greed Plate Helm
+GoldenGoose_Egg	Golden Goose Egg
+GoldOre	Gold Ore
+Goldur_Leather_Armor	Goldur Leather Armor
+Goloduan_PlateArmor_Gloves	Demenissian Elite Plate Gloves
+Gomel_Leather_Armor	Gomel Leather Armor
+Goorba_OneHandMace	Saltroad Mace
+Grace_Blueprint	Cloudcart Blueprint
+Grace_Fabric_Gloves	Runae Cloth Gloves
+Grace_Plate_Boots	Canta Plate Boots
+Grace_PlateArmor_Helm	Grace Plate Helm
+GraceMansion_MetalDoor_Key	Glenbright Manor Key
+GraceMansion_RoomDoor_Key	Glenbright Manor Basement Key
+Grape	Grape
+grape_BackPack	Grape Pack
+grape_Seed	Grape Seed
+GraveRobber_Leather_Armor_I	Grave Robber's Leather Armor
+GraveRobber_Leather_Armor_II	Grave Robber's Leather Armor
+GraveRobber_Leather_Armor_III	Grave Robber's Leather Armor
+GraveRobber_Leather_Armor_IV	Grave Robber's Leather Armor
+graymane_Flag_I	Tiny Greymane Banner Pike
+graymane_Flag_II	Small Greymane Banner Pike
+graymane_Flag_III	Medium Greymane Banner Pike
+Graymane_Token	Greymane's Token
+Greeney_Leather_Armor	Greeney Leather Armor
+greenfrog	Tree Frog
+GreenOrc_TwoHandedWarHammer	Gorthak Warhammer
+GreenStone	Epidote
+Gregor_OneHandShield	Khaled Shield
+Gregrick_TwoHandSword	Dewhaven Longsword
+Grenvar_HorseArmor_Armor	Grenbar Cloth Barding
+Greyfur_Fabric_Armor	Balder's Cloth Armor
+Greyfur_Fabric_Armor_C	Ronald's Cloth Armor
+Greyfur_Fabric_Armor_D	Fritz's Cloth Armor
+Greyfur_Fabric_Armor_I	Matilda's Cloth Armor
+Greyfur_Fabric_Armor_III	Devan's Cloth Armor
+Greyfur_Fabric_Armor_IV	Terry's Cloth Armor
+Greyfur_Fabric_Armor_IX	Falstaff's Cloth Armor
+Greyfur_Fabric_Armor_L	Brennan's Cloth Armor
+Greyfur_Fabric_Armor_LX	Niall's Cloth Armor
+Greyfur_Fabric_Armor_LXX	Luke's Cloth Armor
+Greyfur_Fabric_Armor_LXXX	Vernon's Cloth Armor
+Greyfur_Fabric_Armor_M	Otto's Cloth Armor
+Greyfur_Fabric_Armor_MI	Jian's Cloth Armor
+Greyfur_Fabric_Armor_MII	Marius's Cloth Armor
+Greyfur_Fabric_Armor_MIII	Greymane Cloth Armor
+Greyfur_Fabric_Armor_V	Ryan's Cloth Armor
+Greyfur_Fabric_Armor_VI	Lars's Cloth Armor
+Greyfur_Fabric_Armor_VII	Luther's Cloth Armor
+Greyfur_Fabric_Armor_VIII	Colton's Cloth Armor
+Greyfur_Fabric_Armor_X	Arnold's Cloth Armor
+Greyfur_Fabric_Armor_XC	Xavier's Cloth Armor
+Greyfur_Fabric_Armor_XI	Lucius's Cloth Armor
+Greyfur_Fabric_Armor_XII	Duncan's Cloth Armor
+Greyfur_Fabric_Armor_XL	Wybert's Cloth Armor
+Greyfur_Fabric_Armor_XX	Anders's Cloth Armor
+Greyfur_Fabric_Armor_XXX	Fred's Cloth Armor
+Greyfur_Fabric_Gloves	Greymane Cloth Gloves
+Greyfur_Fabric_Helm	Colton's Cloth Helm
+Greyfur_Fabric_Helm_I	Arnold's Cloth Helm
+Greyfur_Fabric_Helm_II	Wybert's Cloth Helm
+Greyfur_Fabric_Helm_III	Fritz's Cloth Helm
+Greyfur_Fabric_Helm_IV	Shane's Cloth Headband
+Greyfur_Leather_Armor	Greymanes' Leather Armor
+Greyfur_Leather_Armor_I	Greymanes' Leather Armor
+Greyfur_Leather_Armor_II	Greymanes' Leather Armor
+Greyfur_Leather_Armor_III	Greymanes' Leather Armor
+Greyfur_Leather_Armor_IV	Greymanes' Leather Armor
+Greyfur_Leather_Armor_IX	Gilbert's Leather Armor
+Greyfur_Leather_Armor_L	Kenneth's Leather Armor
+Greyfur_Leather_Armor_LX	Aldric's Leather Armor
+Greyfur_Leather_Armor_LXX	Gerald's Leather Armor
+Greyfur_Leather_Armor_LXXX	Duane's Leather Armor
+Greyfur_Leather_Armor_LXXXI	Shane's Leather Armor
+Greyfur_Leather_Armor_LXXXII	Greymanes' Leather Armor
+Greyfur_Leather_Armor_LXXXIII	Greymane's Leather Armor
+Greyfur_Leather_Armor_V	Morrow's Leather Armor
+Greyfur_Leather_Armor_VI	Laurent's Leather Armor
+Greyfur_Leather_Armor_VII	Brant's Leather Armor
+Greyfur_Leather_Armor_VIII	Joseph's Leather Armor
+Greyfur_Leather_Armor_X	Max's Leather Armor
+Greyfur_Leather_Armor_XI	Silvan's Leather Armor
+Greyfur_Leather_Armor_XII	Pierce's Leather Armor
+Greyfur_Leather_Armor_XL	Joan's Leather Armor
+Greyfur_Leather_Armor_XX	Evelyn's Leather Armor
+Greyfur_Leather_Armor_XXX	Andrew's Leather Armor
+Greyfur_Leather_Boots	Evelyn's Leather Boots
+Greyfur_Leather_Boots_I	Morrow's Leather Boots
+Greyfur_Leather_Boots_II	Luther's Leather Boots
+Greyfur_Leather_Boots_III	Andrew's Leather Boots
+Greyfur_Leather_Boots_IV	Arnold's Leather Boots
+Greyfur_Leather_Boots_V	Joan's Leather Boots
+Greyfur_Leather_Boots_VI	Duncan's Leather Boots
+Greyfur_Leather_Boots_VII	Ronald's Leather Boots
+Greyfur_Leather_Gloves	Brant's Leather Gloves
+Greyfur_Leather_Gloves_I	Vernon's Leather Gloves
+Greyfur_Leather_Gloves_II	Laurent's Leather Gloves
+Greyfur_Leather_Helm	Matilda's Leather Headband
+Greyfur_Leather_Helm_I	Jian's Leather Helm
+Greyfur_Leather_Helm_II	Greymane Leather Helm
+Greyfur_Necklace	Greymane Necklace
+Greyfur_PlateArmor_Gloves_I	Darren Plate Gloves
+Greymane_Nobility_Degree_I	Greymane Signet
+GreyWolf_OneHandBow	Grey Wolf Bow
+Grilled_Big_Fish	Large Grilled Fish
+Grilled_Big_Fish_Large	Satisfying Large Grilled Fish
+Grilled_Big_Fish_Medium	Filling Large Grilled Fish
+Grilled_Big_Fish_XLarge	Hearty Large Grilled Fish
+Grilled_Fish	Grilled Fish
+Grilled_Fish_Large	Satisfying Grilled Fish
+Grilled_Fish_Medium	Filling Grilled Fish
+Grilled_Fish_XLarge	Hearty Grilled Fish
+Grilled_Fruit	Grilled Fruit
+Grilled_Fruit_Large	Satisfying Grilled Fruit
+Grilled_Fruit_Medium	Filling Grilled Fruit
+Grilled_Fruit_XLarge	Hearty Grilled Fruit
+Grilled_Meat	Grilled Meat
+Grilled_Meat_Fish	Grilled Meat and Fish
+Grilled_Meat_Fish_Large	Satisfying Grilled Meat and Fish
+Grilled_Meat_Fish_Medium	Filling Grilled Meat and Fish
+Grilled_Meat_Fish_XLarge	Hearty Grilled Meat and Fish
+Grilled_Meat_Large	Satisfying Grilled Meat
+Grilled_Meat_Medium	Filling Grilled Meat
+Grilled_Meat_XLarge	Hearty Grilled Meat
+Grilled_Small_Fish	Small Grilled Fish
+Grilled_Small_Fish_Large	Satisfying Small Grilled Fish
+Grilled_Small_Fish_Medium	Filling Small Grilled Fish
+Grilled_Small_Fish_XLarge	Hearty Small Grilled Fish
+Grilled_Vegetables	Grilled Vegetables
+Grilled_Vegetables_Large	Satisfying Grilled Vegetables
+Grilled_Vegetables_Medium	Filling Grilled Vegetables
+Grilled_Vegetables_XLarge	Hearty Grilled Vegetables
+Grolla_Leather_Armor	Grolla Leather Armor
+Grommet_Leather_Armor	Grommet Leather Armor
+Gronerd_Leather_Armor	Gronerd Leather Armor
+Groucca_Leather_Armor	Groucca Leather Armor
+Gruun_Fabric_Armor	Gruun Cloth Armor
+Guardian_PlateArmor_Armor	Guardian Plate Armor
+GuardianTree_Pear	Fruit of Life
+Guff_Leather_Armor	Guff Leather Armor
+Gun_OneHandShield	Shotgun Shield
+Gun_Powder	Gunpowder
+Gungjung_Tteokbokki	Pan-Fried Rice Cakes
+Gungjung_Tteokbokki_Large	Satisfying Pan-Fried Rice Cakes
+Gungjung_Tteokbokki_Medium	Filling Pan-Fried Rice Cakes
+Gungjung_Tteokbokki_XLarge	Hearty Pan-Fried Rice Cakes
+Gursus_Leather_Armor	Gersens Leather Armor
+Gustav_OneHandMusket	Gustav Musket
+Gut_Leather_Boots	Goot Leather Boots
+Guts_PlateArmor_Armor	Gwets Plate Armor
+Haasam	False Starwort
+Hacking_PlateArmor_Helm	Circuit Hijacking Helm
+Haemuljjim	Steamed Seafood
+Haemuljjim_Large	Satisfying Steamed Seafood
+Haemuljjim_Medium	Filling Steamed Seafood
+Haemuljjim_XLarge	Hearty Steamed Seafood
+Hagmundt_HorseArmor_Armor	Hagmund Barding
+Hagmundt_HorseArmor_Helm	Hagmund Champron
+Hagmundt_HorseArmor_Saddle	Hagmund Saddle
+Hagwood_Leather_Gloves	Hagwood Leather Gloves
+Hailbrin_Fabric_Armor	Nevin Cloth Armor
+Hailbrin_Fabric_Helm	Nevin Cloth Bandana
+Hailbrin_Leather_Armor	Helfryn Leather Armor
+Hailbrin_Leather_Boots	Helfryn Leather Boots
+Hailbrin_Leather_Cloak	Helfryn Leather Cloak
+Hailbrin_Leather_Gloves	Helfryn Leather Gloves
+Hailbrin_Necklace	Helfryn Necklace
+Hailen_Fabric_Armor	Haillen Cloth Armor
+Halkias_Leather_Gloves	Harkias Leather Gloves
+Halsius_Record	Journal on Treating Lunatics
+Hanbok_Fabric_Gloves_T1_QA	Hanbok Fabric Gloves T1 QA
+Harald_Fabric_Cloak	Dewhaven Standard Cloth Cloak
+Harald_Leather_Armor	Dewhaven Standard Leather Armor
+Haran_Fabric_Armor	Harran Cloth Armor
+Hard_Thorn_OneHandTowerShield	Legion Spearmen's Large Shield
+Harghai_Fabric_Armor	Harghai Cloth Armor
+Hark_Leather_Gloves	Hark Leather Gloves
+Harker_Fabric_Helm	Harker Cloth Cap
+Harkias_OneHandAxe	Gilliam Axe
+Haron_Fabric_Gloves	Haron Cloth Gloves
+Harpy_Feather	Harpy Feather
+Hartman_PlateArmor_Helm	Hartmann Plate Helm
+Hasets_ChainMail_Armor	Hasets Chain Mail
+Hassal_Fabric_Armor	Hassal Cloth Armor
+Hazuka_Leather_Armor	Hashaka Leather Armor
+Heat_PlateArmor_Helm	Helm of Ignition
+Heavy_Copper_Pack	Full Copper Pouch
+Heavy_Silver_Pack	Overflowing Silver Pouch
+Hegeh_Leather_Gloves	Hegea Leather Gloves
+Hegeh_TwoHandAlebard	Marauder's Halberd
+Hegeh_TwoHandedWarHammer	Bonepit Warhammer
+Heisellen_Fabric_Armor	The Masked Liberator's Cloth Armor
+Heisellen_Fabric_Cloak	The Masked Liberator's Cloth Cloak
+Heisellen_Fabric_Cloak_T1_QA	Heisellen Fabric Cloak T1 QA
+Hellad_Leather_Armor	Hellad Leather Armor
+Hellhonds_Leather_Helm	Hellhound Leather Helm
+Hemon_Vindel_Leather_Armor	Duskfang Leather Armor
+Hemon_Vindel_Leather_Cloak	Duskfang Leather Cloak
+HemondBindel_TwoHandSword	Hound
+Hentti_Fabric_Armor	Hentree Cloth Armor
+Herbal_Tea	Mild Herbal Tea
+Herbalist_BackPack_I	Herbalist's Pack
+Herbalist_BackPack_II	Herbalist's Pack
+Herdel_Leather_Boots	Herdel Leather Boots
+Hermalfaya_Leather_Armor	Helpaia Leather Armor
+Hernand_Cloak	Hernandian Noble's Cloak
+Hernand_Contribution_Flag	Hernandian Contribution Banner
+Hernand_Crown	Hernandian Crown
+Hernand_Flag_I	Small Hernandian Banner Pike
+Hernand_Flag_II	Medium Hernandian Banner Pike
+Hernand_GuardCaptain_Fabric_Armor	Hernandian Honor Guard Armor
+Hernand_GuardCaptain_Fabric_Cloak	Hernandian Honor Guard Cloak
+Hernand_GuardCaptain_Leather_Boots	Hernandian Honor Guard Boots
+Hernand_GuardCaptain_Leather_Gloves	Hernandian Honor Guard Gloves
+Hernand_HorseArmor_Armor	Hernandian Barding
+Hernand_HorseArmor_Helm	Hernandian Champron
+Hernand_HorseArmor_Saddle	Hernandian Saddle
+Hernand_HorseArmor_Stirrup	Hernandian Stirrups
+Hernand_Nobility_Degree_I	Hernandian Signet
+Hernand_Party_Leather_Boots	Hernandian Banquet Leather Boots
+Hernand_Soldier_HorseArmor_Armor	Hernandian Soldier's Cloth Barding
+Hernand_William_Middler_Fabric_Armor	Williem Middler Cloth Armor
+Hernand_Winery_Key	Hernand Wine Storehouse Key
+Herween_Leather_Armor	Herwin Leather Armor
+Hewlette_Fabric_Armor	Hewlette Cloth Armor
+Hexe_Archer_OneHandBow	Bow of the Fleeting
+Hexe_Earring	Witch's Earring
+Hexe_Soldier_OneHandMace	Mace of the Fleeting
+Hexe_Soldier_OneHandShield	Shell of the Fleeting
+Hexe_Soldier_OneHandSword	Sword of the Fleeting
+Hexe_Soldier_TwoHandSpear	Staff of the Fleeting
+Hexe_Warrior_TwoHandSpear	Spear of the Fleeting
+Hidden_TreasureMap_I	Hidden Treasure Map Piece 1
+Hidden_TreasureMap_II	Hidden Treasure Map Piece 2
+Hidden_TreasureMap_III	Hidden Treasure Map Piece 3
+Hidden_TreasureMap_IV	Hidden Treasure Map Piece 4
+Hidden_TreasureMap_IX	Hidden Treasure Map Piece 9
+Hidden_TreasureMap_V	Hidden Treasure Map Piece 5
+Hidden_TreasureMap_VI	Hidden Treasure Map Piece 6
+Hidden_TreasureMap_VII	Hidden Treasure Map Piece 7
+Hidden_TreasureMap_VIII	Hidden Treasure Map Piece 8
+Hidden_TreasureMap_X	Hidden Treasure Map Piece 10
+Hidden_TreasureMap_XI	Hidden Treasure Map Piece 11
+Hidden_TreasureMap_XII	Hidden Treasure Map Piece 12
+High_HolyWater	Solumen's Holy Water
+High_Meat	Tough Meat
+High_Wine	Delesyian Wine
+Hleinmers_TwoHandAlebard	Iris Halberd
+Hleinmers_TwoHandedWarHammer	Cactus Warhammer
+Hobuka_Leather_Armor	Hobbuca Leather Armor
+Hodges_Leather_Armor	Hodges Leather Armor
+HolyWater	Holy Water
+Home_Key	Key
+Honey	Honey
+Honey_Tea	Honey Tea
+HoneyComb	Beehive
+HoneyComb_OneHandMace	Beehive Club
+Hooburn_Leather_Boots	Hauvern Leather Boots
+Hoobus_Fabric_Helm	Hubus Cloth Cap
+Hoobus_Leather_Armor	Hubus Leather Armor
+Hordyroar_Leather_Boots	Hoardroar Leather Boots
+Horizon_Leather_Armor	Horizon Leather Armor
+HorseFeed_Hay	Hay
+HorseFeed_Hp_Potion	Horse Tonic
+HorseFeed_Lump_Sugar	Sugar Cubes
+HorseFeed_Speed_Potion	Horse Stimulant
+HorseFeed_Sugar_Beet	Sugar Beet
+HorseShoe_HorseArmor_Brass_horseshoe_II	Bronze Horseshoes
+HorseShoe_HorseArmor_Clover_Horseshoe_II	Four-Leaf Horseshoes
+HorseShoe_HorseArmor_marquel_Stirrup	Marcello Stirrups
+HorseShoe_HorseArmor_Shabby_horseshoe_II	Shabby Horseshoes
+HorseShoe_HorseArmor_Shoe	Silver Iron Horseshoes
+HorseShoe_HorseArmor_Shoe_I	Ironstone Horseshoes
+HorseShoe_HorseArmor_Shoe_II	Bow Knot Horseshoes
+HorseShoe_HorseArmor_Shoe_III	Steelheart Horseshoes
+HorseShoe_HorseArmor_Silvermoon_Horseshoe_II	Silvermoon Horseshoes
+HorseShoe_HorseArmor_Steel_Horseshoe_II	Steel Horseshoes
+HorseShoe_HorseArmor_Stirrup	Crude Stirrups
+HorseShoe_HorseArmor_Stirrup_I	Wells Military Stirrups
+HorseShoe_HorseArmor_Stirrup_II	Decorative Dragon Head Stirrups
+HorseShoe_HorseArmor_Stirrup_III	Gold-Decorated Stirrups
+HorseShoe_HorseArmor_Stirrup_IV	Fine Leather Stirrups
+HorseShoe_HorseArmor_Stirrup_V	Exclaire Stirrups
+Hound_Flag_I	Small Hellhounds Banner Pike
+Hound_Flag_II	Medium Hellhounds Banner Pike
+Huge_TwoHandGiantAxe	Inquisitor's Greataxe
+Hunter_BackPack_I	Hunter's Pack
+Hunter_BackPack_II	Hunter's Pack
+Huntington_Leather_Boots	Huntington Leather Boots
+Huntington_OneHandMusket	Arlen Musket
+Huon_Leather_Armor	Huron Leather Armor
+Huroi_Leather_Boots	Scholastone Boots
+Huroi_Leather_Helm	Scholastone Cap
+Huskall_Leather_Armor	Huskall Leather Armor
+Hwando_TwoHandSword	Hwando
+Hyde_OneHandCrossBow	Hyde Crossbow
+Hyena_Leather_Helm	Hyena Helm
+Hymns_of_Dusk_Fabric_Armor_I	Musket Border Guard Standard Armor
+Hymns_of_Dusk_Leather_Armor_I	Dusksongs Leather Armor
+Hymns_of_Dusk_Leather_Boots_I	Dusksongs Leather Boots
+Hymns_of_Dusk_PlateArmor_Armor_I	Dusksongs Plate Armor
+Hymns_of_Dusk_PlateArmor_Gloves_I	Dusksongs Plate Gloves
+Hyosi_Arrow	Whistling Arrow
+Hysilda_Fabric_Armor	Hysilda Cloth Armor
+Ice_Arrow	Chill Arrow
+IceStrandedShip_Book	Shipwreck Voyage Log
+IceThrower	Electromagnetic Frostspitter
+Ignir_TwoHandSword	Ignir
+Iguana_Rider_Leather_Boots	Iguana Rider Leather Boots
+Iguana_Rider_Leather_Cloak_III	Lizard Leather Cloak
+Iguana_Rider_PlateArmor_Armor_I	Iguana Rider's Plate Armor
+Iguana_Rider_PlateArmor_Armor_II	Iguana Rider's Plate Armor
+Iguana_Rider_PlateArmor_Armor_III	Iguana Rider's Plate Armor
+Illinoeon_Leather_Boots	Infreen Leather Boots
+Immediate_SubLevel_AttackSpeedRate	Increased Attack Speed
+Immediate_SubLevel_Hp	Health Amplification
+Immediate_SubLevel_MoveSpeedRate	Increased Movement Speed
+Immediate_SubLevel_Mp	Spirit Amplification
+Immediate_SubLevel_Stamina	Stamina Amplification
+IncreaseSwimmingSpeed_Plate_Boots	Tidebreaker Boots
+Insect_Collect_BackPack	Kuku Insect Gatherer's Pack
+Installation_01_key	Valvegard Garrison Key
+Installation_02_key	Marni's Laboratorium Key
+Installation_03_key	Aeronautical Research Base Key
+InstallationBomb	Deployable Explosive
+Intacuttar_PlateArmor_Helm	Intaka Plate Helm
+Inventory_Expansion_1	Small Bag
+Inventory_Expansion_2	Medium Bag
+Inventory_Expansion_3	Large Bag
+Inventory_Expansion_30	Inventory Expansion Tool
+Inventory_Expansion_4	Extra Large Bag
+Inventory_Expansion_Sellable_1	Small Bag
+Inventory_Expansion_Sellable_2	Medium Bag
+Inventory_Expansion_Sellable_3	Large Bag
+Inventory_Expansion_Sellable_4	Extra Large Bag
+Invisible_TwoHandGiantBastard	Dandelion Longsword
+Inyr_PlateArmor_Helm	Inyr Plate Helm
+Inytium_Leather_Armor	Ynitium Leather Armor
+Inytium_Leather_Boots	Ynitium Leather Boots
+Inytium_Leather_Cloak	Ynitium Leather Cloak
+Inytium_Leather_Gloves	Ynitium Leather Gloves
+Ironfist_Boss_Knuckle	Iron Fists Gauntlet
+IronStone	Iron Ore
+Isilon_Leather_Boots	Isilon Leather Boots
+Itano_CannonBall	Itano Cannonball
+Itano_CannonBall_Errant	Crude Itano Cannonball
+Item_88_Butterfly	Eighty-eight Butterfly
+Item_Abyss_Artifact_Maker	Abyss Artifact Fabricator
+Item_AbyssGear_SKill_Lv1_Box	Unidentified Abyss Gear
+Item_AbyssGear_SKill_Lv2_Box	Unidentified Abyss Gear
+Item_AbyssGear_SKill_Lv3_Box	Unidentified Abyss Gear
+Item_AbyssGear_Special_Box	Unidentified Abyss Gear
+Item_AbyssGear_Stat_Lv1_Box	Unidentified Abyss Gear
+Item_AbyssGear_Stat_Lv2_Box	Unidentified Abyss Gear
+Item_AbyssGear_Stat_Lv3_Box	Unidentified Abyss Gear
+Item_Axolotl	Axolotl
+Item_Baby_Hedgehog	Baby Hedgehog
+Item_BackPackChocolate	Cacao Snack
+Item_BananaSpider	Yellow Garden Spider
+Item_Banded_Peacock	Banded Peacock Butterfly
+Item_Bee	Honeybee
+Item_Beetle	Beetle
+Item_Beighen_Enchant_Coin	Beighen Refinement Token
+Item_Black_Centipede	Black Centipede
+Item_BlackTail_Flycatcher	Desert Wheatear
+Item_Blue_Copper	Blue Lycaenid Butterfly
+Item_Blue_Pansy_Butterfly	Southern Blue Peacock Butterfly
+Item_BlueJay	Blue Jay
+Item_Bumblebee	Bumblebee
+Item_Bunting_Bird	Meadow Bunting
+Item_Butterfly	Meadow Butterfly
+Item_Camel_Cricket	Camel Cricket
+Item_Chameleon	Chameleon
+Item_Checkered_White	Checkered White Butterfly
+Item_Chocolate	Chocolate
+Item_Cockroach	Cockroach
+Item_Colias_Nastes	Green Sulphur Butterfly
+Item_Common_Buckeye	Buckeye Butterfly
+Item_Common_Green_Birdwing	Green Birdwing Butterfly
+Item_Common_Nawab	Nawab Butterfly
+Item_Crimson_Patch	Crimson Patch Butterfly
+Item_Del_Enchant_Coin	Delesyia Refinement Token
+Item_Dem_Enchant_Coin	Demeniss Refinement Token
+Item_Desert_Orange_tip	Scarlet Leafwing Butterfly
+Item_DiademSpider	Golden Silk Spider
+Item_Diana_Fritillary	Diana Fritillary Butterfly
+Item_dragonfly	Dragonfly
+Item_Eastern_Comma	Yellow Comma Butterfly
+Item_Eastern_Tailed_Blue	Blue Tailed Butterfly
+Item_Eastern_Tiger_Swallowtail	Swallowtail
+Item_ETC_CooltimeReduce_ATAG	A.T.A.G. Emergency Power Device
+Item_ETC_CooltimeReduce_ATAGII	A.T.A.G. Power Module
+Item_ETC_CooltimeReduce_Dragon	Dragon Claw Horn
+Item_ETC_CooltimeReduce_DragonII	Narima's Horn
+Item_Firefly	Firefly
+Item_Fist_Damian	Ordinary Gloves
+Item_Fist_Kliff	Ordinary Gloves
+Item_Fist_Oongka	Ordinary Gloves
+Item_Flying_Squirrel	Flying Squirrel
+Item_Frilled_Lizard	Frilled-neck Lizard
+Item_Giant_Salamander	Burrowing Salamander
+Item_gimmick_abyss_quest_kuku_seal_01	Magnetic Power Core
+Item_gimmick_abysscore_0001	Abyss Cell: No. 1
+Item_gimmick_abysscore_0002	Abyss Cell: No. 2
+Item_gimmick_abyssruins_useartifact_01_attach_part	Abyss Transporter
+Item_gimmick_attach_abyss_core_01	Power Core - Gate of Collapse
+Item_gimmick_attach_abyss_core_02	Power Core - Ore of Resipiscence
+Item_gimmick_attach_abyss_core_03	Power Core - Casket of Illusions
+Item_gimmick_attach_abyss_core_04	Power Core - Crown of Shadows
+Item_gimmick_attach_abyss_core_05	Power Core - Spire of Defiance
+Item_gimmick_attach_abyss_core_06	Power Core - Verse of Sowing
+Item_gimmick_attach_marni_machinetank_backpack_01	Marni's Mecha Leap Pack
+Item_gimmick_attach_marni_machinetank_backpack_02	Marni's Mecha Laser Pack
+Item_gimmick_attach_marni_machinetank_backpack_03	Marni's Mecha Blade Pack
+Item_gimmick_attach_marni_machinetank_backpack_04	Marni's Mecha Rocket Pack
+Item_gimmick_attach_marni_machinetank_backpack_05	Marni's Mecha Booster Pack
+Item_gimmick_attach_marni_machinetank_backpack_06	Dreadnought Booster Pack
+Item_gimmick_attach_marni_machinetank_backpack_07	Dreadnought Missile Pack
+Item_gimmick_attach_mechanical_powerplant_0001	Electrical Component
+Item_gimmick_attach_nuclear_fusion_core_01	Tenebrum Magnetic Core
+Item_gimmick_nature_rock_dissolve_stone_core_01	Abyss Cell: No. 0
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01	Fusion Reactor Core: I-I
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index01	Fusion Reactor Core: XI-I
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index03	Fusion Reactor Core: XI-III
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index04	Fusion Reactor Core: XI-IV
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02	Fusion Reactor Core: I-II
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index01	Fusion Reactor Core: XII-I
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index03	Fusion Reactor Core: XII-III
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index04	Fusion Reactor Core: XII-IV
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03	Fusion Reactor Core: I-III
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index01	Fusion Reactor Core: XIII-I
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index03	Fusion Reactor Core: XIII-III
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index04	Fusion Reactor Core: XIII-IV
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04	Fusion Reactor Core: I-IV
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index01	Fusion Reactor Core: XIV-I
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index03	Fusion Reactor Core: XIV-III
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index04	Fusion Reactor Core: XIV-IV
+Item_gimmick_puzzle_antumbra_tokamak_01_parts20	Core of Penitence
+Item_gimmick_puzzle_antumbra_tokamak_01_parts21	Core of Renunciation
+Item_gimmick_puzzle_antumbra_tokamak_01_parts22	Core of Expiation
+Item_gimmick_puzzle_antumbra_tokamak_01_parts23	Core of Oblation
+Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index01	Fusion Reactor Core: XXI-I
+Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index03	Fusion Reactor Core: XXI-III
+Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index04	Fusion Reactor Core: XXI-IV
+Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index01	Fusion Reactor Core: XXII-I
+Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index03	Fusion Reactor Core: XXII-III
+Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index04	Fusion Reactor Core: XXII-IV
+Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index01	Fusion Reactor Core: XXIII-I
+Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index03	Fusion Reactor Core: XXIII-III
+Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index04	Fusion Reactor Core: XXIII-IV
+Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index01	Fusion Reactor Core: XXIV-I
+Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index03	Fusion Reactor Core: XXIV-III
+Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index04	Fusion Reactor Core: XXIV-IV
+Item_gimmick_puzzle_antumbra_tokamak_02_parts20	Core of Mortification
+Item_gimmick_puzzle_antumbra_tokamak_02_parts21	Core of Faith
+Item_gimmick_puzzle_antumbra_tokamak_02_parts22	Core of Benediction
+Item_gimmick_puzzle_antumbra_tokamak_02_parts23	Core of Absolution
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01	Fusion Reactor Core: III-I
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index02	Fusion Reactor Core: XXXI-II
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index04	Fusion Reactor Core: XXXI-IV
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index06	Fusion Reactor Core: XXXI-VI
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02	Fusion Reactor Core: III-II
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index02	Fusion Reactor Core: XXXII-II
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index04	Fusion Reactor Core: XXXII-IV
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index06	Fusion Reactor Core: XXXII-VI
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03	Fusion Reactor Core: III-III
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index02	Fusion Reactor Core: XXXIII-II
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index04	Fusion Reactor Core: XXXIII-IV
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index06	Fusion Reactor Core: XXXIII-VI
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04	Fusion Reactor Core: III-IV
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index02	Fusion Reactor Core: XXXIV-II
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index04	Fusion Reactor Core: XXXIV-IV
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index06	Fusion Reactor Core: XXXIV-VI
+Item_gimmick_puzzle_antumbra_tokamak_03_parts20	Core of Solace
+Item_gimmick_puzzle_antumbra_tokamak_03_parts21	Core of Revelation
+Item_gimmick_puzzle_antumbra_tokamak_03_parts22	Core of Temperance
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index01	Fusion Reactor Core: LI-I
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index02	Fusion Reactor Core: LI-II
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index04	Fusion Reactor Core: LI-IV
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index05	Fusion Reactor Core: LI-VI
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index01	Fusion Reactor Core: LII-I
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index02	Fusion Reactor Core: LII-II
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index04	Fusion Reactor Core: LII-IV
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index05	Fusion Reactor Core: LII-VI
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index01	Fusion Reactor Core: LIII-I
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index02	Fusion Reactor Core: LIII-II
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index04	Fusion Reactor Core: LIII-IV
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index05	Fusion Reactor Core: LIII-VI
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index01	Fusion Reactor Core: LIV-I
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index02	Fusion Reactor Core: LIV-II
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index04	Fusion Reactor Core: LIV-IV
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index05	Fusion Reactor Core: LIV-VI
+Item_gimmick_puzzle_antumbra_tokamak_05_parts20	Core of Atonement
+Item_gimmick_puzzle_antumbra_tokamak_05_parts21	Core of Deliverance
+Item_gimmick_puzzle_antumbra_tokamak_05_parts22	Core of Exaltation
+Item_gimmick_puzzle_antumbra_tokamak_05_parts23	Core of Veneration
+Item_gimmick_puzzle_antumbra_tokamak_05_parts24	Core of Devotion
+Item_gimmick_puzzle_antumbra_tokamak_parts01	Fusion Reactor Core: I
+Item_gimmick_puzzle_antumbra_tokamak_parts02	Fusion Reactor Core: II
+Item_gimmick_puzzle_antumbra_tokamak_parts03	Fusion Reactor Core: III
+Item_gimmick_puzzle_antumbra_tokamak_parts04	Fusion Reactor Core: IV
+Item_gimmick_puzzle_antumbra_tokamak_parts05	Fusion Reactor Core: V
+Item_gimmick_puzzle_antumbra_tokamak_parts06	Fusion Reactor Core: VI
+Item_gimmick_puzzle_antumbra_tokamak_parts07	Fusion Reactor Core: VII
+Item_gimmick_puzzle_antumbra_tokamak_parts08	Fusion Reactor Core: VIII
+Item_gimmick_puzzle_antumbra_tokamak_parts09	Fusion Reactor Core: IX
+Item_gimmick_puzzle_antumbra_tokamak_parts10	Fusion Reactor Core: X
+Item_gimmick_puzzle_antumbra_tokamak_parts11	Fusion Reactor Core: XI
+Item_gimmick_puzzle_antumbra_tokamak_parts12	Fusion Reactor Core: XII
+Item_gimmick_puzzle_antumbra_tokamak_parts13	Fusion Reactor Core: XIII
+Item_gimmick_puzzle_antumbra_tokamak_parts14	Fusion Reactor Core: XIV
+Item_gimmick_puzzle_antumbra_tokamak_parts15	Fusion Reactor Core: XV
+Item_gimmick_puzzle_antumbra_tokamak_parts16	Fusion Reactor Core: XVI
+Item_gimmick_snake_boss_scales_01	Aeserion's Scale
+Item_Gnat	Fruit Fly
+Item_GnatWide	Medium Fly
+Item_Goanna	Goanna
+Item_GrassHopper	Grasshopper
+Item_Great_Purple_Hairstreak	Great Purple Hairstreak Butterfly
+Item_Grizzled_Skipper	Grizzled Skipper Butterfly
+Item_Guava_Skipper	Guava Skipper Butterfly
+Item_Her_Enchant_Coin	Hernand Refinement Token
+Item_Hila_Lizard	Heloderma Lizard
+Item_Hornet	Hornet
+Item_House_Centipede	House Centipede
+Item_Hypaurotis_Crysalus	Violet Hairstreak Butterfly
+Item_Iguana	Iguana
+Item_Jewel_Beetle	Jewel Beetle
+Item_JijeongLeaf_Insect	Palmar Beetle
+Item_Kallima_Inachus	Orange Oakleaf Butterfly
+Item_Kuku_Egg	Kuku Bird's Egg
+Item_Kuku_Pot	Kuku Pot
+Item_Kuku_Pot_02	Enhanced Kuku Pot
+Item_KuKu_Small_ATAG	Small Kuku A.T.A.G.
+Item_Little_Metalmark	Little Metalmark Butterfly
+Item_Little_Wood_Satyr	Little Wood Satyr Butterfly
+Item_Longhorn_Beetle	Longhorn Beetle
+Item_Longtailedtit	Long-Tailed Tit
+Item_Luna_Moth	Wild Silkworm Moth
+Item_Lustrous_Copper	Red Lycaenid Butterfly
+Item_Lycaena_Phlaeas	Spotted Lycaenid Butterfly
+Item_Malachite	Malachite Butterfly
+Item_Meerkat	Meerkat
+Item_Milbert_Tortoiseshell	Flame-Bordered Butterfly
+Item_Mole	Mole
+Item_Monarch	Monarch Butterfly
+Item_Moth	Mountain Moth
+Item_Muskrat	Muskrat
+Item_Myscelia_Ethusa	Bluewing Butterfly
+Item_Neophasia_Terlooii	White Butterfly
+Item_Orange_Barred_Sulphur	Orange-Barred Sulphur Butterfly
+Item_Oriole	Black-Naped Oriole
+Item_Ornythion_Swallowtail	Ornythion Swallowtail Butterfly
+Item_Oxpecker	Yellow-Billed Oxpecker
+Item_Pailoon_Enchant_Coin	Pailune Refinement Token
+Item_Painted_Lady	Painted Lady Butterfly
+Item_Pipevine_Swallowtail	Pipevine Swallowtail Butterfly
+Item_Polydamas_Swallowtail	Polydamas Swallowtail Butterfly
+Item_Possum	Opossum
+Item_Purple_Emperor	Purple Emperor Butterfly
+Item_puzzle_troll_lake_pillar_01_part_01	Kharonso Ruins Pillar: No. 1
+Item_puzzle_troll_lake_pillar_02_part_01	Kharonso Ruins Pillar: No. 2
+Item_puzzle_troll_lake_pillar_03_part_01	Kharonso Ruins Pillar: No. 3
+Item_puzzle_troll_lake_pillar_04_part_01	Kharonso Ruins Pillar: No. 4
+Item_Rare_Collect_amaranth	Amaranth
+Item_Rare_Collect_Chaya	Chaya
+Item_Rare_Collect_chlorella	Green Algae
+Item_Rare_Collect_Dulse	Red Seaweed
+Item_Rare_Collect_Ensete	Enset
+Item_Rare_Collect_jijeongta_leaf	Palmar Leaf
+Item_Rare_Collect_Kudzu	Skyroot
+Item_Rare_Collect_Mercury	Mercury
+Item_Rare_Collect_opuntia	Prickly Pear
+Item_Rare_Collect_Platinum	Platinum
+Item_Rare_Collect_RazorClam	Razor Clam
+Item_Rare_Collect_RazorClam_01	Freshwater Clam
+Item_Rare_Collect_Rubber	Rubber
+Item_Rare_Collect_Stalactites	Stalactite
+Item_Rare_Collect_SulfurStone	Brimstone
+Item_Rare_Collect_Taro	Taro
+Item_Rat	Rat
+Item_Red_Spotted_Purple	Red-spotted Purple Butterfly
+Item_Red_Squirrel	Red Squirrel
+Item_Regal_Fritillary	Regal Fritillary Butterfly
+Item_Rhinoceros_Beetle	Rhinoceros Beetle
+Item_Ruddy_Daggerwing	Ruddy Daggerwing Butterfly
+Item_Rusty_Tipped_Page	Rusty Tipped Page Butterfly
+Item_Salamander	Salamander
+Item_Scale	Scales of Fairness and Justice
+Item_Sea_Siater	Wharf Roach
+Item_Set_A_Enhance_RestArea	Adventurer's Refinement Inventory Type A
+Item_Set_A_RestArea	Adventurer's Cooking Inventory Type A
+Item_Set_B_Enhance_RestArea	Adventurer's Refinement Inventory Type B
+Item_Set_B_RestArea	Adventurer's Cooking Inventory Type B
+Item_Set_C_Enhance_RestArea	Adventurer's Refinement Inventory Type C
+Item_Set_C_RestArea	Adventurer's Cooking Inventory Type C
+Item_Set_D_Enhance_RestArea	Adventurer's Refinement Inventory Type D
+Item_Set_D_RestArea	Adventurer's Cooking Inventory Type D
+Item_Set_E_Enhance_RestArea	Adventurer's Refinement Inventory Type E
+Item_Set_E_RestArea	Adventurer's Cooking Inventory Type E
+Item_Set_F_Enhance_RestArea	Adventurer's Refinement Inventory Type F
+Item_Silkworm_Moth	Silkworm Moth
+Item_Skill_AbyssGear_AbsoluteDefense_LV1	Piercing Bloom
+Item_Skill_AbyssGear_AbyssGrass_Immune	Abyssal Assimilation
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_FabricArmor_LV1	Shred I
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_FabricArmor_LV2	Shred II
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_FabricArmor_LV3	Shred III
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_LeatherArmor_LV1	Rend I
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_LeatherArmor_LV2	Rend II
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_LeatherArmor_LV3	Rend III
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_PlateArmor_LV1	Shatter I
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_PlateArmor_LV2	Shatter II
+Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_PlateArmor_LV3	Shatter III
+Item_Skill_AbyssGear_AddFrendly_LV1	Solidarity I
+Item_Skill_AbyssGear_AddFrendly_LV2	Solidarity II
+Item_Skill_AbyssGear_AddFrendly_LV3	Solidarity III
+Item_Skill_AbyssGear_AdditionalThief_LV1	Ledgermain I
+Item_Skill_AbyssGear_AdditionalThief_LV2	Ledgermain II
+Item_Skill_AbyssGear_AdditionalThief_LV3	Ledgermain III
+Item_Skill_AbyssGear_AddKillSkillLevel_LV1	Energy Drain I
+Item_Skill_AbyssGear_AddKillSkillLevel_LV2	Energy Drain II
+Item_Skill_AbyssGear_AddKillSkillLevel_LV3	Energy Drain III
+Item_Skill_AbyssGear_AddMoneyDropRate_LV1	Fortune I
+Item_Skill_AbyssGear_AddMoneyDropRate_LV2	Fortune II
+Item_Skill_AbyssGear_AddMoneyDropRate_LV3	Fortune III
+Item_Skill_AbyssGear_Antumbra_Spear	Warden of Darkness
+Item_Skill_AbyssGear_Antumbra_TwoHandRod	Dark Crescent
+Item_Skill_AbyssGear_ArrowRain_LV1	Arrow Rain
+Item_Skill_AbyssGear_AtorDrone_LV1	Ator's Orb
+Item_Skill_AbyssGear_Attack_HPRecover_LV1	Life Transference
+Item_Skill_AbyssGear_Attack_MPRecover_LV1	Spirit Transference
+Item_Skill_AbyssGear_Attack_SPRecover_LV1	Stamina Transference
+Item_Skill_AbyssGear_Bastier	Flames of Judgment
+Item_Skill_AbyssGear_BlockAmmoConsume_LV1	Infinite Arrows I
+Item_Skill_AbyssGear_BlockAmmoConsume_LV2	Infinite Arrows II
+Item_Skill_AbyssGear_BlockAmmoConsume_LV3	Infinite Arrows III
+Item_Skill_AbyssGear_BlockAmmoConsume_Special	Greater Infinite Arrows
+Item_Skill_AbyssGear_Boss_AdditionalDamage_LV1	Malicebane I
+Item_Skill_AbyssGear_Boss_AdditionalDamage_LV2	Malicebane II
+Item_Skill_AbyssGear_Boss_AdditionalDamage_LV3	Malicebane III
+Item_Skill_AbyssGear_Boss_AdditionalDamage_Special	Greater Malicebane
+Item_Skill_AbyssGear_Catfish_BodySlam_LV1	Rising Torrent
+Item_Skill_AbyssGear_CollectDrop_Animal_LV1	Blessing of the Beast I
+Item_Skill_AbyssGear_CollectDrop_Animal_LV2	Blessing of the Beast II
+Item_Skill_AbyssGear_CollectDrop_Animal_LV3	Blessing of the Beast III
+Item_Skill_AbyssGear_CollectDrop_Log_LV1	Blessing of the Forest I
+Item_Skill_AbyssGear_CollectDrop_Log_LV2	Blessing of the Forest II
+Item_Skill_AbyssGear_CollectDrop_Log_LV3	Blessing of the Forest III
+Item_Skill_AbyssGear_CollectDrop_Ore_LV1	Blessing of the Earth I
+Item_Skill_AbyssGear_CollectDrop_Ore_LV2	Blessing of the Earth II
+Item_Skill_AbyssGear_CollectDrop_Ore_LV3	Blessing of the Earth III
+Item_Skill_AbyssGear_CollectDrop_Plant_LV1	Blessing of Nature I
+Item_Skill_AbyssGear_CollectDrop_Plant_LV2	Blessing of Nature II
+Item_Skill_AbyssGear_CollectDrop_Plant_LV3	Blessing of Nature III
+Item_Skill_AbyssGear_Combo_LV1	Relentless
+Item_Skill_AbyssGear_CommonAnimal_AdditionalDamage_LV1	Beastbane I
+Item_Skill_AbyssGear_CommonAnimal_AdditionalDamage_LV2	Beastbane II
+Item_Skill_AbyssGear_CommonAnimal_AdditionalDamage_LV3	Beastbane III
+Item_Skill_AbyssGear_CommonAnimal_AdditionalDamage_Special	Greater Beastbane
+Item_Skill_AbyssGear_CommonGolem_AdditionalDamage_LV1	Primalbane I
+Item_Skill_AbyssGear_CommonGolem_AdditionalDamage_LV2	Primalbane II
+Item_Skill_AbyssGear_CommonGolem_AdditionalDamage_LV3	Primalbane III
+Item_Skill_AbyssGear_CommonGolem_AdditionalDamage_Special	Greater Primalbane
+Item_Skill_AbyssGear_CommonHexe_AdditionalDamage_LV1	Hexebane I
+Item_Skill_AbyssGear_CommonHexe_AdditionalDamage_LV2	Hexebane II
+Item_Skill_AbyssGear_CommonHexe_AdditionalDamage_LV3	Hexebane III
+Item_Skill_AbyssGear_CommonHexe_AdditionalDamage_Special	Greater Hexebane
+Item_Skill_AbyssGear_CommonHumanoid_AdditionalDamage_LV1	Bloodbane I
+Item_Skill_AbyssGear_CommonHumanoid_AdditionalDamage_LV2	Bloodbane II
+Item_Skill_AbyssGear_CommonHumanoid_AdditionalDamage_LV3	Bloodbane III
+Item_Skill_AbyssGear_CommonHumanoid_AdditionalDamage_Special	Greater Bloodbane
+Item_Skill_AbyssGear_ContributionExp_LV1	Service I
+Item_Skill_AbyssGear_ContributionExp_LV2	Service II
+Item_Skill_AbyssGear_ContributionExp_LV3	Service III
+Item_Skill_AbyssGear_Creature_AdditionalDamage_LV1	Abyssbane I
+Item_Skill_AbyssGear_Creature_AdditionalDamage_LV2	Abyssbane II
+Item_Skill_AbyssGear_Creature_AdditionalDamage_LV3	Abyssbane III
+Item_Skill_AbyssGear_Creature_AdditionalDamage_Special	Greater Abyssbane
+Item_Skill_AbyssGear_CresecentAura_1_LV1	Crescent Moon Slash
+Item_Skill_AbyssGear_CresecentAura_2_LV1	Half Moon Slash
+Item_Skill_AbyssGear_CresecentAura_3_LV1	Fullmoon Slash
+Item_Skill_AbyssGear_CrowAttack_LV1	Crow's Pursuit
+Item_Skill_AbyssGear_CrowStorm_LV1	Crow Storm
+Item_Skill_AbyssGear_DAM_UP_RotationBash	Momentum
+Item_Skill_AbyssGear_DarkChase_LV1	Greysoul Howling
+Item_Skill_AbyssGear_DarkenRobe_LV1	Wound of Darkness
+Item_Skill_AbyssGear_DogClaw_LV1	Hound's Claws
+Item_Skill_AbyssGear_EnergyBurst_LV1	Kinetic Burst
+Item_Skill_AbyssGear_EnlightenmentWave_LV1	Karmic Pulse
+Item_Skill_AbyssGear_Equip_AddHorseExp_LV1	Equestrian I
+Item_Skill_AbyssGear_Equip_AddHorseExp_LV2	Equestrian II
+Item_Skill_AbyssGear_Equip_AddHorseExp_LV3	Equestrian III
+Item_Skill_AbyssGear_Equip_AddPetFriendly_LV1	Companionship I
+Item_Skill_AbyssGear_Equip_AddPetFriendly_LV2	Companionship II
+Item_Skill_AbyssGear_Equip_AddPetFriendly_LV3	Companionship III
+Item_Skill_AbyssGear_EquipDropRate_LV1	Disarm I
+Item_Skill_AbyssGear_EquipDropRate_LV2	Disarm II
+Item_Skill_AbyssGear_EquipDropRate_LV3	Disarm III
+Item_Skill_AbyssGear_FireBreath_LV1	Volcanic Eruption
+Item_Skill_AbyssGear_FlashCombo_LV1	Slashing Reeds
+Item_Skill_AbyssGear_FoodSkillLevelUp_LV1	Gourmet I
+Item_Skill_AbyssGear_FoodSkillLevelUp_LV2	Gourmet II
+Item_Skill_AbyssGear_FoodSkillLevelUp_LV3	Gourmet III
+Item_Skill_AbyssGear_Forgotten_General	Judgment of the Soul
+Item_Skill_AbyssGear_FrostBreath_LV1	Frost Hail
+Item_Skill_AbyssGear_FrostDeath_LV1	Shattering Frost
+Item_Skill_AbyssGear_FrostSpike_LV1	Frost Spike
+Item_Skill_AbyssGear_Hyena_PoisonImmune	Heart of the Serpent
+Item_Skill_AbyssGear_Immune_Bismuth	Heart of Stone
+Item_Skill_AbyssGear_ImpBoss	Howling of Chaos
+Item_Skill_AbyssGear_Karanda	Pillar of Wind
+Item_Skill_AbyssGear_LandMash_LV1	Groundsurge
+Item_Skill_AbyssGear_LanFord	Parting Gift
+Item_Skill_AbyssGear_Leebur	Shadow Claw
+Item_Skill_AbyssGear_LightningBreath_LV1	Orbs of Lightning
+Item_Skill_AbyssGear_LightningStab_LV1	Storm Fang
+Item_Skill_AbyssGear_Machine_AdditionalDamage_LV1	Steelbane I
+Item_Skill_AbyssGear_Machine_AdditionalDamage_LV2	Steelbane II
+Item_Skill_AbyssGear_Machine_AdditionalDamage_LV3	Steelbane III
+Item_Skill_AbyssGear_Machine_AdditionalDamage_Special	Greater Steelbane
+Item_Skill_AbyssGear_Merrick	Order from Above
+Item_Skill_AbyssGear_Muscan	The Showstopper
+Item_Skill_AbyssGear_Ogre	Colossal Might
+Item_Skill_AbyssGear_PhantomStab_LV1	Abyssal Rays
+Item_Skill_AbyssGear_Praevus	Ancient Wrath
+Item_Skill_AbyssGear_Primus	Ancient Reckoning
+Item_Skill_AbyssGear_Priscus	Ancient Retribution
+Item_Skill_AbyssGear_QueenSpider	Queen's Fangs
+Item_Skill_AbyssGear_ReduceCraftMaterial_LV1	Efficiency I
+Item_Skill_AbyssGear_ReduceCraftMaterial_LV2	Efficiency II
+Item_Skill_AbyssGear_ReduceCraftMaterial_LV3	Efficiency III
+Item_Skill_AbyssGear_Skevald	Putrid Touch
+Item_Skill_AbyssGear_SkillPointExp_LV1	Aptitude I
+Item_Skill_AbyssGear_SkillPointExp_LV2	Aptitude II
+Item_Skill_AbyssGear_SkillPointExp_LV3	Aptitude III
+Item_Skill_AbyssGear_SmashStorm_LV1	Tempest of Destruction
+Item_Skill_AbyssGear_SoulStrike_LV1	Spirit's Judgment
+Item_Skill_AbyssGear_SwordAura_LV1	Wind Slash
+Item_Skill_AbyssGear_TarandusWarrior_WarHammer	Earthrending Strike
+Item_Skill_AbyssGear_Titan	Lightning God's Affliction
+Item_Sleepy_Orange	Sleepy Scarlet Butterfly
+Item_Snail	Snail
+Item_Snow_Chipmunk	Snowfield Chipmunk
+Item_Snowy_Plover	Kentish Plover
+Item_Sparrow	Sparrow
+Item_Spicebush_Swallowtail	Spicebush Swallowtail Butterfly
+Item_Squirrel	Chipmunk
+Item_Stag_Beetle	Stag Beetle
+Item_Stat_AbyssGear_ADR_LV1	Aegis I
+Item_Stat_AbyssGear_ADR_LV2	Aegis II
+Item_Stat_AbyssGear_ADR_LV3	Aegis III
+Item_Stat_AbyssGear_AttackSpeedRate_LV1	Swift I
+Item_Stat_AbyssGear_AttackSpeedRate_LV2	Swift II
+Item_Stat_AbyssGear_AttackSpeedRate_LV3	Swift III
+Item_Stat_AbyssGear_AttackSpeedRate_Special	Greater Swift
+Item_Stat_AbyssGear_ClimbSpeedRate_LV1	Ascent I
+Item_Stat_AbyssGear_ClimbSpeedRate_LV2	Ascent II
+Item_Stat_AbyssGear_ClimbSpeedRate_LV3	Ascent III
+Item_Stat_AbyssGear_CriticalRate_LV1	Insight I
+Item_Stat_AbyssGear_CriticalRate_LV2	Insight II
+Item_Stat_AbyssGear_CriticalRate_LV3	Insight III
+Item_Stat_AbyssGear_CriticalRate_Special	Greater Insight
+Item_Stat_AbyssGear_DDD_LV1	Destruction I
+Item_Stat_AbyssGear_DDD_LV2	Destruction II
+Item_Stat_AbyssGear_DDD_LV3	Destruction III
+Item_Stat_AbyssGear_DDD_Special	Greater Destruction
+Item_Stat_AbyssGear_DPV_LV1	Fortification I
+Item_Stat_AbyssGear_DPV_LV2	Fortification II
+Item_Stat_AbyssGear_DPV_LV3	Fortification III
+Item_Stat_AbyssGear_ElectricityResistance_LV1	Shockward I
+Item_Stat_AbyssGear_ElectricityResistance_LV2	Shockward II
+Item_Stat_AbyssGear_ElectricityResistance_LV3	Shockward III
+Item_Stat_AbyssGear_ElectricityResistance_Special	Greater Shockward
+Item_Stat_AbyssGear_FireResistance_LV1	Flameward I
+Item_Stat_AbyssGear_FireResistance_LV2	Flameward II
+Item_Stat_AbyssGear_FireResistance_LV3	Flameward III
+Item_Stat_AbyssGear_FireResistance_Special	Greater Flameward
+Item_Stat_AbyssGear_GuardPVRate_LV1	Fortitude I
+Item_Stat_AbyssGear_GuardPVRate_LV2	Fortitude II
+Item_Stat_AbyssGear_GuardPVRate_LV3	Fortitude III
+Item_Stat_AbyssGear_HpRegen_LV1	Vitality I
+Item_Stat_AbyssGear_HpRegen_LV2	Vitality II
+Item_Stat_AbyssGear_HpRegen_LV3	Vitality III
+Item_Stat_AbyssGear_IceResistance_LV1	Frostward I
+Item_Stat_AbyssGear_IceResistance_LV2	Frostward II
+Item_Stat_AbyssGear_IceResistance_LV3	Frostward III
+Item_Stat_AbyssGear_IceResistance_Special	Greater Frostward
+Item_Stat_AbyssGear_MoveSpeedRate_LV1	Haste I
+Item_Stat_AbyssGear_MoveSpeedRate_LV2	Haste II
+Item_Stat_AbyssGear_MoveSpeedRate_LV3	Haste III
+Item_Stat_AbyssGear_MpRegen_LV1	Composure I
+Item_Stat_AbyssGear_MpRegen_LV2	Composure II
+Item_Stat_AbyssGear_MpRegen_LV3	Composure III
+Item_Stat_AbyssGear_StaminaRegen_LV1	Vigor I
+Item_Stat_AbyssGear_StaminaRegen_LV2	Vigor II
+Item_Stat_AbyssGear_StaminaRegen_LV3	Vigor III
+Item_Stat_AbyssGear_SwimSpeedRate_LV1	Surge I
+Item_Stat_AbyssGear_SwimSpeedRate_LV2	Surge II
+Item_Stat_AbyssGear_SwimSpeedRate_LV3	Surge III
+Item_Theona_Checkerspot	Theona Checkerspot Butterfly
+Item_Tiger_Mimic_Queen	Tiger Mimic Queen Butterfly
+Item_Tomaso_Enchant_Coin	Tommaso Refinement Token
+Item_troll_academy_Core	Dimensional Fusion Experimental Power Core
+Item_Varnia_Enchant_Coin	Varnia Refinement Token
+Item_Viceroy	Commander Butterfly
+Item_WaterStrider	Water Strider
+Item_White_M_Hairstreak	White Streaked butterfly
+Item_White_Peacock	White Peacock Butterfly
+Item_WhiteWing_Flycatcher	White-winged Redstart
+Item_Wood_Pecker	Three-Toed Woodpecker
+Item_Zebra_Heliconian	Zebra Longwing Butterfly
+Item_Zebra_Swallowtail	Zebra Swallowtail
+ItemCatch_FishingRod	The Claw
+Ivano_Fabric_Armor	Bleed Cloth Armor
+Ivory	Ivory
+Iyratti_Fabric_Armor	Eyratt Cloth Armor
+Iytis_PlateArmor_Gloves	Ettis Plate Gloves
+Izumit_Fabric_Armor	Izumit Cloth Armor
+Jackal_Leather_Helm	Jackals' Leather Helm
+Jackal_Leather_Helm_II	Jackals' Leather Helm
+Jacktar_PlateArmor_Helm	Zachar Plate Helm
+Jacob_Fabric_Armor	Yakkov Cloth Armor
+Japchae	Pan-Fried Vegetables
+Japchae_Large	Satisfying Pan-Fried Vegetables
+Japchae_Medium	Filling Pan-Fried Vegetables
+Japchae_XLarge	Hearty Pan-Fried Vegetables
+Jemel_OneHandPistol	Jemel Pistol
+Jeonju_Bibimbap	Mixed Harvest Bowl
+Jeonju_Bibimbap_Large	Satisfying Mixed Harvest Bowl
+Jeonju_Bibimbap_Medium	Filling Mixed Harvest Bowl
+Jeonju_Bibimbap_XLarge	Hearty Mixed Harvest Bowl
+Jerky	Fine Jerky
+Jerky_Pieces	Jerky
+Jermill_Fabric_Helm	Jermill Cloth Headband
+Jerrphin_TwoHandSpear	Valgash's Incomplete Work
+Jevanars_Leather_Armor	Jevanars Leather Armor
+JijeongTempleShipLog_Book	Voyage Log to Jijeong Temple
+Johannes_PlateArmor_Armor	Johannes Plate Armor
+Johnnycolo_Leather_Armor	Janiklo Leather Armor
+Johnnycolo_Leather_Gloves	Janiklo Leather Gloves
+Joseph_PlateArmor_Armor	Yosef Plate Armor
+Juden_Fabric_Armor	Juden Cloth Armor
+Judge_Plate_Boots	Inquisitor's Plate Boots
+Judge_PlateArmor_Armor	Inquisitor's Plate Armor
+Judge_PlateArmor_Gloves	Inquisitor's Plate Gloves
+Judge_TwoHandSpear	Alfonso Spear
+Juman_Leather_Boots	Juman Leather Boots
+JumpUp_Boots	Kuku Breeze-Step Boots
+Kadel_Leather_Gloves	Rheigis Leather Gloves
+Kadel_OneHandMace	Kadel Mace
+Kahbokahn_Fabric_Armor	Kavokin Cloth Armor
+Kahbotune_Fabric_Armor	Kabotun Cloth Armor
+Kahdet_PlateArmor_Helm	Cadet Plate Helm
+Kahsunan_Fabric_Armor	Kasunan Cloth Armor
+Kahtrahah_Fabric_Armor	Kaetra Cloth Armor
+Kahturaon_Fabric_Armor	Qaturan Cloth Armor
+Kaiko_Leather_Boots	Caico Leather Boots
+Kailok_Fabric_Armor	Kailok's Cloth Armor
+Kairu_Leather_Boots	Caelough Leather Boots
+Kaisan_Leather_Armor	Kaisan Leather Armor
+Kajet_Leather_Boots	Kasset Leather Boots
+Kakuta_PlateArmor_Armor	Kakuta Plate Armor
+Kali_TwoHandedWarHammer	Zargan Warhammer
+Kalrari_ChainMail_Armor	Kallari Chain Mail
+Kamperdian_TwoHandSpear	Warspike Spear
+Kamsen_Leather_Gloves	Camsen Leather Gloves
+Kamsen_PlateArmor_Gloves	Camsen Plate Gloves
+Kamsen_TwoHandAlebard	Alabaster Halberd
+Kang_Fabric_Armor	Kang Cloth Armor
+Kantana_PlateArmor_Armor	Kantana Plate Armor
+Kantuna_PlateArmor_Armor	Kantona Plate Armor
+Karacorum_Leather_Gloves	Cacoreum Leather Gloves
+Karacorum_Leather_Gloves_I	Cacoreum Leather Gloves
+Karanda_Necklace	Karanda's Necklace
+Karas_Fabric_Helm	Karas Cloth Headband
+Kark_ChainMail_Armor	Kark Chain Mail
+Karnitta_Fabric_Armor	Killua Cloth Armor
+Kasria_Leather_Gloves	Kasria Leather Gloves
+Katerm_Leather_Armor	Katerm Leather Armor
+Katian_Leather_Boots	Katian Leather Boots
+Katitz_Leather_Boots	Katitz Leather Boots
+Kattinan_Fabric_Armor	Kattinan Cloth Armor
+Kattinan_Leather_Gloves	Kattinan Leather Gloves
+Katunan_ChainMail_Armor_I	Katunan Chain Mail
+Katz_Leather_Boots	Katz Leather Boots
+Kauria_ChainMail_Armor	Kauria Chain Mail
+Kayson_PlateArmor_Helm	Demenissian Guard's Plate Helm
+Kayson_PlateArmor_Helm_I	Inquisitor's Plate Helm
+Kayson_PlateArmor_Helm_II	Caysonne Plate Helm
+Kebail_PlateArmor_Gloves	Kevile Plate Gloves
+Kedenly_Leather_Armor	Kednry Leather Armor
+Kenav_Fabric_Armor	Kennav Cloth Armor
+Kenav_Fabric_Helm	Kennav Cloth Headband
+Kenmore_PlateArmor_Armor	Kenmore Plate Armor
+Kenmore_PlateArmor_Armor_I	Kenmore Plate Armor
+Keoller_Fabric_Armor	Keller Cloth Armor
+Kephilray_TwoHandSpear	Sydmon Spear
+Kerburn_Leather_Armor	Kerburn Leather Armor
+Kerdmann_Fabric_Boots	Kerdmann Cloth Boots
+Keredig_Leather_Boots	Keredig Leather Boots
+Keredig_PlateArmor_Gloves	Canta Plate Gloves
+Keredig_PlateArmor_Helm	Bolton Plate Helm
+Ketlan_ChainMail_Armor	Ketlan Chain Mail
+Khadiac_TwoHandAxe	Troll Hook Greataxe
+Khadiac_TwoHandSpear	Kylus Spear
+Khadion_TwoHandAlebard	Gilliam Halberd
+Khadion_TwoHandedWarHammer	Arlen Warhammer
+Khadion_TwoHandSword	Iris Longsword
+Khalbydan_Fabric_Armor	Khalbdan Cloth Armor
+Khalbydan_Leather_Gloves	Khalbdan Leather Gloves
+Khanoa_OneHandBow	Sydmon Bow
+Kiahtuth_PlateArmor_Helm	Kiatus Plate Helm
+Kiehrius_TwoHandAlebard	Bonepit Halberd
+Kiehrius_TwoHandSword	Thalwynd Longsword
+Kililli_ChainMail_Armor	Killi Chain Mail
+Killeen_PlateArmor_Armor	Killian Plate Armor
+Killeen_PlateArmor_Armor_I	Killian Plate Armor
+Kimbap	Battered Harvest Roll
+Kimbap_Large	Satisfying Battered Harvest Roll
+Kimbap_Medium	Filling Battered Harvest Roll
+Kimbap_XLarge	Hearty Battered Harvest Roll
+king_LostPeople_PlateArmor_Armor	Frostcursed Plate Armor
+king_LostPeople_PlateArmor_Armor_Upgrade	Kuku Ice-Resistant Armor
+king_LostPeople_PlateArmor_Cloak	Frostcursed Plate Cloak
+Kinloch_PlateArmor_Armor	Kinloch Plate Armor
+Kinloch_PlateArmor_Armor_I	Kinloch Plate Armor
+Kinov_Fabric_Armor	Keanoff Cloth Armor
+Kinross_PlateArmor_Armor	Kinross Plate Armor
+Kinross_PlateArmor_Armor_I	Kinross Plate Armor
+Kintun_ChainMail_Armor	Mortain Chain Mail
+Kite_Metal_OneHandShield	Shield of a Blossoming Spring Day
+Kitee_OneHandShield	Kite Shield
+Kliff_Earring	Greymane's Earring
+Kliff_Glasses	Master Du's Circlet
+Kliff_Mask	Mask
+Kliff_OneHandShotgun	Pailunese Shotgun
+Kliff_Plate_Boots	Kairos Plate Boots
+Kliff_PlateArmor_Armor	Kairos Plate Armor
+Kliff_PlateArmor_Cloak	Kairos Cloak
+Kliff_PlateArmor_Gloves	Kairos Plate Gloves
+Kliff_PlateArmor_Helm	Kairos Plate Helm
+Knight_King_OneHandSword	Knightlord's Sword
+Knowledge_PlateArmor_Helm	Helm of Knowledge
+Konkhar_Fabric_Armor	Concarr Cloth Armor
+Kordaav_Leather_Armor	Kordaav Leather Armor
+Kordaav_Leather_Gloves	Kordaav Leather Gloves
+Kordaav_OneHandMace	Kordaav Mace
+Korean_PlateArmor_Armor	Corinne Plate Armor
+Kramer_TwoHandHammer	Helms Greathammer
+Kriella_Fabric_Armor	Kriella Cloth Armor
+Kriella_Fabric_Gloves	Kriella Cloth Gloves
+Kritha_HorseArmor_Armor	Calphadean Barding
+Kritha_HorseArmor_Helm	Exclaire Champron
+Kritha_HorseArmor_Saddle	Exclaire Saddle
+Kritha_HorseArmor_Stirrup	Calphadean Stirrups
+Ktan_Fabric_Armor	Kithan Cloth Armor
+Ktian_Fabric_Armor	Ketian Cloth Armor
+Kudzu_seed	Skyroot Seed
+Kukan_PlateArmor_Armor	Coogan Plate Armor
+Kukan_PlateArmor_Armor_I	Blacksteel Coogan Plate Armor
+KuKu_Bismuth_TwoHandSpear	Kuku Bismuth Spear
+Kuku_Drone_Backpack	Kuku Watcher Pack
+Kuku_EMP_Enhance_BackPack	Kuku Enhanced Disruptor
+KuKu_EMP_TwoHandSpear	Kuku Disruptor Spear
+KuKu_Fire_staff_spear_TwoHandSpear	Kuku Flame Spear
+Kuku_FlameThrower	Kuku Flamespitter
+KuKu_Golden999K	Kuku Transmission 999K Pack
+Kuku_IceThrower	Kuku Frostspitter
+KuKu_Lightning_TwoHandSpear	Kuku Lightning Spear
+Kuku_LightningThrower	Kuku Boltspitter
+Kuku_Pot_BackPack	Kuku Pack
+KuKu_Pot_TwoHandSpear	Kuku Spear
+KuKu_Wind_TwoHandSpear	Kuku Propeller Spear
+Kuku_YamatoCannon_TwoHandSpear	Kuku Laser Cannon Spear
+Kunan_PlateArmor_Armor	Kunan Plate Armor
+Kunan_PlateArmor_Armor_I	Kunan Plate Armor
+Kurinan_PlateArmor_Armor	Gurrinan Plate Armor
+Kurinan_PlateArmor_Armor_I	Condemner's Plate Armor
+Kurinan_PlateArmor_Cloak_I	Condemner's Plate Cloak
+Kurua_Leather_Boots	Kurua Leather Boots
+Kurua_PlateArmor_Helm	Kurua Plate Helm
+Kydalern_TwoHandSpear	Spear of Righteousness
+Kylidden_Leather_Gloves	Kaeridyn Leather Gloves
+Kylidden_TwoHandSpear	Alabaster Spear
+Labonion_ChainMail_Armor	Lavgnion Chain Mail
+Lacata_PlateArmor_Armor	Lacata Plate Armor
+Lachian_PlateArmor_Armor	Lachian Plate Armor
+Lacklean_Fabric_Gloves	Grey Wolf Cloth Gloves
+Lacquer_Leather_Gloves	Larkri Leather Gloves
+Lacquer_PlateArmor_Armor	Larkri Plate Armor
+Lacrunias_Leather_Helm	Lacrunias Leather Helm
+Lacsha_PlateArmor_Helm	Sahazhad Plate Helm
+Lacusane_PlateArmor_Armor	Lacusane Plate Armor
+Ladete_Leather_Gloves	Layddete Leather Gloves
+Ladete_Plate_Boots	Icewing Plate Boots
+Ladis_Fabric_Helm	Raditz Cloth Cap
+Ladran_Fabric_Armor	Ladran Cloth Armor
+Laehbern_PlateArmor_Helm	Laehbern Plate Helm
+Lafty_Leather_Gloves	Leffri's Leather Gloves
+Lafty_Leather_Gloves_I	Leffri's Leather Gloves
+Lain_Leather_Boots	Layne Leather Boots
+Laitaa_Leather_Boots	Layta Leather Boots
+Laitaa_Plate_Boots	Layta Plate Boots
+LakeGolem_OnehandShield	Runewalker Shield
+Laksh_Leather_Armor	Lakshi Leather Armor
+Laksh_Leather_Boots	Lakshi Leather Shoes
+Lance_OneHandLance	Lance OneHandLance
+Langphash_Fabric_Armor	Ranphas Cloth Armor
+Langtois_Fabric_Armor	Rangtua Cloth Armor
+Langust_Leather_Boots	Ashen Wolf's Leather Boots
+Lankaz_Fabric_Armor	Lancats Cloth Armor
+Lanok_PlateArmor_Armor	Lanauk Plate Armor
+Lanok_PlateArmor_Armor_I	Lanauk Plate Armor
+Lanpheldt_OneHandAxe	Lambert Axe
+Lantern	Lantern
+Laonkel_Leather_Boots	Lankel Leather Boots
+Laplian_Fabric_Helm	Laplian Cloth Cap
+Laplus_Leather_Armor	Laplace Leather Armor
+Laplus_Leather_Gloves	Laplace Leather Gloves
+Laputi_Leather_Boots	Lapprette Leather Boots
+Lardein_Fabric_Helm	Radein Cloth Cap
+Large_Bone	Large Bone
+Lariano_Fabric_Armor	Lariano Cloth Armor
+Lark_PlateArmor_Armor	Larc Plate Armor
+Larkarz_Fabric_Armor	Lacas Cloth Armor
+Larkritt_Fabric_Helm	Larkett Cloth Cap
+Larksia_PlateArmor_Helm	Renkshaw Plate Helm
+Larksia_PlateArmor_Helm_I	Blacksteel Renkshaw Plate Helm
+Larksis_PlateArmor_Helm	Langris Plate Helm
+Larsahn_Fabric_Helm	Larsan Cloth Headband
+Larsiras_Fabric_Helm	Lashiras Cowl
+Larstti_PlateArmor_Helm	Larstrom Plate Helm
+Lascaux_Leather_Boots	Lascaux Leather Boots
+LasentaKum_Leather_Gloves	Renshaku Leather Gloves
+Lashir_Fabric_Helm	Lashir Cloth Cap
+Lasian_Leather_Boots	Lasian Leather Boots
+Laspine_Leather_Armor	Raspin Leather Armor
+Latenta_PlateArmor_Helm	Laterna Plate Helm
+Lathia_Fabric_Armor	Lathia Cloth Armor
+Latian_Leather_Gloves	Latian Leather Gloves
+Latir_Leather_Boots	Latear Leather Boots
+Latrion_ChainMail_Armor	Latrion Chain Mail
+Lattua_Plate_Boots	Lattua Plate Boots
+Lattua_Plate_Boots_I	Blacksteel Lattua Plate Boots
+Laucatti_Fabric_Armor	Larcotti Cloth Armor
+Lauqus_PlateArmor_Helm	Lauques Plate Helm
+Lautar_Fabric_Armor	Lauta Cloth Armor
+Lautia_PlateArmor_Helm	Lautia Plate Helm
+Lave_Leather_Gloves	Lave Leather Gloves
+Lavender	Lavender
+Lavender_blue	Blue Lavender
+Lavender_white	White Lavender
+Lavender_yellow	Yellow Lavender
+Laviren_Fabric_Armor	Ravirun Cloth Armor
+Laviren_Fabric_Armor_1	Bandit Cloth Armor
+Laviren_Fabric_Cloak_I	Bandit Cloth Cloak
+Laviren_Fabric_Helm	Ravirun Cloth Helm
+Laviren_Leather_Armor	Ravirun Leather Armor
+Lavrak_Fabric_Helm	Labrak Cloth Cap
+Lawncheta_Leather_Gloves	Lawson Leather Gloves
+Leadahn_Leather_Helm	Ledan Leather Helm
+Leather	Thin Hide
+Leather_Merchant_BackPack_I	Tanner's Pack
+Leather_Merchant_BackPack_II	Tanner's Pack
+Leather_Merchant_BackPack_III	Tanner's Pack
+Lebideuo_Leather_Boots	Levinto Leather Boots
+Lecruon_Leather_Gloves	Reclonne Leather Gloves
+Ledcy_Leather_Helm	Arkhan Leather Helm
+Leeksha_ChainMail_Armor	Riksha Chain Mail
+Leeksi_Fabric_Helm	Ricksley Cloth Cap
+Leeksia_OneHandSword	Dekarr Sword
+Legend_Black_Lion_Report	Sighting of the Black Lion
+Legend_Coelacanth_Report	Sighting of the Coelacanth
+Legend_Giant_Bull_Report	Giant White Bison Sighting
+Legend_Golden_Coelacanth_Report	Sighting of the Golden Coelacanth
+Legend_GoldenCarp_Report	Sighting of the Golden Carp
+Legend_GoldenTench_Report	Golden Tench Sighting
+Legend_LeeburtheShadowWolf_Report	Sighting of the Black Fang
+Legend_Phoenix_Wild_Report	Sighting of the Phoenix
+Legend_PureWhite_Bion_Report	Sighting of the White Bison
+Legend_PureWhite_Deer_Report	Sighting of the Snowwhite Deer
+Legend_Redriver_hog_Report	Sighting of the Red River Hog
+Legend_SilverFangs_Report	Sighting of the Silver Fang
+Legend_Vined_Deer_Report	Sighting of the Vine Deer
+Legend_White_Bear_Wild_Report	Sighting of the White Bear
+Legend_White_Crocodile_Report	Sighting of the White-Scaled Crocodile
+Legend_White_Lion_Report	Sighting of the White Lion
+Legend_White_Moose_Report	Sighting of the White Moose
+Legend_White_Stag_Report	Sighting of the White Elk
+Legendary_Abyss_OneHandCannon	Sior Blaster
+Legendary_AncientGuardian_TwoHandAxe	Earthsplitter
+Legendary_Animal_Giant_Bull	White King's Candlestick
+Legendary_Animal_Phoenix	Nightmare Burner
+Legendary_Animal_PureWhite_Bion	Lamp of Crossed Dreams
+Legendary_Animal_PureWhite_Deer	Throne of the White Night
+Legendary_Animal_Redriver_hog	Chalice of Devouring
+Legendary_Animal_Vined_Deer	Aged Branch
+Legendary_Animal_White_Moose	Beckoning Forest
+Legendary_Animal_White_Stag	The Beholder
+Legendary_Antumbra_TwoHandedWarHammer	Antumbra's Eye
+Legendary_Antumbra_TwoHandGiantBastard	Darkbringer
+Legendary_BridieGu_TwoHandGiantAxe	Wheel of the Last Toll
+Legendary_Caliburn_OneHandRapier	Royal Oath
+Legendary_CaptainGoblin_OneHandAxe	Double-Headed Axe of Greed
+Legendary_CrimsonScorpion_TwoHandHammer	Rune-Engraved Rock
+Legendary_Deer_Leather_Gloves	Counterweight Leather Gloves
+Legendary_Deer_Leather_Gloves_T4_QA	Legendary Deer Leather Gloves T4 QA
+Legendary_DemenisMusket_OneHandMusket	Demenissian Hero's Musket
+Legendary_Dragon_OneHandSword	Aeserion Sword
+Legendary_Dragon_TwoHandGiantSpear	Aeserion Spear
+Legendary_DragonSlayer_OneHandSword	Nazk Sword
+Legendary_GoldStar_OneHandCannon	Golden Fire
+Legendary_HexeMarie_Earring	Earring of Dark Magic
+Legendary_Kings_OneHandDagger	King's Dagger
+Legendary_Korea_OneHandBow	Noble Man's Bow
+Legendary_Marni_OneHandCannon	Blaster No. 8
+Legendary_MarniDragon_OneHandCannon	Mechanical Clockwork Blaster
+Legendary_MarniGolem_Plate_Armor	Frozen Heart Plate Armor
+Legendary_MarniGolem_Plate_Boots	Frozen Heart Plate Boots
+Legendary_MarniGolem_Plate_Cloak	Frozen Heart Plate Cloak
+Legendary_MarniRegion_OneHandMace	Marni Devotee's Mace
+Legendary_MarniTank_OneHandCannon	Marni Tank Blaster
+Legendary_MarniTank_OneHandShield	Delesyian Ornamental Shield
+Legendary_Moonhead_01_TwoHandGiantSpear	Diverging Moon
+Legendary_Moonhead_02_TwoHandGiantSpear	Circling Moon
+Legendary_Moonhead_TwoHandGiantSpear	Grasping Moon
+Legendary_Ogre_Ring	Ogre's Ring
+Legendary_Orc_Plate_Glove	Frozen Heart Plate Gloves
+Legendary_OwenCraber_TwoHandGiantSpear	Frostfang
+Legendary_Shakatu_OneHandDagger	Goblin King's Treasure Dagger
+Legendary_SkullKnight_OneHandShield	Balgran Shield
+Legendary_Solid_Bringer_TwoHandedWarHamme	Sanguine Knell
+Legendary_Soulknight_OneHandTowerShield	Shield of Sacrifice
+Legendary_StephenBleed_OneHandMace	Mace of Resolve
+Legendary_Tarandus_TwoHandedWarHamme	Ashen Execution
+Legendary_Titan_Ring	Ring of Lightning
+Legendary_WhiteHorn_OneHandSword	Chillfallen Sword
+Legendary_WhiteWolf_Leather_Helm	Silver Fang Helm
+Leinstead_OneHandSword	Glenmore Sword
+Lekia_Leather_Boots	Regglia Leather Boots
+Lekia_Plate_Boots	Unyielding Warrior's Plate Boots
+Lekia_PlateArmor_Helm	Rekhia Plate Helm
+Lentils	Lentils
+Leone_OneHandRapier	Leonne Rapier
+Leontain_Leather_Boots	Leontyne Leather Boots
+Leontain_PlateArmor_Helm	Leontyne Plate Helm
+Leopard_Pattern_Leather_Armor	Leopard Print Leather Armor
+Lepra_Leather_Boots	Lepra Leather Boots
+Lercent_Leather_Gloves	Lercent Leather Gloves
+Letter_Azureian_Secret	Countess Azerian's Secret Letter
+Letter_Elimores_Secret	Countess Azerian's Letter
+Letter_Go_To_ScolaStone	Alustin's Letter
+Letter_TraderLetter	Undelivered Trader's Letter
+Letter_Valgash	Valgash's Letter
+Letter_Visione_MotherLetter	Letter from a Mother
+Letter_Wolfmolar_Mountain_WifeLetter	A Wife's Letter
+Levibb_Fabric_Armor	Ruvib Cloth Armor
+Liberry_OneHandRapier	Liberre Rapier
+License_Operation_HernandBank	Personal Strongbox Permit
+Lickla_PlateArmor_Armor	Ricla Plate Armor
+Liculu_Leather_Gloves	Ricrau Leather Gloves
+Licuna_Leather_Boots	Leguna Leather Boots
+Light_Arrowhead_Fabric_Armor_I	Blinding Arrows Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_II	Blinding Arrows Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_III	Blinding Arrows Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_IV	Blinding Arrows Rider's Cloth Armor
+Light_Arrowhead_Fabric_Armor_V	Blinding Arrows Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_VI	Blinding Arrows Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_VII	Blinding Arrows Scout's Cloth Armor
+Light_Arrowhead_Fabric_Cloak_I	Blinding Arrow Cloth Cloak
+Light_Arrowhead_Fabric_Helm_V	Blinding Arrows' Cloth Cap
+Light_Arrowhead_Leader_OneHandBow	Tormented Soul Bow
+Light_Arrowhead_Leather_Armor_I	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Armor_II	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Armor_III	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Armor_IV	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Armor_IX	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Armor_V	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Armor_VI	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Armor_VII	Blinding Arrows Scout's Leather Armor
+Light_Arrowhead_Leather_Armor_VIII	Blinding Arrows Scout's Leather Armor
+Light_Arrowhead_Leather_Armor_X	Blinding Arrow's Leather Armor
+Light_Arrowhead_Leather_Boots_I	Blinding Arrow's Leather Boots
+Light_Arrowhead_Leather_Boots_II	Blinding Arrow's Leather Boots
+Light_Arrowhead_Leather_Gloves	Blinding Arrow's Leather Gloves
+Light_Of_Giant_Lantern	Shiny Blue Sea Lantern
+Light_Thorn_OneHandTowerShield	Rekel Large Spiked Shield
+Lightning_Arrow	Blitz Arrow
+Lightning_TwoHandSpear	Lightning Spear
+LightningThrower	Electromagnetic Boltspitter
+LightSaber_TwoHandSword	LightSaber TwoHandSword
+Ligtning_TwoHandHammer_I	Lightning Greathammer
+Likarz_Fabric_Armor	Rikkas Cloth Armor
+Likenin_Leather_Gloves	Lennigen Leather Gloves
+Likua_PlateArmor_Helm	Longia Plate Helm
+Likua_PlateArmor_Helm_I	Blacksteel Longia Plate Helm
+lilian_Leather_Boots	Lilian Leather Boots
+Limerhen_TwoHandSpear	Traitor's Spear
+Limerick_ChainMail_Armor	Lemerick Chain Mail
+Liornia_Fabric_Armor	Liorna Cloth Armor
+Lipsort_OneHandTowerShield	Lifsoth Large Shield
+Litra_Leather_Gloves	Leahdra Leather Gloves
+Livneh_Fabric_Armor	Livner Cloth Armor
+LoaderDam_Leather_Gloves	Loudan Leather Gloves
+Loccamashima_Leather_Armor	Locasima Leather Armor
+Lodi_ChainMail_Armor	Lodi Chain Mail
+Logger_BackPack_I	Woodcutter's Pack
+Logger_BackPack_II	Woodcutter's Pack
+Logger_BackPack_III	Woodcutter's Pack
+Logger_BackPack_IV	Woodcutter's Pack
+Londel_Leather_Boots	Scorchflame Leather Boots
+Londel_Leather_Gloves	Rondel Leather Gloves
+Londel_Leather_Helm	Rondel Leather Helm
+Londel_PlateArmor_Gloves	Scorchflame Plate Gloves
+Londel_PlateArmor_Helm	Scorchflame Plate Helm
+LongBeak_OneHandSword	Varnian Sword
+Lopelun_OneHandMusket	Bekker Musket
+LostLetter_Bartholomew	Priest Ordination Recommendation Letter
+LostLetter_Berdo	Letter to a Comrade
+LostLetter_Burk	Letter from Mom
+LostLetter_Castiel	Letter with Smudged Words
+LostLetter_Eirik	Sawdust-Stained Letter
+LostLetter_Food_Trader_1	Periodic Report
+LostLetter_Goorba	Unsealed Secret Letter
+LostLetter_Khadija	News for a Nephew
+LostLetter_Marin	Suspicious Letter
+LostLetter_Mineral_Trader_1	Letter to Croft
+LostLetter_Montpellier	Demeniss Orphanage Registration Form
+LostLetter_Provost_1	Scented Letter
+LostLetter_Provost_4	Scented Letter
+LostLetter_Roger	Letter with a Scorched Corner
+LostLetter_Skint	Crumpled Letter
+LostLetter_Slywick	Unknown Duke's Order
+LostLetter_Sniks	Letter with a Torn Corner
+Lotas_PlateArmor_Helm	Lotas Plate Helm
+Lotas_PlateArmor_Helm_I	Blacksteel Lotas Plate Helm
+Lotunsau_Leather_Armor	Rotunso Leather Armor
+Louis_Fabric_Armor	Louis Cloth Armor
+Lower_ChainMail_Armor	Lauer Chain Mail
+Lowuti_Leather_Boots	Loutte Leather Boots
+Lucan_OneHandTowerShield	Lucon Large Shield
+Lucion_ChainMail_Armor	Lucion Chain Mail
+Lucion_Fabric_Armor	Lucion Cloth Armor
+Lucky_Letter	Letter of Fortune
+Luconek_Fabric_Helm	Rueconec Cloth Cap
+Luconek_Leather_Boots	Rueconec Leather Boots
+Luconek_Leather_Gloves	Rueconec Leather Gloves
+Luconek_Leather_Helm	Rueconec Leather Helm
+Luconek_PlateArmor_Helm	Rueconec Plate Helm
+Luconek_PlateArmor_Helm_I	Demenissian Guard's Plate Helm
+Luconek_PlateArmor_Helm_II	Inquisitor's Plate Helm
+Ludus_PlateArmor_Armor	Ludus Plate Armor
+Ludvic_Leather_Armor	Hungering Fang Leather Armor
+Ludvic_Leather_Armor_II	Lonely Jackals' Leather Armor
+Ludvic_Leather_Boots	Hungering Fang Leather Boots
+Ludvic_Leather_Boots_T4_QA	Ludvic Leather Boots T4 QA
+Ludvic_Leather_Cloak	Hungering Fang Leather Cloak
+Ludvic_Leather_Gloves	Hungering Fang Leather Gloves
+Ludvic_Leather_Gloves_II	Jackals' Leather Gloves
+Ludvic_Necklace	Crossroads Necklace
+Ludvic_OneArmed_Leather_Armor	One-Armed Jackals' Leather Armor
+Ludvic_OneArmed_Leather_Cloak	One-Armed Jackal's Leather Cloak
+Ludvig_OneHandSword	Red Rage
+Ludynn_Fabric_Gloves	Ludynn Cloth Gloves
+Ludynn_Fabric_Helm	Ludynn Cloth Cap
+Ludynn_Leather_Armor	Ludynn Leather Armor
+Ludynn_Leather_Boots	Ludynn Leather Greaves
+Lueh_Fabric_Armor	Luwea Cloth Armor
+Luekushi_Fabric_Helm	Ruckshi Cloth Cap
+Luka_Leather_Gloves	Luca Leather Gloves
+Luka_PlateArmor_Armor	Luca Plate Armor
+Lukas_Leather_Gloves	Lukas' Leather Gloves
+Lukatz_PlateArmor_Armor	Lukatz Plate Armor
+Lukin_Leather_Armor	Lukin Leather Armor
+Luknaon_ChainMail_Armor	Lucnaon Chain Mail
+Luknian_ChainMail_Armor	Lucnian Chain Mail
+Luknian_PlateArmor_Helm	Canta Plate Helm
+Lukran_PlateArmor_Helm	Laccarsa Plate Helm
+Luksa_ChainMail_Armor	Leuksah Chain Mail
+Lunosier_Fabric_Armor	Pailunese Attire
+Lunosier_Fabric_Cloak	Pailunese Cloak
+Lunpherd_Leather_Armor	Lunpherd Leather Armor
+Lunther_PlateArmor_Gloves	Luthor Plate Gloves
+Luon_Plate_Boots	Luon Plate Boots
+Luon_PlateArmor_Armor	Luon Plate Armor
+Luon_PlateArmor_Cloak	Luon Plate Cloak
+Luon_PlateArmor_Gloves	Luon Plate Gloves
+Luon_PlateArmor_Helm	Luon Plate Helm
+Luon_TwoHandAlebard	Golden Vanguard
+Lusek_Giant_TwoHandGiantBastard	Lusec Greatsword
+Lutia_Leather_Boots	Lutia Leather Boots
+Lutinas_Leather_Helm	Lutinas Leather Helm
+Lutis_Leather_Boots	Pailunese Boots
+Lutis_PlateArmor_Gloves	Pailunese Gloves
+Lutzen_Leather_Armor	Lutzen Leather Armor
+Luverne_Leather_Armor	Luverne Leather Armor
+Luwaiet_PlateArmor_Armor	Ruwaite Plate Armor
+Luwaiet_PlateArmor_Armor_I	Demeniss Guard's Plate Armor
+Luwaiet_PlateArmor_Armor_II	Demeniss Guard's Plate Armor
+Luwaiet_PlateArmor_Armor_III	Demeniss Guard's Plate Armor
+Lyfellen_ChainMail_Armor	Northern Fighter's Chain Mail
+Lyfellen_ChainMail_Cloak	Northern Fighter's Chain Cloak
+Lyfellen_Leather_Gloves	Northern Fighter's Leather Gloves
+Lyfellen_OneHandMace	Frozen Soul
+Lyfellen_PlateArmor_Helm	Lyfellen Plate Helm
+Lyfellen_TwoHandAxe	Incomplete Masterpiece
+Mache_Leather_Gloves	Mache Leather Gloves
+Machnan_Fabric_Armor	Maknan Cloth Armor
+Machnynn_Fabric_Armor	Marknin Cloth Armor
+Machrah_Fabric_Armor	Marka Cloth Armor
+Machrahahn_Fabric_Armor	Makran Cloth Armor
+Madacus_PlateArmor_Helm	Bedure Plate Helm
+Maeve_Leather_Gloves	Maeve Leather Gloves
+Maeve_OneHandAxe	Maeve Axe
+Maeve_OneHandMace	Marching Baton
+MagicBullet	Magic Bullet
+MagicBullet_Dark_IceSpear	Dark Ice Spear Magic Bullet
+MagicBullet_DarkBall	Dark Magic Bullet
+MagicBullet_Electric	Lightning Magic Bullet
+MagicBullet_Fire	Fire Magic Bullet
+MagicBullet_Ice	Ice Magic Bullet
+MagicBullet_LightFist	Light Fist Magic Bullet
+MagicBullet_Snow	Snow Magic Bullet
+MagicBullet_Water	Water Magic Bullet
+Magnet_OneHandSword	Red Needle
+Maint_PlateArmor_Helm	Demeniss Ceremonial Plate Helm
+Maint_PlateArmor_Helm_I	Mentz Plate Helm
+Makan_PlateArmor_Armor	Ferman Plate Armor
+Makan_PlateArmor_Cloak	Ferman Plate Cloak
+Makutan_PlateArmor_Helm	Ator's Will Helm
+Makutan_PlateArmor_Helm_II	Troll Maccutan Plate Helm
+Manios_PlateArmor_Armor	Manios Plate Armor
+Mant_PlateArmor_Armor	Mant Plate Armor
+Marathion_Leather_Boots	Marrada Leather Boots
+Marcree_Fabric_Armor	Makri Cloth Armor
+Marcs_PlateArmor_Armor	Malacs Plate Armor
+Marctah_Fabric_Armor	Magta Cloth Armor
+Maredid_Leather_Boots	Maldrick Leather Boots
+Marigold	Marigold
+Mark_Fabric_Helm	Marc Cloth Headband
+Mark_Leather_Armor	Marc Leather Armor
+Mark_PlateArmor_Armor	Marc Plate Armor
+Markman_PlateArmor_Armor	Markman Plate Armor
+Markna_Leather_Gloves	Markna Leather Gloves
+Markris_Plate_Boots	Marcris Plate Boots
+Marni_ChainMail_Boots	Marni's Chain Boots
+Marni_ChainMail_Gloves	Marni's Chain Gloves
+Marni_Devotee_PlateArmor_Helm	Visione
+Marni_Devotee_PlateArmor_Helm_I	Bespoke Visione
+Marni_Devotee_PlateArmor_Helm_II	Guard Visione
+Marni_Devotee_PlateArmor_Helm_III	Military Visione
+Marni_Devotee_PlateArmor_Helm_IV	Prototype Visione
+Marni_Fabric_Armor	Marni's Cloth Armor
+marni_Flag_I	Small Marni Banner Pike
+marni_Flag_II	Medium Marni Banner Pike
+Marni_HorseArmor_Armor	Exclaire Barding
+Marni_HorseArmor_Helm	Wells Military Champron
+Marni_HorseArmor_Stirrup	Marni Stirrups
+Marni_Laser_Helm	Marni Laser Helm
+Marni_Laser_Helm_Upgrade	Kuku Marni Laser Helm
+Marni_MachineFish_Report	Sighting of the Clockwork Fish
+Marni_MachineKnight_TwoHandSpear	Electro-Mecha Spear
+Marni_MachineKnight_TwoHandSword	Electro-Mecha Longsword
+Marni_Special_CannonBall	Disruptor Cannonball
+MarniDragon_DemenissLetter	Caliburn's Orders
+MarniDragon_GoldenStar	Golden Star Blueprint
+MarniDragon_MarniRen	Careful Observation of H.A.L.L.
+MarniDragon_Visione	The Features of the Visione
+MarniMachineDrill	Marni Drill Component
+MarniMachineLaser	Marni Laser Component
+MarniTower_Key	Spire of Clockwork Key
+Marozzo_OneHandRapier	Elemore Rapier
+Marqueeluon_Fabric_Armor	Maquealon Cloth Armor
+Marthana_Leather_Armor	Matana Leather Armor
+MartialArts_Secret_Manual	Secret Book of Unknown Source
+Martin_Leather_Boots	Martin's Leather Boots
+Martindue_Fabric_Armor	Marindo Cloth Armor
+Martins_Leather_Boots	Matrinne Leather Boots
+Mask_Liberator_TwoHandedWarHammer	Oblivion of the Past
+Master_Key	Master Key
+MasterDoo_Scroll	Master Du's Message
+MastKey_Gloves	MastKey Gloves
+Masty_PlateArmor_Gloves	Masti Plate Gloves
+Mataka_Leather_Boots	Matahka Leather Boots
+Matar_Leather_Boots	Matar Leather Boots
+Matarion_PlateArmor_Helm	Matarion Plate Helm
+Matazu_Leather_Gloves	Martail Leather Gloves
+Matia_Leather_Boots	Matia Leather Boots
+Matiras_PlateArmor_Helm	Rhinoceros Plate Helm
+Matiras_PlateArmor_Helm_I	Beaked Plate Helm
+Matis_Leather_Boots	Matis Leather Greaves
+Matraon_Fabric_Armor	Metron Cloth Armor
+Mats_Leather_Gloves	Maters Leather Gloves
+Matthias_Leather_Gloves	Matthias' Leather Gloves
+Maturah_PlateArmor_Helm	Matarra Plate Helm
+Mauryth_Fabric_Armor	Mauryth Cloth Armor
+Mautey_PlateArmor_Helm	Mottie Plate Helm
+Mautey_PlateArmor_Helm_I	Blacksteel Mottie Plate Helm
+Mawin_Leather_Armor	Mavin Leather Armor
+Maydocs_Leather_Armor_I	Maydocs Leather Armor
+Maydocs_PlateArmor_Helm	Maydocs Plate Helm
+Mayon_PlateArmor_Armor	Mahon Plate Armor
+Meadows_Leather_Boots	Meadows Leather Boots
+Meat_BackPack	Hunter's Meat Pack
+Meat_Fish_Fruit_Sanjeok	Assorted Meat and Fish Skewers
+Meat_Fish_Fruit_Sanjeok_Large	Satisfying Assorted Meat and Fish Skewers
+Meat_Fish_Fruit_Sanjeok_Medium	Filling Assorted Meat and Fish Skewers
+Meat_Fish_Fruit_Sanjeok_XLarge	Hearty Assorted Meat and Fish Skewers
+Meat_Fish_Grain_Sanjeok	Grilled Meat Steak
+Meat_Fish_Grain_Sanjeok_Large	Satisfying Grilled Meat Steak
+Meat_Fish_Grain_Sanjeok_Medium	Filling Grilled Meat Steak
+Meat_Fish_Grain_Sanjeok_XLarge	Hearty Grilled Meat Steak
+Meat_Fish_Porridge	Meat and Fish Porridge
+Meat_Fish_Porridge_Large	Satisfying Meat and Fish Porridge
+Meat_Fish_Porridge_Medium	Filling Meat and Fish Porridge
+Meat_Fish_Porridge_XLarge	Hearty Meat and Fish Porridge
+Meat_Fish_Sanjeok	Meat and Fish Skewers
+Meat_Fish_Sanjeok_Large	Satisfying Meat and Fish Skewers
+Meat_Fish_Sanjeok_Medium	Filling Meat and Fish Skewers
+Meat_Fish_Sanjeok_XLarge	Hearty Meat and Fish Skewers
+Meat_Fish_Vegetable_Egg	Meatball Soup
+Meat_Fish_Vegetable_Egg_Large	Satisfying Meatball Soup
+Meat_Fish_Vegetable_Egg_Medium	Filling Meatball Soup
+Meat_Fish_Vegetable_Egg_XLarge	Hearty Meatball Soup
+Meat_Fruit_Porridge	Pan-Fried Marinated Meat
+Meat_Fruit_Porridge_Large	Satisfying Pan-Fried Marinated Meat
+Meat_Fruit_Porridge_Medium	Filling Pan-Fried Marinated Meat
+Meat_Fruit_Porridge_XLarge	Hearty Pan-Fried Marinated Meat
+Meat_I	Lean Meat
+Meat_II	Fine Meat
+Meat_III	Tender Meat
+Meat_IV	Marbled Meat
+Meat_Porridge	Clear Soup
+Meat_Porridge_Large	Satisfying Clear Soup
+Meat_Porridge_Medium	Filling Clear Soup
+Meat_Porridge_XLarge	Hearty Clear Soup
+Meat_Sanjeok	Meat Skewers
+Meat_Sanjeok_Large	Satisfying Meat Skewers
+Meat_Sanjeok_Medium	Filling Meat Skewers
+Meat_Sanjeok_XLarge	Hearty Meat Skewers
+Meat_Vegetable_Porridge	Meat and Vegetable Porridge
+Meat_Vegetable_Porridge_Large	Satisfying Meat and Vegetable Porridge
+Meat_Vegetable_Porridge_Medium	Filling Meat and Vegetable Porridge
+Meat_Vegetable_Porridge_XLarge	Hearty Meat and Vegetable Porridge
+Mechlin_Leather_Gloves	Mechlin Leather Gloves
+Medikit_BackPack_I	Healer's Pack
+Medikit_BackPack_II	Healer's Pack
+Medikit_BackPack_III	Healer's Pack
+Medikit_BackPack_IV	Healer's Pack
+Medikit_BackPack_V	Healer's Pack
+Medikit_BackPack_VI	Healer's Pack
+Medikit_BackPack_VII	Healer's Pack
+Medikit_BackPack_VIII	Healer's Pack
+Mediratu_Leather_Gloves	Merridew Leather Gloves
+Melina_Fabric_Armor	Melina Cloth Armor
+Melvin_Leather_Gloves	Melvin Leather Gloves
+Melvin_Leather_Helm	Melvin Leather Helm
+Memo_ButlerLeftMemo	A Butler's Note
+Memo_CabinLeftMemo	Note in the Cabin
+Memo_Judgment	Warning of Judgment
+Memo_lightningstriketree	Lightning-struck Tree
+Memo_Proceedings	Supply Delivery Log
+Memo_RuinedChapel	Mysterious Note
+Memo_SebastianMemo	Mapmaker's Note
+Memo_Serkis_Clue_1	Clue from Oakenshield Manor
+Memo_Serkis_Clue_2	Clue from Lioncrest Watchtower
+Memo_Serkis_Clue_3	Clue from Duskwood
+Memo_Serkis_Clue_4	Clue from St. Halssius
+Memo_Serkis_Clue_5	Clue from Fort Anvil
+Memo_Serkis_FalseEvidence_1	The Thief's First Note
+Memo_Serkis_FalseEvidence_2	The Thief's Second Note
+Memo_Serkis_FalseEvidence_3	The Thief's Third Note
+Memo_Serkis_Piece_1	Piece from Oakenshield Manor
+Memo_Serkis_Piece_2	Piece from Lioncrest Watchtower
+Memo_Serkis_Piece_3	Piece from Duskwood
+Memo_Serkis_Piece_4	Piece from St. Halssius
+Meravan_Fabric_Armor	Meravan Cloth Armor
+Meravan_Fabric_Helm	Meravan Cloth Cap
+Meravan_Leather_Boots	Meravan Leather Boots
+Mercenary_Gloves	Grey Wolf Leather Gloves
+Mercenary_Leather_Armor	Grey Wolf Leather Armor
+Mercenary_Leather_Boots	Grey Wolf Leather Boots
+Mercenary_Leather_Cloak	Grey Wolf Leather Cloak
+Mercenary_OneHandShield	Freesword's Shield
+Mercenary_PlateArmor_Helm	Troll Gladiator's Plate Helm
+Mercenary_PlateArmor_Helm_I	Gladiator's Thorn Plate Helm
+Mercenary_PlateArmor_Helm_II	Gladiator's Rat Plate Helm
+Mercenary_PlateArmor_Helm_III	Gladiator's Rake Plate Helm
+Mercernary_OneHandBow	White Wood Bow
+Merchant_BackPack_I	Peddler's Pack
+Merchant_BackPack_II	Peddler's Pack
+Merchant_BackPack_III	Peddler's Pack
+Merly_Leather_Armor	Merly Leather Armor
+Mestio_OneHandBow	Bloodsteel Bow
+Metal_Gate_Key	Iron Gate Key
+Methilbalm_OneHandShotgun	Metilbahm Shotgun
+Method_Fabric_Armor	Meishod Cloth Armor
+MiddleBoss_Caliburn_BlackTower_PlateArmor_Armor	Caliburn's Captain Plate Armor
+MiddleBoss_GoldenArmor_TwoHandHammer_I	Golden Greathammer
+MiddleBoss_Pailoon_Ludvig_Leather_Gloves	Jackal Officer's Leather Gloves
+Midlier_Leather_Boots	Midlier Leather Boots
+Militia_Fabric_Cloak_I	Beighen Cloth Cloak
+Militia_Flag	Small Militia Banner Pike
+Milk	Milk
+Mine_BackPack_I	Quarrier's Pack
+Mine_BackPack_II	Quarrier's Pack
+Miner_PlateArmor_Helm	Miner's Lantern Hat
+Minigame_OneHandBow	Competition Wooden Bow
+Minigame_OneHandMusket	Competition Musket
+Minigame_OneHandShield	Competition Shield
+Minigame_OneHandSword	Competition Sword
+Minigame_TwoHandSpear	Competition Spear
+Mining_Drill	Mining Knuckledrill
+Mintuan_Fabric_Armor	Minnutan Cloth Armor
+Mjordin_Lantern	Flame Lantern
+Mjordin_OneHandSword	Melted Ambition
+Mocian_ChainMail_Armor	Moshane Chain Mail
+Mocke_Leather_Armor	Mocke Leather Armor
+Mohill_Leather_Armor	Mohill Leather Armor
+Molduer_Leather_Armor	Moldur Leather Armor
+MonasteryVisitorPass	St. Halssius Visitor Pass
+Mondian_Leather_Armor	Mondian Leather Armor
+Money_Camp_Food	Camp Food
+Money_Camp_Money	Camp Funds
+Money_Camp_Stone	Camp Stone
+Money_Camp_Weapon	Camp Weapons
+Money_Camp_Wood	Camp Timber
+Money_Copper	Silver
+Money_Kuku_MachineBug	Clockwork Insect
+Money_Pearl	Pearl
+Monita_OneHandTowerShield	Balton Large Shield
+Montellanico_Leather_Armor	Montlanico Leather Armor
+Monterima_Fabric_Armor	Monterima Cloth Armor
+Moonhead_Plate_Boots	Half Moon Reaper Plate Boots
+Moonhead_Plate_Boots_Full	Full Moon Reaper Plate Boots
+Moonhead_Plate_Boots_Waning	New Moon Reaper Plate Boots
+Moonhead_PlateArmor_Armor	Half Moon Reaper Plate Armor
+Moonhead_PlateArmor_Armor_Full	Full Moon Reaper Plate Armor
+Moonhead_PlateArmor_Armor_Waning	New Moon Reaper Plate Armor
+Moonhead_PlateArmor_Gloves	Lunar Reapers' Plate Gloves
+Moonhead_PlateArmor_Helm	Half Moon Reaper Plate Helm
+Moonhead_PlateArmor_Helm_Full	Full Moon Reaper Plate Helm
+Moonhead_PlateArmor_Helm_Waning	New Moon Reaper Plate Helm
+Morgren_Fabric_Armor	Morgren Cloth Armor
+Mornington_Fabric_Gloves	Mornington Cloth Gloves
+Mornington_Leather_Boots	Mornington Leather Boots
+Mortain_PlateArmor_Helm	Mortain Plate Helm
+Mortimer_OneHandShotgun	Mortimer Shotgun
+Muchia_Fabric_Armor	Muchia Cloth Armor
+Muchia_Fabric_Helm	Muchia Cloth Cap
+Muddlers_Fabric_Armor	Muddliss Cloth Armor
+Mueo_PlateArmor_Armor	Meyer Plate Armor
+Mueo_PlateArmor_Armor_I	Meyer Plate Armor
+Mueo_PlateArmor_Armor_II	Meyer Plate Armor
+Mueo_PlateArmor_Armor_III	Meyer Plate Armor
+Muglah_Fabric_Armor	Mugleah Cloth Armor
+Mulia_Leather_Boots	Mulia Leather Boots
+MultiArrow	Bundle of Arrows
+MultiArrow_Package_Small	Bundle of Arrows
+MultiBullet	Bundle of Bullets
+MultiBullet_Package_Small	Bundle of Bullets
+MultiCannonBall	Bundle of Cannonballs
+MultiCannonBall_Package_Small	Bundle of Cannonballs
+Munterd_Leather_Boots	Munndt Leather Boots
+Murard_Leather_Armor	Murad Leather Armor
+Muscan_Ghost_Fist	Muskan's Upper Body Clone
+Muscan_Ghost_Fist_I	Muskan's Lower Body Clone
+Muscan_PlateArmor_Armor	Muskan Armor
+Muscan_PlateArmor_Gloves	Combat God's Plate Gloves
+musket_Flag_I	Small Musket of Demeniss Banner Pike
+musket_Flag_II	Medium Musket of Demeniss Banner Pike
+Mynein_OneHandRapier	Gilliam Rapier
+Myrenenn_Fabric_Armor	Myrnen Cloth Armor
+Mysterm_Leather_Boots	Mistum Leather Boots
+Mysterm_Leather_Gloves	Mistum Leather Gloves
+Myurdin_Leather_Armor_II	Myurdin Leather Armor
+Myurdin_Leather_Boots	Myurdin's Leather Boots
+NahabVillage_Pendant	Nahab Pendant
+Nahu_ChainMail_Helm	Nahu Chain Coif
+Nairaden_OneHandMace	Iris Mace
+Nairah_Basic_Leather_Armor	Naira's Basic Attire
+Nairah_Leather_Boots	Naira's Boots
+Nairah_Leather_Gloves	Naira's Gloves
+Nakmore_Leather_Boots	Nagmore Leather Boots
+Namarc_TwoHandedWarHammer	Saltroad Warhammer
+Nantukka_Fabric_Armor	Nantuka Cloth Armor
+Natural_Enemy_Mask	Blinding Arrow's Mask
+Natural_Enemy_PlateArmor_Helm	Thunderbird Mask Plate Helm
+Navan_Fabric_Armor	Navan Cloth Armor
+Navet	Turnip
+NearNym_Leather_Boots	Neirnim Leather Boots
+Neblin_Fabric_Armor	Neblin Cloth Armor
+Nellaccio_Leather_Armor	Nellaccio Leather Armor
+Nelton_Leather_Armor	Nelton Leather Armor
+Nerdhal_OneHandBow	Warspike Bow
+Neut_Delpheon_EMP_key	Gate of Peace Disruptor Key
+NeutralZone_PlateArmor_Helm	Gorthak Orc's Helm
+Nevin_Leather_Boots	Nevin Leather Boots
+Nickna_Leather_Boots	Northern Fighter's Leather Boots
+Nihrutte_Leather_Armor	Nehrut Leather Armor
+Nihrutte_Leather_Boots	Nehrut Leather Shoes
+Noble_Fabric_Armor	Noble Cloth Armor
+Noble_Leather_Helm	Noble's Hat
+Noble_Retainer_Leather_Gloves	Noble Private Soldier's Leather Gloves
+Noble_Retainer_PlateArmor_Armor	Sungrove Standard Plate Armor
+Noble_Retainer_PlateArmor_Armor_I	Marshell Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_II	Marshell Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_III	Azerian Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_IV	Azerian Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_V	Azerian Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_VI	Elemore Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_VII	Elemore Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_VIII	Elemore Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_X	Byron's Soldier Plate Armor
+Noble_Retainer_PlateArmor_Armor_XI	Windmere Standard Plate Armor
+Noble_Retainer_PlateArmor_Armor_XII	Byron's Soldier Plate Armor
+Noble_Retainer_PlateArmor_Armor_XIII	Byron's Soldier Plate Armor
+Noble_Retainer_PlateArmor_Armor_XIV	Private Soldier's Plate Armor
+Noble_Retainer_PlateArmor_Armor_XV	Private Soldier's Plate Armor
+Nocburn_Leather_Gloves	Nocburn Leather Gloves
+Noname_OneHandDagger	Varnian Dagger
+NoName_Wiseman_Leather_Armor	Nameless Sage's Leather Armor
+NoName_Wiseman_Leather_Cloak	Nameless Sage's Leather Cloak
+NoName_Wiseman_Leather_Gloves_I	Nameless Sage's Leather Gloves
+Norman_Leather_Boots	Norman Leather Boots
+Norswitch_Leather_Armor	Norswich Leather Armor
+North_Mercenary_Fabric_Cloak_I	Jackal Cloth Cloak
+North_Mercenary_Leather_Armor_I	Jackals' Leather Armor
+North_Mercenary_Leather_Armor_II	Jackals' Leather Armor
+North_Mercenary_Leather_Armor_III	Jackals' Leather Armor
+North_Mercenary_Leather_Armor_IV	Jackals' Leather Armor
+North_Mercenary_Leather_Gloves_III	Northern Freesword's Leather Gloves
+North_Warrior_OneHandTowerShield	North Wind Shield
+North_Warrior_TwoHandSpear	North Wind Trident
+Northernbead_Leather_Armor	Nordbeid Leather Armor
+Notepad	Notepad
+NoticePaper_ArmWrestle	Recruiting Arm Wrestlers
+NoticePaper_BloodWalkerCrussis	Bounty on the Bloodied Monster
+NoticePaper_Circus_Chairless	[Demeniss Poster] - Invitation to the Demeniss Circus
+NoticePaper_Circus_ComeRightNow	[Demeniss Poster] - Invitation to the Demeniss Circus
+NoticePaper_Circus_DontMissIt	[Demeniss Poster] - Invitation to the Demeniss Circus
+NoticePaper_Finale_Byron	Warning Written in Blood
+NoticePaper_Finale_Calphade	Letter of Gratitude from Calphade
+NoticePaper_Finale_DarkKing	News of Beloth, the Darksworn's Defeat
+NoticePaper_Finale_GoblinSandfang	News of the Sandfang Marauders' Defeat
+NoticePaper_Finale_HyenabossSkevald	News of Skevald the Carrion King's Defeat
+NoticePaper_Finale_LeeburtheShadowWolf	News of the Black Fang's Defeat
+NoticePaper_Finale_Muscan	News of the Bonepit
+NoticePaper_Finale_SkullKnight	News of Skull Knight's Demise
+NoticePaper_Finale_Timberton	Harris's Letter
+NoticePaper_Finale_WhiteHorn	News of White Horn's Defeat
+NoticePaper_Her_CaveSound	Strange Noises from the Cave
+NoticePaper_Her_FindSheep	Missing Wooly
+NoticePaper_Her_LostCow	Missing Cows
+NoticePaper_Her_StolenGoatHorn	Horn Thief
+NoticePaper_Hyenamolar	Bounty Notice - Skevald, the Carrion King
+NoticePaper_MudWalkerLutemir	Bounty on the Mud Monster
+NoticePaper_Village_Muiquun	Request to Punish Outlaws in Muiquun
+Noyvarn_Leather_Armor	Noyvarn Leather Armor
+Nureumjeok	Mixed Skewers
+Nureumjeok_Large	Satisfying Mixed Skewers
+Nureumjeok_Medium	Filling Mixed Skewers
+Nureumjeok_XLarge	Hearty Mixed Skewers
+Nusiran_Fabric_Armor	Nuslan Cloth Armor
+Nusiran_Leather_Armor	Nuslan Leather Armor
+Nysron_Fabric_Armor	Neslan Cloth Armor
+Oakleyman_PlateArmor_Armor	Oakley Plate Armor
+Oakten_Leather_Boots	Oakten Leather Boots
+Oathring_OneHandShield	Oath Ring Shield
+Oats	Oats
+Obit_Leather_Boots	Orbit Leather Boots
+Odori_Fabric_Armor	Odorrey Cloth Armor
+Oharah_Leather_Armor	Ohara Leather Armor
+Oil_Barrel	Oil Barrel
+Oil_Sprayer_BackPack	Lubricant Sprayer
+Old_HorseArmor_Saddle	Shabby Horse Saddle
+Old_Kliff_OneHandSword	Fated Shadow
+Old_Kliff_Plate_Boots	Goyen's Plate Boots
+Old_Kliff_PlateArmor_Armor	Goyen's Plate Armor
+Old_Kliff_PlateArmor_Cloak	Goyen's Cloak
+Old_Kliff_PlateArmor_Gloves	Goyen's Plate Gloves
+Old_Necklace	Worn Necklace
+Old_Ring	Worn Ring
+Old_Wood_Doll_II	Old Wooden Doll
+Old_Wood_OneHandShield	Bekker Shield
+Oleander	Rosebay
+Oltmann_ChainMail_Armor	Oltmann Chain Mail
+Ondrikhan_Leather_Armor	Undriga Leather Armor
+Onion	Onion
+Oongka_Basic_Leather_Armor	Ashen Wolf's Leather Armor
+Oongka_Basic_Leather_Cloak	Ashen Wolf's Leather Cloak
+Oongka_Basic_Leather_Gloves	Ashen Wolf's Leather Gloves
+OOngka_Daeil_Band	Oongka's Axiom Bracelet
+Oongka_Plate_Glove	Brass Warden's Plate Gloves
+Oongka_PlateArmor_Armor_II	Valortread Plate Armor
+Oongka_PlateArmor_Armor_III	Belkandor Plate Armor
+Oongka_PlateArmor_Boots_II	Valortread Plate Boots
+Oongka_PlateArmor_Boots_III	Belkandor Plate Boots
+Oongka_PlateArmor_Cloak_II	Valortread Plate Cloak
+Oongka_PlateArmor_Cloak_III	Belkandor Plate Cloak
+Oongka_PlateArmor_Gloves_II	Valortread Plate Gloves
+Oongka_PlateArmor_Gloves_III	Belkandor Plate Gloves
+Oongka_PlateArmor_Helm_II	Valortread Plate Helm
+Oongka_PlateArmor_Helm_III	Belkandor Plate Helm
+Oongka_Rocket_BackPack	Kuku Rocket Pack
+Oongka_Rocket_Helm	KuKu Rocket Helmet - Equipped by Default
+Ophenber_PlateArmor_Helm	Offenberg Plate Helm
+Optionary_Beekeeping_Cloak	Beekeeping Cloak
+Optionary_Beekeeping_Cloth	Beekeeping Suit
+Optionary_Beekeeping_Leather_Boots	Beekeeping Boots
+Optionary_Beekeeping_Leather_Gloves	Beekeeping Gloves
+Optionary_Bleed_Fabric_Armor	Scarlet Blades Cloth Armor
+Optionary_Demeniss_Soldier_Armor	Demeniss Ceremonial Plate Armor
+Optionary_Demeniss_Soldier_Cloak	Demeniss Ceremonial Cloak
+Optionary_Demeniss_Spy_Cloak	Disguise Cloak
+Optionary_Demeniss_Spy_Cloth	Camouflage Outfit
+Optionary_Desert_Plunderer_Helmet	Desert Marauder's Plate Helm
+Optionary_Ent_Boots	Shadowleaf Boots
+Optionary_Ent_Cloak	Shadowleaf Cloak
+Optionary_Ent_Cloth	Shadowleaf Outfit
+Optionary_Ent_Gloves	Shadowleaf Gloves
+Optionary_Ent_Helm	Shadowleaf Helm
+Optionary_Florin_Cloth	Pororin Cloth Attire
+Optionary_Hernand_Party_Cloak	Hernandian Banquet Cloak
+Optionary_Hernand_Party_Cloth	Hernandian Attire
+Optionary_Monk_cloak	St. Halssius Priest's Cloak
+Optionary_Monk_Cloth	St. Halssius Priest Attire
+Optionary_Monk_Necklace	Saint's Necklace
+Optionary_NonSlip_Boots	Stirrups of the Open Sky
+Optionary_NonSlip_Gloves	Reins of Open Sky
+Optionary_Scholar_Stone_cloak	Scholastone Cloak
+Optionary_Scholar_Stone_Cloth	Scholastone Uniform
+Opuntia_seed	Prickly Pear Seed
+Orange	Orange
+orange_BackPack	Orange Pack
+orange_Seed	Orange Seed
+Orbs_Fabric_Armor	Orbus Cloth Armor
+Orc_Flag_I	Small Ironflame Orcs Banner Pike
+Orc_Flag_II	Medium Ironflame Orcs Banner Pike
+Orc_OneHandCannon	Orc Blaster
+Orc_Warrior_OneHandMace	Octarr's Legacy
+orchids_BackPack	Dendrobium Orchid Pack
+OrcuMer_Fabric_Armor	Trukan Cloth Armor
+OrcuMer_Fabric_Boots	Trukan Cloth Boots
+OrcuMer_Fabric_Cloak	Trukan Cloth Cloak
+OrcuMer_Fabric_Gloves	Trukan Cloth Gloves
+Orcumer_Helm	Wooden Mask of Lost Justice
+OrcuMer_Plate_Boots	Odeck's Protector Plate Boots
+OrcuMer_PlateArmor_Armor	Odeck's Protector Plate Armor
+OrcuMer_PlateArmor_Cloak	Odeck's Protector Plate Cloak
+OrcuMer_PlateArmor_Gloves	Odeck's Protector Plate Gloves
+OrcuMer_PlateArmor_Helm	Odeck's Protector Plate Helm
+Orient_Monk_BackPack	Eastern Monk Pack
+Orjekel_HorseArmor_Armor	Varnian Barding
+Orjekel_HorseArmor_Helm	Varnian Champron
+Orjekel_HorseArmor_Saddle	Varnian Saddle
+Orjekel_HorseArmor_Stirrup	Varnian Stirrups
+Ort_Fabric_Armor	Ort Cloth Armor
+Orthu_Fabric_Armor	Orthu Cloth Armor
+Orton_Fabric_Armor	Orton Cloth Armor
+Otant_PlateArmor_Armor	Ostent Plate Armor
+Ouvre_Fabric_Armor	Oubreve Cloth Armor
+Owls_of_the_Mist_Leahter_Armor_I	Mistcloaked Owl Leather Armor
+Owls_of_the_Mist_Leahter_Armor_II	Mistcloaked Owl Leather Armor
+Owls_of_the_Mist_Leahter_Armor_III	Mistcloaked Owl Leather Armor
+Owls_of_the_Mist_Leahter_Armor_IV	Mistcloaked Owl Leather Armor
+Owls_of_the_Mist_Leahter_Armor_V	Mistcloaked Owl Leather Armor
+Owls_of_the_Mist_Leather_Boots	Mistcloaked Owl Leather Boots
+Owls_of_the_Mist_Leather_Cloak	Mistcloaked Owl Leather Cloak
+Owls_of_the_Mist_PlateArmor_Helm	Mistcloaked Owl Plate Helm
+Owls_of_the_Mist_PlateArmor_Helm_II	Mistcloaked Owl Plate Helm
+Paijal_PlateArmor_Helm	Paizel Bone Helm
+pailloon_Flag_I	Small Pailunese Banner Pike
+pailloon_Flag_II	Medium Pailunese Banner Pike
+Pailoon_OneHandMace	Savage Woodland Spirit Killer
+Pailune_Contribution_Flag	Pailunese Contribution Banner Pike
+Pailune_Necklace	Blue Fang Necklace
+Pailune_Nobility_Degree_I	Pailunese Signet
+Palen_Leather_Armor	Palen Leather Armor
+Paliano_Leather_Armor	Paliano Leather Armor
+Paltz_Leather_Armor	Paltz Leather Armor
+Pan_fried_Fish_Fruit_Pancake	Seafood Stew
+Pan_fried_Fish_Fruit_Pancake_Large	Satisfying Seafood Stew
+Pan_fried_Fish_Fruit_Pancake_Medium	Filling Seafood Stew
+Pan_fried_Fish_Fruit_Pancake_XLarge	Hearty Seafood Stew
+Pan_fried_Fish_Grain_Pancake	Fishball Soup
+Pan_fried_Fish_Grain_Pancake_Large	Satisfying Fishball Soup
+Pan_fried_Fish_Grain_Pancake_Medium	Filling Fishball Soup
+Pan_fried_Fish_Grain_Pancake_XLarge	Hearty Fishball Soup
+Pan_fried_Fish_Pancake	Battered Fish
+Pan_fried_Fish_Pancake_Large	Satisfying Battered Fish
+Pan_fried_Fish_Pancake_Medium	Filling Battered Fish
+Pan_fried_Fish_Pancake_XLarge	Hearty Battered Fish
+Pan_fried_Fish_Vegetable_Pancake	Battered Seafood
+Pan_fried_Fish_Vegetable_Pancake_Large	Satisfying Battered Seafood
+Pan_fried_Fish_Vegetable_Pancake_Medium	Filling Battered Seafood
+Pan_fried_Fish_Vegetable_Pancake_XLarge	Hearty Battered Seafood
+Pan_fried_Fruit_Grain_Pancake	Chewy Rice Cakes
+Pan_fried_Fruit_Grain_Pancake_Large	Satisfying Chewy Rice Cakes
+Pan_fried_Fruit_Grain_Pancake_Medium	Filling Chewy Rice Cakes
+Pan_fried_Fruit_Grain_Pancake_XLarge	Hearty Chewy Rice Cakes
+Pan_fried_Fruit_Pancake	Pickled Fruit
+Pan_fried_Fruit_Pancake_Large	Satisfying Pickled Fruit
+Pan_fried_Fruit_Pancake_Medium	Filling Pickled Fruit
+Pan_fried_Fruit_Pancake_XLarge	Hearty Pickled Fruit
+Pan_fried_Grain_Pancake	Battered Grains
+Pan_fried_Grain_Pancake_Large	Satisfying Battered Grains
+Pan_fried_Grain_Pancake_Medium	Filling Battered Grains
+Pan_fried_Grain_Pancake_XLarge	Hearty Battered Grains
+Pan_fried_Meat_Fish_Pancake	Battered Meat and Fish
+Pan_fried_Meat_Fish_Pancake_Large	Satisfying Battered Meat and Fish
+Pan_fried_Meat_Fish_Pancake_Medium	Filling Battered Meat and Fish
+Pan_fried_Meat_Fish_Pancake_XLarge	Hearty Battered Meat and Fish
+Pan_fried_Meat_Fruit_Pancake	Marinated Meat
+Pan_fried_Meat_Fruit_Pancake_Large	Satisfying Marinated Meat
+Pan_fried_Meat_Fruit_Pancake_Medium	Filling Marinated Meat
+Pan_fried_Meat_Fruit_Pancake_XLarge	Hearty Marinated Meat
+Pan_fried_Meat_Grain_Pancake	Meat Soup
+Pan_fried_Meat_Grain_Pancake_Large	Satisfying Meat Soup
+Pan_fried_Meat_Grain_Pancake_Medium	Filling Meat Soup
+Pan_fried_Meat_Grain_Pancake_XLarge	Hearty Meat Soup
+Pan_fried_Meat_Pancake	Battered Meat
+Pan_fried_Meat_Pancake_Large	Satisfying Battered Meat
+Pan_fried_Meat_Pancake_Medium	Filling Battered Meat
+Pan_fried_Meat_Pancake_XLarge	Hearty Battered Meat
+Pan_fried_Meat_Vegetable_Pancake	Steamed Eggs
+Pan_fried_Meat_Vegetable_Pancake_Large	Satisfying Steamed Eggs
+Pan_fried_Meat_Vegetable_Pancake_Medium	Filling Steamed Eggs
+Pan_fried_Meat_Vegetable_Pancake_XLarge	Hearty Steamed Eggs
+Pan_fried_Vegetable_Fruit_Pancake	Vegetable Rice Cake
+Pan_fried_Vegetable_Fruit_Pancake_Large	Satisfying Vegetable Rice Cake
+Pan_fried_Vegetable_Fruit_Pancake_Medium	Filling Vegetable Rice Cake
+Pan_fried_Vegetable_Fruit_Pancake_XLarge	Hearty Vegetable Rice Cake
+Pan_fried_Vegetable_Grain_Pancake	Grain Soup
+Pan_fried_Vegetable_Grain_Pancake_Large	Satisfying Grain Soup
+Pan_fried_Vegetable_Grain_Pancake_Medium	Filling Grain Soup
+Pan_fried_Vegetable_Grain_Pancake_XLarge	Hearty Grain Soup
+Pan_fried_Vegetable_Pancake	Battered Vegetables
+Pan_fried_Vegetable_Pancake_Large	Satisfying Battered Vegetables
+Pan_fried_Vegetable_Pancake_Medium	Filling Battered Vegetables
+Pan_fried_Vegetable_Pancake_XLarge	Hearty Battered Vegetables
+Pansy	Pansy
+Pantafe_Fabric_Armor	Pantafe Cloth Armor
+Paper_Adelina	Adrina's Note
+Paper_Adelina_I	Carpenter's Note
+Paper_Adelina_II	Training Field Note
+Paper_Aldred	Eldred's Note
+Paper_Aldred_I	Farmer's Note
+Paper_Aldred_II	Provisioner's Shop Note
+Paper_Beatrice	Bea's Note
+Paper_BoundbyLies	Wronged Man's Note
+Paper_BoundbyLies_I	Note at a Man's House
+Paper_BraveToLove	A Man's Note
+Paper_Bruna	Bruna's Note
+Paper_Bruna_I	Saddler's Note
+Paper_Bruna_II	Royal Trading Post Note
+Paper_Castiel	Castiel's Note
+Paper_Castiel_I	Stained Work Log
+Paper_DelesyiaInstitute_Clue_ResearchPaper	Research Suspension Warning
+Paper_Doni	Donny's Note
+Paper_Doni_I	Flower Shop Customer's Note
+Paper_Drianna	Driana's Note
+Paper_Drianna_I	Watchtower Note
+Paper_Eliza	Elise's Note
+Paper_Eliza_I	Note from the Street Shop
+Paper_FieldVoice	Excavation Site Manager's Note
+Paper_FieldVoice_I	Foreman's Note
+Paper_Find_Tolstein	Report on Beighen
+Paper_Fiona	Fiona's Note
+Paper_Fiona_I	Chief Trainer's Journal
+Paper_Flint	Flint's Note
+Paper_Flint_I	Potter's Journal
+Paper_Forex	Forrex's Note
+Paper_Forex_I	Arms Scholar's Note
+Paper_Forex_II	Windrose Farm Note
+Paper_FriendNews	Merchant's Note
+Paper_FriendNews_I	Duskway Camp Note
+Paper_FriendNews_II	Note Found at the Fence
+Paper_FromYann	Yann's Letter
+Paper_GoldleafGuildhouse_Clue_I	Feed Purchase Receipt
+Paper_GoldleafGuildhouse_Clue_II	Trade Schedule Log
+Paper_GoldleafGuildhouse_Clue_III	Tavern Ledger
+Paper_GoldleafGuildhouse_Clue_IV	Tax Notice
+Paper_GoldleafGuildhouse_Clue_V	Guard's Report
+Paper_GoldleafGuildhouse_Clue_VI	Guard's Letter
+Paper_GoldleafGuildhouse_Clue_VII	Merchant Delivery Seal
+Paper_GoldleafGuildhouse_Clue_VIII	Proof of Stay
+Paper_Harveston	Haverson's Note
+Paper_Harveston_I	Baker's Note
+Paper_Harveston_II	Church Note
+Paper_Kuku_Pot	Mysterious Pot Crafting Contract
+Paper_Lenard	Leonard's Note
+Paper_Lenard_I	Assistant's Note
+Paper_Maiden	Maidon's Note
+Paper_Maiden_I	Harbor Manager's Note
+Paper_Maiden_II	Note from the Bank
+Paper_Omar	Omar's Note
+Paper_Omar_I	Varnia Entrance Note
+Paper_RacingStage	Researcher's Note
+Paper_RacingStage_I	Racecourse Owner's Note
+Paper_Randel	Randelle's Note
+Paper_Randel_I	Engineer's Research Log
+Paper_ReventineMonastery_Document	Reventine Monastery Exclusive Document
+Paper_SecretSip	Trainee's Note
+Paper_SecretSip_I	Note at Point of Contact
+Paper_Sniks	Nix's Note
+Paper_Sniks_I	Note from the Freesword Barracks
+Paper_StonemireRuins_Report_2	Stonemire Ruins Record No. 2
+Paper_StonemireRuins_Report_3	Stonemire Ruins Record No. 3
+Paper_Ugmum	Ugmon's Note
+Paper_VegetableBox	Produce Order Form
+Paphneil_PlateArmor_Armor	Scorchflame Plate Armor
+Paphneil_PlateArmor_Armor_Upgrade	Kuku Flame-Resistant Armor
+Paphneil_PlateArmor_Cloak	Scorchflame Plate Cloak
+Parachu_OneHandAxe	Parashu Axe
+Paralyze_OneHandSword	Sword of Wayward Woods
+Parastis_PlateArmor_Helm	Parasis Plate Helm
+Parmen_PlateArmor_Gloves	Ferman Plate Gloves
+Parsley	Parsley
+Parvel_Giant_TwoHandGiantBastard	Parvel Greatsword
+Pasti_Leather_Boots	Pasti Leather Boots
+Patent_Leather_Gloves	Patten's Leather Gloves
+Patent_Leather_Gloves_I	Patten's Leather Gloves
+Patika_Fabric_Armor	Patika Cloth Armor
+Patrol_OneHandShield	Odeck Hardwood Shield
+Pattern_Bronze_Earring	Engraved Copper Earring
+Pattern_Copper_Necklace	Engraved Copper Necklace
+Pattern_Copper_Ring	Crude Blue Ring
+Pattern_Diamond_Earring	Golden Deer's Tear
+Pattern_Gold_Earring	Engraved Gold Earring
+Pattern_Silver_Earring	Engraved Silver Earring
+Pattern_Silver_Necklace	Engraved Silver Necklace
+Pattern_Silver_Ring	Ancient Shell Ring
+Pauherr_Fabric_Armor	Pouhel Cloth Armor
+Paulus_Basic_Leather_Armor	Ironwilled Guardian's Leather Armor
+Paulus_Basic_Leather_cloak	Ironwilled Guardian's Leather Cloak
+Paulus_Leather_Boots	Ironwilled Guardian's Leather Boots
+Paulus_Leather_Gloves	Ironwilled Guardian's Leather Gloves
+Paunah_Leather_Boots	Pahna Leather Boots
+Paunah_OneHandBow	Bekker Bow
+Pavis_Leather_Boots	Pavis Leather Boots
+Pavis_Leather_Boots_I	Pavis Leather Boots
+Pavis_OneHandTowerShield	Gilliam Large Shield
+Peach	Peach
+Peach_Seed	Peach Seed
+Pear	Pear
+PearTree_Seed	Pear Tree Seed
+peas	Peas
+Peony	Peony
+Peori_Leather_Gloves	Fiori Leather Gloves
+Perelli_Leather_Boots	Perelli Leather Boots
+Permit_Bei_General	Provisions Supply Contract - Beighen
+Permit_Cal_Costume	Outfit Supply Contract - Calphade
+Permit_Cal_Equipment	Equipment Supply Contract - Calphade
+Permit_Cal_General	Provisions Supply Contract - Calphade
+Permit_Cal_Seed	Seed Supply Contract - Calphade
+Permit_Cal_Tavern	Food Supply Contract - Calphade
+Permit_Del_Costume	Outfit Supply Contract - Delesyia
+Permit_Del_Equipment	Equipment Supply Contract - Delesyia
+Permit_Del_Furniture	Furniture Supply Contract - Timberton
+Permit_Del_General	Provisions Supply Contract - Delesyia
+Permit_Del_Seed	Seed Supply Contract - Delesyia
+Permit_Del_Tavern	Food Supply Contract - Delesyia
+Permit_Dem_Costume	Outfit Supply Contract - Demeniss
+Permit_Dem_Equipment	Equipment Supply Contract - Demeniss
+Permit_Dem_Furniture	Furniture Supply Contract - Hidden Grove
+Permit_Dem_General	Provisions Supply Contract - Demeniss
+Permit_Dem_Seed	Seed Supply Contract - Demeniss
+Permit_Dem_Tavern	Food Supply Contract - Demeniss
+Permit_DemZoo_Costume	Outfit Supply Contract - Demeniss Wildlife Park
+Permit_Her_Costume	Outfit Supply Contract - Hernand
+Permit_Her_Equipment	Equipment Supply Contract - Hernand
+Permit_Her_Furniture	Furniture Supply Contract - Timberham
+Permit_Her_General	Provisions Supply Contract - Hernand
+Permit_Her_Pass	Hernand Entry Permit
+Permit_Her_Seed	Seed Supply Contract - Hernand
+Permit_Her_Tavern	Food Supply Contract - Hernand
+Permit_Kha_Equipment	Equipment Supply Contract - Kharonso
+Permit_Kha_Tavern	Food Supply Contract - Kharonso
+Permit_Kwe_Furniture	Furniture Supply Contract - Beighen
+Permit_Odeck_Equipment	Equipment Supply Contract - Odeck
+Permit_Pai_Costume	Outfit Supply Contract - Pailune
+Permit_Pai_Equipment	Equipment Supply Contract - Pailune
+Permit_Pai_General	Provisions Supply Contract - Pailune
+Permit_Pai_Seed	Seed Supply Contract - Pailune
+Permit_Pai_Tavern	Food Supply Contract - Pailune
+Permit_Skog_Equipment	Equipment Supply Contract - Skoghorn
+Permit_Skog_General	Provisions Supply Contract - Skoghorn
+Permit_Str_Equipment	Equipment Supply Contract - Stronghelm Forge
+Permit_Tar_Costume	Outfit Supply Contract - Tariv
+Permit_Tar_Equipment	Equipment Supply Contract - Tariv
+Permit_Tash_Costume	Outfit Supply Contract - Tommaso
+Permit_Tash_Equipment	Equipment Supply Contract - Tommaso
+Permit_Tash_General	Provisions Supply Contract - Tommaso
+Permit_Tash_Seed	Seed Supply Contract - Tommaso
+Permit_Tash_Tavern	Food Supply Contract - Tommaso
+Permit_Var_Costume	Outfit Supply Contract - Varnia
+Permit_Var_Equipment	Equipment Supply Contract - Varnia
+Permit_Var_General	Provisions Supply Contract - Varnia
+Permit_Var_Seed	Seed Supply Contract - Varnia
+Permit_Var_Tavern	Food Supply Contract - Varnia
+Permit_Vellua_General	Provisions Supply Contract - Vellua
+Persein_Leather_Gloves	Persein Leather Gloves
+Persein_Leather_Gloves_I	Persein Leather Gloves
+Perseus_Leather_Gloves	Perseus Leather Gloves
+Pervin_Bomb	Perwin Explosive
+PetArmor_backpack_Armor_Cat	Peddler Cat Outfit
+PetArmor_backpack_Helm_Cat	Peddler Cat Hat
+PetArmor_Fabric_Armor_Dog	Puppy Cloth Outfit
+PetArmor_Fabric_Helm_Dog	Puppy Cloth Hat
+PetArmor_Musket_Armor_Cat	Uniform Cat Outfit
+PetArmor_Musket_Helm_Cat	Uniform Cat Hat
+PetArmor_Plate_Armor_Cat	Cat Plate Armor
+PetArmor_Plate_Armor_Dog	Puppy Plate Armor
+PetArmor_Plate_Helm_Cat	Cat Plate Helm
+PetArmor_Plate_Helm_Dog	Puppy Plate Helm
+PetArmor_Rescue_Armor_Dog	Rescue Puppy Outfit
+Petra_Leather_Gloves	Petra Leather Gloves
+Phavan_Leather_Armor	Favan Leather Armor
+Philaphy_OneHandMace	Thalwynd Hammer
+Piatol_Leather_Boots	Fiatol Leather Boots
+Pictead_Leather_Armor	Pictead Leather Armor
+Pieren_OneHandMace	Sydmon Hammer
+Pierpont_Leather_Boots	Pierpont Leather Boots
+Pieti_Leather_Boots	Pieti Leather Boots
+Pieti_OneHandBow	Dekarr Bow
+Pietisus_TwoHandedWarHammer	Dark Worshiper's Staff
+Pineapple	Pineapple
+Pioneer_Fabric_Armor	Pioneer Cloth Armor
+Pirante_PlateArmor_Armor	Frente Plate Armor
+Pirate_Fabric_Armor	Pirate Cloth Armor
+Pirate_Fabric_Armor_I	Pirate Cloth Armor
+Pirate_Fabric_Armor_II	Dancing Catfish Cloth Armor
+Pirate_Fabric_Armor_III	Pirate Cloth Armor
+Pirate_Fabric_Armor_IV	Pirate Cloth Armor
+Pirate_King_Leather_Helm	Pirate King Hat
+Pirate_PlateArmor_Gloves	Pirate Plate Gloves
+Pirate_PlateArmor_Gloves_I	Pirate Plate Gloves
+Pirate_Vice_Captain_Armor	The Singing Catfish Vice Captain's Armor
+Pirin_Leather_Armor	Pirin Leather Armor
+Pisoniano_Leather_Armor	Pisonia Leather Armor
+Pitspec_PlateArmor_Armor	Unyielding Warrior's Plate Armor
+Pitspec_PlateArmor_Cloak	Unyielding Warrior's Plate Cloak
+PlainsGuard_OneHandShield	Musket Shield
+Plant_Collect_BackPack	Kuku Gardening Pack
+Plune_Leather_Armor	Plune Leather Armor
+Poison_Arrow	Poison Arrow
+Poison_Stick	Soporific Blowpipe
+Pomegranate	Pomegranate
+Pomegranate_Seed	Pomegranate Seed
+Porcell_Fabric_Gloves_I	Porcell Cloth Gloves
+Porcell_Fabric_Gloves_II	Porcell Cloth Gloves
+Pormeranian_Leather_Armor	Pomerin Leather Armor
+Pororin_Sacred	Pororin Relic
+PororinChildrenForest_Book	A Traveler's Log
+Porugate_Leather_Gloves	Brogant Leather Gloves
+Possesion_Insam	Ginseng
+Possesion_Myurdin_Leather_Armor	Umbra's Hierophany Leather Armor
+Possesion_Myurdin_Leather_Gloves	Umbra's Hierophany Leather Gloves
+Pot_Head	Jar Lid
+Potato	Potato
+Potion_StatBuff_Tier1_0001	Freya's Lesser Elixir
+Potion_StatBuff_Tier1_0002	Apollonia's Lesser Elixir
+Potion_StatBuff_Tier1_0003	Meliara's Lesser Elixir
+Potion_StatBuff_Tier1_0004	Haiden's Lesser Elixir
+Potion_StatBuff_Tier1_0005	Astrid's Lesser Elixir
+Potion_StatBuff_Tier2_0001	Freya's Elixir
+Potion_StatBuff_Tier2_0002	Apollonia's Elixir
+Potion_StatBuff_Tier2_0003	Meliara's Elixir
+Potion_StatBuff_Tier2_0004	Haiden's Elixir
+Potion_StatBuff_Tier2_0005	Astrid's Elixir
+Potion_StatBuff_Tier3_0001	Freya's Greater Elixir
+Potion_StatBuff_Tier3_0002	Apollonia's Greater Elixir
+Potion_StatBuff_Tier3_0003	Meliara's Greater Elixir
+Potion_StatBuff_Tier3_0004	Haiden's Greater Elixir
+Potion_StatBuff_Tier3_0005	Astrid's Greater Elixir
+PowerDraw_Gloves	Strongbow Gloves
+Prani_PlateArmor_Helm	Prani Plate Helm
+Premium_Stone	Flawless Stone
+Premium_Wood	Flawless Timber
+PriestWand_Big	Solumen Priest's Big Staff
+PriestWand_Big_III	Varnian Priest's Big Staff
+Prinkeypes_PlateArmor_Armor	Princeps Plate Armor
+Prison_Key	Prison Key
+Prisoner_Fabric_Armor	Captive's Cloth Armor
+Prisoner_Fabric_Armor_I	Captive's Cloth Armor
+Prisoner_Fabric_Armor_II	Captive's Cloth Armor
+Prisoner_Fabric_Armor_III	Captive's Cloth Armor
+Prisoner_Fabric_Armor_IV	Captive's Cloth Armor
+Prisoner_Fabric_Armor_IX	Captive's Cloth Armor
+Prisoner_Fabric_Armor_V	Captive's Cloth Armor
+Prisoner_Fabric_Armor_VI	Captive's Cloth Armor
+Prisoner_Fabric_Armor_VII	Captive's Cloth Armor
+Prisoner_Fabric_Armor_VIII	Captive's Cloth Armor
+Prisoner_Fabric_Boots	Captive's Cloth Boots
+Prisoner_Fabric_Helm	Captive's Cloth Headband
+Prisoner_Fabric_Helm_I	Captive's Cloth Helm
+Prisoner_Fabric_Helm_II	Captive's Cloth Helm
+Prisoner_Fabric_Helm_III	Captive's Cloth Helm
+Prisoner_Fabric_Helm_IV	Captive's Cloth Helm
+Prisoner_Leather_Gloves	Leather Half-Gloves
+Prisoner_Leather_Gloves_I	Darren Leather Gloves
+Prisoner_Leather_Gloves_II	Darren Leather Gloves
+Prisoner_Leather_Helm	Captive's Leather Helm
+Prisoner_Leather_Helm_I	Captive's Folded Leather Helm
+Protect_Electric_Leather_Gloves	Insulated Gloves
+Protective_Leather_Armor	Antumbra Bismuth Protection Suit
+Pumpkin	Pumpkin
+Purani_Leather_Boots	Purani Leather Boots
+Puzzle_Reward_TreasureMap_Del	Forgotten Memory
+Puzzle_Reward_TreasureMap_Dem_First	Memories of Prosperity
+Puzzle_Reward_TreasureMap_Dem_Second	Memory of Turbulence
+Puzzle_Reward_TreasureMap_Her_First	Memories of Abundance
+Puzzle_Reward_TreasureMap_Her_Second	Memory of Tide
+Puzzle_Reward_TreasureMap_Kwe	Memories of the Northern Winds
+Pycian_PlateArmor_Helm	Ferman Plate Helm
+Pyeonjeon_Arrow	Stub Arrow
+Pyinca_PlateArmor_Gloves	Pernicia Plate Gloves
+Pyogo_Mushroom	Oakwood Mushroom
+Pyogo_Mushroom_BackPack	Oakwood Mushroom Pack
+Pyogo_Mushroom_Tea	Oakwood Mushroom Tea
+Pypho_Fabric_Armor	Paifo Cloth Armor
+Pyrantha_Fabric_Armor	Pyrantha Cloth Armor
+Querunty_Leather_Boots	Quent Leather Boots
+Querville_Leather_Boots	Kervel Leather Boots
+Quest_Bloodcoronation_CampDocument_I	Informant's First Letter
+Quest_Bloodcoronation_CampDocument_II	Informant's Second Letter
+Quest_Bloodcoronation_CampDocument_III	Informant's Third Letter
+Quest_Bloodcoronation_Document	Report on Myurdin's Whereabouts
+Quest_Book_Mansion_I	Book
+Quest_BrokenVisionPro_Bremer	Broken Visione
+Quest_BrokenVisionPro_Ibano	Broken Visione
+Quest_BrokenVisionPro_MasterGrundir_Diary	Broken Visione
+Quest_BrokenVisionPro_ThiefCave	Broken Visione
+Quest_BrokenVisionPro_Witch_Kidnapped_Memory	Broken Visione
+Quest_Burham_Maze_I	Engraved Stone
+Quest_Burham_Maze_II	Engraved Stone
+Quest_Burham_Maze_III	Engraved Stone
+Quest_ByronBastier_Letter	Anonymous Letter
+Quest_ByronBastier_Letter_1	Alliance Progress Report
+Quest_ByronMyurdin_Letter	Letter from Abroad
+Quest_CelesterToBarden	Celeste's Confidential Letter
+Quest_Crowman_Key_I	Dagger of Radiance
+Quest_DemenisMark	Demeniss Token
+Quest_EastTower_Maze_I	Engraved Stone
+Quest_EastTower_Maze_II	Engraved Stone
+Quest_EastTower_Maze_III	Engraved Stone
+Quest_Faction_Start_LongLeafForest	Warning of Longleaf Forest Entry
+Quest_Fissure_Maze_I	Engraved Stone
+Quest_Fissure_Maze_II	Engraved Stone
+Quest_Fissure_Maze_III	Engraved Stone
+Quest_GoldenStar_key	Golden Star's Power Core
+Quest_Grace_GoldDagger_I	Ruby-Set Golden Dagger
+Quest_Grace_GoldDagger_II	Sapphire-Set Golden Dagger
+Quest_GrayBrotherMark	Greymane's Token
+Quest_Haldin_Stolen_Map	Haldin's Hideout
+Quest_HernandCastle_Underground_Key	Hernand Castle Basement Key
+Quest_Hostages_House_Key	Black Bear Prison Key
+Quest_Hunter_Letter	A Hunter's Letter
+Quest_Legend_Songyi	Mystical Pine Mushroom
+Quest_Mague_Letter	Maegu's Letter
+Quest_MarchellBastier_Letter	Marshell's Letter
+Quest_MarchellByron_Letter	B's Secret Letter
+Quest_Order_Delkin_Pot	Stone Jar
+Quest_Paper_AbyssTeleport	White Crow's Letter
+Quest_Paper_Chocolate_Factory_BackPack	Mobile Chocolate Workshop Research Journal
+Quest_Paper_Circus3	Circus Invitation
+Quest_Paper_ContributionShop_Hernand	Hernand Contribution Shop Flyer
+Quest_Paper_Crim_Arinna	Alina's Poster
+Quest_Paper_Crim_Beatrice	Bea's Poster
+Quest_Paper_Crim_Bruknar	Brookner's Poster
+Quest_Paper_Crim_Elowen	Rowan's Poster
+Quest_Paper_Crim_Esperd	Esford's Poster
+Quest_Paper_Crim_Fatima	Fatima's Poster
+Quest_Paper_Crim_Gwendolyn	Gwendolyn's Poster
+Quest_Paper_Crim_Khadija	Hadiza's Poster
+Quest_Paper_Crim_Khadin	Caden's Poster
+Quest_Paper_Crim_Khalid	Khalid's Poster
+Quest_Paper_Crim_Noor	Nora's Poster
+Quest_Paper_Crim_Omar	Omar's Poster
+Quest_Paper_Crim_Samir	Samir's Poster
+Quest_Paper_Crim_Sniks	Nix's Poster
+Quest_Paper_Crim_Thibault	Tibo's Poster
+Quest_Paper_Crim_Thomas	Thomas's Poster
+Quest_Paper_Crim_Zara	Zara's Poster
+Quest_Paper_Damian_AirJump	Letter for Damiane
+Quest_Paper_Del_Doni	Donny's Poster
+Quest_Paper_Del_Forex	Forrex's Poster
+Quest_Paper_Del_Grundak	Grond's Poster
+Quest_Paper_Del_Herbert	Herbert's Poster
+Quest_Paper_Del_Inn	Anne's Poster
+Quest_Paper_Del_Lior	Leore's Poster
+Quest_Paper_Del_Maiden	Maidon's Poster
+Quest_Paper_Del_Marin	Marin's Poster
+Quest_Paper_Del_Martina	Martina's Poster
+Quest_Paper_Del_Merrigrain	Merrigan's Poster
+Quest_Paper_Del_Nancy	Nancy's Poster
+Quest_Paper_Del_Rainier	Renier's Poster
+Quest_Paper_Del_Randel	Randelle's Poster
+Quest_Paper_Del_Skaldar	Skaldar's Poster
+Quest_Paper_Dem_Eldmor	Eldon's Poster
+Quest_Paper_Dem_Eliza	Elise's Poster
+Quest_Paper_Dem_Fiona	Fiona's Poster
+Quest_Paper_Dem_Flint	Flint's Poster
+Quest_Paper_Dem_Geoffroi	Jofroy's Poster
+Quest_Paper_Dem_GrainHart	Grannard's Poster
+Quest_Paper_Dem_Kata	Kathor's Poster
+Quest_Paper_Dem_Khorn	Khron's Poster
+Quest_Paper_Dem_Kike	Kiki's Poster
+Quest_Paper_Dem_Linda	Linda's Poster
+Quest_Paper_Dem_Mariana	Mariana's Poster
+Quest_Paper_Dem_Mariel	Marielle's Poster
+Quest_Paper_Dem_Orlonel	Olanelle's Poster
+Quest_Paper_Dem_Palga	Palgar's Poster
+Quest_Paper_Dem_Trollmag	Trolmagg's Poster
+Quest_Paper_Dem_Zarkon	Zargon's Poster
+Quest_Paper_DrugFactory_I	Ingredient Dispenser Instructions
+Quest_Paper_DrugFactory_II	Washer Instructions
+Quest_Paper_DrugFactory_III	Grinder Instructions
+Quest_Paper_DrugFactory_IV	Dosing Pump Instructions
+Quest_Paper_DrugFactory_V	Heater Instructions
+Quest_Paper_DrugFactory_VI	Bottling Machine Instructions
+Quest_Paper_DrugFactory_VII	Lift Instructions
+Quest_Paper_Empty_I	Simple Poster
+Quest_Paper_Empty_II	Simple Poster
+Quest_Paper_EmptyIII	Simple Poster
+Quest_Paper_EmptyIV	Simple Poster
+Quest_Paper_Her_Adelina	Adrina's Poster
+Quest_Paper_Her_Aldun	Alden's Poster
+Quest_Paper_Her_Alfred	Alfred's Poster
+Quest_Paper_Her_Anbella	Annabella's Poster
+Quest_Paper_Her_Berdo	Berto's Poster
+Quest_Paper_Her_Bran	Bran's Poster
+Quest_Paper_Her_Bruna	Bruna's Poster
+Quest_Paper_Her_Dahlia	Dahlia's Poster
+Quest_Paper_Her_Delkin	Delkin's Poster
+Quest_Paper_Her_Drianna	Driana's Poster
+Quest_Paper_Her_Frox	Prox's Poster
+Quest_Paper_Her_Gloin	Galen's Poster
+Quest_Paper_Her_Grana	Grania's Poster
+Quest_Paper_Her_Harveston	Haverson's Poster
+Quest_Paper_Her_Matilda	Matilda's Poster
+Quest_Paper_Her_Peregrine	Peregrine's Poster
+Quest_Paper_Her_Raine	Renee's Poster
+Quest_Paper_Her_Rhett	Rhett's Poster
+Quest_Paper_Her_Shirg	Serge's Poster
+Quest_Paper_Her_Timmyr	Temir's Poster
+Quest_Paper_Her_Tina	Tina's Poster
+Quest_Paper_Her_Turnuli	Turnali's Poster
+Quest_Paper_Her_Ugmum	Ugmon's Poster
+Quest_Paper_Her_Yjork	Nork's Poster
+Quest_Paper_HowToMakeFundAccount	Investment Offer
+Quest_Paper_HowToQuenching_I	Turnali's Smithy Flyer
+Quest_Paper_HowToRemoveCrime	Light's Guidance
+Quest_Paper_KuKuATAG	Small Kuku A.T.A.G. Design
+Quest_Paper_Kwe_Aeba	Ava's Poster
+Quest_Paper_Kwe_Aldred	Eldred's Poster
+Quest_Paper_Kwe_Bargul	Bargul's Poster
+Quest_Paper_Kwe_Baris	Varis's Poster
+Quest_Paper_Kwe_Gonthyr	Gunter's Poster
+Quest_Paper_Kwe_Gorio	Gorio's Poster
+Quest_Paper_Kwe_Henri	Harry's Poster
+Quest_Paper_Kwe_Lenard	Leonard's Poster
+Quest_Paper_Kwe_Lora	Lola's Poster
+Quest_Paper_Kwe_Ratko	Rocco's Poster
+Quest_Paper_Kwe_Richart	Richart's Poster
+Quest_Paper_Kwe_RonHardt	Ronnard's Poster
+Quest_Paper_Kwe_Terinand	Terianne's Poster
+Quest_Paper_Nature	Lost Letter
+Quest_Paper_Progression	Alustin's Letter
+Quest_Paper_Propagation	Wisdom between Donation and Fruition
+Quest_Paper_Recipe_KuKu_Pot_RoketBag	Letter from Grimnir
+Quest_Paper_Stamina	Lost Letter
+Quest_Paper_TaxStatement	Tax Notice
+Quest_PendantInSnow_Letter	Letter to Younger Brother
+Quest_Poison_Pyogo	Poison-Soaked Oakwood Mushroom
+Quest_TrollCube_I	Engraved Stone
+Quest_TrollCube_III	Engraved Stone
+Quest_TrollCube_IV	Engraved Stone
+Quest_TrolluniversityTower_Key	Spire of the Stars Key
+Quest_Ulzok_Stolen_Map	Ulzok's Hideout
+Quest_WantedPaper_0001	Bounty Notice - Simon de Montfort
+Quest_WantedPaper_0002	Bounty Notice - Ulzok
+Quest_WantedPaper_0003	Bounty Notice - Haldin
+Quest_WantedPaper_0004	Bounty Notice - Alessio
+Quest_WantedPaper_0005	Bounty Notice - Blix
+Quest_WantedPaper_0006	Bounty Notice - Bianca
+Quest_WantedPaper_0007	Bounty Notice - Salvatore
+Quest_WantedPaper_0008	Bounty Notice - Dante
+Quest_WantedPaper_0009	Bounty Notice - Warren
+Quest_WantedPaper_0011	Bounty Notice - Grull
+Quest_WantedPaper_0012	Bounty Notice - Fabrizio
+Quest_WantedPaper_0013	Bounty Notice - Garth
+Quest_WantedPaper_0014	Bounty Notice - Selene
+Quest_WantedPaper_0015	Bounty Notice - Cecil
+Quest_WantedPaper_0016	Bounty Notice - Blair
+Quest_WantedPaper_0017	Bounty Notice - Bo
+Quest_WantedPaper_0019	Bounty Notice - Ursula
+Quest_WantedPaper_0020	Bounty Notice - Helia
+Quest_WantedPaper_0021	Bounty Notice - Elara
+Quest_WantedPaper_0022	Bounty Notice - Sigor
+Quest_WantedPaper_0023	Bounty Notice - Duran
+Quest_WantedPaper_0024	Bounty Notice - Borzak
+Quest_WantedPaper_0025	Bounty Notice - Giovanni
+Quest_WantedPaper_0026	Bounty Notice - Morga
+Quest_WantedPaper_0027	Bounty Notice - Lilith
+Quest_WantedPaper_0028	Bounty Notice - Zelia
+Quest_WantedPaper_0029	Bounty Notice - Talgrim
+Quest_WantedPaper_0031	Bounty Notice - Torfinn
+Quest_WantedPaper_0032	Bounty Notice - Sigrid
+Quest_WantedPaper_0033	Bounty Notice - Throk
+Quest_WantedPaper_0034	Bounty Notice - Rolf
+Quest_WantedPaper_0035	Bounty Notice - Wolfe
+Quest_WantedPaper_0036	Bounty Notice - Aera
+Quest_WantedPaper_0037	Bounty Notice - Kronk
+Quest_WantedPaper_0038	Bounty Notice - Ivar
+Quest_WantedPaper_0039	Bounty Notice - Snaggle
+Quest_WantedPaper_0040	Bounty Notice - Sienna
+Quest_WantedPaper_0041	Bounty Notice - Caesar
+Quest_WantedPaper_0042	Bounty Notice - Barrick
+Quest_WantedPaper_0043	Bounty Notice - Sigrun
+Quest_WantedPaper_0044	Bounty Notice - Tarik
+Quest_WantedPaper_0045	Bounty Notice - Zahir
+Quest_WantedPaper_0047	Bounty Notice - Nabila
+Quest_WantedPaper_0048	Bounty Notice - Brogar
+Quest_WantedPaper_0049	Bounty Notice - Varka
+Quest_WantedPaper_0050	Bounty Notice - Hakim
+Quest_WantedPaper_0052	Bounty Notice - Rinaldo
+Quest_WantedPaper_0059	Bounty Notice - Jeffrey
+Quest_WantedPaper_0101	Bounty Notice - Billy
+Quest_WantedPaper_0102	Bounty Notice - Gunder
+Quest_WantedPaper_0103	Bounty Notice - Henrik
+Quest_WantedPaper_0104	Bounty Notice - Aksel
+Quest_WantedPaper_0105	Bounty Notice - Brooks
+Quest_WantedPaper_0106	Bounty Notice - Obyss
+Quest_WantedPaper_0107	Bounty Notice - Patrick
+Quest_WantedPaper_0108	Bounty Notice - Jonathan
+Quest_WantedPaper_0109	Bounty Notice - Frank
+Quest_WantedPaper_0110	Bounty Notice - Broll
+Quest_Witch_Token_I	Witch's Token
+Quest_Witch_Token_II	Witch's Token
+Quest_Witch_Token_III	Witch's Token
+Quest_Witch_Token_IV	Witch's Token
+Quiver	Replenishing Arrows
+Qunicks_Leather_Armor	Kenecks Leather Armor
+Rabbid_Fabric_Helm	Raveed Cloth Cap
+Raccoon_Fabric_Helm	Raccoon Cloth Hat
+Racky_Fabric_Armor	Lackey Cloth Armor
+Raddlerz_Fabric_Armor	Raddler Cloth Armor
+Radian_Fabric_Armor	Radian Cloth Armor
+Radiano_Leather_Armor	Radiano Leather Armor
+Radley_Fabric_Armor	Radley Cloth Armor
+Rafflia_Leather_Boots	Raphelia Leather Boots
+Raging_Tempests_Leader_Leather_Gloves	Raging Tempest's Leather Gloves
+Raging_Tempests_Leader_Plate_Boots	Raging Tempest's Plate Boots
+Raging_Tempests_Leader_PlateArmor_Armor	Raging Tempest's Plate Armor
+Raging_Tempests_Leader_PlateArmor_Helm	Raging Tempest's Plate Helm
+Rahelm_Fabric_Helm	Rahelm Cloth Headband
+Rakhir_Fabric_Gloves	Rakhir Cloth Gloves
+Rakkli_PlateArmor_Armor	Rakkli Plate Armor
+Rakuzen_Leather_Boots	Rezzcan Leather Boots
+Ramastern_Leather_Boots	Ramastern Leather Boots
+Ranibider_Leather_Helm	Lanweiter Leather Helm
+Ranubio_Leather_Armor	Ranubio Leather Armor
+Raphtha_PlateArmor_Helm_I	Demenissian Guard's Plate Helm
+Raphtha_PlateArmor_Helm_II	Demenissian Guard's Plate Helm
+Raphtha_PlateArmor_Helm_III	Inquisitor's Plate Helm
+Rapid_Leather_Armor	Rapid Leather Armor
+Rapid_Leather_Gloves	Rapid Leather Gloves
+Rapitz_Leather_Gloves	Rannys Leather Gloves
+Rarchrah_Fabric_Armor	Lokra Cloth Armor
+Rarkah_Fabric_Armor	Rarkah Cloth Armor
+Rarksian_Leather_Armor	Larkson Leather Armor
+Rasb_Leather_Gloves	Rainier Leather Gloves
+Rasberry	Raspberry
+Rasens_Leather_Gloves	Reshesh Leather Gloves
+Raska_Leather_Gloves	Remebrou Leather Gloves
+Rasku_Leather_Gloves	Ravellu Leather Gloves
+Raspel_Leather_Gloves	Lasfeld Leather Gloves
+Ratisan_Fabric_Gloves	Ratisan Cloth Gloves
+Rattan_Wood_OneHandShield	Rattan Shield
+Ratti_Leather_Boots	Ratti Leather Boots
+Ratti_PlateArmor_Gloves	Ratti Plate Gloves
+Ratti_PlateArmor_Gloves_I	Blacksteel Ratti Plate Gloves
+Ratti_PlateArmor_Gloves_II	Ratti Plate Gloves II
+Ratu_Fabric_Gloves	Rattu Cloth Gloves
+Ratuni_Leather_Boots	Lutteri Leather Boots
+Raukington_Fabric_Helm	Rockington Cloth Cap
+Raven_PlateArmor_Armor	Levin Plate Armor
+Raven_PlateArmor_Armor_I	Levin Plate Armor
+Raven_PlateArmor_Armor_II	Levin Plate Armor
+Raxion_TwoHandAxe	Bonepit Greataxe
+Rayhorn_TwoHandSword	Rhett's Longsword
+Rayra_Fabric_Helm	Leila Cloth Cap
+Rayra_Leather_Gloves	Leila Leather Gloves
+Reak_Leather_Armor	Reak Leather Armor
+Recipe_Beef_Bone_Soup	Recipe: Meat Stew
+Recipe_Berry_Juice	Recipe: Fruit Juice
+Recipe_BoiledPork	Recipe: Boiled Meat
+Recipe_Book_Accessory_I	Accessories of the World, Vol. I
+Recipe_Book_Accessory_II	Accessories of the World, Vol. II
+Recipe_Book_Accessory_III	Accessories of the World, Vol. III
+Recipe_Book_Accessory_IV	Accessories of the World, Vol. IV
+Recipe_Book_Beekeeping	Beekeeper Gear Blueprint
+Recipe_Book_Ent	Shadowleaf Disguise Blueprint
+Recipe_Book_Equip_Felling_Axe_I	Fine Logging Axe Blueprint
+Recipe_Book_Equip_Felling_Axe_II	Olvald's Logging Axe Blueprint
+Recipe_Book_Equip_Pickaxe_I	Fine Pickaxe Blueprint
+Recipe_Book_Equip_Pickaxe_II	Bernor's Pickaxe Blueprint
+Recipe_Book_FabricArmor_I	Cloth Armors of the World, Vol. I
+Recipe_Book_FabricArmor_II	Cloth Armors of the World, Vol. II
+Recipe_Book_FabricArmor_III	Cloth Armors of the World, Vol. III
+Recipe_Book_FabricArmor_IV	Cloth Armors of the World, Vol. IV
+Recipe_Book_FishingRod_II	Fine Fishing Rod Blueprint
+Recipe_Book_LeatherArmor_I	Leather Armors of the World, Vol. I
+Recipe_Book_LeatherArmor_II	Leather Armors of the World, Vol. II
+Recipe_Book_LeatherArmor_III	Leather Armors of the World, Vol. III
+Recipe_Book_LeatherArmor_IV	Leather Armors of the World, Vol. IV
+Recipe_Book_OneHandShield_I	Shields of the World, Vol. I
+Recipe_Book_OneHandShield_II	Shields of the World, Vol. II
+Recipe_Book_OneHandShield_III	Shields of the World, Vol. III
+Recipe_Book_OneHandShield_IV	Shields of the World, Vol. IV
+Recipe_Book_OneHandWeapon_I	One-Handed Weapons of the World, Vol. I
+Recipe_Book_OneHandWeapon_II	One-Handed Weapons of the World, Vol. II
+Recipe_Book_OneHandWeapon_III	One-Handed Weapons of the World, Vol. III
+Recipe_Book_OneHandWeapon_IV	One-Handed Weapons of the World, Vol. IV
+Recipe_Book_PlateArmor_I	Plate Armors of the World, Vol. I
+Recipe_Book_PlateArmor_II	Plate Armors of the World, Vol. II
+Recipe_Book_PlateArmor_III	Plate Armors of the World, Vol. III
+Recipe_Book_PlateArmor_IV	Plate Armors of the World, Vol. IV
+Recipe_Book_Posion_Aroww	Poison Arrow Blueprint
+Recipe_Book_RangeWeapon_Metal_I	Ranged Weapons of the World - Guns, Vol. I
+Recipe_Book_RangeWeapon_Metal_II	Ranged Weapons of the World - Guns, Vol. II
+Recipe_Book_RangeWeapon_Metal_III	Ranged Weapons of the World - Guns, Vol. III
+Recipe_Book_RangeWeapon_Metal_IV	Ranged Weapons of the World - Guns, Vol. IV
+Recipe_Book_RangeWeapon_Wood_I	Ranged Weapons of the World - Bows, Vol. I
+Recipe_Book_RangeWeapon_Wood_II	Ranged Weapons of the World - Bows, Vol. II
+Recipe_Book_RangeWeapon_Wood_III	Ranged Weapons of the World - Bows, Vol. III
+Recipe_Book_RangeWeapon_Wood_IV	Ranged Weapons of the World - Bows, Vol. IV
+Recipe_Book_Scarecrow_Camouflage_Cloak	Scarecrow Cloak Blueprint
+Recipe_Book_Spear_Fire	Flame Spear Blueprint
+Recipe_Book_Spear_Lightning	Lightning Spear Blueprint
+Recipe_Book_Spear_Wind	Propeller Spear Blueprint
+Recipe_Book_TwoHandWeapon_I	Two-Handed Weapons of the World, Vol. I
+Recipe_Book_TwoHandWeapon_II	Two-Handed Weapons of the World, Vol. II
+Recipe_Book_TwoHandWeapon_III	Two-Handed Weapons of the World, Vol. III
+Recipe_Book_TwoHandWeapon_IV	Two-Handed Weapons of the World, Vol. IV
+Recipe_Book_Varnia	Varnian Equipment Blueprint
+Recipe_Book_Wells_HorseArmor	Wells Military Tack Blueprint
+Recipe_Braised_Fish	Recipe: Braised Fish
+Recipe_Braised_Fish_Vegetable	Recipe: Braised Fish and Vegetables
+Recipe_Braised_Meat	Recipe: Braised Meat
+Recipe_Braised_Meat_Fish	Recipe: Braised Meat and Fish
+Recipe_Braised_Meat_Vegetable	Recipe: Braised Ribs
+Recipe_Braised_Vegetable	Recipe: Pickled Vegetables
+Recipe_Chocolate	Recipe: Chocolate
+Recipe_Deactived_Abyss_Artifact	Blueprint: Faded Abyss Artifact
+Recipe_DeerAntler_Fruit_Tea	Recipe: Antler Tea
+Recipe_DeerAntler_Soup	Recipe: Longhorn Soup
+Recipe_Fish_Bulgogi	Recipe: Pan-Fried Marinated Fish
+Recipe_Fish_Fruit_Porridge	Recipe: Steamed Fish
+Recipe_Fish_Porridge	Recipe: Fish Porridge
+Recipe_Fish_Sanjeok	Recipe: Fish Skewers
+Recipe_Fish_Soup	Recipe: Mixed Stew
+Recipe_Fish_Stew	Recipe: Fish Stew
+Recipe_Fish_Vegetable_Porridge	Recipe: Vegetable and Seafood Porridge
+Recipe_Fruit_Porridge	Recipe: Fruit Punch
+Recipe_Fruit_Wine	Recipe: Wine
+Recipe_FruitTea	Recipe: Fruit Tea
+Recipe_Full_Course_of_Braised_Fish	Recipe: Assorted Braised Fish
+Recipe_GoldBar	Alchemy Formula: Gold Bar
+Recipe_Grilled_Meat_Fish	Recipe: Grilled Meat and Fish
+Recipe_Gungjung_Tteokbokki	Recipe: Pan-Fried Rice Cakes
+Recipe_Haemuljjim	Recipe: Steamed Seafood
+Recipe_Herbal_Tea	Recipe: Mild Herbal Tea
+Recipe_High_Wine	Recipe: Delesyian Wine
+Recipe_Honey_Tea	Recipe: Honey Tea
+Recipe_Item_Skill_AbyssGear_AbsoluteDefense_LV1	Gear Blueprint: Piercing Bloom
+Recipe_Item_Skill_AbyssGear_AbyssGrass_Immune	Gear Blueprint: Abyssal Assimilation
+Recipe_Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_FabricArmor_LV1	Gear Blueprint: Shred
+Recipe_Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_LeatherArmor_LV1	Gear Blueprint: Rend
+Recipe_Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_PlateArmor_LV1	Gear Blueprint: Shatter
+Recipe_Item_Skill_AbyssGear_AddFrendly_LV1	Gear Blueprint: Solidarity
+Recipe_Item_Skill_AbyssGear_AdditionalThief_LV1	Gear Blueprint: Ledgermain
+Recipe_Item_Skill_AbyssGear_AddKillSkillLevel_LV1	Gear Blueprint: Energy Drain
+Recipe_Item_Skill_AbyssGear_AddMoneyDropRate_LV1	Gear Blueprint: Fortune
+Recipe_Item_Skill_AbyssGear_Antumbra_Spear	Gear Blueprint: Warden of Darkness
+Recipe_Item_Skill_AbyssGear_Antumbra_TwoHandRod	Gear Blueprint: Dark Crescent
+Recipe_Item_Skill_AbyssGear_ArrowRain_LV1	Gear Blueprint: Arrow Rain
+Recipe_Item_Skill_AbyssGear_AtorDrone_LV1	Gear Blueprint: Ator's Orb
+Recipe_Item_Skill_AbyssGear_Attack_HPRecover_LV1	Gear Blueprint: Life Transference
+Recipe_Item_Skill_AbyssGear_Attack_MPRecover_LV1	Gear Blueprint: Spirit Transference
+Recipe_Item_Skill_AbyssGear_Attack_SPRecover_LV1	Gear Blueprint: Stamina Transference
+Recipe_Item_Skill_AbyssGear_Bastier	Gear Blueprint: Flames of Judgment
+Recipe_Item_Skill_AbyssGear_BlockAmmoConsume_LV1	Gear Blueprint: Infinite Arrows
+Recipe_Item_Skill_AbyssGear_Boss_AdditionalDamage_LV1	Gear Blueprint: Malicebane
+Recipe_Item_Skill_AbyssGear_Catfish_BodySlam_LV1	Gear Blueprint: Rising Torrent
+Recipe_Item_Skill_AbyssGear_CollectDrop_Animal_LV1	Gear Blueprint: Blessing of the Beast
+Recipe_Item_Skill_AbyssGear_CollectDrop_Log_LV1	Gear Blueprint: Blessing of the Forest
+Recipe_Item_Skill_AbyssGear_CollectDrop_Ore_LV1	Gear Blueprint: Blessing of the Earth
+Recipe_Item_Skill_AbyssGear_CollectDrop_Plant_LV1	Gear Blueprint: Blessing of Nature
+Recipe_Item_Skill_AbyssGear_Combo_LV1	Gear Blueprint: Relentless
+Recipe_Item_Skill_AbyssGear_CommonAnimal_AdditionalDamage_LV1	Gear Blueprint: Beastbane
+Recipe_Item_Skill_AbyssGear_CommonGolem_AdditionalDamage_LV1	Gear Blueprint: Primalbane
+Recipe_Item_Skill_AbyssGear_CommonHexe_AdditionalDamage_LV1	Gear Blueprint: Hexebane
+Recipe_Item_Skill_AbyssGear_CommonHumanoid_AdditionalDamage_LV1	Gear Blueprint: Bloodbane
+Recipe_Item_Skill_AbyssGear_ContributionExp_LV1	Gear Blueprint: Service
+Recipe_Item_Skill_AbyssGear_Creature_AdditionalDamage_LV1	Gear Blueprint: Abyssbane
+Recipe_Item_Skill_AbyssGear_CresecentAura_1_LV1	Gear Blueprint: Crescent Moon Slash
+Recipe_Item_Skill_AbyssGear_CresecentAura_2_LV1	Gear Blueprint: Half Moon Slash
+Recipe_Item_Skill_AbyssGear_CresecentAura_3_LV1	Gear Blueprint: Fullmoon Slash
+Recipe_Item_Skill_AbyssGear_CrowAttack_LV1	Gear Blueprint: Crow's Pursuit
+Recipe_Item_Skill_AbyssGear_CrowStorm_LV1	Gear Blueprint: Crow Storm
+Recipe_Item_Skill_AbyssGear_DAM_UP_RotationBash	Gear Blueprint: Momentum
+Recipe_Item_Skill_AbyssGear_DarkChase_LV1	Gear Blueprint: Greysoul Howling
+Recipe_Item_Skill_AbyssGear_DarkenRobe_LV1	Gear Blueprint: Wound of Darkness
+Recipe_Item_Skill_AbyssGear_DogClaw_LV1	Gear Blueprint: Hound's Claws
+Recipe_Item_Skill_AbyssGear_EnergyBurst_LV1	Gear Blueprint: Kinetic Burst
+Recipe_Item_Skill_AbyssGear_EnlightenmentWave_LV1	Gear Blueprint: Karmic Pulse
+Recipe_Item_Skill_AbyssGear_Equip_AddHorseExp_LV1	Gear Blueprint: Equestrian
+Recipe_Item_Skill_AbyssGear_Equip_AddPetFriendly_LV1	Gear Blueprint: Companionship
+Recipe_Item_Skill_AbyssGear_EquipDropRate_LV1	Gear Blueprint: Disarm
+Recipe_Item_Skill_AbyssGear_FireBreath_LV1	Gear Blueprint: Volcanic Eruption
+Recipe_Item_Skill_AbyssGear_FlashCombo_LV1	Gear Blueprint: Slashing Reeds
+Recipe_Item_Skill_AbyssGear_FoodSkillLevelUp_LV1	Gear Blueprint: Gourmet
+Recipe_Item_Skill_AbyssGear_Forgotten_General	Gear Blueprint: Judgment of the Soul
+Recipe_Item_Skill_AbyssGear_FrostBreath_LV1	Gear Blueprint: Frost Hail
+Recipe_Item_Skill_AbyssGear_FrostDeath_LV1	Gear Blueprint: Shattering Frost
+Recipe_Item_Skill_AbyssGear_FrostSpike_LV1	Gear Blueprint: Frost Spike
+Recipe_Item_Skill_AbyssGear_Hyena_PoisonImmune	Gear Blueprint: Heart of the Serpent
+Recipe_Item_Skill_AbyssGear_Immune_Bismuth	Gear Blueprint: Heart of Stone
+Recipe_Item_Skill_AbyssGear_ImpBoss	Gear Blueprint: Howling of Chaos
+Recipe_Item_Skill_AbyssGear_Karanda	Gear Blueprint: Pillar of Wind
+Recipe_Item_Skill_AbyssGear_LandMash_LV1	Gear Blueprint: Groundsurge
+Recipe_Item_Skill_AbyssGear_LanFord	Gear Blueprint: Parting Gift
+Recipe_Item_Skill_AbyssGear_Leebur	Gear Blueprint: Shadow Claw
+Recipe_Item_Skill_AbyssGear_LightningBreath_LV1	Gear Blueprint: Orbs of Lightning
+Recipe_Item_Skill_AbyssGear_LightningStab_LV1	Gear Blueprint: Storm Fang
+Recipe_Item_Skill_AbyssGear_Machine_AdditionalDamage_LV1	Gear Blueprint: Steelbane
+Recipe_Item_Skill_AbyssGear_Merrick	Gear Blueprint: Order from Above
+Recipe_Item_Skill_AbyssGear_Muscan	Gear Blueprint: The Showstopper
+Recipe_Item_Skill_AbyssGear_Ogre	Gear Blueprint: Colossal Might
+Recipe_Item_Skill_AbyssGear_PhantomStab_LV1	Gear Blueprint: Abyssal Rays
+Recipe_Item_Skill_AbyssGear_Praevus	Gear Blueprint: Ancient Wrath
+Recipe_Item_Skill_AbyssGear_Primus	Gear Blueprint: Ancient Reckoning
+Recipe_Item_Skill_AbyssGear_Priscus	Gear Blueprint: Ancient Retribution
+Recipe_Item_Skill_AbyssGear_QueenSpider	Gear Blueprint: Queen's Fangs
+Recipe_Item_Skill_AbyssGear_ReduceCraftMaterial_LV1	Gear Blueprint: Efficiency
+Recipe_Item_Skill_AbyssGear_Skevald	Gear Blueprint: Putrid Touch
+Recipe_Item_Skill_AbyssGear_SkillPointExp_LV1	Gear Blueprint: Aptitude
+Recipe_Item_Skill_AbyssGear_SmashStorm_LV1	Gear Blueprint: Tempest of Destruction
+Recipe_Item_Skill_AbyssGear_SoulStrike_LV1	Gear Blueprint: Spirit's Judgment
+Recipe_Item_Skill_AbyssGear_SwordAura_LV1	Gear Blueprint: Wind Slash
+Recipe_Item_Skill_AbyssGear_TarandusWarrior_WarHammer	Gear Blueprint: Earthrending Strike
+Recipe_Item_Skill_AbyssGear_Titan	Gear Blueprint: Lightning God's Affliction
+Recipe_Item_Stat_AbyssGear_ADR_LV1	Gear Blueprint: Aegis
+Recipe_Item_Stat_AbyssGear_AttackSpeedRate_LV1	Gear Blueprint: Swift
+Recipe_Item_Stat_AbyssGear_ClimbSpeedRate_LV1	Gear Blueprint: Ascent
+Recipe_Item_Stat_AbyssGear_CriticalRate_LV1	Gear Blueprint: Insight
+Recipe_Item_Stat_AbyssGear_DDD_LV1	Gear Blueprint: Destruction
+Recipe_Item_Stat_AbyssGear_DPV_LV1	Gear Blueprint: Fortification
+Recipe_Item_Stat_AbyssGear_ElectricityResistance_LV1	Gear Blueprint: Shockward
+Recipe_Item_Stat_AbyssGear_FireResistance_LV1	Gear Blueprint: Flameward
+Recipe_Item_Stat_AbyssGear_GuardPVRate_LV1	Gear Blueprint: Fortitude
+Recipe_Item_Stat_AbyssGear_HpRegen_LV1	Gear Blueprint: Vitality
+Recipe_Item_Stat_AbyssGear_IceResistance_LV1	Gear Blueprint: Frostward
+Recipe_Item_Stat_AbyssGear_MoveSpeedRate_LV1	Gear Blueprint: Haste
+Recipe_Item_Stat_AbyssGear_MpRegen_LV1	Gear Blueprint: Composure
+Recipe_Item_Stat_AbyssGear_StaminaRegen_LV1	Gear Blueprint: Vigor
+Recipe_Item_Stat_AbyssGear_SwimSpeedRate_LV1	Gear Blueprint: Surge
+Recipe_Japchae	Recipe: Pan-Fried Vegetables
+Recipe_Jeonju_Bibimbap	Recipe: Mixed Harvest Bowl
+Recipe_Kimbap	Recipe: Battered Harvest Roll
+Recipe_Meat_Fish_Fruit_Sanjeok	Recipe: Assorted Meat and Fish Skewers
+Recipe_Meat_Fish_Grain_Sanjeok	Recipe: Grilled Meat Steak
+Recipe_Meat_Fish_Porridge	Recipe: Meat and Fish Porridge
+Recipe_Meat_Fish_Sanjeok	Recipe: Meat and Fish Skewers
+Recipe_Meat_Fish_Vegetable_Egg	Recipe: Meatball Soup
+Recipe_Meat_Fruit_Porridge	Recipe: Pan-Fried Marinated Meat
+Recipe_Meat_Porridge	Recipe: Clear Soup
+Recipe_Meat_Sanjeok	Recipe: Meat Skewers
+Recipe_Meat_Vegetable_Porridge	Recipe: Meat and Vegetable Porridge
+Recipe_Nureumjeok	Recipe: Mixed Skewers
+Recipe_Pan_fried_Fish_Fruit_Pancake	Recipe: Seafood Stew
+Recipe_Pan_fried_Fish_Grain_Pancake	Recipe: Fishball Soup
+Recipe_Pan_fried_Fish_Pancake	Recipe: Battered Fish
+Recipe_Pan_fried_Fish_Vegetable_Pancake	Recipe: Battered Seafood
+Recipe_Pan_fried_Fruit_Grain_Pancake	Recipe: Chewy Rice Cakes
+Recipe_Pan_fried_Fruit_Pancake	Recipe: Pickled Fruit
+Recipe_Pan_fried_Grain_Pancake	Recipe: Battered Grains
+Recipe_Pan_fried_Meat_Fish_Pancake	Recipe: Battered Meat and Fish
+Recipe_Pan_fried_Meat_Fruit_Pancake	Recipe: Marinated Meat
+Recipe_Pan_fried_Meat_Grain_Pancake	Recipe: Meat Stew
+Recipe_Pan_fried_Meat_Pancake	Recipe: Battered Meat
+Recipe_Pan_fried_Meat_Vegetable_Pancake	Recipe: Steamed Eggs
+Recipe_Pan_fried_Vegetable_Fruit_Pancake	Recipe: Vegetable Rice Cake
+Recipe_Pan_fried_Vegetable_Grain_Pancake	Recipe: Grain Soup
+Recipe_Pan_fried_Vegetable_Pancake	Recipe: Battered Vegetables
+Recipe_Platinum	Alchemy Formula: Platinum
+Recipe_Potion_DDD_LV1	Alchemy Formula: Freya's Lesser Elixir
+Recipe_Potion_DDD_LV2	Alchemy Formula: Freya's Elixir
+Recipe_Potion_DDD_LV3	Alchemy Formula: Freya's Greater Elixir
+Recipe_Potion_DPV_LV1	Alchemy Formula: Apollonia's Lesser Elixir
+Recipe_Potion_DPV_LV2	Alchemy Formula: Apollonia's Elixir
+Recipe_Potion_DPV_LV3	Alchemy Formula: Apollonia's Greater Elixir
+Recipe_Potion_HP_LV1	Alchemy Formula: Meliara's Lesser Elixir
+Recipe_Potion_HP_LV2	Alchemy Formula: Meliara's Elixir
+Recipe_Potion_HP_LV3	Alchemy Formula: Meliara's Greater Elixir
+Recipe_Potion_MP_LV1	Alchemy Formula: Haiden's Lesser Elixir
+Recipe_Potion_MP_LV2	Alchemy Formula: Haiden's Elixir
+Recipe_Potion_MP_LV3	Alchemy Formula: Haiden's Greater Elixir
+Recipe_Potion_SP_LV1	Alchemy Formula: Astrid's Lesser Elixir
+Recipe_Potion_SP_LV2	Alchemy Formula: Astrid's Elixir
+Recipe_Potion_SP_LV3	Alchemy Formula: Astrid's Greater Elixir
+Recipe_Pyogo_Mushroom_Tea	Recipe: Oakwood Mushroom Tea
+Recipe_RevivalItem	Alchemy Formula: Refined Palmar Pill
+Recipe_RevivalItemPartialRecovery	Alchemy Formula: Palmar Pill
+Recipe_Roast_Chicken	Recipe: Salt-Roasted Bird Meat
+Recipe_Roast_Fish	Recipe: Salt-Roasted Fish
+Recipe_SamGyeTang	Recipe: Bird Soup
+Recipe_Seafood_Soup	Recipe: Seafood Soup
+Recipe_Sinseollo	Recipe: Harvest Soup
+Recipe_Songyi_Mushroom_Tea	Recipe: Pine Mushroom Tea
+Recipe_Ssari_Mushroom_Tea	Recipe: Coral Mushroom Tea
+Recipe_Surasang_00	Recipe: Grand Meal
+Recipe_Surasang_01	Recipe: Extravagant Meal
+Recipe_Surasang_02	Recipe: Lavish Meal
+Recipe_Surasang_03	Recipe: Fine Meal
+Recipe_Surasang_04	Recipe: Special Meal
+Recipe_Surasang_05	Recipe: Meal
+Recipe_Tteokgalbi	Recipe: Grilled Meat Patties
+Recipe_Vegetable_Fruit_Porridge	Recipe: Harvest Roll
+Recipe_Vegetable_Juice	Recipe: Vegetable Juice
+Recipe_Vegetable_Porridge	Recipe: Vegetable Porridge
+Reckleeman_TwoHandSword	Balton Longsword
+Recle_OneHandTowerShield	Rekel Large Shield
+Red_Ring	Rough Bluestone Ring
+Redbeet	Beet
+RedDeerHorn_Mushroom	Poison Fire Coral Mushroom
+RedHare_Horse_Report	Sighting of Camora
+Redin_ChainMail_Armor	Reddin Chain Mail
+Redknight_Plate_Boots	Plate Boots of Cursed Soul
+Redknight_PlateArmor_Armor	Plate Armor of Cursed Soul
+Redknight_PlateArmor_Cloak	Plate Cloak of Cursed Soul
+Redknight_PlateArmor_Gloves	Plate Gloves of Cursed Soul
+Redknight_PlateArmor_Helm	Plate Helm of Cursed Soul
+Redknight_PlateArmor_Helm_II	Turncoat Plate Helm
+Redknight_PlateArmor_Helm_III	Plumed Wells Rebel's Plate Helm
+Redknight_PlateArmor_Helm_IV	Wells Rebel's Silver Plate Helm
+Redleader_Leather_Gloves	Red Rider's Leather Gloves
+Redleader_PlateArmor_Armor	Red Rider's Plate Armor
+Redleader_PlateArmor_Helm	Red Rider's Plate Helm
+Redman_PlateArmor_Armor	Redman Plate Armor
+RedNose_Lantern	Dark Fog Lantern
+Redrin_Fabric_Helm	Redrin Cloth Cap
+Redsentinel_ChainMail_Armor	Crimson Chaser Mail
+Redsentinel_ChainMail_Cloak	Crimson Chaser Chain Cloak
+Redsentinel_Necklace	Crimson Warden's Necklace
+Redsentinel_PlateArmor_Gloves	Crimson Chaser Chain Gloves
+Redsentinel_PlateArmor_Helm	Crimson Chaser Plate Helm
+RedStone	Bloodstone
+ReedDevil_Doll	Devil of the Reed Field's Doll
+Reeddevil_Fabric_Boots	Sunset Reed Cloth Boots
+Reeddevil_Fabric_Boots_T5_QA	Reeddevil Fabric Boots T5 QA
+Reeddevil_Fabric_Gloves	Sunset Reed Cloth Gloves
+Reeddevil_Fabric_Gloves_T5_QA	Reeddevil Fabric Gloves T5 QA
+Reeddevil_Fabric_Helm_I	Reed Devil Minion's Cloth Helm
+Reeddevil_Fabric_Helm_II	Reed Devil Minion's Cloth Helm
+Reeddevil_Fabric_Helm_III	Reed Devil Minion's Cloth Helm
+Reeddevil_Leather_Armor	Sunset Reed Leather Armor
+Reeddevil_Leather_Armor_I	Reed Devil Underling's Red Armor
+Reeddevil_Leather_Armor_II	Reed Devil Underling's Yellow Armor
+Reeddevil_Leather_Armor_III	Reed Devil Underling's Armor
+Reeddevil_Leather_Cloak	Sunset Reed Leather Cloak
+ReedDevil_Mask	Mask of the Devil of the Reed Field
+Reeddevil_Troll_Fabric_Helm	Reed Devil Minion Troll's Cloth Helm
+Reeddevil_Troll_Leather_Armor	Reed Devil Troll Armor
+Regglin_Boss_Fabric_Boots	Fundamentalist Officer Cloth Boots
+Regglin_Boss_Helm	Leather Hat of Enlightenment
+Regglin_Boss_TwoHandSword	Bringer of Balance
+Regglin_Fabric_Armor	Fundamentalist's Cloth Armor
+Regglin_Fabric_Armor_I	Fundamentalist's Cloth Armor
+Regglin_Fabric_Armor_II	Fundamentalist's Cloth Armor
+Regglin_Fabric_Armor_III	Fundamentalist's Cloth Armor
+Regglin_Fabric_Armor_IV	Gilded Goblin's Cloth Armor
+Regglin_Fabric_Armor_MiddleBoss	Fundamentalist Goblin Cloth Armor
+Regglin_Fabric_Armor_MiddleBoss_I	Fundamentalist Goblin Cloth Armor
+Regglin_Fabric_Armor_MiddleBoss_II	Fundamentalist Goblin Cloth Armor
+Regglin_Fabric_Armor_MiddleBoss_III	Fundamentalist Goblin Cloth Armor
+Regglin_Fabric_Armor_V	Gilded Goblin's Cloth Armor
+Regglin_Fabric_Armor_VI	Gilded Goblin's Cloth Armor
+Regglin_Leather_Boots	Fundamentalist Goblin Leather Boots
+Regglin_PlateArmor_Helm	Regglin Plate Helm
+Rehsian_Leather_Armor	Resian Leather Armor
+ReiGhis_Leather_Boots	Rhegis Leather Boots
+ReiGhis_Leather_Boots_I	Large Rhegis Leather Boots
+ReiGhis_Leather_Boots_II	Rhegis Leather Boots
+ReiGhis_Leather_Boots_III	Large Rhegis Leather Boots
+ReiGhis_PlateArmor_Helm	Musket Border Guard Standard Helm
+ReiGhis_Wood_OneHandShield	Balton Shield
+Reikiru_Leather_Boots	Leegrau Leather Boots
+Reinbaldt_Plate_Boots	Demenissian Plate Boots
+ReinforcedSteel_OneHandCannon	Reinforced Steel Blaster
+Rekklann_Fabric_Armor	Rexlan Cloth Armor
+Reklenne_Fabric_Gloves	Recklin Cloth Gloves
+Rellone_Fabric_Armor	Rellone Cloth Armor
+Reltan_Fabric_Armor	Reltan Cloth Armor
+Reltian_Fabric_Armor	Reltian Cloth Armor
+Reltinan_Fabric_Armor	Reltinan Cloth Armor
+Renarto_OneHandRapier	Brass Rose Rapier
+Rendal_Leather_Boots	Wendahl Leather Shoes
+Rendal_Leather_Gloves	Wendahl Leather Gloves
+Repen_PlateArmor_Armor	Reppin Plate Armor
+Repo_Leather_Gloves	Leppo Leather Gloves
+Reputy_Leather_Boots	Rafferty Leather Shoes
+Restraint_Rope_Fabric_Gloves_I	Restraint Rope Fabric Gloves I
+RevivalItem	Refined Palmar Pill
+RevivalItemPartialRecovery	Palmar Pill
+Revog_PlateArmor_Armor	Leighbog Plate Armor
+RevolutionaryArmy_Fabric_Armor	Demenissian Rebel Cloth Armor
+RevolutionaryArmy_Fabric_Armor_I	Demenissian Rebel Cloth Armor
+RevolutionaryArmy_Fabric_Armor_II	Demenissian Rebel Cloth Armor
+RevolutionaryArmy_Fabric_Armor_III	Demenissian Rebel Cloth Armor
+RevolutionaryArmy_Leather_Gloves	Demenissian Rebel Leather Gloves
+Rhapts_Leather_Armor	Rapps Leather Armor
+Rhapts_PlateArmor_Helm	Rapps Plate Helm
+Rhias_Fabric_Boots	Reus Cloth Boots
+Rhias_Leather_Boots	Reus Leather Boots
+Rhias_OneHandAxe	Rhias's Axe
+Rhinard_Leather_Gloves	Rhinard Leather Gloves
+Rhinard_TwoHandCannon	Rhinard Cannon
+Rhinard_TwoHandCannon_I	Finest Rhinard Cannon
+Rhodelphine_Leather_Armor	Rhodelphine Leather Armor
+Rhonda_Leather_Boots	Rhonda Leather Boots
+Rhyspidon_Leather_Armor	Lespedan Leather Armor
+Rhyspidon_Leather_Gloves	Lespedan Leather Gloves
+Rhystizer_Leather_Gloves_I	Rowley Leather Gloves
+Rhystizer_OneHandMusket	Helms Musket
+Rhytem_Leather_Armor	Rittem Leather Armor
+Rhytrian_Fabric_Helm	Rhytrian Cloth Cap
+Ribben_Fabric_Helm	Riven Cloth Cap
+Ribentain_Priest_OneHandShield	Saint's Blessing
+Ribentain_Priest_TwoHandSpear	Reventine Priest's Spear
+Rice	Toasted Grains
+Rice_Large	Satisfying Toasted Grains
+Rice_Medium	Filling Toasted Grains
+Rice_XLarge	Hearty Toasted Grains
+Rickaltje_Leather_Boots	Ligatra Leather Boots
+Riclia_Leather_Armor	Riclia Leather Armor
+Riding_AlpineIbex_Amulet	Sigil of Solidarity (Icicle Edge Alpine Ibex)
+Riding_AlpineIbex_Horn	Icicle Edge Alpine Ibex Horn
+Riding_Bear_Amulet	Sigil of Solidarity (White Bear)
+Riding_Bear_Claw	White Bear Claws
+Riding_Deer_Amulet	Sigil of Solidarity (Snowwhite Deer)
+Riding_Deer_Horn	Snowwhite Deer Antlers
+Riding_Fabric_Armor	Riding Attire
+Riding_Fabric_Cloak	Riding Cloak
+riding_Leather_Boots	Riding Boots
+riding_Leather_Gloves	Master Trainer's Touch
+riding_Leather_Helm	Leather Riding Hat
+Riding_Warthog_Amulet	Sigil of Solidarity (Rock Tusk Warthog)
+Riding_Warthog_Tooth	Rock Tusk Warthog Molar
+Riding_Wolf_Amulet	Sigil of Solidarity (Silver Fang)
+Riding_Wolf_Tooth	Fang of Silver Fang
+Riesi_Boots	Shoddy Rishi's Boots
+Riesi_Boots_Upgrade	Kuku Rishi's Boots
+Rik_Leather_Gloves	Reak Leather Gloves
+Rikisis_OneHandDagger	Sydmon Dagger
+Rikkmah_Fabric_Helm	Rigma Cloth Headband
+Rikkmah_Leather_Armor	Rigma Leather Armor
+Rikkmah_Leather_Gloves	Rigma Leather Gloves
+Rikkutan_Fabric_Armor	Rikkutan Cloth Armor
+Riknaon_Leather_Gloves	Rignon Leather Gloves
+Riurian_OneHandDagger	Dekarr Dagger
+Rivelorn_Fabric_Helm	Rivellon Cloth Cap
+Riverdine_ChainMail_Armor	Riverdine Chain Mail
+Roast_Chicken	Salt-Roasted Bird Meat
+Roast_Chicken_Large	Satisfying Salt-Roasted Bird Meat
+Roast_Chicken_Medium	Filling Salt-Roasted Bird Meat
+Roast_Chicken_XLarge	Hearty Salt-Roasted Bird Meat
+Roast_Fish	Salt-Roasted Fish
+Roast_Fish_Large	Satisfying Salt-Roasted Fish
+Roast_Fish_Medium	Filling Salt-Roasted Fish
+Roast_Fish_XLarge	Hearty Salt-Roasted Fish
+Robbery_Boots	Pillager's Leather Boots
+Robinhood_OneHandBow	Crimson Warden's Bow
+Rochi_PlateArmor_Armor	Roshee Plate Armor
+Rochi_PlateArmor_Armor_I	Blacksteel Roshee Plate Armor
+Rocko_PlateArmor_Armor	Rhogo Plate Armor
+Rocko_PlateArmor_Armor_I	Rhogo Plate Armor
+Roctar_Fabric_Armor	Roctar Cloth Armor
+Roderem_Leather_Boots	Rodderham Leather Boots
+Roderem_PlateArmor_Helm	Rodderham Plate Helm
+Romaned_PlateArmor_Armor	Romund Plate Armor
+Romaned_PlateArmor_Armor_I	Romund Plate Armor
+Rombardina_Leather_Armor	Rombardina Leather Armor
+Ronied_Fabric_Armor	Rhonid Cloth Armor
+Ronied_OneHandTowerShield	Rhonid Large Shield
+Rosardeuin_Fabric_Armor	Rosarduin Cloth Armor
+Rosemand_OneHandPistol	Rosemond Pistol
+Rosemary	Rosemary
+Rosemary_pink	Pink Rosemary
+Rosemary_white	White Rosemary
+Rosemary_yellow	Yellow Rosemary
+Roshine_Fabric_Armor	Roshayne Cloth Armor
+Rossbara_Leather_Gloves	Rossbara Leather Gloves
+Rosvar_HorseArmor_Helm	Rosbar Champron
+Royal_Hunting_Ground_Flag_III	Small Royal Hunting Ground Banner Pike
+RoyalGuard_OneHandShield	Royal Guard Shield
+Rubaunon_Fabric_Armor	Lubonon Cloth Armor
+Rubber_seed	Rubber Tree Seed
+Rubbiden_Leather_Armor	Rubidan Leather Armor
+Ruberfeldy_Leather_Armor	Roverfelt Leather Armor
+Ruby	Garnet
+Rudion_PlateArmor_Armor	Ludeon Plate Armor
+Ruischule_Fabric_Armor	Ruschelle Cloth Armor
+Rune_Leather_Boots	Runae Leather Boots
+Ruschar_Fabric_Cloak	Ruschar Cloth Cloak
+Ruschar_Leather_Armor	Ruschar Leather Armor
+Rush_Storm_Wood_OneHandShield	Iris Shield
+Russell_Leather_Armor	Russell Leather Armor
+Russmore_Leather_Boots	Russmore Leather Boots
+Rusty_Cigar_TwoHandAxe	Dekarr Greataxe
+Rusty_Deadwid_TwoHandAxe	Bekker Greataxe
+Rusty_Hagwood_OneHandDagger	Bekker Dagger
+Rusty_Hunter_OneHandSword	Volono Sword
+Rusty_TwoHandHammer	Bekker Greathammer
+Ruthie_Leather_Boots	Ruthie Leather Boots
+Rybee_PlateArmor_Helm	Rahbae Plate Helm
+Rybee_PlateArmor_Helm_I	Modified Rahbae Plate Helm
+Salami_Leather_Boots	Salmae Leather Shoes
+Salami_Leather_Gloves	Salmae Leather Gloves
+Salash_Fabric_Armor	Salash Cloth Armor
+Salimi_Fabric_Helm	Salimi Cloth Cap
+Salimi_Leather_Armor	Salimi Leather Armor
+Salt	Salt
+SamGyeTang	Bird Soup
+SamGyeTang_Large	Satisfying Bird Soup
+SamGyeTang_Medium	Filling Bird Soup
+SamGyeTang_XLarge	Hearty Bird Soup
+Samuel_Plate_Boots	Dark Marksman's Plate Boots
+Samuel_PlateArmor_Armor	Dark Marksman's Plate Armor
+Samuel_PlateArmor_Cloak	Dark Marksman's Plate Cloak
+Samuel_PlateArmor_Gloves	Dark Marksman's Plate Gloves
+Saolo_Leather_Armor	Saolo Leather Armor
+Sarantos_Leather_Boots	Sarantos Leather Boots
+Sarantos_Leather_Boots_I	Dirty Sarantos Leather Boots
+Sarantos_Leather_Boots_II	Worn Sarantos Leather Boots
+Sarendion_Fabric_Armor	Sarendion Cloth Armor
+Saristi_Fabric_Helm	Saristi Cloth Headband
+Sartalos_Leather_Gloves	Salatos Leather Gloves
+Saruen_Leather_Armor	Saruen Leather Armor
+Saruen_Leather_Boots	Saruen Leather Boots
+Saruen_Leather_Gloves	Saruen Leather Gloves
+Sarun_Leather_Gloves	Salun Leather Gloves
+Satyr_PlateArmor_Gloves	Satyros Plate Gloves
+Satyr_TwoHandedWarHammer	Thalwynd Warhammer
+Sazahan_PlateArmor_Armor	Sahazhad Plate Armor
+Sazahan_PlateArmor_Cloak	Sahazhad Plate Cloak
+Scalaphynion_Fabric_Armor	Skyblazer Cloth Armor
+Scalaphynion_Fabric_Armor_T4_QA	Scalaphynion Fabric Armor T4 QA
+Scalaphynion_Fabric_Cloak	Skyblazer Cloth Cloak
+Scalaphynion_Fabric_Cloak_T4_QA	Scalaphynion Fabric Cloak T4 QA
+Scalaphynion_Fabric_Helm	Skyblazer Cloth Helm
+Scalaphynion_Fabric_Helm_T4_QA	Scalaphynion Fabric Helm T4 QA
+Scalaphynion_Leather_Gloves	Skyblazer Leather Gloves
+Scarecrow_Camouflage_Cloak	Scarecrow Cloak
+Scarfle_OneHandMace	Balton Mace
+Scarlet_Excecutioner_Leather_Boots	Crimson Warden's Leather Boots
+Schillerbin_Fabric_Armor	Schillerbin Cloth Armor
+Schlitz_Leather_Armor	Schlitz Leather Armor
+Schmidt_PlateArmor_Armor	Schmidt Plate Armor
+Schtump_Fabric_Armor	Schtump Cloth Armor
+Schtump_Fabric_Cloak	Schtump Cloth Cloak
+Scopa_Leather_Boots	Scoppa Leather Boots
+scorpion	Scorpion
+Scouter_HP_PlateArmor_Helm	Health Detection Device
+Scovi_Fabric_Helm	Scobby Cloth Headband
+ScrapMetal_BackPack_I	Scrap Metal Pack
+ScrapMetal_BackPack_II	Scrap Metal Pack
+ScrapMetal_BackPack_III	Scrap Metal Pack
+Seafood_Soup	Seafood Soup
+Seafood_Soup_Large	Satisfying Seafood Soup
+Seafood_Soup_Medium	Filling Seafood Soup
+Seafood_Soup_XLarge	Hearty Seafood Soup
+Seal_Epistle	Sealed Letter
+Sealed_Abyss_Artifact_0001	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0002	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0003	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0004	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0005	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0006	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0007	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0008	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0009	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0010	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0011	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0012	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0013	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0014	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0015	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0016	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0017	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0018	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0019	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0020	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0021	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0022	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0023	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0024	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0025	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0026	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0027	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0028	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0029	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0030	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0031	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0032	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0033	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0034	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0035	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0036	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0037	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0038	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0039	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0040	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0041	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0042	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0043	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0044	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0045	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0046	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0047	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0048	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0049	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0050	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0051	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0052	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0053	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0054	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0055	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0056	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0057	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0058	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0059	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0060	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0061	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0062	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0063	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0064	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0065	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0066	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0067	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0068	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0069	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0070	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0071	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0072	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0073	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0074	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0075	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0076	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0077	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0078	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0079	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0080	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0081	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0082	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0083	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0084	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0085	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0086	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0087	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0088	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0089	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0090	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0091	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0092	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0093	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0094	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0095	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0096	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0097	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0098	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0099	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0100	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0101	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0102	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0103	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0104	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0105	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0106	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0107	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0108	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0109	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0110	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0111	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0112	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0113	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0114	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0115	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0116	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0117	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0118	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0119	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0120	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0121	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0122	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0123	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0124	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0125	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0126	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0127	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0128	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0129	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0130	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0131	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0132	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0133	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0134	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0135	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0136	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0137	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0138	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0139	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0140	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0141	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0142	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0143	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0144	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0145	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0146	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0147	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0148	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0149	Sealed Abyss Artifact
+Sealed_Abyss_Artifact_0150	Sealed Abyss Artifact
+Seidin_Leather_Armor	Seiden Leather Armor
+Sein_Leather_Boots	Sein Leather Boots
+Senian_ChainMail_Armor	Senian Chain Mail
+Senian_Fabric_Armor	Senian Cloth Armor
+Senon_PlateArmor_Armor	Senon Plate Armor
+Seodri_PlateArmor_Armor	Seddry Plate Armor
+Seras_Leather_Boots	Seras Leather Boots
+Serdhal_Plate_Boots	Serval Plate Boots
+Serdhal_Plate_Boots_I	Serval Plate Boots
+Serdin_Giant_TwoHandGiantBastard	Serdin Greatsword
+Serrin_PlateArmor_Helm	Sorin Plate Helm
+Servano_HorseArmor_Saddle	Servano Saddle
+Sestio_OneHandRapier	Rapier of Amity
+Shakatu_Scroll	Shakatu's Letter
+Shaman_TwoHandedWarHammer	Shaman's Staff
+Shay_Cat_Clue	Shai's Pendant
+Shay_Cat_Clue_Shining	Shining Shai Pendant
+Shellus_Leather_Gloves	Shellus Leather Gloves
+Shellus_Leather_Helm	Shellus Leather Helm
+Shepherd_Leather_Gloves	Herder Leather Gloves
+Sherborn_Leather_Armor_I	Sherborn Leather Armor
+Sherwooden_Fabric_Armor	Sherwood Cloth Armor
+Shield_Flag_IV	Damaged Medium Calphadean Banner Pike
+ShinyStone_02	Shiny Rock
+Short_Horn	Short Horn
+Shotgun_Bullet	Buckshot Bullet
+Sian_Fabric_Helm	Sian Cloth Cap
+Sicillion_Leather_Armor	Sicillion Leather Armor
+Sidmon_Leather_Boots	Sydmon Leather Boots
+Sidmon_OneHandSword	Sydmon Sword
+silence_Flag_I	Small Heavy Silence Banner Pike
+silence_Flag_II	Medium Heavy Silence Banner Pike
+Silien_Leather_Boots	Cyllian Leather Boots
+Silien_OneHandSword	Wells Sword
+Silver_Armor_OneHandMace	Mace of Betrayal
+Silver_Armor_OneHandTowerShield	Shield of Betrayal
+Silver_Bullet	Silver Bullet
+Silver_Pack	Full Silver Pouch
+Silver_PlateArmor_Armor	Sliver Plate Armor
+Silver_PlateArmor_Cloak	Silver Plate Cloak
+Silver_Vizione_Stand_TwoHandSpear	Silver Visione Stand
+SilverArmor_PlateArmor_Gloves	Silver Plate Gloves
+SilverArmor_PlateArmor_Helm	Inquisitor's Plate Helm
+SilverOre	Silver Ore
+Sinseollo	Harvest Soup
+Sinseollo_Large	Satisfying Harvest Soup
+Sinseollo_Medium	Filling Harvest Soup
+Sinseollo_XLarge	Hearty Harvest Soup
+Sir_Catfish_Plate_Boots	Sir Catfish's Plate Boots
+Sir_Catfish_PlateArmor_Armor	Sir Catfish's Armor
+Sir_Catfish_PlateArmor_Gloves	Sir Catfish's Plate Gloves
+Sirion_Fabric_Armor	Sirion Cloth Armor
+Sirius_Barley_Fabric_Helm	Wyvernflame Cloth Helm
+Sitanca_PlateArmor_Armor	Sitanca Plate Armor
+Skardoo_Leather_Armor	Scarteau Leather Armor
+Skian_Fabric_Helm	Skian Cloth Cap
+Skull_Knight_Plate_Boots	Frostcursed Plate Boots
+Skull_Knight_PlateArmor_Gloves	Frostcursed Plate Gloves
+SkullKnight_Follower_Plate_Boots_I	Skull Knight Follower's Plate Boots
+SkullKnight_PlateArmor_Helm	Frostcursed Plate Helm
+Sladen_Leather_Gloves	Sladen Leather Gloves
+Slarke_OneHandMace	Dekarr Hammer
+Slaughterer_Leahter_Armor	Slaughterer's Leather Armor
+Slave_Fabric_Boots	Slave's Cloth Boots
+Sleep_Arrow	Sleep Arrow
+Sleeshorn_Leather_Gloves	Sleishorn Leather Gloves
+Slowin_Leather_Armor	Slouwen Leather Armor
+Small_Copper_Pack	Light Copper Pouch
+Small_Mechanical_Powerplant	Small Battery
+Small_Mechanical_Powerplant_Pack	Small Battery
+Small_Silver_Pack	Modest Silver Pouch
+SmallAnimal_Poop	Manure
+Smilodon_Leather_Armor	Smilodon Leather Armor
+Smoke_Bomb	Smoke Bomb
+SnapDragon	Snapdragon
+Socket_Test_Gloves	Socket Test Gloves
+Solas_PlateArmor_Armor	Solas Plate Armor
+Solas_PlateArmor_Boots	Solas Plate Boots
+Solas_PlateArmor_Cloak	Solas Plate Cloak
+Solas_PlateArmor_Gloves	Solas Plate Gloves
+Solas_PlateArmor_Gloves_I	Eclipsed Solas Plate Gloves
+Solas_PlateArmor_Helm	Solas Plate Helm
+Soldier_BackPack	Soldier's Pack
+Soldier_General_Fabric_Cloak	Hernandian Guard Captain's Cloth Cloak
+Soldier_General_Plate_Boots	Guard Captain's Plate Boots
+Soldier_General_PlateArmor_Armor	Guard Captain's Plate Armor
+Soldier_General_PlateArmor_Gloves	Hernandian Guard Captain's Plate Gloves
+Soldier_General_PlateArmor_Helm	Guard Captain's Plate Helm
+Soldworth_Leather_Armor	Solworth Leather Armor
+Somieh_Leather_Armor	Somier Leather Armor
+Songyi_Mushroom	Pine Mushroom
+Songyi_Mushroom_BackPacK	Pine Mushroom Pack
+Songyi_Mushroom_Tea	Pine Mushroom Tea
+Soron_Leather_Armor	Soron Leather Armor
+Soul_TwoHandSpear	Soul Spear
+SoulKnight_OneHandSword	Shackle of Might
+Soulknight_Sprit_OneHandSword	Specter Sword
+Soulknight_Sprit_OneHandTowerShield	Shield of the Phantom
+Sound_OneHandShield	Shield of Ringing
+South_Wanderer_Troll_OneHandCrossBow	Southern Wandering Troll's Crossbow
+Spada_OneHandSword	Spada Sword
+Specialty_Cigar_TwoHandAxe	Specialty Cigar TwoHandAxe
+Specialty_Dragon_Slayer_OneHandSword	Specialty Dragon Slayer OneHandSword
+Specialty_Mercenary_OneHandSword	Specialty Mercenary OneHandSword
+Specialty_Oil	Lubricant
+Specialty_Oil_Pack	Lubricant
+Sphezajon_Fabric_Armor	Spetsahorn Cloth Armor
+Spider	Spider
+Spider_Poison	Poison
+Spider_Web	Spider Web
+Spiken_Fabric_Armor	Spiken Cloth Armor
+Spital_PlateArmor_Armor	Spiddle Plate Armor
+Spital_PlateArmor_Armor_I	Spiddle Plate Armor
+Spital_PlateArmor_Armor_II	Blacksteel Spiddle Plate Armor
+Spital_PlateArmor_Armor_III	Blacksteel Spiddle Plate Armor
+Sprayer_BackPack	Field Sprayer
+Srasika_Leather_Gloves	Duskfang Leather Gloves
+Ssari_Mushroom	Coral Mushroom
+Ssari_Mushroom_BackPack	Coral Mushroom Pack
+Ssari_Mushroom_Tea	Coral Mushroom Tea
+Stammers_Leather_Gloves	Steinmers Leather Gloves
+Stardust_Necklace	Stardust Necklace
+Steel_OneHandCannon	Steel Blaster
+StellenManor_ClosetKey	Stellen Manor Closet Key
+Stephan_Bleed_Metal_OneHandTowerShield	Shield of Conviction
+Steyer_Leather_Boots	Steyer Leather Boots
+Stian_Fabric_Helm	Stian Cloth Headband
+Stiff_Leather_Armor	Stiv Leather Armor
+Stole_PlateArmor_Armor	Strell Plate Armor
+Stone_Honey	Wild Rock Honey
+Stone_Quarry	Stone
+StoreWitchHint_Book	Witches of Pywel
+Storm_Cliff_Flag	Small Vellua Pirates Banner Pike
+Storm_Cliff_Flag_I	Small Vellua Pirates Banner Pike
+Storm_Cliff_Flag_II	Medium Vellua Pirate Banner Pike
+Stratton_Leather_Gloves	Stratton Leather Gloves
+Straw_Fabric_Helm	Straw Bale Helm
+Strawberry	Strawberry
+Studded_Leather_Boots	Stoddard Leather Boots
+Stugrub_Fabric_Gloves	Stugrub Cloth Gloves
+Stugrub_Leather_Boots	The Masked Liberator's Leather Boots
+Stugrub_TwoHandSword	Tardik Longsword
+Stugrup_Leather_Armor	Stugrub Leather Armor
+Sugar	Sugar
+SungroveManor_HomeKey	Sungrove Manor Key
+Surasang_00	Grand Meal
+Surasang_00_jijeongta	Aromatic Grand Meal
+Surasang_00_Taro	Refreshing Grand Meal
+Surasang_01	Extravagant Meal
+Surasang_01_chlorella	Energizing Extravagant Meal
+Surasang_01_Chocolate	Satisfying Extravagant Meal
+Surasang_02	Lavish Meal
+Surasang_02_Dulse	Hearty Lavish Meal
+Surasang_02_Ensete	Piquant Lavish Meal
+Surasang_03	Fine Meal
+Surasang_03_Chaya	Refreshing Fine Meal
+Surasang_03_RazorClam	Zesty Fine Meal
+Surasang_04	Special Meal
+Surasang_04_Coffee	Herby Special Meal
+Surasang_04_Kudzu	Tart Special Meal
+Surasang_05	Meal
+Surasang_05_amaranth	Fluffy Meal
+Surasang_05_opuntia	Fancy Meal
+Sven_Fabric_Armor	Sven's Cloth Armor
+SweetPotato	Sweet Potato
+Sword_DelesyiaInstitute_Clue_CrimDagger	Sharp Dagger
+Syritina_Fabric_Armor	Sirenta Cloth Armor
+Tachan_PlateArmor_Armor	Takhan Plate Armor
+Taebaerae_Leather_Armor	Tarabe Leather Armor
+Tahkah_Fabric_Gloves	Takah Cloth Gloves
+Tahntutta_Fabric_Armor	Tantuta Cloth Armor
+Tainsel_OneHandAxe	Black Iron Axe
+Taitolan_TwoHandAlebard	Freesword Halberd
+Takao_PlateArmor_Armor	Takao Plate Armor
+Takat_Leather_Armor	Takkat Leather Armor
+Takatin_Leather_Gloves	Takkan Leather Gloves
+Talbern_Fabric_Armor	Talbern Cloth Armor
+Taliesin_Leather_Gloves	Talisin Leather Gloves
+Tanfat_Leather_Armor	Tavat Leather Armor
+Tanion_Fabric_Armor	Tanion Cloth Armor
+Tanion_PlateArmor_Helm	Tanion Plate Helm
+Tanturhee_Fabric_Armor	Tanturi Cloth Armor
+Taorant_Fabric_Armor	Militia Cloth Armor
+Taorant_Fabric_Armor_II	Tiorant Cloth Armor
+Taorant_Fabric_Cloak	Tiorant Cloth Cloak
+Taoria_OneHandSword	Tauria Curved Sword
+Taos_OneHandTowerShield	Lanford Large Shield
+Taos_PlateArmor_Helm	Taos Plate Helm
+Tarandus_Leather_Boots	Tarandus Leather Boots
+Tarandus_PlateArmor_Armor	Tarandus Plate Armor
+Tarandus_PlateArmor_Gloves	Tarandus Plate Gloves
+Tarandus_PlateArmor_Helm	Tarandus Plate Helm
+Tarbal_PlateArmor_Helm	Northern Fighter's Plate Helm
+Tarchana_Fabric_Armor	Takana Cloth Armor
+Tarchet_PlateArmor_Helm	Unyielding Warrior's Plate Helm
+Tardik_OneHandAxe	Tardik Axe
+Tardik_OneHandBow	Golden-Knotted Ancestral Bow
+Tardik_OneHandTowerShield	Reinforced Warspike Large Shield
+Tarif_Fabric_Armor	Tariv Cloth Attire
+Tarif_Fabric_Boots	Tariv Cloth Boots
+Tarif_Fabric_Boots_T3_QA	Tarif Fabric Boots T3 QA
+Tarif_Fabric_Boots_T4_QA	Tarif Fabric Boots T4 QA
+Tarif_Fabric_Cloak	Tariv Cloth Cloak
+Tarif_Fabric_Cloak_I	Bleed Officer's Cloth Cloak
+Tarif_Fabric_Gloves	Tariv Cloth Gloves
+Tarif_Fabric_Gloves_T3_QA	Tarif Fabric Gloves T3 QA
+Tarif_Fabric_Gloves_T4_QA	Tarif Fabric Gloves T4 QA
+Tarif_Necklace	Tarivian Necklace
+Tarman_ChainMail_Armor	Tarman Chain Mail
+Tarmiden_Fabric_Armor	Tarmiden Cloth Armor
+Taro_seed	Taro Seed
+Tarofierer_Leather_Armor	Tallofer Leather Armor
+Taron_Leather_Gloves	Taylonne Leather Gloves
+Taroon_Fabric_Armor	Tarun Cloth Armor
+Tarrdik_Wood_OneHandShield	Dekarr Shield
+Tartinan_Fabric_Armor	Lauques Cloth Armor
+Tartinan_Fabric_Cloak	Lauques Cloth Cloak
+Tartis_TwoHandSpear	Sorcerer's Staff
+Tartti_PlateArmor_Helm	Tartry Plate Helm
+Tarura_Leather_Armor	Tatura Leather Armor
+Tashkalp_Contribution_Flag	Tommasoan Contribution Banner Pike
+Tashkalpan_Nobility_Degree_I	Tashkalp Signet
+Teaghbed_TwoHandAxe	Pailunese Logging Axe
+Technician_BackPack	Technician's Pack
+Telford_Fabric_Armor	Telford Cloth Armor
+Telin_Fabric_Armor	Telin Cloth Armor
+Tesslit_Leather_Boots	Tesslit Leather Boots
+Tesslit_Leather_Gloves	Pavis Leather Gloves
+Tesslit_Leather_Gloves_I	Large Pavis Leather Gloves
+Tesslit_Leather_Gloves_II	Russet Pavis Leather Gloves
+Tesslit_Leather_Gloves_III	Large Pavis Leather Gloves
+Tesslit_Leather_Helm	Helm of Loyal Friendship
+Tesslit_Leather_Helm_T2_QA	Tesslit Leather Helm T2 QA
+Test_OneHandAxe	Test OneHandAxe
+Test_OneHandMace	Test OneHandMace
+Testarmor	Testarmor
+TestNeck_1_1	TestNeck 1 1
+TestNeck_1_2	TestNeck 1 2
+TestNeck_2_1	TestNeck 2 1
+TestNeck_2_2	TestNeck 2 2
+TestNeck_3_1	TestNeck 3 1
+TestNeck_3_2	TestNeck 3 2
+TestNeck_4_1	TestNeck 4 1
+TestNeck_4_2	TestNeck 4 2
+TestNeck_5_1	TestNeck 5 1
+TestNeck_5_2	TestNeck 5 2
+TestNeck_5_3	TestNeck 5 3
+TestShield	TestShield
+TestSword	TestSword
+TestTwoHandAxe	TestTwoHandAxe
+ThiefGloves	Great Thief's Gloves
+ThiefWand_Flower	Shrubby Sophora
+Tibbletanus_Fabric_Cloak	Black Bears' Cloth Cloak
+Tibbletanus_Leather_Armor	Ashclaw Leather Armor
+Tickatle_Fabric_Armor	Tegatel Cloth Armor
+Ticon_PlateArmor_Armor	Ticon Plate Armor
+Tiger_Report	Sighting of the White Tiger
+Tiger_Tooth_Ring	Tigerfang Ring
+Tikan_Leather_Gloves	Dark Ringleader's Leather Gloves
+Tikkar_Leather_Armor	Tikkal Leather Armor
+Tikkar_Leather_Gloves	Tikkal Leather Gloves
+Tikkree_Fabric_Helm	Tegri Cloth Headband
+Tiknean_Fabric_Armor	Teknin Cloth Armor
+TimeBomb	Time Bomb
+Tina_Noble_Leather_Helm	Noble's Hat
+Tinchaon_Fabric_Armor	Tenkan Cloth Armor
+Tinian_Fabric_Armor	Tynion Cloth Armor
+Tionis_Leather_Boots	Grey Rhegis Leather Boots
+Tionis_Leather_Boots_I	Russet Rhegis Leather Boots
+Tirone_Fabric_Armor	Tiron Cloth Armor
+Tirone_Fabric_Gloves	Tiron Cloth Gloves
+Tirone_Leather_Armor	Tiron Leather Armor
+Tirone_Leather_Boots	Tiron Leather Boots
+Tirone_Leather_Gloves	Tiron Leather Gloves
+Tirone_OneHandAxe	Crow Brothers Axe
+Tironet_OneHandRapier	Grace Rapier
+Tirtit_Leather_Boots	Ator's Will Leather Boots
+Tiruna_Leather_Boots	Tiruna Leather Boots
+Titan_Necklace	Necklace of Lightning
+Titan_Plate_Boots	Lightning Bolt Plate Boots
+Titan_PlateArmor_Armor	Lightning Bolt Plate Armor
+Titan_PlateArmor_Armor_Upgrade	Kuku Lightning-Resistant Armor
+Titan_PlateArmor_Gloves	Lightning Bolt Plate Gloves
+Titan_PlateArmor_Helm	Lightning Bolt Plate Helm
+Titan_Spear	Titan's Spear
+Titunan_Fabric_Armor	Tytuan Cloth Armor
+toad	Toad
+Tobias_Leather_Boots	Tobias Leather Boots
+Toddbern_OneHandShotgun	Delesyian Shotgun
+Tohkar_Fabric_Armor	Tohkar Cloth Armor
+Toireth_Fabric_Armor	Torress Cloth Armor
+Toitte_Fabric_Armor	Totte Cloth Armor
+Tokart_Fabric_Armor	Wyvernflames Cloth Armor
+Tokart_Fabric_Cloak	Toggart Cloth Cloak
+Tolkane_Fabric_Armor	Tolkane Cloth Armor
+Tomaso_Soldiers_TwoHandSpear	Tommaso Guard's Dagger-Tipped Spear
+Tomato	Tomato
+Tomato_Seed	Tomato Seed
+tommaso_Flag_I	Small Tommaso Banner Pike
+tommaso_Flag_II	Medium Tommaso Banner Pike
+Torben_Fabric_Helm	Torben Cloth Cap
+Torch	Torch
+Tormand_ChainMail_Armor	Tormand Chain Mail
+Torphel_TwoHandAxe	Hellhounds Chopping Axe
+Torrance_Leather_Armor	Torrance Leather Armor
+Torretlan_OneHandMusket	Wells Musket
+Tortriden_TwoHandHammer	Lanford Greathammer
+Toudon_Fabric_Armor	Toudon Cloth Armor
+Tower_Key	Beacon Key
+Trade_Armor_03	Ceremonial Armor
+Trade_Armor_PackedInVehicle	Packaged Ceremonial Armor
+Trade_Armor_Wild_Chain_01	Field Chain Mail
+Trade_Armor_Wild_Chain_PackedInVehicle	Packaged Field Chain Mail
+Trade_Armor_Wild_Fabric_01	Field Cloth Armor
+Trade_Armor_Wild_Fabric_PackedInVehicle	Packaged Field Cloth Armor
+Trade_Caligraphy_02	Calligraphic Paintings
+Trade_Caligraphy_PackedInVehicle	Packaged Calligraphic Paintings
+Trade_Camp_Food	Camp Food
+Trade_Camp_Stone	Camp Stone
+Trade_Camp_Weapon	Camp Weapons
+Trade_Camp_Wood	Camp Timber
+Trade_Carpet_02	Carpet
+Trade_Carpet_PackedInVehicle	Packaged Carpets
+Trade_Ceramics_03	Ceramic
+Trade_Ceramics_PackedInVehicle	Packaged Ceramic
+Trade_Cheese_03	Well-Aged Cheese
+Trade_Cheese_PackedInVehicle	Packaged Cheese
+Trade_FishMeat_03	Fish Meat
+Trade_FishMeat_PackedInVehicle	Packaged Fish Meat
+Trade_Flour_01	Flour
+Trade_Flour_PackedInVehicle	Packaged Flour
+Trade_Food_PackedInVehicle	Packaged Provisions
+Trade_Fur_01	Pelt
+Trade_Fur_PackedInVehicle	Packaged Pelt
+Trade_Ginseng_03	Red Ginseng
+Trade_Ginseng_PackedInVehicle	Packaged Red Ginseng
+Trade_Glass_02	Glass
+Trade_Glass_PackedInVehicle	Packaged Glass
+Trade_Golden_Sword_Unpack	Golden Sword
+Trade_Gun_02	Gun
+Trade_Gun_PackedInVehicle	Packaged Packaged Gun
+Trade_Gunpowder_02	High-Purity Gunpowder
+Trade_Gunpowder_PackedInVehicle	Packaged Gunpowder
+Trade_Honey_02	Honey
+Trade_Honey_PackedInVehicle	Packaged Honey
+Trade_Ivory_03	Finely Crafted Ivory
+Trade_Ivory_PackedInVehicle	Packaged Ivory
+Trade_Jade_03	Jade
+Trade_Jade_PackedInVehicle	Packaged Jade
+Trade_PearlLacquerware_01	Nacre Lacquer
+Trade_PearlLacquerware_PackedInVehicle	Packaged Nacre Lacquer
+Trade_Pepper_02	Pepper
+Trade_Pepper_PackedInVehicle	Packaged Black Pepper
+Trade_Salt_01	Finely Ground Salt
+Trade_Salt_PackedInVehicle	Packaged Salt
+Trade_Silk_02	Silk
+Trade_Silk_PackedInVehicle	Packaged Silk
+Trade_Stone_PackedInVehicle	Packaged Stone
+Trade_Sugar_02	Richly Flavored Sugar
+Trade_Sugar_PackedInVehicle	Packaged Sugar
+Trade_Sulfur_02	Brimstone
+Trade_Sulfur_PackedInVehicle	Packaged Brimstone
+Trade_Sword_03	Ceremonial Sword
+Trade_Sword_PackedInVehicle	Packaged Ceremonial Sword
+Trade_Tobacco_02	Tobacco
+Trade_Tobacco_PackedInVehicle	Packaged Tobacco
+Trade_Weapon_PackedInVehicle	Packaged Arms
+Trade_Wine_01	Fragrant Fruit Wine
+Trade_Wine_PackedInVehicle	Packaged Wine
+Trade_Wood_PackedInVehicle	Packaged Timber
+Trade_Wool_03	Wool
+Trade_Wool_PackedInVehicle	Packaged Wool
+Traley_ChainMail_Armor	Traley Chain Mail
+Tran_Leather_Gloves	Dram Leather Bracers
+Trap_Bomb	Trap Bomb
+Trap_Summon_Decoy_Ball_I	Decoy Summon Ball
+TreasureBuried_FirstPiece	First Piece
+TreasureBuried_SecondPiece	Second Piece
+TreasureBuried_ThirdPiece	Third Piece
+TreasureMap_Dead_Pirate_King_Treasure	Dead Pirate King's Treasure Map
+TreasureMap_Elcard_I	Ercaid's Treasure Map Piece 1
+TreasureMap_Elcard_II	Ercaid's Treasure Map Piece 2
+TreasureMap_Elcard_III	Ercaid's Treasure Map Piece 3
+TreasureMap_FalseEvidence_1	A Map Left at the Torchlight Beacon
+TreasureMap_Famous_Thief_I	Notorious Thief's Map Piece 1
+TreasureMap_Famous_Thief_II	Notorious Thief's Map Piece 2
+TreasureMap_Famous_Thief_III	Notorious Thief's Map Piece 3
+TreasureMap_Legendary_Armor_I	Legendary Armor Map Piece 1
+TreasureMap_Legendary_Armor_II	Legendary Armor Map Piece 2
+TreasureMap_Legendary_Armor_III	Legendary Armor Map Piece 3
+TreasureMap_Mysterious_Totem_I	Mysterious Totem Treasure Map Piece 1
+TreasureMap_Summer_I	Farmer's Treasure Map Piece 1
+TreasureMap_Summer_II	Farmer's Treasure Map Piece 2
+TreasureMap_Summer_III	Farmer's Treasure Map Piece 3
+TreasureMap_Summer_IV	Farmer's Treasure Map Piece 4
+TreasureMap_TreasureBuried	Ursula's Treasure Map
+Treeon_Leather_Gloves	Trion Leather Gloves
+Tregllin_TwoHandAlebard	Bekker Halberd
+Triali_PlateArmor_Armor	Triali Plate Armor
+Triden_OneHandMace	Artisan's Hand
+Trier_ChainMail_Armor	Trier Chain Mail
+Trier_Leather_Boots	Trier Leather Boots
+Trillion_Leather_Armor	Trellian Leather Armor
+Trinodd_TwoHandAlebard	Celeste Halberd
+Triroan_Fabric_Helm	Triloan Cloth Headband
+Triroan_Leather_Boots	Triloan Leather Boots
+Triroan_Leather_Gloves	Silverwolf Leather Gloves
+Trish_Leather_Boots	Trish Leather Boots
+Trish_Leather_Gloves	Trish Leather Gloves
+Trizion_Leather_Boots	Tression Leather Boots
+TrollMerchant_BackPack_I	Troll Peddler's Pack
+Troom_TwoHandSpear	Ancient Wood Pole
+Troopers_HorseArmor_Armor	Hyperion Barding
+Troopers_HorseArmor_Helm	Hyperion Champron
+Troopers_HorseArmor_Saddle	Hyperion Saddle
+Troopers_HorseArmor_Saddle_I	Wells Military Saddle
+Troopers_HorseArmor_Stirrup	Hyperion Stirrups
+Troopers_TwoHandSpear	Derictus Spear
+Trosdern_OneHandMace	Lanford Mace
+Trouter_Leather_Boots	Trowder Leather Boots
+Trouter_Leather_Gloves	Trowder Leather Gloves
+Troyquartz_Plate_Armor	Troccars Plate Armor
+Trudy_Leather_Armor	Trudy Leather Armor
+Trumpet_OneHandShotgun	Trumpet Shotgun
+Tryah_Fabric_Armor	Tryah Cloth Armor
+Tteokgalbi	Grilled Meat Patties
+Tteokgalbi_Large	Satisfying Grilled Meat Patties
+Tteokgalbi_Medium	Filling Grilled Meat Patties
+Tteokgalbi_XLarge	Hearty Grilled Meat Patties
+Tuetti_Fabric_Armor	Trilly Cloth Armor
+Tuetti_Leather_Boots	Trilly Leather Boots
+Tulio_OneHandTowerShield	Bekker Large Shield
+Turacon_OneHandMusket	Leofric Musket
+Turcadian_TwoHandHammer	Bonepit Greathammer
+Turden_OneHandMace	The Grove's Thorn
+Turtle_BackPack	Turtle Pack
+Tutan_Fabric_Armor	Tutan Cloth Armor
+Twelgh_Leather_Armor	Twell Leather Armor
+Twich_Earring	Purple Scout Earring
+Twich_Fabric_Armor	Purple Scout Armor
+Twich_Fabric_Cloak	Purple Scout Cloak
+Twich_HorseArmor_Helm	Purple Scout Champron
+Twich_HorseArmor_Saddle	Purple Scout Saddle
+Twich_HorseArmor_Stirrup	Purple Scout Stirrups
+Twich_Lantern	Purple Scout Lantern
+Twich_Leather_Helm	Purple Scout Hat
+Twich_Necklace	Purple Scout Necklace
+Twich_OneHandShield	Purple Scout Shield
+Twich_Ring	Purple Scout Ring
+Twilight_Whistlers_PlateArmor_Armor_I	Twilight Messengers' Plate Armor
+Twilight_Whistlers_PlateArmor_Armor_II	Golden Free Company's Plate Armor
+Twilight_Whistlers_PlateArmor_Armor_III	Twilight Messengers' Plate Armor
+Twilight_Whistlers_PlateArmor_Cloak	Twilight Messengers' Cloak
+Twilight_Whistlers_PlateArmor_Gloves	Twilight Messengers' Plate Gloves
+Twilight_Whistlers_PlateArmor_Helm_I	Twilight Messengers' Plate Helm
+Twilight_Whistlers_PlateArmor_Helm_II	Golden Free Company's Plate Helm
+Tybloc_Leather_Armor	Teblecc Leather Armor
+Tychaon_Fabric_Armor	Dark Ringleader's Cloth Armor
+Tychaon_Fabric_Armor_T5_QA	Tychaon Fabric Armor T5 QA
+Tychaon_Fabric_Cloak	Dark Ringleader's Cloth Cloak
+Tychaon_Fabric_Cloak_T5_QA	Tychaon Fabric Cloak T5 QA
+Tyguis_OneHandMace	Entwined Red Thread Hammer
+Tykatan_Fabric_Armor	Tikatan Cloth Armor
+Tynion_Giant_TwoHandGiantBastard	Absolute Justice Greatsword
+Tynion_TwoHandWarHammer	Crow Brothers Warhammer
+Tyran_Fabric_Armor	Tyran Cloth Armor
+Tyran_Leather_Armor	Tyran Leather Armor
+Tyran_Leather_Boots	Tyran Leather Boots
+Tyran_Leather_Gloves	Tyran Leather Gloves
+Tyran_PlateArmor_Helm	Tailan Plate Helm
+Tyrandah_TwoHandedWarHammer	Tardik Warhammer
+Tyrannus_Leather_Armor	Tyrannus Leather Armor
+Tyrcion_Leather_Gloves	Tershan Leather Gloves
+Tyrdal_Leather_Boots	Tyrdall Leather Boots
+Tyrendhal_OneHandMace	Alabaster Mace
+Tyrun_Fabric_Boots	Tyrune Cloth Boots
+Tyrune_Fabric_Armor	Tyrune Cloth Armor
+Ulman_Fabric_Helm	Ulman Cloth Cap
+Ulrich_PlateArmor_Helm	Ulrich Plate Helm
+Ultar_Fabric_Armor	Ultar Cloth Armor
+Ultarine_Leather_Helm	Uphren Leather Helm
+Umbra_Necklace	Eternal Darkness
+Umbrella_Mushroom	Grisette Mushroom
+University_BackPack	Student's Pack
+UnknownDiary_Aldun	Unknown Adventurer's Log
+UnknownDiary_Bernor	Unknown Adventurer's Log
+UnknownDiary_Contribution_5001	Unknown Adventurer's Log
+UnknownDiary_Faisal	Unknown Adventurer's Log
+UnknownDiary_Khadin	Unknown Adventurer's Log
+UnknownDiary_Nolpix	Unknown Adventurer's Log
+UnknownDiary_Orlonel	Unknown Adventurer's Log
+UnknownDiary_Provost_2	Unknown Adventurer's Log
+UnknownDiary_Rainier	Unknown Adventurer's Log
+UnknownDiary_Retonic	Unknown Adventurer's Log
+UnknownDiary_Richart	Unknown Adventurer's Log
+UnknownDiary_RonHardt	Unknown Adventurer's Log
+UnknownDiary_Shay_Research	Unknown Adventurer's Log
+UnSeal_Epistle	Unsealed Letter
+UnyieldingShields_Flag	Small Calphadean Banner Pike
+Uronthai_Leather_Armor	Ulontai Leather Armor
+Vain_Leather_Gloves	Byren's Leather Gloves
+Vainbridge_Fabric_Armor	Vainbridge Cloth Armor
+Valcroden_Leather_Armor	Balgraun Leather Armor
+Valion_Leather_Armor	Valion Leather Armor
+Valkyder_PlateArmor_Armor	Valkyder Plate Armor
+Valkyder_PlateArmor_Armor_I	Valkyder Plate Armor
+ValleyRockWatchTower_Book	Gorgerock Watchman's Journal
+Valliron_ChainMail_Armor	Valton Chain Mail
+Valoric_PlateArmor_Helm	Sungrove Standard Plate Helm
+Vanti_Fabric_Armor	Bantree Cloth Armor
+Varanguard_Leather_Armor	Varanguard Leather Armor
+Varantine_Fabric_Armor	Delesyian Cloth Attire
+Varantine_Fabric_Cloak	Delesyian Cloth Cloak
+Varantine_Necklace	Varantin Necklace
+Variska_Leather_Armor	Variska Leather Armor
+Varken_HorseArmor_Helm	Varken Champron
+Varnia_Cloak	Varnian Noble's Cloak
+Varnia_Contribution_Flag	Varnian Contribution Banner Pike
+Varnia_Crown	Varnian Crown
+Varunin_Leather_Armor	Barunin Leather Armor
+Vdure_ChainMail_Armor	Bedure Chain Mail
+Vdure_ChainMail_Cloak	Bedure Chain Cloak
+Vegetable_Fruit_Porridge	Harvest Roll
+Vegetable_Fruit_Porridge_Large	Satisfying Harvest Roll
+Vegetable_Fruit_Porridge_Medium	Filling Harvest Roll
+Vegetable_Fruit_Porridge_XLarge	Hearty Harvest Roll
+Vegetable_Juice	Vegetable Juice
+Vegetable_Porridge	Vegetable Porridge
+Vegetable_Porridge_Large	Satisfying Vegetable Porridge
+Vegetable_Porridge_Medium	Filling Vegetable Porridge
+Vegetable_Porridge_XLarge	Hearty Vegetable Porridge
+Veil_Leather_Gloves	Veile Leather Gloves
+Vellian_OneHandBow	Kylus Bow
+Vendurs_Leather_Armor	Bendurs Leather Armor
+Vennebis_PlateArmor_Armor_I	Vennebis Plate Armor
+Vennebis_PlateArmor_Armor_II	Righteous Inquisitors Guard's Plate Armor
+Vennebis_PlateArmor_Armor_III	Righteous Inquisitors Guard's Plate Armor
+Vennebis_PlateArmor_Armor_IV	Righteous Inquisitors Guard's Plate Armor
+Verak_Giant_TwoHandGiantBastard	Verak Greatsword
+Verdinan_Fabric_Armor	Verdinan Cloth Armor
+Vergill_Fabric_Armor	Berghill Cloth Armor
+Vergill_Fabric_Helm	Berghill Cloth Cap
+Verheim_TwoHandSword	Sielos Longsword
+Veronde_Fabric_Armor	Veronde Cloth Armor
+Veronde_Fabric_Helm	Veronde Cloth Cap
+Veroon_Leather_Gloves	Behrun Hide Bracers
+Vertical_PlateArmor_Armor	Serroa Plate Armor
+Very_Small_Copper_Pack	Paltry Copper Pouch
+Vex_Fabric_Armor	Vex Cloth Armor
+Victorialis	Wild Garlic
+Vigil_OneHandMace	Crude Club
+Vilancia_OneHandPistol	Vilancia Pistol
+Vine_Bomb	Vine Bomb
+Viranche_TwoHandAxe	Horseshoe-Blade Greataxe
+Virerette_Fabric_Armor	Verette Cloth Armor
+Visione_Chip_AbandonedHouse	Abandoned House
+Visione_Chip_AbandonedMineVillage	Abandoned Mining Village
+Visione_Chip_Abyss_Platform_01	Memories of the Disconnected Truth
+Visione_Chip_Abyss_Platform_02	Shadows Within the Ether Fragment
+Visione_Chip_Abyss_Platform_03	Memories of the Loop of Life
+Visione_Chip_Alustainroom	The Alchemist's Chamber
+Visione_Chip_AnchorForest	Abandoned Anchor
+Visione_Chip_AntumbraAltar	Antumbra's Ritual Site
+Visione_Chip_AntumbraFanatic	Suspicious Religion
+Visione_Chip_ArcheryRange	Vellua Hill Archery Range
+Visione_Chip_ArcosaHouse	Empty House of Arcosa
+Visione_Chip_Azureiansister	Azerian Manor
+Visione_Chip_Bariklair	Barrick's Hideout
+Visione_Chip_BaronBarrel	Keglord Garnier Mk. XXIII
+Visione_Chip_BigTreeRoots	Hollow Tree
+Visione_Chip_BlockedSupply	Blocked Supply Route
+Visione_Chip_Bloodcoronation	The Blood Coronation
+Visione_Chip_BloodTombstone	Blood-Soaked Gravestone
+Visione_Chip_BloodyFarmhouse	Bloody Farmhouse
+Visione_Chip_BluemontManorAlley	Bluemont Manor Alley
+Visione_Chip_Bolmen	Dolmen
+Visione_Chip_BolsteinnRuins	Volstein Ruins
+Visione_Chip_BoneAndSword	Skull and Sword
+Visione_Chip_BoneCollectorWagon	The Skull Collector's Wagon
+Visione_Chip_Bonesrobbed	Bones of the Bandits' Victims
+Visione_Chip_Bremer	Missing Cows
+Visione_Chip_BrokenMill	Broken Watermill
+Visione_Chip_BrokenRaft	Broken Raft
+Visione_Chip_BrokenWindmill	Broken Windmill Blade
+Visione_Chip_BrookFieldManor	Brookfield Manor
+Visione_Chip_BumperCrop	Bountiful Harvest
+Visione_Chip_BursadaIslandRuins	Remote Ruins
+Visione_Chip_CarnageStreet	Bloodstained Street
+Visione_Chip_castleruincamp	Castle Ruins Encampment
+Visione_Chip_CaveEntrance	Mysterious Cave Entrance
+Visione_Chip_CliffUnderHome	Settlement Beneath the Cliff
+Visione_Chip_CrowdedBranch	Branch of Birds
+Visione_Chip_Crowmanribentain	Crow's Ambush
+Visione_Chip_CryingRock	Weeping Rocks
+Visione_Chip_DanteAndBleed	Dante and the Bleed
+Visione_Chip_DeadTree	Dead Tree
+Visione_Chip_DeadTreeRoad	Withered Path
+Visione_Chip_DeathSandpit	Pit of Death
+Visione_Chip_DelesiaAcademy	Inside of the Delesyian Institute
+Visione_Chip_DelesyiaBell	Bell of Delesyia
+Visione_Chip_DemenissCabin	Demeniss Cabin
+Visione_Chip_DemenissFuture	Future of Demeniss
+Visione_Chip_DemenissOrphanage	Demeniss Orphanage
+Visione_Chip_DemJohnDoe	Unidentifiable Corpse
+Visione_Chip_DesertCrocodile	Ruler of the Oasis
+Visione_Chip_DesertShipwreck	Desert Shipwreck
+Visione_Chip_DesertSwamp	Desert Swamp
+Visione_Chip_DesperateSituation	Dire Situation
+Visione_Chip_DestroyedMerchantShip	Stranded Merchant Vessel
+Visione_Chip_DinosaurBones	Giant Bone Pile
+Visione_Chip_DumpBell	Abandoned Bell
+Visione_Chip_Dungeon	Dungeon
+Visione_Chip_EdgeAltar	Cliff Edge Altar
+Visione_Chip_emptycoffin	Empty Coffin
+Visione_Chip_EmptyRanch	Abandoned Ranch
+Visione_Chip_EndlessDanger	Lonely Troll
+Visione_Chip_EntHunterLair	Mistwood Hunters' Hideout
+Visione_Chip_FallenBallon	Crashed Cloudcart
+Visione_Chip_FallenExplorer	Corpse of an Adventurer
+Visione_Chip_FireFlySwarm	Hayroof Farm Fireflies
+Visione_Chip_FiresideTale	Fireside Story
+Visione_Chip_FishermanPlace	Bounty's Net
+Visione_Chip_FishingSpot	Creaky Fishing Dock
+Visione_Chip_FiveFingerMountain	Five-Finger Mountain
+Visione_Chip_ForsakenHome	Abandoned House
+Visione_Chip_GiantBallista	Giant Ballista
+Visione_Chip_GiantBone	Remains of the Giants
+Visione_Chip_GiantBoots	Giant's Boot
+Visione_Chip_GiantRoots	Wide Roots Hideout
+Visione_Chip_GodsGarden	Garden of the Gods
+Visione_Chip_GodTreeCamp	Eldertree Research Camp
+Visione_Chip_GraceMansion	Glenbright Manor
+Visione_Chip_GraceMansionStorage	Glenbright Manor Storage
+Visione_Chip_GreyRift	Ashen Rift
+Visione_Chip_guardiandeity	Guardian Deity Altar
+Visione_Chip_Hall	H.A.L.L.
+Visione_Chip_Halsius	St. Halssius's House of Healing
+Visione_Chip_HatRock	Hat Shaped Boulder
+Visione_Chip_HayroofFarmWindmill	Hayroof Farm Windmill
+Visione_Chip_HellWoodFortGoblin	Goblins of Fort Hellwood
+Visione_Chip_HelmaraVillageScrapGrave	Helmara Scrap Graveyard
+Visione_Chip_hernandcampsite	Hernand Encampment
+Visione_Chip_HernandcastleBallroom	Hernand Banquet Hall
+Visione_Chip_HernandcastleChamber	Hernand Office
+Visione_Chip_HernandGibbet	Hernand Gallows
+Visione_Chip_HiddenSpace_0001	Hidden Space - 0001
+Visione_Chip_HiddenSpace_0002	Hidden Space - 0002
+Visione_Chip_HiddenSpace_0003	Hidden Space - 0003
+Visione_Chip_HiddenSpace_0004	Hidden Space - 0004
+Visione_Chip_HiddenSpace_0005	Hidden Space - 0005
+Visione_Chip_HiddenSpace_0006	Hidden Space - 0006
+Visione_Chip_HiddenSpace_0007	Hidden Space - 0007
+Visione_Chip_HiddenSpace_0008	Hidden Space - 0008
+Visione_Chip_HiddenSpace_0009	Hidden Space - 0009
+Visione_Chip_HiddenSpace_0010	Hidden Space - 0010
+Visione_Chip_HiddenSpace_0011	Hidden Space - 0011
+Visione_Chip_HiddenSpace_0012	Hidden Space - 0012
+Visione_Chip_HiddenSpace_0013	Hidden Space - 0013
+Visione_Chip_HiddenSpace_0014	Hidden Space - 0014
+Visione_Chip_HiddenSpace_0015	Hidden Space - 0015
+Visione_Chip_HiddenSpace_0016	Hidden Space - 0016
+Visione_Chip_HiddenSpace_0017	Hidden Space - 0017
+Visione_Chip_HiddenSpace_0018	Hidden Space - 0018
+Visione_Chip_HiddenSpace_0019	Hidden Space - 0019
+Visione_Chip_HiddenSpace_0020	Hidden Space - 0020
+Visione_Chip_HiddenSpace_0021	Hidden Space - 0021
+Visione_Chip_HiddenSpace_0022	Hidden Space - 0022
+Visione_Chip_HiddenSpace_0023	Hidden Space - 0023
+Visione_Chip_HiddenSpace_0024	Hidden Space - 0024
+Visione_Chip_HiddenSpace_0025	Hidden Space - 0025
+Visione_Chip_HiddenSpace_0026	Hidden Space - 0026
+Visione_Chip_HiddenSpace_0027	Hidden Space - 0027
+Visione_Chip_HiddenSpace_0028	Hidden Space - 0028
+Visione_Chip_HiddenSpace_0029	Hidden Space - 0029
+Visione_Chip_HiddenSpace_0030	Hidden Space - 0030
+Visione_Chip_HiddenSpace_0031	Hidden Space - 0031
+Visione_Chip_HiddenSpace_0032	Hidden Space - 0032
+Visione_Chip_HiddenSpace_0033	Hidden Space - 0033
+Visione_Chip_HiddenSpace_0034	Hidden Space - 0034
+Visione_Chip_HiddenSpace_0035	Hidden Space - 0035
+Visione_Chip_HiddenSpace_0036	Hidden Space - 0036
+Visione_Chip_HiddenSpace_0037	Hidden Space - 0037
+Visione_Chip_HiddenSpace_0038	Hidden Space - 0038
+Visione_Chip_HiddenSpace_0039	Hidden Space - 0039
+Visione_Chip_HiddenSpace_0040	Hidden Space - 0040
+Visione_Chip_HiddenSpace_0041	Hidden Space - 0041
+Visione_Chip_HiddenSpace_0042	Hidden Space - 0042
+Visione_Chip_HiddenSpace_0043	Hidden Space - 0043
+Visione_Chip_HiddenSpace_0044	Hidden Space - 0044
+Visione_Chip_HiddenSpace_0045	Hidden Space - 0045
+Visione_Chip_HiddenSpace_0046	Hidden Space - 0046
+Visione_Chip_HiddenSpace_0047	Hidden Space - 0047
+Visione_Chip_HiddenSpace_0048	Hidden Space - 0048
+Visione_Chip_HiddenSpace_0049	Hidden Space - 0049
+Visione_Chip_HiddenSpace_0050	Hidden Space - 0050
+Visione_Chip_HiddenSpace_0051	Hidden Space - 0051
+Visione_Chip_HiddenSpace_0052	Hidden Space - 0052
+Visione_Chip_HiddenSpace_0053	Hidden Space - 0053
+Visione_Chip_HiddenSpace_0054	Hidden Space - 0054
+Visione_Chip_HiddenSpace_0055	Hidden Space - 0055
+Visione_Chip_HiddenSpace_0056	Hidden Space - 0056
+Visione_Chip_HiddenSpace_0057	Hidden Space - 0057
+Visione_Chip_HiddenSpace_0058	Hidden Space - 0058
+Visione_Chip_HiddenSpace_0059	Hidden Space - 0059
+Visione_Chip_HiddenSpace_0060	Hidden Space - 0060
+Visione_Chip_HiddenSpace_0061	Hidden Space - 0061
+Visione_Chip_HiddenSpace_0062	Hidden Space - 0062
+Visione_Chip_HiddenSpace_0063	Hidden Space - 0063
+Visione_Chip_HiddenSpace_0064	Hidden Space - 0064
+Visione_Chip_HiddenSpace_0065	Hidden Space - 0065
+Visione_Chip_HiddenSpace_0066	Hidden Space - 0066
+Visione_Chip_HiddenSpace_0067	Hidden Space - 0067
+Visione_Chip_HiddenSpace_0068	Hidden Space - 0068
+Visione_Chip_HiddenSpace_0069	Hidden Space - 0069
+Visione_Chip_HiddenSpace_0070	Hidden Space - 0070
+Visione_Chip_HiddenSpace_0071	Hidden Space - 0071
+Visione_Chip_HiddenSpace_0072	Hidden Space - 0072
+Visione_Chip_HiddenSpace_0073	Hidden Space - 0073
+Visione_Chip_HiddenSpace_0074	Hidden Space - 0074
+Visione_Chip_HiddenSpace_0075	Hidden Space - 0075
+Visione_Chip_HiddenSpace_0076	Hidden Space - 0076
+Visione_Chip_HiddenSpace_0077	Hidden Space - 0077
+Visione_Chip_HiddenSpace_0078	Hidden Space - 0078
+Visione_Chip_HiddenSpace_0079	Hidden Space - 0079
+Visione_Chip_HiddenSpace_0080	Hidden Space - 0080
+Visione_Chip_HiddenSpace_0081	Hidden Space - 0081
+Visione_Chip_HiddenSpace_0082	Hidden Space - 0082
+Visione_Chip_HiddenSpace_0083	Hidden Space - 0083
+Visione_Chip_HiddenSpace_0084	Hidden Space - 0084
+Visione_Chip_HiddenSpace_0085	Hidden Space - 0085
+Visione_Chip_HiddenSpace_0086	Hidden Space - 0086
+Visione_Chip_HiddenSpace_0087	Hidden Space - 0087
+Visione_Chip_HiddenSpace_0088	Hidden Space - 0088
+Visione_Chip_HiddenSpace_0089	Hidden Space - 0089
+Visione_Chip_HiddenSpace_0090	Hidden Space - 0090
+Visione_Chip_HiddenSpace_0091	Hidden Space - 0091
+Visione_Chip_HiddenSpace_0092	Hidden Space - 0092
+Visione_Chip_HiddenSpace_0093	Hidden Space - 0093
+Visione_Chip_HiddenSpace_0094	Hidden Space - 0094
+Visione_Chip_HiddenSpace_0095	Hidden Space - 0095
+Visione_Chip_HiddenSpace_0096	Hidden Space - 0096
+Visione_Chip_HiddenSpace_0097	Hidden Space - 0097
+Visione_Chip_HiddenSpace_0098	Hidden Space - 0098
+Visione_Chip_HiddenSpace_0099	Hidden Space - 0099
+Visione_Chip_HiddenSpace_0100	Hidden Space - 0100
+Visione_Chip_HiddenSpace_0101	Hidden Space - 0101
+Visione_Chip_HiddenSpace_0102	Hidden Space - 0102
+Visione_Chip_HiddenSpace_0103	Hidden Space - 0103
+Visione_Chip_HiddenSpace_0104	Hidden Space - 0104
+Visione_Chip_HiddenSpace_0105	Hidden Space - 0105
+Visione_Chip_HiddenSpace_0106	Hidden Space - 0106
+Visione_Chip_HiddenSpace_0107	Hidden Space - 0107
+Visione_Chip_HiddenSpace_0108	Hidden Space - 0108
+Visione_Chip_HiddenSpace_0109	Hidden Space - 0109
+Visione_Chip_HiddenSpace_0110	Hidden Space - 0110
+Visione_Chip_HiddenSpace_0111	Hidden Space - 0111
+Visione_Chip_HiddenSpace_0112	Hidden Space - 0112
+Visione_Chip_HiddenSpace_0113	Hidden Space - 0113
+Visione_Chip_HiddenSpace_0114	Hidden Space - 0114
+Visione_Chip_HiddenSpace_0115	Hidden Space - 0115
+Visione_Chip_HiddenSpace_0116	Hidden Space - 0116
+Visione_Chip_HiddenSpace_0117	Hidden Space - 0117
+Visione_Chip_HiddenSpace_0118	Hidden Space - 0118
+Visione_Chip_HiddenSpace_0119	Hidden Space - 0119
+Visione_Chip_HiddenSpace_0120	Hidden Space - 0120
+Visione_Chip_HiddenSpace_0121	Hidden Space - 0121
+Visione_Chip_HiddenSpace_0122	Hidden Space - 0122
+Visione_Chip_HiddenSpace_0123	Hidden Space - 0123
+Visione_Chip_HiddenSpace_0124	Hidden Space - 0124
+Visione_Chip_HiddenSpace_0125	Hidden Space - 0125
+Visione_Chip_HiddenSpace_0126	Hidden Space - 0126
+Visione_Chip_HiddenSpace_0127	Hidden Space - 0127
+Visione_Chip_HiddenSpace_0128	Hidden Space - 0128
+Visione_Chip_HiddenSpace_0129	Hidden Space - 0129
+Visione_Chip_HiddenSpace_0130	Hidden Space - 0130
+Visione_Chip_HiddenSpace_0131	Hidden Space - 0131
+Visione_Chip_HiddenSpace_0132	Hidden Space - 0132
+Visione_Chip_HiddenSpace_0133	Hidden Space - 0133
+Visione_Chip_HiddenSpace_0134	Hidden Space - 0134
+Visione_Chip_HiddenSpace_0135	Hidden Space - 0135
+Visione_Chip_HiddenSpace_0136	Hidden Space - 0136
+Visione_Chip_HiddenSpace_0137	Hidden Space - 0137
+Visione_Chip_HiddenSpace_0138	Hidden Space - 0138
+Visione_Chip_HiddenSpace_0139	Hidden Space - 0139
+Visione_Chip_HiddenSpace_0140	Hidden Space - 0140
+Visione_Chip_HiddenSpace_0141	Hidden Space - 0141
+Visione_Chip_HiddenSpace_0142	Hidden Space - 0142
+Visione_Chip_HiddenSpace_0143	Hidden Space - 0143
+Visione_Chip_HiddenSpace_0144	Hidden Space - 0144
+Visione_Chip_HiddenSpace_0145	Hidden Space - 0145
+Visione_Chip_HiddenSpace_0146	Hidden Space - 0146
+Visione_Chip_HiddenSpace_0147	Hidden Space - 0147
+Visione_Chip_HiddenSpace_0148	Hidden Space - 0148
+Visione_Chip_HiddenSpace_0149	Hidden Space - 0149
+Visione_Chip_HiddenSpace_0150	Hidden Space - 0150
+Visione_Chip_HiddenSpace_0151	Hidden Space - 0151
+Visione_Chip_HiddenSpace_0152	Hidden Space - 0152
+Visione_Chip_HiddenSpace_0153	Hidden Space - 0153
+Visione_Chip_HiddenSpace_0154	Hidden Space - 0154
+Visione_Chip_HiddenSpace_0155	Hidden Space - 0155
+Visione_Chip_HiddenSpace_0156	Hidden Space - 0156
+Visione_Chip_HiddenTreasure	Hidden Treasure
+Visione_Chip_HolyGlass	Sacred Chalice
+Visione_Chip_HoopLakeCave	Horseshoe Lake Burrow
+Visione_Chip_HumanUnderBridge	Someone Living Under a Bridge
+Visione_Chip_Ibano	Hornless Goats
+Visione_Chip_IguanaHatchery	Iguana Hatchery
+Visione_Chip_IronWing	Wings of Steel
+Visione_Chip_JohnDoe	Unidentified Corpse
+Visione_Chip_JungleRuins	Jungle Ruins
+Visione_Chip_KnottedHollow	Forest Memorial Stone
+Visione_Chip_Kukucraft	Pot Artisans
+Visione_Chip_LadyJustice	Statue of the Goddess of Justice
+Visione_Chip_LakeAltar	Communal Ritual
+Visione_Chip_LampkeeperPatrol	Stone Lantern Keeper's Patrol
+Visione_Chip_LightningstrikeTree	Lightning-Struck Tree
+Visione_Chip_LioncrestManor	Lioncrest Manor
+Visione_Chip_LoggingCabin	Timberdale Cabin
+Visione_Chip_LongleafTree_DailyLife	Day of the Longleaf Tribe
+Visione_Chip_LongleafTree_HuntBegin	Beginning of the Hunt
+Visione_Chip_LongleafTree_OmenMisfortune	Signs of Misfortune
+Visione_Chip_MaidsTales	Stories of the Maids
+Visione_Chip_Mansion_Byron_Memory	Memory of Byron Manor
+Visione_Chip_Mansion_Marseille_Memory_I	Azerian's Whereabouts
+Visione_Chip_Mansion_Marseille_Memory_II	Bastier's Co-conspirators
+Visione_Chip_MarniFirstMeet	Secret of the Helm
+Visione_Chip_Marnisecretplace	Marni's Secret Laboratory
+Visione_Chip_MentalCareRoom	Mental Reconditioning
+Visione_Chip_MerchantRefuge	Snowy Plains Hearth
+Visione_Chip_Meteor	Meteorite
+Visione_Chip_MeteorHouse	Boulder Crash Site
+Visione_Chip_MissingStatue	Vanished Statue
+Visione_Chip_Mjordinludvig	Myurdin and Ludvig
+Visione_Chip_MossyGenerator	Mossy Generator
+Visione_Chip_MotherAndSon	Mother and Son
+Visione_Chip_MuralCave	Breezeblown Knoll Cave
+Visione_Chip_MushroomCave	Mushroom Cave
+Visione_Chip_MushroomRock	Mushroom Rock
+Visione_Chip_MysteryTower	Mysterious Giant Tower
+Visione_Chip_NamelessHeorGrave	A Hero's Tomb
+Visione_Chip_NoEenterZone	Restricted Area
+Visione_Chip_Oakenshieldmanor	Serkis's Study
+Visione_Chip_OakenshieldManorhall	Oakenshield Manor Reception Room
+Visione_Chip_OasisMonument	Oasis Headstone
+Visione_Chip_OasisShelter	Oasis Hearth
+Visione_Chip_OdeckHunterCamp	Hunters of Odeck
+Visione_Chip_OldBattlefield	Old Battlefield
+Visione_Chip_OldGrave	Timeworn Graves
+Visione_Chip_OldKingOfTheSea	Old King of the Sea
+Visione_Chip_OldQuarry	Old Quarry
+Visione_Chip_OminousProphecy	Ominous Prophecy
+Visione_Chip_OrcCamp	Freesword Dwelling
+Visione_Chip_Orcneutralzone	Gorthak
+Visione_Chip_OwnerlessGrave	Empty Grave
+Visione_Chip_Pailoonoldtree	Old Tree
+Visione_Chip_Pailoonwatergate	Runaway
+Visione_Chip_PailuneSecretBase	Pailune Secret Vault
+Visione_Chip_PaintedCave	Painted Cavern
+Visione_Chip_PainterRegret	A Painter's Regret
+Visione_Chip_PetrifiedHumans	Petrified Humans
+Visione_Chip_pharmacy	Halssius Apothecary
+Visione_Chip_PororinCave	Pororin Cave
+Visione_Chip_PrecariousRock	Unstable Rock
+Visione_Chip_precipicecoffin	Clifftop Coffin
+Visione_Chip_RectangularStone	Square Rock
+Visione_Chip_ReventineWinery	Reventine Winery
+Visione_Chip_RidgehunterLeatherMaker	Ridgehunter Tannery
+Visione_Chip_RightHandStone	Right Hand Boulder
+Visione_Chip_riverdam	Upper Nas River Dam
+Visione_Chip_RiverwardOutpost	Riverward Outpost Dispatch
+Visione_Chip_RockCreviceRuinse	Rockshard Valley Ruins
+Visione_Chip_RockingStone	Rocking Boulder
+Visione_Chip_RockShelter	A House Between Rocks
+Visione_Chip_RockshroudRuins	Rockveil Ruins
+Visione_Chip_Roofless	Roofless House
+Visione_Chip_RootFortress	Report on Roothold
+Visione_Chip_RordOfBones	Path of Giant Bones
+Visione_Chip_RuinedHouse	Abandoned House on the Water
+Visione_Chip_RuinedHouse_II	Dyer on the Water
+Visione_Chip_RuinsSite	Ruins Excavation
+Visione_Chip_SafetyFlowerBush	Flowerbush of Safety
+Visione_Chip_SaltRoadRuins	Ruins by the Saltroad Camp
+Visione_Chip_SandHole	Sand Dunes
+Visione_Chip_SavageFangStele	Savage Fangs Monument
+Visione_Chip_ScaryHole	Eerie Pit
+Visione_Chip_Sculptor	A Suspicious Sculptor
+Visione_Chip_Shipwreck	Sky Galleon
+Visione_Chip_ShipWreckOakBarrel	Shipwreck Oak Barrel
+Visione_Chip_SilenceShipwreck	Shipwreck in Silence
+Visione_Chip_SilverbrookRuins	Silverbrook Ruins
+Visione_Chip_Sinkhole	Sinkhole
+Visione_Chip_SkyBluePool	Turquoise Rock Pools
+Visione_Chip_SmugglerDock	Smugglers' Dock
+Visione_Chip_Splithornrobber	Sword of the Cursed
+Visione_Chip_StoneAltar	Desolate Monolith Altar
+Visione_Chip_StonemireRuins	Stonemire Ruins
+Visione_Chip_StoryWell	A Well with a Story
+Visione_Chip_Suspiciouscult	The Madman and the Crows
+Visione_Chip_SwordAndThrone	The Sword's Grave and Throne
+Visione_Chip_TestToMarni	An Experiment to Reach Marni
+Visione_Chip_ThiefCave	Lair of Animal Thieves
+Visione_Chip_TrainThief	Ironcrawler Thief's Hideout
+Visione_Chip_TreeForestTomb	Birch Forest Grave
+Visione_Chip_TreeOfAxes	Axe-Studded Tree
+Visione_Chip_Trolluniversity	Scholastone Celestial Telescope
+Visione_Chip_UndertheBridge	Treasure Under the Bridge
+Visione_Chip_UnknownCave	Unknown Cave
+Visione_Chip_UpLionTower	Lioncrest Watchtower
+Visione_Chip_ValleyRockWatchTower	Gorgerock Watchtower
+Visione_Chip_VatnhollCamp	Vat'nholl Camp
+Visione_Chip_VerheimRuins	Verheim Ruins
+Visione_Chip_VikingTomb	Grave of Warriors' Axes
+Visione_Chip_vinevillage	Ivynook
+Visione_Chip_WagonOnATree	Treetop Wagon
+Visione_Chip_WarNews	News of War
+Visione_Chip_WaterFallsCabin	Cabin by the Waterfall
+Visione_Chip_WeirdSkull	A Strange Skull
+Visione_Chip_WindmillCoastShipWreck	Coast Windmill Shipwreck
+Visione_Chip_WisdomWell	Well of Enlightenment
+Visione_Chip_Witch_Kidnapped_Memory	Memory of the Kidnapped Witch
+Visione_Chip_WoodenGazebo	Wooden Pavilion
+Visione_Chip_WoodKnot	Shipyard Wood Knot
+Visione_Chip_WreckedTradingShip	Wrecked Trading Ship
+Visione_Chip_ZianeTomb	Burial Mound
+Visione_Chip_ZooHole	Wildlife Park Passageway
+Vixer_Leather_Boots	Vixer Leather Shoes
+Volcanic_OneHandCannon	Volcanic Blaster
+Volcker_Fabric_Helm	St. Halssius Priest's Hat
+Volcker_Leather_Boots	St. Halssius Priest's Leather Footwear
+Volcker_Leather_Gloves	Vulker Leather Gloves
+Volcker_Leather_Gloves_I	Vulker Leather Gloves
+Volf_Leather_Armor	Rolfe Leather Armor
+Volghan_Fabric_Armor	Bolgan Cloth Armor
+Volghan_Leather_Gloves	The Masked Liberator's Leather Gloves
+Volghan_PlateArmor_Helm	Bolgan Plate Helm
+Volkard_Fabric_Armor	Volghad Cloth Armor
+Volkirk_Fabric_Armor	Volkirk Cloth Armor
+Volmers_Fabric_Armor	Bahlmers Cloth Armor
+Volono_OneHandRapier	Volono Rapier
+Volruin_Fabric_Armor	Bollin Cloth Armor
+Volruin_Fabric_Helm	Bollin Cloth Cap
+Volruin_Leather_Boots	Bollin Leather Boots
+Volruin_Leather_Gloves	Bollin Leather Gloves
+Volta_OneHandRapier	Dueling Rapier
+Vorren_Leather_Helm	Boren Leather Helm
+Vueh_OneHandRapier	Inquisitor's Rapier
+Vuldrion_Leather_Armor	Valldren Leather Armor
+Vyrer_Leather_Armor	Vyer Leather Armor
+Wagon_HorseArmor_Armor	Wagon Barding
+Wagon_HorseArmor_Armor_II	Wagon Barding II
+Wakhan_Leather_Armor	Wakhan Leather Armor
+Walder_Leather_Boots	Walder Leather Boots
+Waller_Leather_Gloves	Waller Leather Gloves
+Walter_OneHandShotgun	Bleed Shotgun
+Wanderer_Mercenary_TwoHandSword	Sydmon Longsword
+Wandering_Leather_Helm	Wandering Leather Helm
+Wandering_Mercenary_Leather_Armor	Wandering Freesword's Leather Armor
+Wanted_Criminal_BackPack_I	Outlaw's Gold Ore Pack
+Wanted_Criminal_BackPack_II	Outlaw's Graverobber Pack
+Wants_Leather_Gloves	Wentz Leather Gloves
+Warblick_Fabric_Armor	Warblick Cloth Armor
+Warren_Beynon_Leather_Boots	Warren Beynon's Leather Boots
+WarRobot_Backpack_01	A.T.A.G. Thrusterpack Mk I
+WarRobot_Backpack_02	A.T.A.G. Thrusterpack Mk II
+WarRobot_Backpack_03	A.T.A.G. Thrusterpack Mk III
+WarRobot_Body_01	A.T.A.G. Plating Mk I
+WarRobot_Body_02	A.T.A.G. Plating Mk II
+WarRobot_Body_03	A.T.A.G. Plating Mk III
+WarRobot_Cannon_01	A.T.A.G. Cannon
+WarRobot_Fist_01	A.T.A.G. Fist
+WarRobot_FlameThrower_01	A.T.A.G. Flamespitter
+WarRobot_Foot_01	A.T.A.G. Boots Mk I
+WarRobot_Foot_02	A.T.A.G. Boots Mk II
+WarRobot_Foot_03	A.T.A.G. Boots Mk III
+WarRobot_Gatling_01	A.T.A.G. Machine Gun
+WarRobot_Laser_01	A.T.A.G. Laser
+WarRobot_RepairTool_01_L	A.T.A.G. Pincers
+WarRobot_RepairTool_01_R	A.T.A.G. Welder
+Warstein_Fabric_Armor	Warstein Cloth Armor
+Watcher_BackPack	Watcher Pack
+Water	Water
+Water_Bomb	Water Bomb
+WaterPower_BackPack	Hydro Generator Bag
+WaterSliding_Plate_Boots	Vaporwalker
+Watous_Leather_Gloves	Wertesh Leather Gloves
+Weapon_BackPack_I	Weaponsmith's Pack
+Weapon_BackPack_II	Weaponsmith's Pack
+Weapon_BackPack_III	Weaponsmith's Pack
+Weapon_BackPack_IV	Weaponsmith's Pack
+Weapon_BackPack_IX	Weaponsmith's Pack
+Weapon_BackPack_V	Weaponsmith's Pack
+Weapon_BackPack_VI	Weaponsmith's Pack
+Weapon_BackPack_VII	Weaponsmith's Pack
+Weapon_BackPack_VIII	Weaponsmith's Pack
+Weapon_BackPack_X	Weaponsmith's Pack
+Weasel_Leather_Armor	Weasel Leather Armor
+Weasel_Leather_Boots	Weasel Leather Boots
+Weasel_Leather_Cloak	Weasel Leather Cloak
+Weasel_Leather_Gloves	Weasel Leather Gloves
+WeatherWeaver_Necklace	Rainstorm Necklace
+WeatherWeaver_Sunny_Necklace	Radiant Necklace
+Weeren_PlateArmor_Gloves	Weirren Plate Gloves
+Wegalawn_Leather_Gloves	Vicaron Leather Gloves
+Wells_Brigade_Flag	Small Wells Brigade Banner Pike
+Wells_Brigade_Rebel_ChainMail_Armor_I	Turncoat Chain Mail
+Wells_Brigade_Rebel_ChainMail_Armor_II	Turncoat Chain Mail
+Wells_Brigade_Rebel_Fabric_Armor_I	Turncoat Cloth Armor
+Wells_Brigade_Rebel_Fabric_Armor_II	Wells Rebel Light Cloth Armor
+Wells_Brigade_Rebel_Fabric_Armor_III	Turncoat Cloth Armor
+Wells_Brigade_Rebel_Leather_Armor_I	Wells Rebel's Leather Armor
+Wells_Brigade_Rebel_PlateArmor_Armor_I	Turncoat Plate Armor
+Wells_Brigade_Rebel_PlateArmor_Armor_II	Turncoat Plate Armor
+Wells_Brigade_Rebel_PlateArmor_Armor_III	Turncoat Plate Armor
+Wells_Brigade_Rebel_PlateArmor_Armor_IV	Elite Turncoat Plate Armor
+Wells_Brigade_Rebel_PlateArmor_Armor_V	Elite Turncoat Plate Armor
+Wells_Brigade_Rebel_PlateArmor_Gloves	Wells Rebel's Plate Gloves
+Wells_Flag_I	Small Wells Banner Pike
+Wells_Flag_II	Medium Wells Banner Pike
+Wells_HorseArmor_Armor	Wells Military Barding
+Wells_PlateArmor_Armor	Wells Rider Plate Armor
+Wells_TwoHandGiantSpear	Elite Vanguard
+WellsDungeon_Key	Thornbriar Dungeon Key
+WellsKnight_Plate_Boots	Grotevant Plate Boots
+WellsKnight_PlateArmor_Armor	Grotevant Plate Armor
+WellsKnight_PlateArmor_Cloak	Grotevant Cloak
+WellsKnight_PlateArmor_Gloves	Grotevant Plate Gloves
+WellsKnight_PlateArmor_Helm	Grotevant Plate Helm
+WestDemenissChurch_Key	Church Crypt Key
+Wheat	Wheat
+Wheel_BackPack	Wheelwright's Pack
+White_Bear_Leather_Helm	White Bear Helm
+White_Crocodile_Leather_Gloves	Pale Predator's Leather Gloves
+White_Douglas_Leather_Gloves	Crowcaller's White Leather Gloves
+White_Horse_Report	Sighting of Royler
+White_Lion_Necklace	White Lion Necklace
+WhiteBear_TwoHandAxe	Split Tooth
+WhiteCrow_Witch_TwoHandedWarHammer	Crow Whisperer
+WhiteHair_Root	Satintail Root
+WhiteHorn_Earring	White Horn's Earring
+WhiteHorn_Leather_Helm	White Horn Leather Helm
+WhiteStone	Scolecite Ore
+Wild_Honey	Wild Honey
+Wild_Insam	Wild Ginseng
+Wind_Power_OneHandShield	Gale Shield
+Wind_TwoHandSpear	Propeller Spear
+WindmillCoastShipWreck_Book	Navigator's Log
+Wintharden_Fabric_Armor	Ator's Will Cloth Armor
+Witch_WingFan	Eastern Witch's Fan
+WitchWarehouse_Key	Witch's Storehouse Key
+Witley_Fabric_Boots	Whitley Cloth Boots
+Witley_Fabric_Gloves	Whitley Cloth Gloves
+Witley_Leather_Armor	Whitley Leather Armor
+Witters_Plate_Boots	Witters Plate Boots
+Witters_PlateArmor_Gloves	Witters Plate Gloves
+Witters_PlateArmor_Helm	Witters Plate Helm
+Wolf_Chief_Leather_Helm	Alpha Wolf Helm
+Wolf_Leather	Long Hair Hide
+Wolf_OneHandSword	Sword of the Wolf
+Wolf_Pursuer_Fabric_Armor	Wolf Tracker Cloth Armor
+Wolf_Pursuer_Fabric_Cloak	Wolf Tracker Cloth Cloak
+Wolf_Pursuer_Fabric_Helm	Wolf Tracker Helm
+Wolf_Pursuer_Leather_Armor	Wolf Tracker Leather Armor
+Wolf_Pursuer_Leather_Boots	Wolf Tracker Leather Boots
+Wolf_Pursuer_Leather_Gloves	Wolf Tracker Leather Gloves
+Wolf_Test_OneHandSword	Wolf Test OneHandSword
+Wood	Timber
+Wood_Lantern	Wooden Lantern
+Wood_OneHandShield	Grey Wolf Wooden Shield
+Woodbrock_Leather_Boots	Woodbrock Leather Boots
+Woodys_Leather_Gloves	Wyrdins Leather Gloves
+Wooeun_Leather_Boots	Wattern Leather Boots
+Wool	Fleece
+Worstern_Leather_Gloves	Weiston Leather Gloves
+Wurten_Leather_Armor	Buellen Leather Armor
+Wusian_Fabric_Armor	Ushreen Cloth Armor
+Wyvern_Flag_I	Small Wyvernflames Banner Pike
+Wyvern_Flag_II	Medium Wyvernflames Banner Pike
+Wyvern_Leather_Helm	Lizard Leather Helm
+Xasameruen_Leather_Gloves	Jasmern Leather Gloves
+YamatoCannon_TwoHandSpear	Laser Cannon Spear
+Yann_Basic_Leather_Armor	Silverwolf Leather Armor
+Yorkey_Fabric_Armor	Yorkey Cloth Armor
+Yuzel_Fabric_Helm	Yuzel Cloth Cap
+Zamir_Fabric_Armor	Zamir Cloth Armor
+Zial_Fabric_Armor	Ziahl Cloth Armor
+Ziane_Diary	Jian's Journal
+Ziane_OneHandSword	Wolf's Fang
+Ziggurat_Fabric_Helm	Ziggurat Cloth Helm
+Ziggurat_Leather_Gloves_I	Ziggurat Leather Gloves
+Ziggurat_Leather_Gloves_II	Ziggurat Leather Gloves
+Ziggurat_Leather_Helm_II	Chemists' Mask Leather Helm
+Ziggurat_Leather_Helm_III	Chemists' Iron Mask Leather Helm
+Zinianne_Fabric_Armor	Zynian Cloth Armor

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,6 @@
-## [Title for next release]
+## Human-Readable Item Names & Overlay Improvements
 
-- New feature
-- Bug fix
-- Improvement
+- Item picker now shows human-readable display names (e.g. "Kliff's Leather Armor" instead of "Kliff_Leather_Armor") with the internal name shown below in gray
+- Search now matches both display names and internal names
+- Item slot detection rewritten to be more accurate across the full catalog
+- Name table scan no longer gives up after 15 attempts, it keeps retrying until the game is ready

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -171,7 +171,7 @@ See the full list at the [url=https://github.com/tkhquang/DetourModKit?tab=readm
 
 [list]
 [*][b]Item catalog may be incomplete[/b] -the armor list is filtered to exclude known-broken items. Some wearable items may be missing. If you find one, please report it in the Bugs or Posts tab.
-[*][b]Yann leather armor has quirks[/b] -[b]Yann_Basic_Leather_Armor[/b] may flash briefly when switching presets. Workaround: untick the chest slot, then retick it. Also, Yann leather is a single-mesh outfit that covers both chest and cloak regions -deactivate the Cloak slot when using it to avoid visual conflicts.
+[*][b]Silverwolf Leather Armor[/b]* and some other armor seems to have combined with cloak. If you apply it and it disappears right afterwards, you should try setting the cloak slot and armor slot to none, save, then reapply the armor again.
 [*][b]NPC armor variants and damaged variants render via carrier[/b] -items tagged [b](carrier)[/b] in the picker use an automatic carrier swap + character-class bypass. Most work; a few may still produce empty slots depending on the item's internal skeleton bindings.
 [*][b]Non-humanoid items crash[/b] -horse tack, pet armor, and wagon gear crash the mesh binder. The "Safe only" filter hides these by default.
 [*][color=#ff0000][b]Wrong-slot or non-equipment items will crash[/b][/color] -selecting a chest piece for the helm slot, or picking non-armor items (dog armor, recipes, seeds, etc.) will crash the game. The safety filters prevent this by default -[b]do not disable them unless you know what you're doing[/b].

--- a/CrimsonDesertLiveTransmog/src/constants.hpp
+++ b/CrimsonDesertLiveTransmog/src/constants.hpp
@@ -12,6 +12,7 @@ namespace Transmog
     inline constexpr const char *LOG_FILE = "CrimsonDesertLiveTransmog.log";
     inline constexpr const char *INI_FILE = "CrimsonDesertLiveTransmog.ini";
     inline constexpr const char *PRESETS_FILE = "CrimsonDesertLiveTransmog_presets.json";
+    inline constexpr const char *DISPLAY_NAMES_FILE = "CrimsonDesertLiveTransmog_display_names.tsv";
     inline constexpr const wchar_t *INSTANCE_MUTEX_PREFIX = L"CrimsonDesertLiveTransmog_";
 
     // --- Process gate ---

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <cstring>
 #include <fstream>
+#include <string_view>
 #include <mutex>
 #include <unordered_map>
 
@@ -268,85 +269,6 @@ namespace Transmog
 
     // --- Slot classification ---
 
-    // Strip trailing variant/noise tokens in-place so the tail-match below
-    // sees the meaningful last segment. CE-verified noise tokens against
-    // the v1.02.00 catalog: _UpgradeN, _IVX (roman), _NN (numeric),
-    // _Large/_XLarge/_Medium/_Small, _Pancake.
-    static void strip_variant_tail(std::string &s) noexcept
-    {
-        auto ends_with = [](const std::string &str, const char *suf)
-        {
-            const auto n = std::strlen(suf);
-            if (str.size() < n)
-                return false;
-            return std::memcmp(str.data() + str.size() - n, suf, n) == 0;
-        };
-
-        for (;;)
-        {
-            const auto prev = s.size();
-
-            // _UpgradeN? (N optional, 1-3 digits)
-            {
-                auto pos = s.rfind("_Upgrade");
-                if (pos != std::string::npos)
-                {
-                    bool allDigits = true;
-                    for (auto i = pos + 8; i < s.size(); ++i)
-                    {
-                        if (!std::isdigit(static_cast<unsigned char>(s[i])))
-                        {
-                            allDigits = false;
-                            break;
-                        }
-                    }
-                    if (allDigits)
-                        s.resize(pos);
-                }
-            }
-
-            // _<roman> (single trailing run of I/V/X)
-            if (auto pos = s.find_last_of('_'); pos != std::string::npos)
-            {
-                bool romanOnly = (pos + 1 < s.size());
-                for (auto i = pos + 1; i < s.size() && romanOnly; ++i)
-                {
-                    const char c = s[i];
-                    if (c != 'I' && c != 'V' && c != 'X')
-                        romanOnly = false;
-                }
-                if (romanOnly)
-                    s.resize(pos);
-            }
-
-            // _<digits>
-            if (auto pos = s.find_last_of('_'); pos != std::string::npos)
-            {
-                bool digitsOnly = (pos + 1 < s.size());
-                for (auto i = pos + 1; i < s.size() && digitsOnly; ++i)
-                {
-                    if (!std::isdigit(static_cast<unsigned char>(s[i])))
-                        digitsOnly = false;
-                }
-                if (digitsOnly)
-                    s.resize(pos);
-            }
-
-            // Size tags.
-            for (const char *suf : {"_Large", "_XLarge", "_Medium", "_Small", "_Pancake"})
-            {
-                if (ends_with(s, suf))
-                {
-                    s.resize(s.size() - std::strlen(suf));
-                    break;
-                }
-            }
-
-            if (s.size() == prev)
-                break;
-        }
-    }
-
     // Returns true if the item name starts with a known non-equipment
     // prefix — crafting recipes, recipe books, knowledge books, etc.
     // These items sometimes end with armor-slot suffixes (e.g.
@@ -373,15 +295,18 @@ namespace Transmog
         return false;
     }
 
-    // Case-insensitive comparison helper for suffix matching.
-    static bool tail_eq_ci(const std::string &tail, const char *target) noexcept
+    // Case-insensitive comparison of a token view against a compile-time
+    // literal. Zero-allocation — operates on the caller's string_view
+    // without copying.
+    static bool token_eq_ci(std::string_view token,
+                            const char *target,
+                            std::size_t targetLen) noexcept
     {
-        const auto n = std::strlen(target);
-        if (tail.size() != n)
+        if (token.size() != targetLen)
             return false;
-        for (std::size_t i = 0; i < n; ++i)
+        for (std::size_t i = 0; i < targetLen; ++i)
         {
-            if (std::tolower(static_cast<unsigned char>(tail[i])) !=
+            if (std::tolower(static_cast<unsigned char>(token[i])) !=
                 std::tolower(static_cast<unsigned char>(target[i])))
                 return false;
         }
@@ -399,27 +324,40 @@ namespace Transmog
         if (is_non_equipment_prefix(name))
             return TransmogSlot::Count;
 
-        std::string stripped = name;
-        strip_variant_tail(stripped);
+        // Scan underscore-delimited tokens right-to-left for the first
+        // slot keyword match. This naturally ignores arbitrary trailing
+        // suffixes (roman numerals, upgrade tiers, size tags, NPC
+        // variant ids like _XL, _XX, _I) without enumerating them.
+        // Case-insensitive — CE-verified: v1.02.00 has 4 items with
+        // lowercase "_cloak" that are real equippable cloaks.
+        const std::string_view sv{name};
+        std::size_t end = sv.size();
+        while (end > 0)
+        {
+            const auto dash = sv.find_last_of('_', end - 1);
+            const std::size_t start =
+                (dash == std::string_view::npos) ? 0 : dash + 1;
+            const std::string_view token = sv.substr(start, end - start);
 
-        // Find the last underscore and compare the tail. Case-INSENSITIVE —
-        // CE-verified: v1.02.00 has 4 items with lowercase "_cloak" that
-        // are real equippable cloaks (Paulus_Basic_Leather_cloak, etc).
-        const auto dash = stripped.find_last_of('_');
-        std::string tail = (dash == std::string::npos)
-                               ? stripped
-                               : stripped.substr(dash + 1);
+            // Ordered by catalog frequency (v1.02.00):
+            // Armor=984, Helm=367, Boots=339, Gloves=352, Cloak=111.
+            if (token_eq_ci(token, "Armor", 5))
+                return TransmogSlot::Chest;
+            if (token_eq_ci(token, "Helm", 4))
+                return TransmogSlot::Helm;
+            if (token_eq_ci(token, "Boots", 5))
+                return TransmogSlot::Boots;
+            if (token_eq_ci(token, "Gloves", 6))
+                return TransmogSlot::Gloves;
+            if (token_eq_ci(token, "Cloak", 5))
+                return TransmogSlot::Cloak;
+            if (token_eq_ci(token, "Cloth", 5))
+                return TransmogSlot::Chest;
 
-        if (tail_eq_ci(tail, "Helm"))
-            return TransmogSlot::Helm;
-        if (tail_eq_ci(tail, "Armor") || tail_eq_ci(tail, "Cloth"))
-            return TransmogSlot::Chest;
-        if (tail_eq_ci(tail, "Cloak"))
-            return TransmogSlot::Cloak;
-        if (tail_eq_ci(tail, "Gloves"))
-            return TransmogSlot::Gloves;
-        if (tail_eq_ci(tail, "Boots"))
-            return TransmogSlot::Boots;
+            if (dash == std::string_view::npos)
+                break;
+            end = dash;
+        }
 
         return TransmogSlot::Count;
     }
@@ -901,23 +839,37 @@ namespace Transmog
             const bool hasVariant = (vit != m_variantFlag.end()) && (vit->second != 0);
             auto pit = m_playerFlag.find(id);
             const bool isPlayer = (pit == m_playerFlag.end()) || (pit->second != 0);
+            // Look up display name by lowercased internal name.
+            std::string lowerName = name;
+            for (auto &c : lowerName)
+                c = static_cast<char>(
+                    std::tolower(static_cast<unsigned char>(c)));
+            auto dit = m_displayNames.find(lowerName);
+            std::string dispName =
+                (dit != m_displayNames.end()) ? dit->second : std::string();
+
             m_sortedCache.push_back({
                 id,
                 classify_slot(name),
                 hasVariant,
                 isPlayer,
                 name,
+                std::move(dispName),
             });
         }
 
         std::sort(m_sortedCache.begin(), m_sortedCache.end(),
                   [](const Entry &a, const Entry &b)
                   {
-                      // Case-insensitive lexicographic compare so "Kliff"
-                      // and "kliff" sort together; items lowercase anyway
-                      // but this survives future catalog changes.
-                      const auto &sa = a.name;
-                      const auto &sb = b.name;
+                      // Sort by display name when available, else by
+                      // internal name. Case-insensitive so "Kliff" and
+                      // "kliff" sort together.
+                      const auto &sa = a.displayName.empty()
+                                           ? a.name
+                                           : a.displayName;
+                      const auto &sb = b.displayName.empty()
+                                           ? b.name
+                                           : b.displayName;
                       const std::size_t n = (std::min)(sa.size(), sb.size());
                       for (std::size_t i = 0; i < n; ++i)
                       {
@@ -975,6 +927,73 @@ namespace Transmog
 
         logger.info("[nametable] dumped {} entries to CrimsonDesertLiveTransmog_items.tsv",
                     entries.size());
+    }
+
+    void ItemNameTable::load_display_names(const std::string &tsvPath)
+    {
+        auto &logger = DMK::Logger::get_instance();
+
+        std::ifstream file(tsvPath);
+        if (!file.is_open())
+        {
+            logger.warning("[nametable] display names file not found: '{}'",
+                           tsvPath);
+            return;
+        }
+
+        std::unordered_map<std::string, std::string> names;
+        names.reserve(6100);
+        std::string line;
+        while (std::getline(file, line))
+        {
+            if (line.empty())
+                continue;
+            if (line.back() == '\r')
+                line.pop_back();
+
+            const auto tab = line.find('\t');
+            if (tab == std::string::npos || tab == 0 ||
+                tab + 1 >= line.size())
+                continue;
+
+            std::string key = line.substr(0, tab);
+            for (auto &c : key)
+                c = static_cast<char>(
+                    std::tolower(static_cast<unsigned char>(c)));
+            names.emplace(std::move(key), line.substr(tab + 1));
+        }
+
+        {
+            std::lock_guard<std::mutex> lk(s_tableMtx);
+            m_displayNames = std::move(names);
+            // Callers must invoke load_display_names() before any
+            // sorted_entries() access (i.e. before dump_catalog_tsv)
+            // so the cache is still empty here — no re-sort needed.
+            m_sortedCache.clear();
+        }
+
+        logger.info("[nametable] loaded {} display names from '{}'",
+                    m_displayNames.size(), tsvPath);
+    }
+
+    std::string ItemNameTable::display_name_of(
+        std::string_view internalName) const
+    {
+        // Lowercase into a stack buffer to avoid heap allocation.
+        // Item names in the catalog are bounded by k_maxNameLen (256).
+        char buf[256];
+        const auto len = (std::min)(internalName.size(), sizeof(buf) - 1);
+        for (std::size_t i = 0; i < len; ++i)
+            buf[i] = static_cast<char>(
+                std::tolower(static_cast<unsigned char>(internalName[i])));
+        buf[len] = '\0';
+        const std::string key{buf, len};
+
+        std::lock_guard<std::mutex> lk(s_tableMtx);
+        const auto it = m_displayNames.find(key);
+        if (it == m_displayNames.end())
+            return {};
+        return it->second;
     }
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/item_name_table.hpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -209,6 +210,7 @@ namespace Transmog
             bool hasVariantMeta;
             bool isPlayerCompatible;
             std::string name;
+            std::string displayName; // human-readable name from display_names.json
         };
         const std::vector<Entry> &sorted_entries() const;
 
@@ -242,6 +244,29 @@ namespace Transmog
         /// Columns: ItemID, Slot, Variant, PlayerSafe, Name.
         void dump_catalog_tsv() const;
 
+        /**
+         * @brief Load human-readable display names from a TSV file.
+         *
+         * Each line is `internalName<TAB>displayName`. Keys are
+         * lowercased at load time for case-insensitive matching.
+         * Must be called after a successful build(). Invalidates the
+         * sorted cache so the next sorted_entries() picks up display
+         * names.
+         *
+         * @param tsvPath Path to the display names TSV file.
+         */
+        void load_display_names(const std::string &tsvPath);
+
+        /**
+         * @brief Look up a display name by internal name.
+         *
+         * @param internalName The item's internal catalog name.
+         * @return The human-readable display name, or empty string
+         *         if no mapping exists.
+         */
+        [[nodiscard]] std::string display_name_of(
+            std::string_view internalName) const;
+
     private:
         ItemNameTable() = default;
 
@@ -249,6 +274,7 @@ namespace Transmog
         std::unordered_map<std::string, uint16_t> m_nameToId;
         std::unordered_map<uint16_t, uint8_t> m_variantFlag;
         std::unordered_map<uint16_t, uint8_t> m_playerFlag;
+        std::unordered_map<std::string, std::string> m_displayNames; // lowercase internal -> display
         mutable std::vector<Entry> m_sortedCache;
 
         // Stability detector: tracks the valid count from the previous

--- a/CrimsonDesertLiveTransmog/src/overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay.cpp
@@ -142,14 +142,14 @@ namespace Transmog
         ImGui::SameLine();
         ImGui::Checkbox("Hide variants", &ui.hideVariants);
 
-        ImGui::SetNextItemWidth(200.0f);
+        ImGui::SetNextItemWidth(250.0f);
         if (ImGui::IsWindowAppearing())
         {
             ImGui::SetKeyboardFocusHere();
             ui.navIndex = -1;
         }
         const bool searchEdited = ImGui::InputTextWithHint(
-            "##search", "search by name...",
+            "##search", "search by name or id...",
             ui.searchBuf, sizeof(ui.searchBuf));
         if (searchEdited)
             ui.navIndex = 0;
@@ -188,11 +188,14 @@ namespace Transmog
         const auto &entries = table.sorted_entries();
 
         const float rowH = ImGui::GetTextLineHeightWithSpacing();
+        const float lineH = ImGui::GetTextLineHeight();
+        // Two-line row: display name + smaller internal name line.
+        const float twoLineH = lineH * 2.0f + 4.0f;
 
         // Fixed-height scrollable region so the popup doesn't resize
         // per keystroke as the filter narrows.
         ImGui::BeginChild("##itemlist",
-                          ImVec2(340.0f, rowH * 22.0f),
+                          ImVec2(420.0f, twoLineH * 12.0f),
                           true);
 
         // Increase vertical spacing between items for easier click/hover
@@ -224,6 +227,15 @@ namespace Transmog
             }
         }
 
+        // Hoist draw-list pointer outside the loop — it is stable for
+        // the entire BeginChild region and avoids a per-item lookup.
+        ImDrawList *const dl = ImGui::GetWindowDrawList();
+
+        // Semantic color constants for the two-line item display.
+        static constexpr ImU32 k_colorCrashRisk = IM_COL32(255, 89, 89, 255);
+        static constexpr ImU32 k_colorCarrier = IM_COL32(128, 217, 255, 255);
+        static constexpr ImU32 k_colorDimmed = IM_COL32(160, 160, 160, 200);
+
         int shown = 0;
         int filteredByCategory = 0;
         int filteredByUnsafe = 0;
@@ -251,7 +263,8 @@ namespace Transmog
                 ++filteredByUnsafe;
                 continue;
             }
-            if (!name_contains_ci(e.name, ui.searchBuf))
+            if (!name_contains_ci(e.name, ui.searchBuf) &&
+                !name_contains_ci(e.displayName, ui.searchBuf))
                 continue;
             if (shown >= k_maxShown)
                 break;
@@ -260,7 +273,6 @@ namespace Transmog
             //   - "CRASH RISK"  -> !isPlayerCompatible (red)
             //   - "carrier"     -> hasVariantMeta, rendered via carrier
             //                      + char-class bypass (cyan)
-            char label[200];
             const char *tag = nullptr;
             // NPC variant items (hasVariantMeta) are humanoid and now
             // render via carrier + char-class bypass. True crash risks
@@ -273,30 +285,59 @@ namespace Transmog
             else if (usesCarrier)
                 tag = "carrier";
 
-            if (tag)
-                std::snprintf(label, sizeof(label),
-                              "%s  [0x%04X]  (%s)##picker",
-                              e.name.c_str(), e.id, tag);
-            else
-                std::snprintf(label, sizeof(label), "%s  [0x%04X]##picker",
-                              e.name.c_str(), e.id);
-
-            if (crashRisk)
-                ImGui::PushStyleColor(ImGuiCol_Text,
-                                      ImVec4(1.0f, 0.35f, 0.35f, 1.0f));
-            else if (usesCarrier)
-                ImGui::PushStyleColor(ImGuiCol_Text,
-                                      ImVec4(0.5f, 0.85f, 1.0f, 1.0f));
-
             const bool isNavTarget = (shown == ui.navIndex);
             const bool highlighted =
                 (targetItemId == e.id) || isNavTarget;
-            if (ImGui::Selectable(label, highlighted))
+
+            // Two-line selectable: hidden label, custom text overlay.
+            char hiddenId[32];
+            std::snprintf(hiddenId, sizeof(hiddenId),
+                          "##picker_%04X", e.id);
+            ImVec2 pos = ImGui::GetCursorScreenPos();
+            if (crashRisk)
+                ImGui::PushStyleColor(ImGuiCol_Header,
+                                      ImVec4(0.4f, 0.1f, 0.1f, 0.6f));
+            else if (usesCarrier)
+                ImGui::PushStyleColor(ImGuiCol_Header,
+                                      ImVec4(0.1f, 0.2f, 0.35f, 0.6f));
+            if (ImGui::Selectable(hiddenId, highlighted,
+                                  0, ImVec2(0, twoLineH)))
             {
                 targetItemId = e.id;
                 committed = true;
                 ImGui::CloseCurrentPopup();
             }
+
+            // Overlay text on top of the selectable region.
+            const bool hasDisplay = !e.displayName.empty();
+            const char *primaryName =
+                hasDisplay ? e.displayName.c_str() : e.name.c_str();
+
+            // Line 1: display name (or internal name fallback) + tag.
+            char line1[256];
+            if (tag)
+                std::snprintf(line1, sizeof(line1), "%s  (%s)",
+                              primaryName, tag);
+            else
+                std::snprintf(line1, sizeof(line1), "%s", primaryName);
+
+            const ImU32 mainColor = crashRisk    ? k_colorCrashRisk
+                                    : usesCarrier ? k_colorCarrier
+                                    : ImGui::GetColorU32(ImGuiCol_Text);
+
+            dl->AddText(ImVec2(pos.x + 2.0f, pos.y + 1.0f),
+                        mainColor, line1);
+
+            // Line 2: internal name + hex id (dimmed).
+            char line2[256];
+            if (hasDisplay)
+                std::snprintf(line2, sizeof(line2),
+                              "  %s  [0x%04X]", e.name.c_str(), e.id);
+            else
+                std::snprintf(line2, sizeof(line2),
+                              "  [0x%04X]", e.id);
+            dl->AddText(ImVec2(pos.x + 2.0f, pos.y + lineH + 2.0f),
+                        k_colorDimmed, line2);
 
             // Scroll the nav-highlighted row into view and handle
             // Enter to commit.
@@ -339,7 +380,7 @@ namespace Transmog
             }
 
             if (crashRisk || usesCarrier)
-                ImGui::PopStyleColor();
+                ImGui::PopStyleColor(); // Header color
 
             ++shown;
         }
@@ -726,11 +767,14 @@ namespace Transmog
                     }
                     else if (tableReady)
                     {
-                        auto name = table.name_of(m.targetItemId);
-                        if (name.empty())
-                            pickerLabel = "(unknown)";
+                        auto internalName = table.name_of(m.targetItemId);
+                        auto dispName = table.display_name_of(internalName);
+                        if (!dispName.empty())
+                            pickerLabel = dispName;
+                        else if (!internalName.empty())
+                            pickerLabel = internalName;
                         else
-                            pickerLabel = std::move(name);
+                            pickerLabel = "(unknown)";
                     }
                     else
                     {
@@ -742,8 +786,8 @@ namespace Transmog
                                   "%s  [0x%04X]##pick", pickerLabel.c_str(),
                                   m.targetItemId);
 
-                    ImGui::SetNextItemWidth(240.0f);
-                    if (ImGui::Button(btnLabel, ImVec2(240.0f, 0.0f)))
+                    ImGui::SetNextItemWidth(280.0f);
+                    if (ImGui::Button(btnLabel, ImVec2(280.0f, 0.0f)))
                     {
                         if (tableReady)
                         {

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -1,7 +1,30 @@
 #include "shared_state.hpp"
 
+#include <DetourModKit.hpp>
+
+#include <Windows.h>
+
 namespace Transmog
 {
+    std::string runtime_dir_utf8()
+    {
+        std::wstring dirW = DMK::Filesystem::get_runtime_directory();
+        if (dirW.empty())
+            return {};
+        const int n = WideCharToMultiByte(
+            CP_UTF8, 0, dirW.data(), static_cast<int>(dirW.size()),
+            nullptr, 0, nullptr, nullptr);
+        if (n <= 0)
+            return {};
+        std::string dir(static_cast<std::size_t>(n), '\0');
+        WideCharToMultiByte(
+            CP_UTF8, 0, dirW.data(), static_cast<int>(dirW.size()),
+            dir.data(), n, nullptr, nullptr);
+        if (dir.back() != '\\' && dir.back() != '/')
+            dir.push_back('\\');
+        return dir;
+    }
+
     static ResolvedAddresses s_resolvedAddrs{};
     static std::array<SlotMapping, k_slotCount> s_slotMappings{};
     static std::array<uint16_t, k_slotCount> s_lastAppliedIds{};

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <string>
 
 namespace Transmog
 {
@@ -117,5 +118,10 @@ namespace Transmog
                    std::chrono::steady_clock::now().time_since_epoch())
             .count();
     }
+
+    /// Convert the wide runtime directory to a UTF-8 string with a
+    /// trailing path separator. Returns empty on failure. Used by
+    /// init and deferred-scan paths to locate sidecar data files.
+    std::string runtime_dir_utf8();
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -360,6 +360,16 @@ namespace Transmog
                     "[nametable] built synchronously at init "
                     "({} entries)",
                     ItemNameTable::instance().size());
+                // Load display names BEFORE dump_catalog_tsv so the
+                // sorted cache (built lazily by the dump) already
+                // contains display names and doesn't need a second
+                // rebuild that would stall the overlay render thread.
+                {
+                    const auto dir = runtime_dir_utf8();
+                    if (!dir.empty())
+                        ItemNameTable::instance().load_display_names(
+                            dir + DISPLAY_NAMES_FILE);
+                }
                 if (logger.is_enabled(DMK::LogLevel::Trace))
                     ItemNameTable::instance().dump_catalog_tsv();
             }
@@ -475,26 +485,8 @@ namespace Transmog
         // --- Load presets ---
 
         {
-            std::wstring rtDirW = DMK::Filesystem::get_runtime_directory();
-            std::string rtDir;
-            if (!rtDirW.empty())
-            {
-                int needed = WideCharToMultiByte(
-                    CP_UTF8, 0,
-                    rtDirW.data(), static_cast<int>(rtDirW.size()),
-                    nullptr, 0, nullptr, nullptr);
-                if (needed > 0)
-                {
-                    rtDir.resize(static_cast<std::size_t>(needed));
-                    WideCharToMultiByte(
-                        CP_UTF8, 0,
-                        rtDirW.data(), static_cast<int>(rtDirW.size()),
-                        rtDir.data(), needed, nullptr, nullptr);
-                }
-            }
-            if (!rtDir.empty() && rtDir.back() != '\\' && rtDir.back() != '/')
-                rtDir.push_back('\\');
-            std::string presetsPath = rtDir + PRESETS_FILE;
+            const auto rtDir = runtime_dir_utf8();
+            const std::string presetsPath = rtDir + PRESETS_FILE;
 
             auto &pm = PresetManager::instance();
             pm.load(presetsPath);

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -1,4 +1,5 @@
 #include "transmog_worker.hpp"
+#include "constants.hpp"
 #include "item_name_table.hpp"
 #include "preset_manager.hpp"
 #include "shared_state.hpp"
@@ -35,7 +36,6 @@ namespace Transmog
 
     static constexpr int k_nametableInitialDelayMs = 8000;
     static constexpr int k_nametableRetryMs = 2000;
-    static constexpr int k_nametableMaxAttempts = 15;
 
     static void deferred_nametable_scan_fn() noexcept
     {
@@ -69,6 +69,14 @@ namespace Transmog
                     "[nametable] deferred scan succeeded on attempt {} "
                     "({} entries)",
                     attempt + 1, size);
+                // Load display names before dump so the sorted cache
+                // built by the dump already contains them.
+                {
+                    const auto dir = runtime_dir_utf8();
+                    if (!dir.empty())
+                        ItemNameTable::instance().load_display_names(
+                            dir + DISPLAY_NAMES_FILE);
+                }
                 if (logger.is_enabled(DMK::LogLevel::Trace))
                     ItemNameTable::instance().dump_catalog_tsv();
 
@@ -94,17 +102,12 @@ namespace Transmog
                 return;
             }
 
-            // Deferred: sleep and retry.
+            // Deferred: sleep and retry indefinitely until the game
+            // populates the catalog or shutdown is requested.
             ++attempt;
-            if (attempt >= k_nametableMaxAttempts)
-            {
-                logger.error(
-                    "[nametable] deferred scan exhausted {} attempts — "
-                    "item catalog unavailable, mod disabled",
-                    k_nametableMaxAttempts);
-                flag_enabled().store(false, std::memory_order_release);
-                return;
-            }
+            if (attempt % 50 == 0)
+                logger.warning(
+                    "[nametable] still waiting after {} attempts", attempt);
 
             for (int slept = 0; slept < k_nametableRetryMs; slept += 250)
             {


### PR DESCRIPTION
## Summary

- Show human-readable display names (e.g. "Kairos Plate Helm") in the item picker with two-line layout: display name on top, internal name + hex ID dimmed below
- Search matches both display and internal names
- Rework `classify_slot` to scan tokens right-to-left, fixing misclassification of items like `Greyfur_Leather_Armor_XL` (suffix no longer needs stripping)
- Ship `CrimsonDesertLiveTransmog_display_names.tsv` (6019 entries from community item DB) via build template

## Other changes

- Extract `runtime_dir_utf8()` into `shared_state` to eliminate duplicated WideCharToMultiByte boilerplate
- Remove deferred nametable scan max-attempts bailout (retries indefinitely until shutdown)
- `display_name_of()` uses stack buffer to avoid heap allocation
- Hoist `GetWindowDrawList()` and color constants outside overlay render loop
- Update known limitations in README and Nexus BBCode (Silverwolf Leather Armor cloak conflict)