### PR TITLE
fix(live-transmog): extend auto-apply retry window and fix overlay layout

### DIFF
--- a/CrimsonDesertLiveTransmog/src/dx_overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/dx_overlay.cpp
@@ -21,19 +21,16 @@
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(
     HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-// ====================================================================== //
-//  Swap-chain-free transparent overlay                                    //
-//                                                                         //
-//  OptiScaler hooks ALL DXGI swap chain creation and asserts on its        //
-//  ImGui re-init.  This approach creates NO swap chain at all:             //
-//    1. D3D11 WARP device (no swap chain — only CreateDevice)              //
-//    2. Offscreen Texture2D render target                                  //
-//    3. ImGui renders to the texture via ImGui_ImplDX11                    //
-//    4. Texture pixels copied to a DIB section                             //
-//    5. UpdateLayeredWindow composites the DIB onto the screen             //
-//                                                                         //
-//  Zero DXGI swap chain → zero OptiScaler interference.                   //
-// ====================================================================== //
+// Swap-chain-free transparent overlay.
+//
+// OptiScaler hooks all DXGI swap chain creation and asserts on its
+// ImGui re-init.  This approach creates no swap chain at all:
+//   1. D3D11 WARP device (CreateDevice only, no swap chain)
+//   2. Offscreen Texture2D render target
+//   3. ImGui renders to the texture via ImGui_ImplDX11
+//   4. Texture pixels copied to a DIB section
+//   5. UpdateLayeredWindow composites the DIB onto the screen
+// Zero DXGI swap chain means zero OptiScaler interference.
 
 namespace Transmog
 {
@@ -62,9 +59,7 @@ namespace Transmog
 
     static HANDLE s_renderThread = nullptr;
 
-    // ------------------------------------------------------------------ //
-    //  Render target + staging + DIB management                           //
-    // ------------------------------------------------------------------ //
+    // --- Render target + staging + DIB management ---
 
     static void release_targets()
     {
@@ -179,9 +174,7 @@ namespace Transmog
                             s_memDC, &ptSrc, 0, &blend, ULW_ALPHA);
     }
 
-    // ------------------------------------------------------------------ //
-    //  Helpers                                                            //
-    // ------------------------------------------------------------------ //
+    // --- Helpers ---
 
     static HWND find_game_hwnd()
     {
@@ -207,9 +200,7 @@ namespace Transmog
         return ctx.result;
     }
 
-    // ------------------------------------------------------------------ //
-    //  Overlay WndProc                                                    //
-    // ------------------------------------------------------------------ //
+    // --- Overlay WndProc ---
 
     static LRESULT CALLBACK overlay_wndproc(HWND hWnd, UINT msg,
                                             WPARAM wParam, LPARAM lParam)
@@ -230,9 +221,7 @@ namespace Transmog
         return DefWindowProcW(hWnd, msg, wParam, lParam);
     }
 
-    // ------------------------------------------------------------------ //
-    //  Render loop                                                        //
-    // ------------------------------------------------------------------ //
+    // --- Render loop ---
 
     static DWORD WINAPI render_thread(LPVOID)
     {
@@ -435,9 +424,7 @@ namespace Transmog
         return 0;
     }
 
-    // ------------------------------------------------------------------ //
-    //  Public API                                                         //
-    // ------------------------------------------------------------------ //
+    // --- Public API ---
 
     bool init_dx_overlay()
     {

--- a/CrimsonDesertLiveTransmog/src/overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay.cpp
@@ -1,11 +1,9 @@
-// ====================================================================== //
-//  overlay.cpp — Standalone overlay path (D3D11 WARP + GDI blit)         //
-//                                                                         //
-//  This TU includes overlay_ui.inl which resolves ImGui calls against     //
-//  imgui_lib (the real ImGui compiled from source).  The ReShade path     //
-//  lives in overlay_reshade.cpp which resolves against ReShade's          //
-//  function-table wrappers instead.                                       //
-// ====================================================================== //
+// overlay.cpp — Standalone overlay path (D3D11 WARP + GDI blit).
+//
+// This TU includes overlay_ui.inl which resolves ImGui calls against
+// imgui_lib (the real ImGui compiled from source).  The ReShade path
+// lives in overlay_reshade.cpp which resolves against ReShade's
+// function-table wrappers instead.
 
 #include "overlay.hpp"
 #include "constants.hpp"
@@ -58,6 +56,7 @@ namespace Transmog
             ImGui::End();
             return;
         }
+        s_standaloneMode = true;
         draw_overlay_content();
         ImGui::End();
     }

--- a/CrimsonDesertLiveTransmog/src/overlay_reshade.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay_reshade.cpp
@@ -1,19 +1,16 @@
-// ====================================================================== //
-//  overlay_reshade.cpp — ReShade addon overlay path                       //
-//                                                                         //
-//  This TU includes the ReShade SDK's imgui.h which defines ImGui         //
-//  functions as inline wrappers that call through ReShade's function       //
-//  table.  This is a DIFFERENT ImGui from imgui_lib (the real compiled     //
-//  ImGui used by the standalone overlay).                                  //
-//                                                                         //
-//  overlay_ui.inl is included here so draw_overlay_content() resolves     //
-//  ImGui calls to ReShade's wrappers — rendering appears inside           //
-//  ReShade's addon tab, not a separate window.                            //
-//                                                                         //
-//  IMPORTANT: This file must NOT see imgui_lib's include path.  The       //
-//  CMakeLists.txt configures this TU with the ReShade SDK include         //
-//  directory instead.                                                     //
-// ====================================================================== //
+// overlay_reshade.cpp — ReShade addon overlay path.
+//
+// This TU includes the ReShade SDK's imgui.h which defines ImGui
+// functions as inline wrappers that call through ReShade's function
+// table.  This is a different ImGui from imgui_lib (the real compiled
+// ImGui used by the standalone overlay).
+//
+// overlay_ui.inl is included here so draw_overlay_content() resolves
+// ImGui calls to ReShade's wrappers, rendering appears inside
+// ReShade's addon tab, not a separate window.
+//
+// This file must NOT see imgui_lib's include path.  The CMakeLists.txt
+// configures this TU with the ReShade SDK include directory instead.
 
 #include "constants.hpp"
 #include "item_name_table.hpp"

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -1,32 +1,25 @@
-// ====================================================================== //
-//  overlay_ui.inl — Shared transmog overlay widget code                   //
-//                                                                         //
-//  Included by BOTH overlay.cpp (standalone D3D11 path) and               //
-//  overlay_reshade.cpp (ReShade addon path).  Each TU provides its own    //
-//  ImGui symbols — the standalone path links against imgui_lib while the  //
-//  ReShade path uses the function-table wrappers from reshade.hpp.        //
-//                                                                         //
-//  Everything here is static (internal linkage per TU).  Only one path    //
-//  is active at runtime so the duplicated state is harmless (~2 KB).      //
-//                                                                         //
-//  REQUIRES the including TU to have these headers already included:      //
-//    - imgui.h (either real or ReShade wrapper — controls which ImGui)    //
-//    - constants.hpp, item_name_table.hpp, preset_manager.hpp,            //
-//      shared_state.hpp, transmog.hpp, transmog_map.hpp                   //
-//    - <DetourModKit.hpp>                                                 //
-//    - <cstdio>, <cstring>, <string>                                      //
-// ====================================================================== //
+// overlay_ui.inl — Shared transmog overlay widget code.
+//
+// Included by both overlay.cpp (standalone D3D11 path) and
+// overlay_reshade.cpp (ReShade addon path).  Each TU provides its own
+// ImGui symbols: the standalone path links against imgui_lib while the
+// ReShade path uses the function-table wrappers from reshade.hpp.
+//
+// Everything here is static (internal linkage per TU).  Only one path
+// is active at runtime so the duplicated state is harmless (~2 KB).
+//
+// Requires the including TU to have these headers already included:
+//   imgui.h (either real or ReShade wrapper), constants.hpp,
+//   item_name_table.hpp, preset_manager.hpp, shared_state.hpp,
+//   transmog.hpp, transmog_map.hpp, <DetourModKit.hpp>,
+//   <cstdarg>, <cstdio>, <cstring>, <string>
 
-// ------------------------------------------------------------------ //
-//  Non-variadic ImGui wrappers                                        //
-//                                                                      //
-//  ImGui::Text, TextColored, TextDisabled, and SetTooltip are          //
-//  variadic (va_args).  The compiler cannot inline them, so ReShade's  //
-//  reshade_overlay.hpp emits out-of-line COMDAT copies that conflict   //
-//  with imgui_lib's strong symbols at link time.  These helpers call   //
-//  only non-variadic ImGui functions (TextUnformatted, PushStyleColor) //
-//  which inline correctly in both the ReShade and standalone paths.    //
-// ------------------------------------------------------------------ //
+// ImGui::Text, TextColored, TextDisabled, and SetTooltip are variadic.
+// The compiler cannot inline them, so ReShade's reshade_overlay.hpp
+// emits out-of-line COMDAT copies that conflict with imgui_lib's strong
+// symbols at link time.  These helpers call only non-variadic ImGui
+// functions (TextUnformatted, PushStyleColor) which inline correctly
+// in both the ReShade and standalone paths.
 
 static void ui_text(const char *fmt, ...)
 {
@@ -69,6 +62,13 @@ static void ui_tooltip(const char *text)
     ImGui::TextUnformatted(text);
     ImGui::EndTooltip();
 }
+
+// Set by the including TU before draw_overlay_content runs.
+// true  = standalone overlay (wider layout for high-DPI)
+// false = ReShade addon tab  (compact layout)
+// Cannot use FontGlobalScale to detect this because ReShade at 4K
+// also sets FontGlobalScale > 1.
+static bool s_standaloneMode = false;
 
 // Minimum time (ms) the cursor must rest on a picker item before
 // hover-apply fires.  Prevents rapid apply cycles while scrolling.
@@ -243,8 +243,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
 
     // Fixed-height scrollable region so the popup doesn't resize
     // per keystroke as the filter narrows.
-    const float popupScale = ImGui::GetIO().FontGlobalScale;
-    const float popupW = popupScale > 1.05f ? 420.0f * popupScale : 520.0f;
+    const float popupW = s_standaloneMode ? 720.0f : 560.0f;
     ImGui::BeginChild("##itemlist",
                       ImVec2(popupW, twoLineH * 12.0f),
                       true);
@@ -733,10 +732,7 @@ static void draw_overlay_content()
                 manual_apply_slot(i);
             }
 
-            {
-                const float s = ImGui::GetIO().FontGlobalScale;
-                ImGui::SameLine(s > 1.05f ? 90.0f * s : 120.0f);
-            }
+            ImGui::SameLine(s_standaloneMode ? 160.0f : 120.0f);
 
             // --- Picker button ---
             {
@@ -766,11 +762,10 @@ static void draw_overlay_content()
                               "%s  [0x%04X]##pick", pickerLabel.c_str(),
                               m.targetItemId);
 
-                const float s = ImGui::GetIO().FontGlobalScale;
-                const float bw = s > 1.05f ? 280.0f * s : 380.0f;
+                const float bw = s_standaloneMode ? 520.0f : 380.0f;
                 ImGui::SetNextItemWidth(bw);
                 ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign,
-                                    ImVec2(0.03f, 0.5f));
+                                    ImVec2(0.02f, 0.5f));
                 if (ImGui::Button(btnLabel, ImVec2(bw, 0.0f)))
                 {
                     if (tableReady)
@@ -828,10 +823,7 @@ static void draw_overlay_content()
                 std::snprintf(ui.hexBuf, sizeof(ui.hexBuf), "%04X",
                               m.targetItemId);
 
-            {
-                const float hs = ImGui::GetIO().FontGlobalScale;
-                ImGui::SetNextItemWidth(hs > 1.05f ? 64.0f * hs : 64.0f);
-            }
+            ImGui::SetNextItemWidth(64.0f);
             if (ImGui::InputText(
                     "##hex", ui.hexBuf, sizeof(ui.hexBuf),
                     ImGuiInputTextFlags_CharsHexadecimal |

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -180,6 +180,11 @@ namespace Transmog
     static std::atomic<std::uint64_t> s_applyDeadlineTick{0};
     static std::atomic<bool> s_applyPending{false};
 
+    // Set by run_debounced_apply: true if the last apply completed
+    // without SEH fault, false on exception. Used by load-detect to
+    // stop retrying once a boot-time apply succeeds.
+    static std::atomic<bool> s_lastApplyOk{false};
+
     static std::mutex s_applyCvMtx;
     static std::condition_variable s_applyCv;
     static std::thread s_applyWorker;
@@ -231,9 +236,11 @@ namespace Transmog
                 apply_all_transmog(a1);
                 logger.debug("Transmog applied (debounced)");
             }
+            s_lastApplyOk.store(true, std::memory_order_release);
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
+            s_lastApplyOk.store(false, std::memory_order_release);
             // Expected during load-retry window (game visual state not
             // ready yet). Logged at debug to avoid false-alarm noise.
             logger.debug("Transmog {} exception (debounced)",
@@ -384,20 +391,45 @@ namespace Transmog
 
                 // Retry through the debounce worker. The game's visual
                 // state isn't ready immediately after load detect — the
-                // first attempt often faults. Each schedule fires the
-                // worker with deadline=now (immediate), and the 2s
-                // sleep gives the game time to finish loading between
-                // attempts. Applies are serialized through the single
-                // worker thread, avoiding data races.
-                for (int attempt = 0; attempt < 5; ++attempt)
+                // first attempt often faults because the PartDef array
+                // and scene graph are still being populated. We retry
+                // with exponential backoff up to ~90s total, exiting
+                // early once the apply succeeds (no SEH fault).
+                //
+                // Backoff schedule: 2s, 2s, 3s, 4s, 5s, 5s, 5s, ...
+                // This gives fast feedback when the game loads quickly
+                // but doesn't burn CPU during longer load screens.
+                static constexpr int k_maxAutoApplyAttempts = 20;
+                s_lastApplyOk.store(false, std::memory_order_release);
+
+                for (int attempt = 0; attempt < k_maxAutoApplyAttempts;
+                     ++attempt)
                 {
-                    sleep_interruptible(2000);
+                    const int delayMs =
+                        (attempt < 2) ? 2000 :
+                        (attempt < 3) ? 3000 :
+                        (attempt < 4) ? 4000 : 5000;
+                    sleep_interruptible(delayMs);
                     if (shutdown_requested().load(std::memory_order_relaxed))
                         break;
                     schedule_transmog_ms(0);
-                    logger.info("Load detect: scheduled apply (attempt {})",
+                    logger.debug("Load detect: scheduled apply (attempt {})",
                                 attempt + 1);
+
+                    // Give the worker time to finish, then check result.
+                    sleep_interruptible(500);
+                    if (s_lastApplyOk.load(std::memory_order_acquire))
+                    {
+                        logger.info(
+                            "Load detect: auto-apply succeeded on attempt {}",
+                            attempt + 1);
+                        break;
+                    }
                 }
+                if (!s_lastApplyOk.load(std::memory_order_acquire))
+                    logger.warning(
+                        "Load detect: auto-apply failed after {} attempts",
+                        k_maxAutoApplyAttempts);
             }
             else if (comp > 0x10000)
             {
@@ -418,8 +450,9 @@ namespace Transmog
     {
         if (s_loadDetectThread)
         {
-            // Polls via sleep_interruptible(1000), retries up to 5x
-            // with 2s intervals. Worst case: 1s + 5*2s + margin = 12s.
+            // Polls via sleep_interruptible(1000), auto-apply retries up
+            // to 20x with backoff. All sleeps check shutdown_requested
+            // every 100ms, so drain completes well under 1s.
             WaitForSingleObject(s_loadDetectThread, 15000);
             CloseHandle(s_loadDetectThread);
             s_loadDetectThread = nullptr;


### PR DESCRIPTION
## Summary
- Fix auto-apply failing on boot/save-reload, the 5×2s retry window was too short for the game's ~60-90s PartDef/scene-graph init time. Now retries up to 20× with exponential backoff (2-5s) and exits early on success via atomic flag.
- Add `s_standaloneMode` flag for overlay layout sizing instead of unreliable `FontGlobalScale` heuristic.
- Clean up box-style comment headers to match project conventions.