### PR TITLE
feat(live-transmog): add multi-character support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,11 @@
 # IDE / editor
-.idea
+00_idea
 .vscode/*
 
 # Build artifacts
-CrimsonDesertEquipHide/build/*
-CrimsonDesertEquipHide/build_*/*
-!CrimsonDesertEquipHide/build/template
-
-CrimsonDesertLiveTransmog/build/*
-CrimsonDesertLiveTransmog/build_*/*
-!CrimsonDesertLiveTransmog/build/template
+CrimsonDesert*/build/*
+CrimsonDesert*/build_*/*
+!CrimsonDesert*/build/template
 
 # Keep marker files
 !/**/.gitkeep

--- a/CrimsonDesertCore/src/aob_resolver.cpp
+++ b/CrimsonDesertCore/src/aob_resolver.cpp
@@ -5,9 +5,105 @@
 #include <Windows.h>
 
 #include <cstdint>
+#include <string>
 
 namespace CDCore
 {
+    // ---------------------------------------------------------------
+    // Inline-hook tolerance for already-hooked function prologues.
+    //
+    // When two mods share a function target and use the same AOB, the
+    // first mod installs its SafetyHook-style inline hook and
+    // overwrites the first 5 bytes of the function with
+    // `E9 xx xx xx xx` (near-relative JMP). The second mod's AOB
+    // scan fails because the prologue pattern no longer matches.
+    //
+    // Build a fallback pattern by replacing the first 5 bytes with
+    // `E9 ?? ?? ?? ??`: the literal `E9` opcode plus four wildcard
+    // displacement bytes. If the original pattern was long enough
+    // (more than 5 bytes total) the remaining tail is still very
+    // distinctive, so the fallback finds exactly the hooked target
+    // and nothing else. Returns an empty string for patterns shorter
+    // than 5 bytes (no room to host the JMP prefix).
+    //
+    // Tokens are whitespace-separated; each byte is one token (either
+    // `XX` hex or `??` wildcard or partial `X?`/`?X`). A pipe `|`
+    // marker is sometimes used to tag a RIP offset inside a longer
+    // pattern; we preserve anything past the 5th byte verbatim.
+    static std::string build_hooked_prologue_pattern(
+        const char *orig) noexcept
+    {
+        if (!orig)
+            return {};
+        const std::string s(orig);
+        std::size_t i = 0;
+        int byteTokens = 0;
+        while (i < s.size() && byteTokens < 5)
+        {
+            // Skip whitespace.
+            while (i < s.size() &&
+                   (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' ||
+                    s[i] == '\r'))
+                ++i;
+            if (i >= s.size())
+                break;
+            // Skip the pipe marker without counting as a byte.
+            if (s[i] == '|')
+            {
+                ++i;
+                continue;
+            }
+            // Consume one token.
+            while (i < s.size() && s[i] != ' ' && s[i] != '\t' &&
+                   s[i] != '\n' && s[i] != '\r')
+                ++i;
+            ++byteTokens;
+        }
+        if (byteTokens < 5)
+            return {};
+
+        std::string out = "E9 ?? ?? ?? ??";
+        out += s.substr(i); // whatever remained, including leading space
+        return out;
+    }
+
+    static std::uintptr_t resolve_match(
+        std::uintptr_t match, const AddrCandidate &c) noexcept;
+    // forward decl -- definition lives below scan_for_address.
+
+    static std::uintptr_t scan_for_hooked_address(
+        const AddrCandidate *candidates, std::size_t count,
+        const char *&matchedName) noexcept
+    {
+        for (std::size_t i = 0; i < count; ++i)
+        {
+            // Only attempt the inline-hook fallback for direct-mode
+            // candidates (the ones that hook a function entry). RIP-
+            // relative candidates typically target instructions deeper
+            // in the body and are unaffected by another mod's 5-byte
+            // JMP rewrite at the prologue.
+            if (candidates[i].mode != ResolveMode::Direct)
+                continue;
+
+            auto hooked = build_hooked_prologue_pattern(
+                candidates[i].pattern);
+            if (hooked.empty())
+                continue;
+            auto p = DMK::Scanner::parse_aob(hooked.c_str());
+            if (!p)
+                continue;
+            auto *match = DMK::Scanner::scan_executable_regions(*p);
+            if (match)
+            {
+                matchedName = candidates[i].name;
+                return resolve_match(
+                    reinterpret_cast<std::uintptr_t>(match),
+                    candidates[i]);
+            }
+        }
+        return 0;
+    }
+
     bool sanity_check_function_prologue(std::uintptr_t addr) noexcept
     {
         if (!addr)
@@ -86,7 +182,27 @@ namespace CDCore
             return result;
         }
 
-        logger.warning("{} AOB scan failed — feature disabled", label);
+        // Fallback: the function may already have been inline-hooked
+        // by another mod that loaded before us. SafetyHook rewrites
+        // the first 5 bytes of the prologue with a relative JMP, so
+        // our normal AOB scan finds zero matches. Retry with the
+        // first 5 bytes replaced by `E9 ?? ?? ?? ??` -- if the tail
+        // of the pattern is specific enough we still locate the
+        // function, and SafetyHook chains our hook behind theirs
+        // cleanly.
+        const char *hookedMatch = nullptr;
+        const auto hookedResult = scan_for_hooked_address(
+            candidates, count, hookedMatch);
+        if (hookedResult)
+        {
+            logger.info(
+                "{} resolved via '{}' at 0x{:X} "
+                "(already inline-hooked by another mod; reusing target)",
+                label, hookedMatch, hookedResult);
+            return hookedResult;
+        }
+
+        logger.warning("{} AOB scan failed -- feature disabled", label);
         return 0;
     }
 

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -34,11 +34,11 @@ namespace EquipHide
         CDCore::Anchors::k_mapLookupCandidates;
     inline constexpr auto &k_partAddShowCandidates =
         CDCore::Anchors::k_partAddShowCandidates;
-    // sub_14076D520 — EH calls this "VisualEquipChange" (so does LT); keep
+    // sub_14076D520 -- EH calls this "VisualEquipChange" (so does LT); keep
     // the unified name.
     inline constexpr auto &k_visualEquipChangeCandidates =
         CDCore::Anchors::k_visualEquipChangeCandidates;
-    // sub_14075BBF0 — EH historically called this "VisualEquipSwap", LT
+    // sub_14075BBF0 -- EH historically called this "VisualEquipSwap", LT
     // called it "BatchEquip". Unified as "BatchEquip" (LT's name) since it
     // better describes the function's role (entry-table scan + dispatch).
     // An alias is provided under the old EH name so existing EH call sites
@@ -51,7 +51,7 @@ namespace EquipHide
     // --- EquipHide-only candidate tables ---------------------------------
 
     /**
-     * @brief ChildActor vtable — static data pointer resolved via three
+     * @brief ChildActor vtable -- static data pointer resolved via three
      *        nearby RIP-relative loads. All three candidates resolve to the
      *        same `lea rax, [rip+disp32]` that loads the vtable base; the
      *        cascade picks whichever anchor shape survives the current build.
@@ -61,21 +61,21 @@ namespace EquipHide
      *       follows the vtable store. Wildcarding its opcode loses
      *       uniqueness on the live build (5 matches without it). If a
      *       future compiler flips this jmp to the 6-byte `E9 rel32` form,
-     *       P2 will stop matching — P1 and P3 pick up the slack. P1 no
+     *       P2 will stop matching -- P1 and P3 pick up the slack. P1 no
      *       longer crosses the jmp (truncated 2026-04-19) so it is
      *       encoding-independent. P3 wildcards the preceding `74 ??` jz
      *       pair as `?? ??` so it only declares a 2-byte slot, not the
      *       rel8 opcode literal.
      */
     inline constexpr AddrCandidate k_childActorVtblCandidates[] = {
-        // P1 — truncated 2026-04-19: ends at the `mov [rsi], rax` that
+        // P1 -- truncated 2026-04-19: ends at the `mov [rsi], rax` that
         // stores the vtable. Does NOT cross the trailing `EB 03` jmp, so
         // it survives a Jcc-encoding flip.
         {"ChildActorVtbl_P1_AllocCtor",
          "48 8B 55 ?? 48 89 F1 E8 ?? ?? ?? ?? 90 48 8D 05 ?? ?? ?? ?? 48 89 06",
          ResolveMode::RipRelative, 16, 20},
 
-        // P2 — retains the trailing `EB ?? 4C`: without the `4C` byte
+        // P2 -- retains the trailing `EB ?? 4C`: without the `4C` byte
         // of the post-jmp `mov rsi, r13` continuation, the lead-in is
         // structurally shared with 4 other ctor sites (CE aob_scan
         // 2026-04-19: 5 hits). Tied to the 2-byte jmp encoding.
@@ -83,7 +83,7 @@ namespace EquipHide
          "48 89 F1 E8 ?? ?? ?? ?? 90 48 8D 05 ?? ?? ?? ?? 48 89 06 EB ?? 4C",
          ResolveMode::RipRelative, 12, 16},
 
-        // P3 — rel8 jz at offset +6 is wildcarded to `?? ??` (both bytes).
+        // P3 -- rel8 jz at offset +6 is wildcarded to `?? ??` (both bytes).
         // Does not hardcode the opcode literal, but still only matches
         // the 2-byte form (fails on `0F 84 rel32`).
         {"ChildActorVtbl_P3_WiderCtorStore",
@@ -92,7 +92,7 @@ namespace EquipHide
     };
 
     /**
-     * @brief IndexedStringA map insert routine — companion to MapLookup.
+     * @brief IndexedStringA map insert routine -- companion to MapLookup.
      */
     inline constexpr AddrCandidate k_mapInsertCandidates[] = {
         {"MapInsert_P1_FullPrologue",
@@ -121,7 +121,7 @@ namespace EquipHide
      *   [RBP+0x67] = a4 (transition type byte, saved from R9B at prologue)
      *   [RBP+0x4F] = a1 context pointer
      *
-     * Register layout at hook point (v1.02.00 — legacy):
+     * Register layout at hook point (v1.02.00 -- legacy):
      *   R10 = pointer to part hash DWORD
      *   R13 = pointer to PartInOutSocket struct (Visible byte at +0x1C)
      *   R8B = exclusion-list flag
@@ -130,7 +130,7 @@ namespace EquipHide
      *
      * Cross-version cascade. v1.03.01 candidates come first (current live
      * game returns 1 hit for each); v1.02.00 candidates are retained for
-     * users still on the older build and return 0 on the v1.03.01 game —
+     * users still on the older build and return 0 on the v1.03.01 game --
      * that's expected, not broken.
      */
     // @note Branch-encoding caveat (aob-signatures.md §8):
@@ -143,52 +143,25 @@ namespace EquipHide
     //       `movzx` instruction from the same match position (truncation
     //       only shortens the verified suffix, not the match start).
     inline constexpr AobCandidate k_hookSiteCandidates[] = {
-        // --- v1.03.01 (PartInOut struct pointer in RAX, loaded from [RBP+5F]) ---
-        // P1 — ends at `cmp al, 3`, does not cross the jz.
-        {"PartInOut_v103_P1_DirectSite",
+        // PartInOut struct pointer in RAX, loaded from [RBP+5F].
+        // P1 -- ends at `cmp al, 3`, does not cross the jz.
+        {"PartInOut_P1_DirectSite",
          "48 8B 45 5F 0F B6 40 1C 3C 03",
          4},
 
-        // P2 — ends at `cmp rax, rcx`, does not cross the following jz.
-        {"PartInOut_v103_P2_WiderContext",
+        // P2 -- ends at `cmp rax, rcx`, does not cross the following jz.
+        {"PartInOut_P2_WiderContext",
          "45 32 C0 49 8B 45 ?? 41 8B 4D ?? 48 C1 E1 04 48 03 C8 48 3B C1",
          0x30},
 
-        // P3 — ends at `cmp al, 3`, does not cross the jz.
-        {"PartInOut_v103_P3_PrecedingGate",
+        // P3 -- ends at `cmp al, 3`, does not cross the jz.
+        {"PartInOut_P3_PrecedingGate",
          "41 B0 01 48 8B 45 5F 0F B6 40 1C 3C 03",
          7},
-
-        // --- v1.02.00 legacy (PartInOut struct pointer in R13) ---
-        // CE returns 0 hits for all three on v1.03.01 by design — the
-        // live game has migrated the struct-pointer register and these
-        // candidates serve as fallbacks for anyone still on v1.02.00.
-        // Same truncation rule applied: terminate at or before the first
-        // rel8 branch to avoid §8 violations.
-        //
-        // P1 — movzx + cmp + {2-byte branch} + test r8b + {2-byte branch}
-        //      + test al. Branch opcode bytes wildcarded as `?? ??`
-        //      rather than literal `74`/`75` to satisfy §8 (no rel8
-        //      literal in the body); still only matches the 2-byte
-        //      encoding of both branches.
-        {"PartInOut_v102_P1_DirectSite",
-         "41 0F B6 45 1C 3C 03 ?? ?? 45 84 C0 ?? ?? 84 C0",
-         0},
-
-        // P2 — ends at `cmp rax, rcx`, mirrors v103_P2 truncation.
-        {"PartInOut_v102_P2_WiderContext",
-         "45 32 C0 48 8B 4D ?? 48 8B 41 ?? 8B 49 ?? 48 C1 E1 04 48 03 C8 48 3B C1",
-         0x36},
-
-        // P3 — `mov r8b,1` prelude + movzx + cmp + {2-byte branch} +
-        //      test r8b. Same §8 treatment as P1.
-        {"PartInOut_v102_P3_PrecedingGate",
-         "41 B0 01 41 0F B6 45 1C 3C 03 ?? ?? 45 84 C0",
-         3},
     };
 
     /**
-     * @brief AOB candidates for sub_1423FDEB0 — Postfix rule evaluator.
+     * @brief AOB candidates for sub_1423FDEB0 -- Postfix rule evaluator.
      *
      * Virtual function at vtable[4] of objects with vtable 0x144CC8248.
      * Evaluates whether a postfix rule matches currently equipped items.

--- a/CrimsonDesertEquipHide/src/armor_injection.cpp
+++ b/CrimsonDesertEquipHide/src/armor_injection.cpp
@@ -114,7 +114,7 @@ namespace EquipHide
                 auto bucketKey = compute_bucket_key(hash);
                 if (bucketKey == 0)
                 {
-                    logger.trace("  0x{:X} — skipped (no bucket key)", hash);
+                    logger.trace("  0x{:X} -- skipped (no bucket key)", hash);
                     ++skipped_key;
                     continue;
                 }
@@ -142,7 +142,7 @@ namespace EquipHide
 
                 if (!outExisted)
                 {
-                    logger.debug("  0x{:X} — INJECTED new entry", hash);
+                    logger.debug("  0x{:X} -- INJECTED new entry", hash);
                     ++injected;
                 }
             }
@@ -209,14 +209,11 @@ namespace EquipHide
             /* Per-player SEH so one bad pointer does not skip the rest. */
             __try
             {
-                // v1.03.01 shifted comp from +0x48 to +0x58.
                 auto comp = read_ptr_unsafe(vc, 0x58);
                 if (!comp)
-                    comp = read_ptr_unsafe(vc, 0x48);
-                if (!comp)
                 {
-                    logger.trace("ArmorInject [{}]: vc=0x{:X} comp=NULL "
-                                 "(+0x58 and +0x48 both null)", i, vc);
+                    logger.trace("ArmorInject [{}]: vc=0x{:X} comp=NULL (+0x58)",
+                                 i, vc);
                     continue;
                 }
                 auto descNode = read_ptr_unsafe(comp, 0x218);

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -10,6 +10,22 @@
 namespace EquipHide
 {
     static PostfixEvalFn s_originalPostfixEval = nullptr;
+
+    // Single-slot cache of the player's PostfixEval context. A wider
+    // set-based cache (per-protagonist slots) was attempted and
+    // crashed at load -- the game's PostfixEval also fires for NPC
+    // contexts with populated item arrays, and the override code
+    // writes into those items' +0x70 bitmasks. NPC item structs have
+    // different layouts, so the priority-bit write corrupts game
+    // state and crashes on later traversal.
+    //
+    // Current design: single slot, first populated call wins. In
+    // practice this is the character you load in as (typically Kliff).
+    // Swapping to Damiane/Oongka leaves them bald when helm/mask is
+    // hidden. A proper fix requires validating each cached context
+    // belongs to a player character -- e.g. reading an identity byte
+    // off the context struct -- before accepting it into the cache.
+    // See memory note `project_baldfix_multichar_deferred`.
     static std::atomic<uintptr_t> s_cachedContext{0};
 
     void set_postfix_eval_trampoline(PostfixEvalFn original)
@@ -60,7 +76,7 @@ namespace EquipHide
 
     /* Build a bitmask of hidden head-covering categories for per-item
        filtering.  Only items belonging to a hidden category get the
-       priority override — items for shown categories keep their original
+       priority override -- items for shown categories keep their original
        bitmask so PostfixEval still hides hair/beard under them. */
     static CategoryMask hidden_headgear_mask() noexcept
     {
@@ -73,7 +89,7 @@ namespace EquipHide
 
     /* Temporarily set bit 19 on items whose category is hidden, call
        the original PostfixEval, then restore.  Only items belonging to
-       a hidden headgear category are overridden — e.g. hiding Mask only
+       a hidden headgear category are overridden -- e.g. hiding Mask only
        overrides Mask items (beard stays visible) while Helm items keep
        their bitmask (hair hidden under helmet as normal). */
     static __int64 eval_with_priority_override(
@@ -152,10 +168,8 @@ namespace EquipHide
                     }
                 }
 
-                /* Only override for the player context + hair-hiding rules
-                   + any head-covering gear hidden.  Per-item category
-                   filtering ensures only items for hidden categories are
-                   overridden.  NPC contexts have different addresses. */
+                /* Only override for the cached player context + hair-hiding
+                   rules + any head-covering gear hidden. */
                 if (ctx == s_cachedContext.load(std::memory_order_relaxed) &&
                     is_hair_hiding_rule(ruleObj) &&
                     (is_category_hidden(Category::Helm) ||

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -24,11 +24,6 @@
 
 namespace EquipHide
 {
-    // v1.03.01 changed register allocation: PartInOut struct pointer moved
-    // from R13 to RAX (loaded from [RBP+5Fh]).  Set by init() based on
-    // which AOB pattern matched (V103_ prefix → true).
-    static bool s_partInOutFromRax{false};
-
     // Indexed by truncated part hash; R8B gate-skip lock prevents PartInOut
     // from re-running the transition dispatch after the first vis=2 frame.
     static uint8_t s_hideLocked[0x10000]{};
@@ -206,9 +201,8 @@ namespace EquipHide
         if (mask == 0)
             return;
 
-        // v1.03.01: PartInOut struct is in RAX (loaded from [rbp+5F] before hook).
-        // v1.02.00: PartInOut struct is in R13 directly.
-        auto partInOut = s_partInOutFromRax ? ctx.rax : ctx.r13;
+        // PartInOut struct pointer is in RAX (loaded from [rbp+5F] before hook).
+        auto partInOut = ctx.rax;
         if (partInOut < 0x10000)
             return;
 
@@ -287,7 +281,7 @@ namespace EquipHide
 
     /* SEH wrapper: separate function because MSVC SEH cannot coexist with
        C++ destructors in the same frame. Swallows faults if the mod is
-       outdated and register layout has changed — don't crash the game. */
+       outdated and register layout has changed -- don't crash the game. */
     static int seh_filter(unsigned int /*code*/) { return EXCEPTION_EXECUTE_HANDLER; }
 
     static void on_vis_check(SafetyHookContext &ctx)
@@ -307,7 +301,7 @@ namespace EquipHide
         auto &logger = DMK::Logger::get_instance();
 
         if (!DMK::Memory::init_cache())
-            logger.warning("Memory cache init failed — pointer reads may be slower");
+            logger.warning("Memory cache init failed -- pointer reads may be slower");
 
         auto &addrs = resolved_addrs();
 
@@ -406,15 +400,6 @@ namespace EquipHide
             return false;
         }
 
-        // v1.03.01 moved PartInOut struct pointer from R13 to RAX
-        // and shifted struct offsets (+0x48 → +0x58). body_to_vis_ctrl
-        // chain is still correct; comp offset fix handles the rest.
-        if (matchedSource && std::string_view(matchedSource->name).starts_with("V103_"))
-        {
-            s_partInOutFromRax = true;
-            logger.info("v1.03.01 layout detected (partInOut via RAX, comp at +0x58)");
-        }
-
         auto &hookMgr = DMK::HookManager::get_instance();
         auto hookResult = hookMgr.create_mid_hook("EquipVisCheck", hookAddr, on_vis_check);
 
@@ -450,12 +435,12 @@ namespace EquipHide
                                 partAddShowAddr);
                 }
                 else
-                    logger.warning("PartAddShow hook failed: {} — gliding flash fix disabled",
+                    logger.warning("PartAddShow hook failed: {} -- gliding flash fix disabled",
                                    DetourModKit::Hook::error_to_string(result.error()));
             }
             else
             {
-                logger.warning("PartAddShow AOB scan failed — gliding flash fix disabled");
+                logger.warning("PartAddShow AOB scan failed -- gliding flash fix disabled");
             }
         }
 
@@ -480,21 +465,21 @@ namespace EquipHide
                 if (result.has_value())
                 {
                     set_postfix_eval_trampoline(trampoline);
-                    logger.info("PostfixEval inline hook installed at 0x{:X} — bald fix active",
+                    logger.info("PostfixEval inline hook installed at 0x{:X} -- bald fix active",
                                 postfixEvalAddr);
                 }
                 else
-                    logger.warning("PostfixEval hook failed: {} — bald fix disabled",
+                    logger.warning("PostfixEval hook failed: {} -- bald fix disabled",
                                    DetourModKit::Hook::error_to_string(result.error()));
             }
             else
             {
-                logger.warning("PostfixEval AOB scan failed — bald fix disabled");
+                logger.warning("PostfixEval AOB scan failed -- bald fix disabled");
             }
         }
         else
         {
-            logger.info("BaldFix disabled in config — hair-hiding rules will apply normally");
+            logger.info("BaldFix disabled in config -- hair-hiding rules will apply normally");
         }
 
         // Equipment change detection for CascadeFix re-sync.

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -13,7 +13,13 @@ namespace EquipHide
     static uintptr_t s_prevVisCtrls[k_maxProtagonists]{};
     static int s_prevCount = 0;
 
-    /** @brief Traverse body -> vis_ctrl pointer chain. Caller MUST be SEH-protected. */
+    /** @brief Traverse body -> vis_ctrl pointer chain. Caller MUST be SEH-protected.
+     *  @details Trace-logs only when a (body -> vc) mapping is new or has
+     *           changed since the last walk; successful walks with a
+     *           previously-seen mapping are silent. The resolver fires
+     *           hundreds of times per second and a full trace on every call
+     *           floods the log. Chain-broken paths always log since those
+     *           indicate real state transitions worth seeing. */
     static uintptr_t body_to_vis_ctrl(uintptr_t body) noexcept
     {
         if (!body)
@@ -34,6 +40,21 @@ namespace EquipHide
             return 0;
         }
         auto vc = read_ptr_unsafe(sub, 0xE8);
+
+        // Dedupe on (body, vc): only log when this body resolves to a
+        // different vc than last seen. Small fixed LRU sized to the max
+        // protagonist count -- any more is not useful for this resolver.
+        struct Entry { uintptr_t body, vc; };
+        static Entry s_lru[k_maxProtagonists]{};
+        static int s_next = 0;
+        for (auto &e : s_lru)
+        {
+            if (e.body == body && e.vc == vc)
+                return vc;
+        }
+        s_lru[s_next] = {body, vc};
+        s_next = (s_next + 1) % k_maxProtagonists;
+
         DMK::Logger::get_instance().trace(
             "body_to_vis_ctrl: body=0x{:X} inner=0x{:X} sub=0x{:X} vc=0x{:X}",
             body, inner, sub, vc);
@@ -137,7 +158,7 @@ namespace EquipHide
                             ps.armorInjected[j].store(false, std::memory_order_relaxed);
                         needs_direct_write().store(true, std::memory_order_relaxed);
                         DMK::Logger::get_instance().debug(
-                            "Player set changed — scheduling injection + direct write");
+                            "Player set changed -- scheduling injection + direct write");
                     }
                     mtx.unlock();
                 }
@@ -179,11 +200,9 @@ namespace EquipHide
         if (flag_fallback_mode().load(std::memory_order_relaxed))
         {
             /* Actor type byte: *(*(actor+0x88)+1). Value 1 = local player,
-               3-6 = party members. Same mechanism the headgear visibility system uses.
-               v1.03.01 shifted comp from +0x48 to +0x58. */
+               3-6 = party members. Same mechanism the headgear visibility
+               system uses. */
             auto comp = read_ptr_unsafe(a1, 0x58);
-            if (!comp)
-                comp = read_ptr_unsafe(a1, 0x48);
             if (comp)
             {
                 auto actor = read_ptr_unsafe(comp, 0x08);

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -34,14 +34,11 @@ namespace EquipHide
                 if (!vc)
                     continue;
 
-                // v1.03.01 shifted comp from +0x48 to +0x58.
                 auto comp = read_ptr_unsafe(vc, 0x58);
                 if (!comp)
-                    comp = read_ptr_unsafe(vc, 0x48);
-                if (!comp)
                 {
-                    logger.trace("DirectWrite [{}]: vc=0x{:X} comp=NULL "
-                                 "(+0x58 and +0x48 both null)", i, vc);
+                    logger.trace("DirectWrite [{}]: vc=0x{:X} comp=NULL (+0x58)",
+                                 i, vc);
                     continue;
                 }
                 auto descNode = read_ptr_unsafe(comp, 0x218);

--- a/CrimsonDesertLiveTransmog/LICENSE
+++ b/CrimsonDesertLiveTransmog/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025-present Quang Trinh (tkhquang) <khacquang.trinh@gmail.com>
+https://tkhquang.dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -1,6 +1,6 @@
 # Crimson Desert - Live Transmog
 
-**This mod is in BETA** and edge cases may exist. Use at your own risk. Please report any issues you find! **Currently only works with Kliff** - other playable characters are not supported yet.
+**This mod is in BETA** and edge cases may exist. Use at your own risk. Please report any issues you find! Supports **Kliff, Damiane, and Oongka** -- presets are stored per character and the active preset swaps automatically when you switch who you are controlling in-game.
 
 [![Live Transmog Demo](https://img.youtube.com/vi/B4xX3LkgXhs/maxresdefault.jpg)](https://www.youtube.com/watch?v=B4xX3LkgXhs)
 
@@ -10,11 +10,12 @@
 
 ## Features
 
-- Built-in overlay GUI — no external tools required (toggle with **Home** key)
+- Built-in overlay GUI -- no external tools required (toggle with **Home** key)
 - In-game item browser with search-filterable dropdown, auto-categorized by slot (Helm, Chest, Cloak, Gloves, Boots)
 - Preset system: save, load, rename, and cycle through multiple transmog presets per character
+- Multi-character support: independent preset lists for Kliff, Damiane, and Oongka; the active preset swaps automatically when you change who you control
 - NPC armor variants and damaged variants render via automatic carrier swap
-- Safety filters: non-player gear (horse tack, pet armor) and wrong-slot items are hidden by default
+- Body-type picker filter: hides items whose body (male/female) does not match the active character so broken meshes stay out of the list. Per-character override available in the overlay for body-swap mod users
 - Per-slot control: enable/disable transmog independently for each equipment slot
 - Optional hotkeys: all disabled by default, configurable via INI
 - Open-source with full transparency
@@ -174,8 +175,8 @@ See the full list at the [Supported Input Names](https://github.com/tkhquang/Det
 
 - **Item catalog may be incomplete** - the armor list is filtered to exclude known-broken items. Some wearable items may be missing. Report missing items in the Bugs or Posts tab.
 - **Silverwolf Leather Armor** and some other armor seems to have combined with cloak. If you apply it and it disappears right afterwards, you should try setting the cloak slot and armor slot to none, save, then reapply the armor again.
-- **NPC armor variants and damaged variants render via carrier** — items tagged `(carrier)` in the picker use an automatic carrier swap + character-class bypass to render. Most work; a few may still produce empty slots depending on the item's internal skeleton bindings.
-- **Non-humanoid items crash** — horse tack, pet armor, and wagon gear crash the mesh binder. The "Safe only" filter hides these by default.
+- **NPC armor variants and damaged variants render via carrier** -- items tagged `(carrier)` in the picker use an automatic carrier swap + character-class bypass to render. Most work; a few may still produce empty slots depending on the item's internal skeleton bindings.
+- **Non-humanoid items crash** -- horse tack, pet armor, and wagon gear crash the mesh binder. The "Safe only" filter hides these by default.
 - **Wrong-slot or non-equipment items will crash** - selecting a chest piece for the helm slot, or non-armor items (dog armor, recipes, etc.) crashes the game. Safety filters prevent this by default. Do not disable them unless you know what you are doing.
 - **Dyeing is not supported yet** - transmog items use their default colors.
 - **Special-effect armor may have visual quirks** - armor with particle effects (e.g. Marni Laser Helm) may not render particles correctly. Hair may clip through some helmets. I haven't been able to make these work yet.

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_Acknowledgements.txt
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_Acknowledgements.txt
@@ -96,6 +96,36 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -------------------------------------------------------------------------
 
+nlohmann/json
+   Author/Maintainer: Niels Lohmann
+   Project URL: https://github.com/nlohmann/json
+   Copyright (c) 2013-2025 Niels Lohmann
+   MIT License
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2025 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------
+
 ReShade
    Author/Maintainer: crosire
    Project URL: https://reshade.me/

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_Readme.txt
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_Readme.txt
@@ -2,45 +2,68 @@ CrimsonDesertLiveTransmog
 =========================
 Runtime visual armor swap (transmog) for Crimson Desert.
 Changes the appearance of equipped armor without affecting stats.
+Supports Kliff, Damiane, and Oongka with per-character presets
+that swap automatically when you change who you control.
 
 BETA: This mod injects visual data into the game's equipment pipeline
-at runtime. Use it for aesthetics and screenshots  - side effects may
+at runtime. Use it for aesthetics and screenshots -- side effects may
 exist. Install at your own risk.
 
-Author:  tkhquang
-Source:  https://github.com/tkhquang/CrimsonDesertTools
+Author:   tkhquang
+Source:   https://github.com/tkhquang/CrimsonDesertTools
+Nexus:    https://www.nexusmods.com/crimsondesert/mods/25
+Issues:   https://github.com/tkhquang/CrimsonDesertTools/issues
 
 Requirements
 ------------
 - Crimson Desert (PC, Steam)
-- ReShade (for the overlay GUI  - mod works via hotkeys without it)
 - ASI Loader (e.g. Ultimate ASI Loader)
+  https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases
+- ReShade is OPTIONAL. If present, the overlay registers as a ReShade
+  addon tab. If not, the mod provides its own standalone overlay.
+  https://reshade.me/
 
 Installation
 ------------
-1. Install ReShade for Crimson Desert (https://reshade.me/)
-2. Copy "CrimsonDesertLiveTransmog.asi" and
-   "CrimsonDesertLiveTransmog.ini" into:
-     <Game Folder>/bin64/
-3. Launch the game. Press Home to open ReShade, find the Transmog tab.
+1. Install an ASI Loader (skip if you already have one).
+2. Copy ALL of the following into <Game Folder>/bin64/:
+     - CrimsonDesertLiveTransmog.asi
+     - CrimsonDesertLiveTransmog.ini
+     - CrimsonDesertLiveTransmog_display_names.tsv
+     - CrimsonDesertLiveTransmog_Acknowledgements.txt (optional)
+     - CrimsonDesertLiveTransmog_Readme.txt          (optional)
+3. Launch the game. Press Home to open the overlay.
+
+IMPORTANT: The .tsv file MUST sit next to the .asi. It maps internal
+item ids to human-readable display names in the picker. Without it,
+the picker shows raw ids only.
 
 Usage
 -----
-1. Open ReShade overlay (Home key), find the Transmog tab
-2. Click a slot picker (Helm, Chest, etc.) to browse armor
-3. Search by name, select an item  - changes stay pending
-4. Click "Apply All" to commit all slot changes
-5. Use "Append" to save your look as a preset
+1. Press Home to open the overlay (ReShade tab or standalone window).
+2. Click a slot picker (Helm, Chest, Cloak, Gloves, Boots) to browse
+   armor. Use the search box to filter by name.
+3. Select an item -- changes stay pending until you click "Apply All".
+4. Click "Apply All" to commit all slot changes at once.
+5. Use "Append" in the Presets section to save the current look as a
+   preset. Use "Prev" / "Next" to cycle presets.
+
+Tip: enable "Instant Apply" in the overlay to preview items on hover
+without clicking Apply All.
+
+Without the overlay: use the online preset builder
+https://tkhquang.github.io/CrimsonDesertTools/live-transmog/
+or edit CrimsonDesertLiveTransmog_presets.json by hand.
 
 Configuration
 -------------
-Edit CrimsonDesertLiveTransmog.ini for global settings and hotkeys.
-All hotkeys are DISABLED by default  - the ReShade overlay is the
+Edit CrimsonDesertLiveTransmog.ini for global settings and optional
+hotkeys. All hotkeys are DISABLED by default -- the overlay is the
 primary interface. Set bindings in the INI if you prefer keyboard
 shortcuts.
 
-Presets are stored in CrimsonDesertLiveTransmog_presets.json
-(auto-generated alongside the INI).
+Presets are stored in CrimsonDesertLiveTransmog_presets.json, which
+is auto-generated alongside the INI on first launch.
 
 Logs
 ----
@@ -49,23 +72,32 @@ Set LogLevel = Debug or Trace for detailed output.
 
 Uninstall
 ---------
-Delete CrimsonDesertLiveTransmog.asi, .ini, .log, and
-_presets.json from your game folder.
+Delete the following from your bin64 folder:
+  - CrimsonDesertLiveTransmog.asi
+  - CrimsonDesertLiveTransmog.ini
+  - CrimsonDesertLiveTransmog.log
+  - CrimsonDesertLiveTransmog_presets.json
+  - CrimsonDesertLiveTransmog_display_names.tsv
+  - CrimsonDesertLiveTransmog_Acknowledgements.txt
+  - CrimsonDesertLiveTransmog_Readme.txt
 
 Known Limitations
 -----------------
-- BETA: side effects may exist  - use for aesthetics/screenshots
+- BETA: side effects may exist -- use for aesthetics/screenshots.
 - Some armor in the picker may not render (other body types, damaged
   variants). Safety filters are on by default.
 - Wrong-slot or non-equipment items will crash the game. Do not
   disable safety filters unless you know what you are doing.
+- Non-humanoid items (horse tack, pet armor) crash the mesh binder.
+  The "Safe only" filter hides these by default.
 - Dye is not supported yet.
 - Special-effect armor (e.g. particle helmets) may have visual quirks.
 - Hair may clip through some helmets.
-- Major game updates may break the mod.
+- Major game updates may break the mod until a new version ships.
 - Only tested with the Steam version.
 
 Third-Party Notices
 -------------------
 See CrimsonDesertLiveTransmog_Acknowledgements.txt for third-party
-software licenses.
+software licenses (SafetyHook, Zydis, SimpleIni, Dear ImGui,
+DirectXMath, ReShade addon SDK).

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -2,7 +2,7 @@
 [size=4]Runtime Armor Appearance Swap for Crimson Desert[/size][/center]
 
 [b][color=#ff6600]This mod is in BETA[/color][/b] -edge cases may exist. Use at your own risk. Please report any issues you find!
-[b][color=#ff6600]Currently only works with Kliff[/color][/b] -other playable characters are not supported yet.
+[b]Supports Kliff, Damiane, and Oongka.[/b] Presets are stored per character and the active preset swaps automatically when you switch who you control in-game.
 
 [youtube]B4xX3LkgXhs[/youtube]
 
@@ -18,6 +18,8 @@ Change the visual appearance of your equipped armor [b]in real time[/b] without 
 [*][b]Built-in overlay[/b] -no external tools required. Press [b]Home[/b] to toggle the overlay
 [*][b]In-game item browser[/b] -searchable dropdown with all armor pieces, auto-categorized by slot (Helm, Chest, Cloak, Gloves, Boots)
 [*][b]Preset system[/b] -save, load, rename, and cycle through multiple transmog presets per character
+[*][b]Multi-character support[/b] -independent preset lists for Kliff, Damiane, and Oongka; the active preset swaps automatically when you change who you control
+[*][b]Body-type filter[/b] -hides items whose body type (male/female) does not match the active character so broken meshes stay out of the picker. Per-character override available in the overlay for body-swap mod users
 [*][b]NPC and damaged variants[/b] -NPC armor variants and damaged variants render via automatic carrier swap
 [*][b]Safety filters[/b] -non-player gear (horse tack, pet armor) and wrong-slot items are filtered out by default
 [*][b]Per-slot control[/b] -enable/disable transmog independently for each equipment slot
@@ -56,8 +58,15 @@ Download the [b]x64[/b] build of [url=https://github.com/ThirteenAG/Ultimate-ASI
 [size=4]Step 2 -Install the mod[/size]
 [list=1]
 [*]Download the latest release from the Files tab
-[*]Extract [b]CrimsonDesertLiveTransmog.asi[/b] and [b]CrimsonDesertLiveTransmog.ini[/b] into your [b]bin64[/b] folder
+[*]Extract [b]ALL[/b] of the following into your [b]bin64[/b] folder:
+[list]
+[*][b]CrimsonDesertLiveTransmog.asi[/b] -the mod binary
+[*][b]CrimsonDesertLiveTransmog.ini[/b] -configuration
+[*][b]CrimsonDesertLiveTransmog_display_names.tsv[/b] -human-readable item names for the picker
 [/list]
+[/list]
+
+[color=#ff6600][b]Important:[/b][/color] the [b].tsv[/b] file must sit next to the [b].asi[/b]. It maps internal item ids to display names shown in the overlay picker. Without it, the picker shows raw ids only.
 
 [size=4]Step 3 -Launch and play[/size]
 Launch the game. Press [b]Home[/b] to open the transmog overlay and start browsing armor.
@@ -65,11 +74,12 @@ Launch the game. Press [b]Home[/b] to open the transmog overlay and start browsi
 [size=4]File placement[/size]
 [code]
 <Crimson Desert>/bin64/
-├── CrimsonDesert.exe                          (Game executable)
-├── winmm.dll                                  (ASI Loader)
-├── CrimsonDesertLiveTransmog.asi              (This mod)
-├── CrimsonDesertLiveTransmog.ini              (Configuration)
-├── CrimsonDesertLiveTransmog_presets.json     (Auto-generated preset file)
+├── CrimsonDesert.exe                                (Game executable)
+├── winmm.dll                                        (ASI Loader)
+├── CrimsonDesertLiveTransmog.asi                    (This mod)
+├── CrimsonDesertLiveTransmog.ini                    (Configuration)
+├── CrimsonDesertLiveTransmog_display_names.tsv      (Item display names, REQUIRED)
+├── CrimsonDesertLiveTransmog_presets.json           (Auto-generated preset file)
 └── ...
 [/code]
 
@@ -91,12 +101,13 @@ If you use [url=https://github.com/cdozdil/OptiScaler]OptiScaler[/url] for frame
 [code]
 <Crimson Desert>/bin64/
 ├── CrimsonDesert.exe
-├── OptiScaler.ini                             (LoadAsiPlugins = true)
-├── dxgi.dll                                   (OptiScaler)
+├── OptiScaler.ini                                   (LoadAsiPlugins = true)
+├── dxgi.dll                                         (OptiScaler)
 ├── plugins/
 │   ├── CrimsonDesertLiveTransmog.asi
 │   ├── CrimsonDesertLiveTransmog.ini
-│   └── ...                                    (Other ASI mods go here too)
+│   ├── CrimsonDesertLiveTransmog_display_names.tsv  (REQUIRED, keep next to the .asi)
+│   └── ...                                          (Other ASI mods go here too)
 └── ...
 [/code]
 
@@ -209,14 +220,25 @@ If you encounter issues:
 
 [size=5]Credits & Source Code[/size]
 
-Built with [url=https://github.com/tkhquang/DetourModKit]DetourModKit[/url] for core functionality.
+[b]Author:[/b] tkhquang ([url=https://github.com/tkhquang]GitHub[/url] / [url=https://next.nexusmods.com/profile/tkhquang]Nexus[/url])
+[b]Source:[/b] [url=https://github.com/tkhquang/CrimsonDesertTools]github.com/tkhquang/CrimsonDesertTools[/url]
+[b]Report issues:[/b] [url=https://github.com/tkhquang/CrimsonDesertTools/issues]GitHub Issues[/url] or the Bugs tab on this Nexus page
 
+Built with [url=https://github.com/tkhquang/DetourModKit]DetourModKit[/url] for core functionality (AOB scanning, hook management, logging, input).
+
+[b]Third-party libraries:[/b]
 [list]
-[*][url=https://github.com/ThirteenAG]ThirteenAG[/url] -Ultimate ASI Loader
-[*][url=https://github.com/cursey]cursey[/url] -SafetyHook
-[*]Brodie Thiesfield -SimpleIni
-[*][url=https://github.com/ocornut]Omar Cornut[/url] -Dear ImGui
+[*][url=https://github.com/ThirteenAG/Ultimate-ASI-Loader]Ultimate ASI Loader[/url] by ThirteenAG -ASI loading layer
+[*][url=https://github.com/cursey/safetyhook]SafetyHook[/url] by cursey -inline / mid-function hooking
+[*][url=https://github.com/zyantific/zydis]Zydis[/url] / [url=https://github.com/zyantific/zycore-c]Zycore[/url] by Florian Bernd & Joel Höner -x86/x64 disassembly (used by SafetyHook)
+[*][url=https://github.com/brofield/simpleini]SimpleIni[/url] by Brodie Thiesfield -INI configuration parser
+[*][url=https://github.com/nlohmann/json]nlohmann/json[/url] by Niels Lohmann -JSON preset serialization
+[*][url=https://github.com/ocornut/imgui]Dear ImGui[/url] by Omar Cornut -overlay GUI
+[*][url=https://github.com/microsoft/DirectXMath]DirectXMath[/url] by Microsoft -math primitives
+[*][url=https://reshade.me/]ReShade[/url] by crosire -optional addon host
 [*]Pearl Abyss -Crimson Desert
 [/list]
 
-All Crimson Desert mods and tools can be found in this [url=https://github.com/tkhquang/CrimsonDesertTools]GitHub repository[/url]. Feel free to contribute or suggest improvements!
+See [b]CrimsonDesertLiveTransmog_Acknowledgements.txt[/b] bundled with the download for full license texts.
+
+All Crimson Desert mods and tools in this series can be found in the [url=https://github.com/tkhquang/CrimsonDesertTools]CrimsonDesertTools GitHub repository[/url]. Feel free to contribute or suggest improvements!

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -25,13 +25,13 @@ namespace Transmog
 
     // Variant-metadata detection (see item_name_table.hpp::has_variant_meta).
     // Clean base items have `*(desc+0x3A0) == <sentinel>` where <sentinel>
-    // is a shared empty-object pointer (IDA: off_1459D0B38 on v1.02.00 — an
+    // is a shared empty-object pointer (IDA: off_1459D0B38 on v1.02.00 -- an
     // IRefCounted vtable in the exe's .data section). Non-sentinel values
     // point to a per-item metadata struct threaded through a catalog-wide
     // linked list. Members of this list failed to render via runtime
     // transmog on all tested samples.
     //
-    // The sentinel's RVA is NOT stable across patches — any .data reshuffle
+    // The sentinel's RVA is NOT stable across patches -- any .data reshuffle
     // moves it. Instead of hardcoding the RVA, we resolve the sentinel
     // statistically at catalog-build time: scan every valid descriptor's
     // +0x3A0 qword, the value that appears in the clear majority of items
@@ -48,7 +48,7 @@ namespace Transmog
     static constexpr std::ptrdiff_t k_iteminfoPtrArrayOffset = 0x50; // 80: qword base of descriptor ptr array
 
     // Resolved sentinel, cached after first successful build().
-    // 0 means "not yet resolved" — has_variant_meta() falls back to false
+    // 0 means "not yet resolved" -- has_variant_meta() falls back to false
     // (preferring to let a bad item through rather than mis-flag a clean
     // one) until the next build() populates it.
     static std::atomic<uintptr_t> s_variantMetaSentinel{0};
@@ -116,6 +116,21 @@ namespace Transmog
         }
     }
 
+    static uint16_t read_u16_safe(uintptr_t addr, bool &ok) noexcept
+    {
+        __try
+        {
+            uint16_t v = *reinterpret_cast<const uint16_t *>(addr);
+            ok = true;
+            return v;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            ok = false;
+            return 0;
+        }
+    }
+
     // --- Player-compatibility detection via rule-classifier tokens ---
     //
     // Every armor descriptor at `+0x248` holds a stride-0x38 rule list;
@@ -130,7 +145,7 @@ namespace Transmog
     // CE-verified distribution (v1.02.00):
     //   - 2109 items have >=1 player classifier in their rule list (safe)
     //   - 3184 items have only non-player classifiers (unsafe, hidden)
-    //   - 731 items have no rules at all (default: treat as safe — these
+    //   - 731 items have no rules at all (default: treat as safe -- these
     //     are inert cosmetics / quest items, not mount armor)
     //   - 80/80 HorseArmor items correctly flagged unsafe; spot checks
     //     (Wolf_Pursuer, Bear_Chief, Kliff_Helm, Antra_Helm) all correct.
@@ -144,6 +159,65 @@ namespace Transmog
         0x02E3,
         0x039D,
     };
+    // Body-type classifier token sets (CE-verified 2026-04-21). The
+    // game's rule evaluator gates armor by body-type tokens in each
+    // rule's classifier array. Humanoid party gear slots into two
+    // body families:
+    //
+    //   Male:   {0x0018, 0x0058, 0x02E3}  -- Kliff / Oongka / most male NPCs
+    //   Female: {0x0072, 0x0382, 0x0300}  -- Damiane / female NPCs
+    //
+    // Character-identity tokens (Kliff 0x0015/0x039D, Oongka 0x0028,
+    // Demian 0x0021, Drottesel 0x012F, etc.) live alongside these and
+    // let the engine gate per-character-specific variants. For the
+    // picker filter, body-type membership is the decisive signal:
+    // male-body items on a female skeleton produce broken meshes, and
+    // vice versa.
+    //
+    // Items with NO body-type token (e.g. Drottesel_Leather_Armor has
+    // only {0x012F}) are classified as Generic -- the engine accepts
+    // them on any humanoid body, so the picker shows them for every
+    // character.
+    static constexpr std::uint16_t k_maleBodyTokens[] = {
+        0x0018, 0x0058, 0x02E3,
+    };
+    static constexpr std::uint16_t k_femaleBodyTokens[] = {
+        0x0072, 0x0382, 0x0300,
+    };
+    // Body bits are accumulated during the classifier scan:
+    //   Male / Female  -- saw a token from the respective body set
+    //   HasTokens      -- saw ANY classifier token (humanoid or not)
+    //   NonHumanoid    -- saw a token >= 0x1000 (mount/pet/wagon/dragon
+    //                     pools all sit in this range; every humanoid
+    //                     token observed so far lives below 0x0400).
+    // Classification (derived in sorted_entries):
+    //   NonHumanoid set                      -> BodyKind::NonHumanoid (hide)
+    //   Male+Female, no NonHumanoid          -> Both
+    //   Male alone                           -> Male
+    //   Female alone                         -> Female
+    //   HasTokens but no body/NonHumanoid    -> Ambiguous  (e.g. {0x012F}-only
+    //                                           NPC variants; render is
+    //                                           inconsistent so the picker
+    //                                           flags them with amber)
+    //   No tokens at all                     -> Generic    (rule-less items)
+    static constexpr std::uint8_t k_bodyBitMale = 0x01;
+    static constexpr std::uint8_t k_bodyBitFemale = 0x02;
+    static constexpr std::uint8_t k_bodyBitHasTokens = 0x04;
+    static constexpr std::uint8_t k_bodyBitNonHumanoid = 0x08;
+    // Set when the item has >= 2 rules that each contain a body token
+    // (male or female) -- i.e. the item ships separate male and female
+    // rule definitions, each gated on that rule's own identity tokens.
+    // Empirically this correlates with "needs carrier to render on
+    // the off-native-class character" (CE-verified 2026-04-21: Varantine,
+    // Samuel, Heisellen all fit this pattern and need carrier for
+    // Damiane; WellsKnight / Redknight have exactly one body-bearing
+    // rule and direct-wear works for every protagonist).
+    static constexpr std::uint8_t k_bodyBitMultiBodyRules = 0x10;
+    // Any classifier token >= this threshold is treated as non-humanoid
+    // (horse saddles, dragon armors, pet harnesses). CE-verified: every
+    // humanoid token seen in v1.03.01 fits below 0x0400.
+    static constexpr std::uint16_t k_nonHumanoidTokenThreshold = 0x1000;
+
     static constexpr std::ptrdiff_t k_ruleListPtrOffset = 0x248;
     static constexpr std::ptrdiff_t k_ruleListCountOffset = 0x250;
     static constexpr std::size_t k_ruleStride = 0x38;
@@ -152,21 +226,27 @@ namespace Transmog
     static constexpr std::uint32_t k_maxPlausibleRuleCount = 64;
     static constexpr std::uint32_t k_maxPlausibleClassCount = 32;
 
-    // Returns true if the item at `descPtr` has at least one rule whose
-    // classifier array contains a player body-type token. Items with no
-    // rules (or unreadable fields) default to true — we'd rather let a
-    // player-safe cosmetic through than hide it by accident.
-    static bool item_has_player_classifier(uintptr_t descPtr) noexcept
+    // Walk an item's rule-classifier arrays once and return a 2-bit
+    // body-kind summary:
+    //   bit 0 (k_bodyBitMale)   set if any rule has a male-body token
+    //   bit 1 (k_bodyBitFemale) set if any rule has a female-body token
+    // Items with no rules (or unreadable fields) return 0 (Generic) --
+    // the picker treats Generic as "accepted by every body", matching
+    // the engine's observed behaviour for rule-less cosmetics.
+    static std::uint8_t item_body_bits(uintptr_t descPtr) noexcept
     {
         bool ok = false;
         const auto rulesPtr = read_qword_safe(
             descPtr + k_ruleListPtrOffset, ok);
         if (!ok || rulesPtr < 0x10000)
-            return true;
+            return 0;
         const auto ruleCount = read_u32_safe(
             descPtr + k_ruleListCountOffset, ok);
         if (!ok || ruleCount == 0 || ruleCount > k_maxPlausibleRuleCount)
-            return true;
+            return 0;
+
+        std::uint8_t bits = 0;
+        std::uint32_t bodyBearingRuleCount = 0; // rules with any body token
 
         for (std::uint32_t i = 0; i < ruleCount; ++i)
         {
@@ -180,6 +260,7 @@ namespace Transmog
             if (!ok || clsCount == 0 || clsCount > k_maxPlausibleClassCount)
                 continue;
 
+            bool ruleHasBodyToken = false;
             for (std::uint32_t j = 0; j < clsCount; ++j)
             {
                 std::uint16_t cls = 0;
@@ -192,15 +273,41 @@ namespace Transmog
                 {
                     break;
                 }
-                for (const auto pc : k_playerClassifiers)
+                bits |= k_bodyBitHasTokens;
+                if (cls >= k_nonHumanoidTokenThreshold)
+                    bits |= k_bodyBitNonHumanoid;
+                for (const auto mt : k_maleBodyTokens)
                 {
-                    if (cls == pc)
-                        return true;
+                    if (cls == mt)
+                    {
+                        bits |= k_bodyBitMale;
+                        ruleHasBodyToken = true;
+                        break;
+                    }
+                }
+                for (const auto ft : k_femaleBodyTokens)
+                {
+                    if (cls == ft)
+                    {
+                        bits |= k_bodyBitFemale;
+                        ruleHasBodyToken = true;
+                        break;
+                    }
                 }
             }
+            if (ruleHasBodyToken)
+                ++bodyBearingRuleCount;
         }
-        return false;
+
+        // Dual-body NPC item: male and female variants split across
+        // separate rules, each identity-gated. Render fidelity on an
+        // off-native character requires the carrier mechanism.
+        if (bodyBearingRuleCount >= 2)
+            bits |= k_bodyBitMultiBodyRules;
+
+        return bits;
     }
+
 
     /**
      * Decode a relative-call instruction ( `E8 disp32` ) at the given
@@ -250,7 +357,7 @@ namespace Transmog
             while (len < bufSize - 1 && src[len] != '\0')
             {
                 const auto c = src[len];
-                // Accept printable ASCII only — reject if we see control
+                // Accept printable ASCII only -- reject if we see control
                 // chars (suggests we're reading the wrong pointer).
                 if (static_cast<unsigned char>(c) < 0x20 ||
                     static_cast<unsigned char>(c) > 0x7E)
@@ -268,99 +375,35 @@ namespace Transmog
     }
 
     // --- Slot classification ---
+    //
+    // Driven entirely by the canonical item-type code at desc+0x44 as
+    // captured during the catalog build. Name-parsing heuristics have
+    // been removed -- they produced false positives on non-armor items
+    // whose names happened to contain tokens like "_Armor_" (horse
+    // armors, shields, quest treasure maps, etc.). The game's own
+    // type code is unambiguous; the fallback is to treat anything
+    // unmapped as non-equipment.
 
-    // Returns true if the item name starts with a known non-equipment
-    // prefix — crafting recipes, recipe books, knowledge books, etc.
-    // These items sometimes end with armor-slot suffixes (e.g.
-    // "CraftingRecipe_Oongka_PlateArmor_Helm_III") but are NOT
-    // equippable armor. CE-verified: all such items have ruleCount=0
-    // and default to isPlayer=true, so this prefix check is the only
-    // gate keeping them out of the picker.
-    static bool is_non_equipment_prefix(const std::string &name) noexcept
+    // Slot mapping for the canonical item-type code at desc+0x44.
+    // Values verified via CE on v1.03.01, 2026-04-21:
+    //   0x04=Helm  0x05=Chest  0x06=Gloves  0x07=Boots  0x45=Cloak
+    // Other observed codes (explicitly rejected -- these are not
+    // transmog-compatible armor slots):
+    //   0x20=Shield, 0x53=Horse/mount armor, 0xFFFF=Quest/non-equipment,
+    //   plus any other unmapped code.
+    static TransmogSlot slot_from_type_code(std::uint16_t code) noexcept
     {
-        // Sorted by frequency in v1.02.00 catalog.
-        static constexpr const char *k_prefixes[] = {
-            "CraftingRecipe_",
-            "Recipe_",
-            "Book_",
-            "Item_Skill_",
-        };
-        for (const char *pfx : k_prefixes)
+        switch (code)
         {
-            const auto n = std::strlen(pfx);
-            if (name.size() >= n &&
-                std::memcmp(name.data(), pfx, n) == 0)
-                return true;
+        case 0x04: return TransmogSlot::Helm;
+        case 0x05: return TransmogSlot::Chest;
+        case 0x06: return TransmogSlot::Gloves;
+        case 0x07: return TransmogSlot::Boots;
+        case 0x45: return TransmogSlot::Cloak;
+        default:   return TransmogSlot::Count;
         }
-        return false;
     }
 
-    // Case-insensitive comparison of a token view against a compile-time
-    // literal. Zero-allocation — operates on the caller's string_view
-    // without copying.
-    static bool token_eq_ci(std::string_view token,
-                            const char *target,
-                            std::size_t targetLen) noexcept
-    {
-        if (token.size() != targetLen)
-            return false;
-        for (std::size_t i = 0; i < targetLen; ++i)
-        {
-            if (std::tolower(static_cast<unsigned char>(token[i])) !=
-                std::tolower(static_cast<unsigned char>(target[i])))
-                return false;
-        }
-        return true;
-    }
-
-    TransmogSlot ItemNameTable::classify_slot(const std::string &name) noexcept
-    {
-        if (name.empty())
-            return TransmogSlot::Count;
-
-        // Non-equipment prefixes (recipes, books, skill items) can
-        // carry armor-slot suffixes — reject them early so they never
-        // classify into a transmog slot.
-        if (is_non_equipment_prefix(name))
-            return TransmogSlot::Count;
-
-        // Scan underscore-delimited tokens right-to-left for the first
-        // slot keyword match. This naturally ignores arbitrary trailing
-        // suffixes (roman numerals, upgrade tiers, size tags, NPC
-        // variant ids like _XL, _XX, _I) without enumerating them.
-        // Case-insensitive — CE-verified: v1.02.00 has 4 items with
-        // lowercase "_cloak" that are real equippable cloaks.
-        const std::string_view sv{name};
-        std::size_t end = sv.size();
-        while (end > 0)
-        {
-            const auto dash = sv.find_last_of('_', end - 1);
-            const std::size_t start =
-                (dash == std::string_view::npos) ? 0 : dash + 1;
-            const std::string_view token = sv.substr(start, end - start);
-
-            // Ordered by catalog frequency (v1.02.00):
-            // Armor=984, Helm=367, Boots=339, Gloves=352, Cloak=111.
-            if (token_eq_ci(token, "Armor", 5))
-                return TransmogSlot::Chest;
-            if (token_eq_ci(token, "Helm", 4))
-                return TransmogSlot::Helm;
-            if (token_eq_ci(token, "Boots", 5))
-                return TransmogSlot::Boots;
-            if (token_eq_ci(token, "Gloves", 6))
-                return TransmogSlot::Gloves;
-            if (token_eq_ci(token, "Cloak", 5))
-                return TransmogSlot::Cloak;
-            if (token_eq_ci(token, "Cloth", 5))
-                return TransmogSlot::Chest;
-
-            if (dash == std::string_view::npos)
-                break;
-            end = dash;
-        }
-
-        return TransmogSlot::Count;
-    }
 
     // --- Singleton ---
 
@@ -384,7 +427,7 @@ namespace Transmog
     {
         bool resolved = false;
         uintptr_t globalHolder = 0; // &qword_145CEF370
-        uintptr_t itemAccessor = 0; // sub_1402D75D0 — IndexedStringA short->hash
+        uintptr_t itemAccessor = 0; // sub_1402D75D0 -- IndexedStringA short->hash
     };
 
     static ResolvedChain &cached_chain()
@@ -405,7 +448,7 @@ namespace Transmog
 
         if (!subTranslatorAddr)
         {
-            logger.warning("[nametable] sub_14076D950 not resolved — skipping");
+            logger.warning("[nametable] sub_14076D950 not resolved -- skipping");
             return false;
         }
 
@@ -464,7 +507,7 @@ namespace Transmog
         //   41 56 48 83 EC 40 0F B7 39
         // (push r14 / sub rsp,40h / movzx edi,word ptr [rcx]) which
         // pins the specific call site inside a bounded 0x40-byte scan
-        // of THIS function — global uniqueness doesn't matter, the
+        // of THIS function -- global uniqueness doesn't matter, the
         // scan is locally bounded.
         const auto itemAccessorStart = reinterpret_cast<const std::byte *>(itemAccessor);
         auto anchor3 = DMK::Scanner::parse_aob(
@@ -548,20 +591,20 @@ namespace Transmog
         auto &logger = DMK::Logger::get_instance();
 
         // Step A: resolve and cache the address chain. Fatal on decoder
-        // mismatch — retries won't help.
+        // mismatch -- retries won't help.
         if (!resolve_chain(subTranslatorAddr))
             return BuildResult::Fatal;
 
         const uintptr_t globalHolder = cached_chain().globalHolder;
 
-        // Step B: dereference the holder. Deferred when null — the
+        // Step B: dereference the holder. Deferred when null -- the
         // game may not have initialized the iteminfo container yet.
         bool ok = false;
         const uintptr_t globalPtr = read_qword_safe(globalHolder, ok);
         if (!ok || globalPtr < 0x10000)
         {
             logger.trace("[nametable] iteminfo global not initialized "
-                         "(holder=0x{:X} value=0x{:X}) — deferring",
+                         "(holder=0x{:X} value=0x{:X}) -- deferring",
                          globalHolder, globalPtr);
             return BuildResult::Deferred;
         }
@@ -570,7 +613,7 @@ namespace Transmog
         if (!ok || count == 0 || count > k_maxCatalogSize)
         {
             logger.trace("[nametable] catalog count implausible: {} "
-                         "(globalPtr=0x{:X}) — deferring",
+                         "(globalPtr=0x{:X}) -- deferring",
                          count, globalPtr);
             return BuildResult::Deferred;
         }
@@ -580,7 +623,7 @@ namespace Transmog
         if (!ok || ptrArray < 0x10000)
         {
             logger.trace("[nametable] iteminfo ptrArray null "
-                         "(globalPtr=0x{:X} ptrArray=0x{:X}) — deferring",
+                         "(globalPtr=0x{:X} ptrArray=0x{:X}) -- deferring",
                          globalPtr, ptrArray);
             return BuildResult::Deferred;
         }
@@ -598,10 +641,16 @@ namespace Transmog
         std::unordered_map<std::string, uint16_t> nameToId;
         std::unordered_map<uint16_t, uint8_t> variantFlag;
         std::unordered_map<uint16_t, uint8_t> playerFlag;
+        std::unordered_map<uint16_t, uint16_t> equipTypeMap;
+        std::unordered_map<uint16_t, uint8_t> bodyBitsMap;
+        std::unordered_map<uint16_t, uint16_t> typeCodeMap;
         idToName.reserve(count);
         nameToId.reserve(count);
         variantFlag.reserve(count);
         playerFlag.reserve(count);
+        equipTypeMap.reserve(count);
+        bodyBitsMap.reserve(count);
+        typeCodeMap.reserve(count);
 
         // Pass 1: walk the catalog, collect names + variant-meta pointers
         // + player-classifier flag for every valid descriptor. Variant flag
@@ -613,6 +662,9 @@ namespace Transmog
             std::string name;
             uintptr_t metaPtr; // 0 on read fault
             bool playerCompatible;
+            uint16_t equipType; // raw u16 at desc+0x42, 0 on read fault
+            uint8_t bodyBits; // k_bodyBitMale | k_bodyBitFemale
+            uint16_t typeCode; // desc+0x44 -- canonical item-type code
         };
         std::vector<ScratchEntry> scratch;
         scratch.reserve(count);
@@ -643,19 +695,40 @@ namespace Transmog
             const auto id16 = static_cast<uint16_t>(id);
             const uintptr_t metaPtr = read_qword_safe(
                 descPtr + k_descVariantMetaOffset, ok);
-            const bool playerCompat = item_has_player_classifier(descPtr);
+
+            // Body-bits summary walked once; Kliff "PlayerSafe" is
+            // equivalent to "item has a male-body token".
+            const uint8_t bodyBits = item_body_bits(descPtr);
+            const bool playerCompat = (bodyBits & k_bodyBitMale) != 0;
             if (!playerCompat)
                 ++nonPlayerCount;
+
+            bool etOk = false;
+            const uint16_t equipType =
+                read_u16_safe(descPtr + 0x42, etOk);
+
+            // Item-type code at desc+0x44 (u16). CE-verified 2026-04-21:
+            //   0x04=Helm, 0x05=Chest, 0x06=Gloves, 0x07=Boots, 0x45=Cloak,
+            //   0x20=Shield, 0x53=Horse/mount armor, 0xFFFF=Quest/Non-equipment.
+            // This is the canonical game-side classifier for item category;
+            // slot derivation no longer depends on parsing the item name.
+            bool tcOk = false;
+            const uint16_t typeCode =
+                read_u16_safe(descPtr + 0x44, tcOk);
+
             scratch.push_back({
                 id16,
                 std::string(buf, len),
                 ok ? metaPtr : 0,
                 playerCompat,
+                etOk ? equipType : uint16_t{0},
+                bodyBits,
+                tcOk ? typeCode : uint16_t{0xFFFF},
             });
             ++valid;
         }
 
-        // Pass 2 — statistically derive the variant-meta sentinel.
+        // Pass 2 -- statistically derive the variant-meta sentinel.
         // The sentinel is the value that appears at desc+0x3A0 in the
         // clear majority of items (historically ~60% on v1.02.00). Any
         // other pointer at that slot = per-item variant metadata and
@@ -680,13 +753,13 @@ namespace Transmog
                     resolvedSentinel = kv.first;
                 }
             }
-            // Require the mode to dominate — at least 1/3 of valid items
-            // must point at it — otherwise we're looking at garbage and
+            // Require the mode to dominate -- at least 1/3 of valid items
+            // must point at it -- otherwise we're looking at garbage and
             // should not flag anything as variant.
             if (valid == 0 || sentinelCount * 3 < valid)
             {
                 logger.debug("[nametable] variant sentinel not dominant "
-                             "(best=0x{:X} count={}/{}) — disabling "
+                             "(best=0x{:X} count={}/{}) -- disabling "
                              "variant-meta filter",
                              resolvedSentinel, sentinelCount, valid);
                 resolvedSentinel = 0;
@@ -701,16 +774,31 @@ namespace Transmog
             }
         }
 
-        // Pass 3 — publish the scratch rows into the maps, flagging
+        // Pass 3 -- publish the scratch rows into the maps, flagging
         // variants against the resolved sentinel + the player-classifier
         // verdict captured in pass 1.
         std::size_t variantCount = 0;
         for (auto &e : scratch)
         {
-            const bool hasVariant =
+            // Item "has variant" (picker shows carrier-color) if either:
+            //   - desc+0x3A0 is non-sentinel (traditional catalog-level
+            //     variant-meta record), OR
+            //   - the item has >= 2 body-bearing classifier rules,
+            //     i.e. separate male + female identity-gated rules.
+            //     Empirically these are dual-body NPC items that need
+            //     the carrier mechanism to render on the off-native
+            //     body (Varantine, Samuel, Heisellen pattern). An item
+            //     with exactly one body-bearing rule (WellsKnight,
+            //     Redknight) direct-wears because every protagonist's
+            //     own class pool covers the identity tokens in that
+            //     single rule.
+            const bool hasVariantByMeta =
                 (resolvedSentinel != 0) &&
                 (e.metaPtr != 0) &&
                 (e.metaPtr != resolvedSentinel);
+            const bool hasMultiBodyRules =
+                (e.bodyBits & k_bodyBitMultiBodyRules) != 0;
+            const bool hasVariant = hasVariantByMeta || hasMultiBodyRules;
             if (hasVariant)
                 ++variantCount;
 
@@ -720,6 +808,10 @@ namespace Transmog
                 ++collisions;
             variantFlag.emplace(e.id, hasVariant ? uint8_t{1} : uint8_t{0});
             playerFlag.emplace(e.id, e.playerCompatible ? uint8_t{1} : uint8_t{0});
+            if (e.equipType != 0)
+                equipTypeMap.emplace(e.id, e.equipType);
+            bodyBitsMap.emplace(e.id, e.bodyBits);
+            typeCodeMap.emplace(e.id, e.typeCode);
         }
 
         // Stability check: the game sets the iteminfo count to its
@@ -728,18 +820,18 @@ namespace Transmog
         // against a magic "good enough" threshold (the old 50% gate
         // let a 3432/6024 partial catalog through on v1.03.01), we
         // wait until two consecutive scans produce the same valid
-        // count — meaning the array has stopped growing.  This
+        // count -- meaning the array has stopped growing.  This
         // self-adapts to any catalog size and any game version.
         if (valid == 0)
         {
-            logger.trace("[nametable] no valid descriptors — deferring");
+            logger.trace("[nametable] no valid descriptors -- deferring");
             m_lastBuildValid = 0;
             return BuildResult::Deferred;
         }
         if (valid != m_lastBuildValid)
         {
             logger.trace("[nametable] catalog still loading "
-                         "({} -> {} valid) — deferring",
+                         "({} -> {} valid) -- deferring",
                          m_lastBuildValid, valid);
             m_lastBuildValid = static_cast<uint32_t>(valid);
             return BuildResult::Deferred;
@@ -752,6 +844,9 @@ namespace Transmog
             m_nameToId = std::move(nameToId);
             m_variantFlag = std::move(variantFlag);
             m_playerFlag = std::move(playerFlag);
+            m_equipType = std::move(equipTypeMap);
+            m_bodyBits = std::move(bodyBitsMap);
+            m_typeCode = std::move(typeCodeMap);
             m_sortedCache.clear(); // will be rebuilt lazily on next access
         }
 
@@ -796,10 +891,42 @@ namespace Transmog
     {
         std::lock_guard<std::mutex> lk(s_tableMtx);
         auto it = m_playerFlag.find(itemId);
-        // Unknown ids default to true — prefer to surface rather than hide.
+        // Unknown ids default to true -- prefer to surface rather than hide.
         if (it == m_playerFlag.end())
             return true;
         return it->second != 0;
+    }
+
+    uint16_t ItemNameTable::equip_type_of(uint16_t itemId) const noexcept
+    {
+        std::lock_guard<std::mutex> lk(s_tableMtx);
+        auto it = m_equipType.find(itemId);
+        return (it != m_equipType.end()) ? it->second : uint16_t{0};
+    }
+
+    TransmogSlot ItemNameTable::category_of(uint16_t itemId) const noexcept
+    {
+        std::lock_guard<std::mutex> lk(s_tableMtx);
+        auto it = m_typeCode.find(itemId);
+        if (it == m_typeCode.end())
+            return TransmogSlot::Count;
+        return slot_from_type_code(it->second);
+    }
+
+    ItemNameTable::BodyKind ItemNameTable::body_kind_for_character(
+        const std::string &charName) noexcept
+    {
+        // Male: Kliff, Oongka (their native rule sets include male-body
+        //       tokens {0x0018, 0x0058, 0x02E3}).
+        // Female: Damiane (tokens {0x0072, 0x0382, 0x0300}).
+        // Unknown characters default to Generic -- we don't know their
+        // body, so treat every item as potentially compatible rather
+        // than silently hiding their picker.
+        if (charName == "Kliff" || charName == "Oongka")
+            return BodyKind::Male;
+        if (charName == "Damiane")
+            return BodyKind::Female;
+        return BodyKind::Generic;
     }
 
     bool ItemNameTable::has_npc_equip_type(uint16_t itemId) const noexcept
@@ -812,7 +939,7 @@ namespace Transmog
 
         const auto desc = descriptor_of(itemId);
         if (desc == 0)
-            return false; // can't read — default to direct apply
+            return false; // can't read -- default to direct apply
 
         __try
         {
@@ -841,6 +968,44 @@ namespace Transmog
             const bool hasVariant = (vit != m_variantFlag.end()) && (vit->second != 0);
             auto pit = m_playerFlag.find(id);
             const bool isPlayer = (pit == m_playerFlag.end()) || (pit->second != 0);
+            auto eit = m_equipType.find(id);
+            const uint16_t equipT = (eit != m_equipType.end()) ? eit->second : uint16_t{0};
+            auto bit = m_bodyBits.find(id);
+            // Unknown ids default to Generic (bodyBits=0). Picker
+            // shows Generic on every character, matching the engine's
+            // behaviour for rule-less cosmetics.
+            const uint8_t bBits =
+                (bit != m_bodyBits.end()) ? bit->second : uint8_t{0};
+            BodyKind kind;
+            const bool hasM = (bBits & k_bodyBitMale) != 0;
+            const bool hasF = (bBits & k_bodyBitFemale) != 0;
+            const bool hasT = (bBits & k_bodyBitHasTokens) != 0;
+            const bool hasNH = (bBits & k_bodyBitNonHumanoid) != 0;
+            // Order matters: an item that carries a male/female body
+            // token is humanoid by definition, even if it ALSO carries
+            // an NPC-class identity token in the 0x1xxx range (e.g.
+            // Wellsknight, Blackstar, etc.). Checking the NonHumanoid
+            // bit first would misclassify those as mount/pet armors
+            // and flag them red for every character. NonHumanoid is
+            // the fallback only when no body-token match is found.
+            if (hasM && hasF)
+                kind = BodyKind::Both;
+            else if (hasM)
+                kind = BodyKind::Male;
+            else if (hasF)
+                kind = BodyKind::Female;
+            else if (hasNH)
+                // Token >= 0x1000 with no humanoid body-token present
+                // => actual mount/pet/wagon/dragon gear. Hide.
+                kind = BodyKind::NonHumanoid;
+            else if (hasT)
+                // Humanoid-range tokens but no body-specific match --
+                // NPC-variant glove/armor items that carry only
+                // identity tokens like `0x012F`. Render behaviour is
+                // inconsistent so the picker colours these amber.
+                kind = BodyKind::Ambiguous;
+            else
+                kind = BodyKind::Generic;
             // Look up display name by lowercased internal name.
             std::string lowerName = name;
             for (auto &c : lowerName)
@@ -850,11 +1015,24 @@ namespace Transmog
             std::string dispName =
                 (dit != m_displayNames.end()) ? dit->second : std::string();
 
+            // Canonical item-type code at desc+0x44 is authoritative.
+            // Unmapped codes (0x20 shield, 0x53 horse armor, 0xFFFF
+            // quest, etc.) map to Count → item is hidden as non-
+            // equipment. An absent type-code entry also collapses to
+            // Count; there's no name-parsing fallback because the
+            // engine itself reads this field to categorize the item.
+            TransmogSlot slot = TransmogSlot::Count;
+            auto tcit = m_typeCode.find(id);
+            if (tcit != m_typeCode.end())
+                slot = slot_from_type_code(tcit->second);
+
             m_sortedCache.push_back({
                 id,
-                classify_slot(name),
+                slot,
                 hasVariant,
                 isPlayer,
+                equipT,
+                kind,
                 name,
                 std::move(dispName),
             });
@@ -970,7 +1148,7 @@ namespace Transmog
             m_displayNames = std::move(names);
             // Callers must invoke load_display_names() before any
             // sorted_entries() access (i.e. before dump_catalog_tsv)
-            // so the cache is still empty here — no re-sort needed.
+            // so the cache is still empty here -- no re-sort needed.
             m_sortedCache.clear();
         }
 

--- a/CrimsonDesertLiveTransmog/src/item_name_table.hpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.hpp
@@ -24,7 +24,7 @@ namespace Transmog
      *
      * Resolution chain (verified against v1.02.00 via IDA + CE):
      *
-     *   1. AOB-scan `sub_14076D950` (SlotPopulator translator — unique 1-hit).
+     *   1. AOB-scan `sub_14076D950` (SlotPopulator translator -- unique 1-hit).
      *   2. Bounded AOB scan of the first 0x80 bytes of sub_14076D950 for a
      *      unique 14-byte anchor preceding `E8 disp32` -> `sub_141D45270`
      *      (item descriptor initializer). Offset NOT hardcoded.
@@ -58,11 +58,11 @@ namespace Transmog
         {
             Ok,       // Catalog walked successfully, table populated.
             Deferred, // Address chain resolved but the iteminfo
-                      // global is still null — retry later on a
+                      // global is still null -- retry later on a
                       // background thread.
             Fatal,    // Address resolution failed (bounded AOB
                       // anchor missed, no relative call found, etc).
-                      // Do not retry — address chain is broken.
+                      // Do not retry -- address chain is broken.
         };
 
         /**
@@ -101,7 +101,7 @@ namespace Transmog
          * linked list threaded via `desc+0x3A0`. Across the 14 labeled
          * armor samples we tested live, flagged items all failed to
          * render via runtime transmog on the player. The exact semantic
-         * meaning of the meta struct is not fully mapped — users see
+         * meaning of the meta struct is not fully mapped -- users see
          * these as "damaged" in-game but the catalog-wide population
          * (~2399/6024 items) includes non-armor readables too, so the
          * label is intentionally mechanism-neutral. The overlay treats
@@ -109,7 +109,7 @@ namespace Transmog
          *
          * Detector: the sentinel pointer is resolved STATISTICALLY at
          * build() time as the mode of `*(desc+0x3A0)` across all valid
-         * descriptors (~60% share it on v1.02.00). No hardcoded RVA —
+         * descriptors (~60% share it on v1.02.00). No hardcoded RVA --
          * the detector self-heals across future .data shuffles. Returns
          * false for unknown ids or when the catalog isn't yet built.
          */
@@ -122,7 +122,7 @@ namespace Transmog
          * the descriptor rule list at `+0x248` has a classifier-hash
          * array containing a known "player body-type" token. Items whose
          * rules use only non-player classifiers (horse/mount/pet tack,
-         * wagon gear) are flagged unsafe — equipping them on the player
+         * wagon gear) are flagged unsafe -- equipping them on the player
          * crashes the mesh binder downstream.
          *
          * Unknown ids and items with no rules default to `true`: the
@@ -198,47 +198,78 @@ namespace Transmog
          * Returned by const reference so the overlay can hold onto it
          * without copying the 6000+ entries per frame.
          *
-         * `category` is the auto-detected transmog slot (see
-         * classify_slot below), or `TransmogSlot::Count` if the item
-         * doesn't match any known armor-slot suffix (weapon, consumable,
-         * recipe, quest item, etc).
+         * `category` is the transmog slot derived from the canonical
+         * item-type code at `desc+0x44` (see `category_of` below), or
+         * `TransmogSlot::Count` if the item is not a transmog-eligible
+         * armor slot (weapon, shield, horse armor, quest item, etc).
          */
+        /// Body-type classification derived from an item's rule
+        /// classifier tokens (CE-verified 2026-04-21). Drives the
+        /// picker's per-character visibility: an item rendered on the
+        /// wrong body produces broken meshes, so the filter hides
+        /// opposite-body items by default.
+        ///
+        ///   Generic:     no classifier tokens at all (rule-less items)
+        ///   Male:        has male tokens   {0x0018, 0x0058, 0x02E3}
+        ///   Female:      has female tokens {0x0072, 0x0382, 0x0300}
+        ///   Both:        rare -- has both male and female tokens
+        ///   Ambiguous:   humanoid-range tokens only, but not in the
+        ///                male or female body sets (e.g. NPC-specific
+        ///                variants like `0x012F`-only items --
+        ///                Antumbra/Badran/Luka gloves). Picker shows
+        ///                with an amber badge because render fidelity
+        ///                is inconsistent -- some work, some break.
+        ///   NonHumanoid: has any token >= 0x1000 (mount/pet/wagon/
+        ///                dragon armors). Hidden from all human-
+        ///                character pickers.
+        enum class BodyKind : std::uint8_t
+        {
+            Generic = 0,
+            Male = 1,
+            Female = 2,
+            Both = 3,
+            NonHumanoid = 4,
+            Ambiguous = 5,
+        };
+
         struct Entry
         {
             uint16_t id;
             TransmogSlot category;
             bool hasVariantMeta;
             bool isPlayerCompatible;
+            /// Raw equip-type u16 from desc+0x42. Informational only;
+            /// the primary compatibility signal is `bodyKind`.
+            uint16_t equipType;
+            BodyKind bodyKind;
             std::string name;
             std::string displayName; // human-readable name from display_names.json
         };
         const std::vector<Entry> &sorted_entries() const;
 
+        /// Raw equip-type u16 for a specific item. Returns 0 if unknown
+        /// (catalog not ready or item never seen).
+        std::uint16_t equip_type_of(std::uint16_t itemId) const noexcept;
+
+        /// Map character name -> body kind. Returns `BodyKind::Generic`
+        /// for unknown names so future characters produce a wide-open
+        /// picker instead of an empty one.
+        static BodyKind body_kind_for_character(
+            const std::string &charName) noexcept;
+
         /**
-         * @brief Classify an item name into a transmog slot by suffix.
+         * @brief Look up the transmog slot for an item id.
          *
-         * Rejects known non-equipment prefixes (`CraftingRecipe_`,
-         * `Recipe_`, `Book_`, `Item_Skill_`) first — these items
-         * sometimes carry armor-slot suffixes but are recipes/books,
-         * not equippable armor (CE-verified: all have ruleCount=0).
+         * Driven by the canonical item-type code at `desc+0x44` captured
+         * during the catalog build (CE-verified on v1.03.01):
          *
-         * Then strips trailing noise (`_Upgrade\\d*`, roman numerals,
-         * `_\\d+`, size tags) and case-insensitively matches the final
-         * underscore-delimited token:
+         *   0x04 -> Helm    0x05 -> Chest    0x06 -> Gloves
+         *   0x07 -> Boots   0x45 -> Cloak
          *
-         *   `_Helm`                 -> Helm
-         *   `_Armor`, `_Cloth`      -> Chest
-         *   `_Cloak`                -> Cloak
-         *   `_Gloves`               -> Gloves
-         *   `_Boots`                -> Boots
-         *
-         * Any other tail returns `TransmogSlot::Count` (unclassified).
-         * CE-verified against the full 6024-entry v1.02.00 catalog:
-         * Helm=367, Armor=984, Cloth=7, Cloak=111, Gloves=352, Boots=339.
-         * (Includes 4 lowercase `_cloak` items and 12 recipe false
-         * positives now correctly excluded.)
+         * Every other code (shields 0x20, horse 0x53, quest 0xFFFF, ...)
+         * or an unknown id returns `TransmogSlot::Count`.
          */
-        static TransmogSlot classify_slot(const std::string &name) noexcept;
+        TransmogSlot category_of(uint16_t itemId) const noexcept;
 
         /// Dump the full catalog to a TSV file next to the game exe.
         /// Columns: ItemID, Slot, Variant, PlayerSafe, Name.
@@ -274,6 +305,9 @@ namespace Transmog
         std::unordered_map<std::string, uint16_t> m_nameToId;
         std::unordered_map<uint16_t, uint8_t> m_variantFlag;
         std::unordered_map<uint16_t, uint8_t> m_playerFlag;
+        std::unordered_map<uint16_t, uint16_t> m_equipType;
+        std::unordered_map<uint16_t, uint8_t> m_bodyBits;
+        std::unordered_map<uint16_t, uint16_t> m_typeCode; // desc+0x44 canonical item-type code
         std::unordered_map<std::string, std::string> m_displayNames; // lowercase internal -> display
         mutable std::vector<Entry> m_sortedCache;
 

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -1,4 +1,4 @@
-// overlay_ui.inl — Shared transmog overlay widget code.
+// overlay_ui.inl -- Shared transmog overlay widget code.
 //
 // Included by both overlay.cpp (standalone D3D11 path) and
 // overlay_reshade.cpp (ReShade addon path).  Each TU provides its own
@@ -20,6 +20,12 @@
 // symbols at link time.  These helpers call only non-variadic ImGui
 // functions (TextUnformatted, PushStyleColor) which inline correctly
 // in both the ReShade and standalone paths.
+
+// Anonymous namespace wraps the entire body so each including TU
+// (overlay.cpp, overlay_reshade.cpp) gets its own unique implicit
+// namespace name -- makes TU-locality explicit and silences
+// IntelliSense's cross-TU "ambiguous declaration" diagnostics.
+namespace {
 
 static void ui_text(const char *fmt, ...)
 {
@@ -77,7 +83,7 @@ static constexpr int64_t k_hoverDebounceMs = 300;
 // --- Overlay preferences (render-thread only) ---
 
 // Instant Apply mode: applies transmog immediately on hover, pick,
-// slot toggle, and clear — no Apply All click needed.  Off by default
+// slot toggle, and clear -- no Apply All click needed.  Off by default
 // because each action triggers a tear-down + SlotPopulator cycle.
 static bool s_autoApply = false;
 
@@ -97,8 +103,10 @@ struct SlotUIState
     // matches THIS slot.  Defaults to ON so the dropdown shows ~350
     // relevant items instead of all 6024.
     bool exactFilter = true;
-    bool hideIncompatible = true; // hide crash-risk + non-equipment
-    bool hideVariants = false;    // hide NPC variants (carrier items)
+    bool hideIncompatible = true;   // hide crash-risk + non-equipment
+    bool hideVariants = false;      // hide NPC variants (carrier items)
+    bool hideBodyMismatch = true;   // hide items whose body type doesn't
+                                    // match the active character's
     // Hover-apply debounce state.  We track which item the cursor is
     // on and when it first landed there.  Apply fires only after the
     // cursor has settled on the same item for k_hoverDebounceMs,
@@ -187,6 +195,12 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
     ImGui::Checkbox("Safe only", &ui.hideIncompatible);
     ImGui::SameLine();
     ImGui::Checkbox("Hide variants", &ui.hideVariants);
+    ImGui::SameLine();
+    ImGui::Checkbox("Hide cross-body", &ui.hideBodyMismatch);
+    if (ImGui::IsItemHovered())
+        ui_tooltip("Hide items whose body type (male/female) "
+                   "doesn't match the active character. Cross-body "
+                   "items may render with broken meshes.");
 
     ImGui::SetNextItemWidth(320.0f);
     if (ImGui::IsWindowAppearing())
@@ -250,7 +264,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
 
     // Increase vertical spacing between items for easier click/hover
     // targets.  Pushed INSIDE BeginChild so the popup-level spacing
-    // stays default — otherwise the popup's own scroll region may
+    // stays default -- otherwise the popup's own scroll region may
     // capture mouse wheel events instead of the child.
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
                         ImVec2(ImGui::GetStyle().ItemSpacing.x,
@@ -277,13 +291,23 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         }
     }
 
-    // Hoist draw-list pointer outside the loop — it is stable for
+    // Hoist draw-list pointer outside the loop -- it is stable for
     // the entire BeginChild region and avoids a per-item lookup.
     ImDrawList *const dl = ImGui::GetWindowDrawList();
 
     // Semantic color constants for the two-line item display.
     static constexpr ImU32 k_colorCrashRisk = IM_COL32(255, 89, 89, 255);
     static constexpr ImU32 k_colorCarrier = IM_COL32(128, 217, 255, 255);
+    // Orange -- carrier path works but body type mismatched. Item
+    // will equip and may display with minor mesh artifacts; we show
+    // it when the user disables "Hide cross-body".
+    static constexpr ImU32 k_colorCrossBody = IM_COL32(255, 176, 64, 255);
+    // Amber -- item has humanoid-range classifier tokens but none are
+    // in the male/female body set (e.g. NPC variants like
+    // Antumbra/Badran gloves with only `0x012F`). Equip goes through
+    // the carrier path but render fidelity is inconsistent -- some
+    // items resolve correctly, others show as broken meshes.
+    static constexpr ImU32 k_colorAmbiguous = IM_COL32(230, 210, 120, 255);
     static constexpr ImU32 k_colorDimmed = IM_COL32(160, 160, 160, 200);
 
     int shown = 0;
@@ -299,11 +323,61 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         }
         const bool nonEquipment =
             (e.category == Transmog::TransmogSlot::Count);
-        const bool incompatible =
-            (!e.isPlayerCompatible && !e.hasVariantMeta) ||
-            nonEquipment;
+        // Per-character body-kind filter (CE-verified 2026-04-21).
+        // Armor rule classifier tokens partition the catalog into
+        // disjoint body families:
+        //   Male:   {0x0018, 0x0058, 0x02E3}
+        //   Female: {0x0072, 0x0382, 0x0300}
+        //   Horse / pet / wagon / dragon: separate token pools with
+        //     zero overlap with humanoid. Flagged as NonHumanoid and
+        //     hidden unconditionally -- these never render on a human
+        //     skeleton (horse saddles, cat backpacks, etc.).
+        const auto &pm = Transmog::PresetManager::instance();
+        using BK = Transmog::ItemNameTable::BodyKind;
+        // Resolve the active character's body kind: per-character
+        // override in presets.json wins, "Auto" falls through to the
+        // hardcoded default (Kliff/Oongka = Male, Damiane = Female).
+        BK charBody;
+        {
+            const std::string ov =
+                pm.body_kind_of(pm.active_character());
+            if (ov == "Male")
+                charBody = BK::Male;
+            else if (ov == "Female")
+                charBody = BK::Female;
+            else if (ov == "Both")
+                charBody = BK::Both;
+            else // "Auto" or unrecognised
+                charBody =
+                    Transmog::ItemNameTable::body_kind_for_character(
+                        pm.active_character());
+        }
+        const bool nonHumanoid = (e.bodyKind == BK::NonHumanoid);
+        const bool ambiguousBody = (e.bodyKind == BK::Ambiguous);
+        // Ambiguous items pass the body-match gate (still humanoid-
+        // range), but get an amber tag in the color logic below so
+        // the user knows render fidelity is inconsistent.
+        const bool bodyMatches =
+            !nonHumanoid && (
+                ambiguousBody ||
+                (e.bodyKind == BK::Generic) ||
+                (e.bodyKind == BK::Both) ||
+                (charBody == BK::Generic) ||
+                (e.bodyKind == charBody));
+        // Non-humanoid items are always treated as "incompatible" --
+        // there's no toggle to show them; they'd never render.
+        const bool incompatible = nonEquipment || nonHumanoid;
         const bool npcVariant = e.hasVariantMeta;
         if (ui.hideIncompatible && incompatible)
+        {
+            ++filteredByUnsafe;
+            continue;
+        }
+        // Cross-body filter: hide items whose body type doesn't
+        // match the active character. Default on; can be toggled
+        // off for experimentation (they may still partially render
+        // via the carrier path but often look broken).
+        if (ui.hideBodyMismatch && !bodyMatches)
         {
             ++filteredByUnsafe;
             continue;
@@ -328,10 +402,29 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         // render via carrier + char-class bypass.  True crash risks
         // are non-player items WITHOUT variant meta (horse tack, etc).
         const bool usesCarrier = e.hasVariantMeta;
-        const bool crashRisk =
-            !e.isPlayerCompatible && !e.hasVariantMeta;
+        // Colour tiers:
+        //   red    CRASH RISK         -- rule list rejects this body,
+        //                               no carrier path rescue.
+        //   orange BODY MISMATCH      -- cross-body carrier, will equip
+        //                               but mesh likely breaks.
+        //   amber  UNCERTAIN BODY     -- humanoid-range but no body-
+        //                               set match (e.g. 0x012F-only
+        //                               NPC variants); render may or
+        //                               may not resolve correctly.
+        //   blue   carrier            -- NPC variant, same-body match,
+        //                               reliable carrier path.
+        const bool crashRisk = !bodyMatches && !e.hasVariantMeta;
+        const bool crossBodyCarrier = !bodyMatches && e.hasVariantMeta;
+        // Only flag ambiguous when it's actually a carrier item and
+        // not already bucketed as cross-body (it isn't -- ambiguous
+        // passes bodyMatches above).
+        const bool ambiguousCarrier = ambiguousBody && e.hasVariantMeta;
         if (crashRisk)
             tag = "non-player -- CRASH RISK";
+        else if (crossBodyCarrier)
+            tag = "carrier -- BODY MISMATCH";
+        else if (ambiguousCarrier)
+            tag = "carrier -- UNCERTAIN BODY";
         else if (usesCarrier)
             tag = "carrier";
 
@@ -347,6 +440,12 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         if (crashRisk)
             ImGui::PushStyleColor(ImGuiCol_Header,
                                   ImVec4(0.4f, 0.1f, 0.1f, 0.6f));
+        else if (crossBodyCarrier)
+            ImGui::PushStyleColor(ImGuiCol_Header,
+                                  ImVec4(0.45f, 0.28f, 0.08f, 0.6f));
+        else if (ambiguousCarrier)
+            ImGui::PushStyleColor(ImGuiCol_Header,
+                                  ImVec4(0.38f, 0.32f, 0.12f, 0.6f));
         else if (usesCarrier)
             ImGui::PushStyleColor(ImGuiCol_Header,
                                   ImVec4(0.1f, 0.2f, 0.35f, 0.6f));
@@ -371,8 +470,10 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         else
             std::snprintf(line1, sizeof(line1), "%s", primaryName);
 
-        const ImU32 mainColor = crashRisk    ? k_colorCrashRisk
-                                : usesCarrier ? k_colorCarrier
+        const ImU32 mainColor = crashRisk          ? k_colorCrashRisk
+                                : crossBodyCarrier ? k_colorCrossBody
+                                : ambiguousCarrier ? k_colorAmbiguous
+                                : usesCarrier      ? k_colorCarrier
                                 : ImGui::GetColorU32(ImGuiCol_Text);
 
         dl->AddText(ImVec2(pos.x + 2.0f, pos.y + 1.0f),
@@ -429,7 +530,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
             ui.navIndex = shown;
         }
 
-        if (crashRisk || usesCarrier)
+        if (crashRisk || crossBodyCarrier || ambiguousCarrier || usesCarrier)
             ImGui::PopStyleColor(); // Header color
 
         ++shown;
@@ -440,7 +541,8 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         if (ui.exactFilter && filteredByCategory > 0)
             ui_text_disabled("no matches in this category -- "
                             "uncheck Exact to widen");
-        else if ((ui.hideIncompatible || ui.hideVariants) &&
+        else if ((ui.hideIncompatible || ui.hideVariants ||
+                  ui.hideBodyMismatch) &&
                  filteredByUnsafe > 0)
             ui_text_disabled("no matches -- uncheck filters "
                             "to show more items");
@@ -464,7 +566,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
     // --- Hover-apply debounce ---
     // Fire manual_apply_slot() only after the cursor has rested on
     // the same item for k_hoverDebounceMs.  Uses the slot-scoped
-    // apply path so only this slot re-equips — other slots are
+    // apply path so only this slot re-equips -- other slots are
     // untouched and don't flicker.
     if (autoApply &&
         ui.hoverPendingId != ui.hoverAppliedId &&
@@ -552,7 +654,7 @@ static void draw_overlay_content()
     ImGui::Checkbox("Instant Apply", &s_autoApply);
     if (ImGui::IsItemHovered())
         ui_tooltip("Apply changes immediately on hover, "
-                   "pick, toggle, and clear — no Apply All "
+                   "pick, toggle, and clear -- no Apply All "
                    "needed");
 
     ImGui::SameLine();
@@ -560,6 +662,126 @@ static void draw_overlay_content()
     if (ImGui::IsItemHovered())
         ui_tooltip("Preserve the search field when "
                    "re-opening a slot picker");
+
+    ImGui::Separator();
+
+    // --- Character picker ---
+    //
+    // Presets are stored per character (Kliff / Damiane / Oongka).
+    // Selecting a character swaps the active preset list to that
+    // character's, re-applies its active preset, and clears the
+    // drop-detection state so the next apply pass does not confuse
+    // the previous character's cached itemIds with the new one's.
+    //
+    // Auto-detection of the currently-controlled character from a1
+    // is deferred: the type-byte at *(actor+0x88)+1 is role-based
+    // (controlled vs background), not character-based, and the
+    // static WorldSystem → ActorManager → UserActor chain did not
+    // update live on control-swap in our 1.03.01 probe. Until that
+    // RE lands, the user picks the character manually here.
+    {
+        // Fixed stack buffer -- the game has a small, closed roster of
+        // playable characters (Kliff / Damiane / Oongka at time of
+        // writing). k_maxChars is oversized so adding a new playable
+        // character later doesn't need a code change here beyond
+        // adding its preset in the JSON.
+        constexpr std::size_t k_maxChars = 8;
+        const auto names = pm.character_names();
+        const std::size_t n =
+            (names.size() < k_maxChars) ? names.size() : k_maxChars;
+        if (n > 0)
+        {
+            const char *cstrs[k_maxChars]{};
+            int selectedIdx = 0;
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                cstrs[i] = names[i].c_str();
+                if (names[i] == pm.active_character())
+                    selectedIdx = static_cast<int>(i);
+            }
+
+            // Character picker is READ-ONLY for now. Load-detect writes
+            // active_character on every char-swap (ActorManager+0x30
+            // byte) so manual picks get snapped back instantly. The
+            // fix is to split active_character into controlled (game-
+            // driven) and editing (UI-driven) states plus per-char
+            // actor enumeration from user+0xD0..+0x108 -- see memory
+            // note `project_per_companion_edit_deferred`. Until then
+            // the combo just shows which character load-detect
+            // currently thinks is controlled.
+            ImGui::SetNextItemWidth(200.0f);
+            ImGui::BeginDisabled(true);
+            if (ImGui::Combo("Character##char_picker",
+                             &selectedIdx,
+                             cstrs,
+                             static_cast<int>(n)))
+            {
+                const auto &pick = names[static_cast<std::size_t>(selectedIdx)];
+                if (pick != pm.active_character())
+                {
+                    pm.set_active_character(pick);
+                    for (auto &m : slot_mappings())
+                    {
+                        m.active = false;
+                        m.targetItemId = 0;
+                    }
+                    pm.apply_to_state();
+                    last_applied_ids().fill(0);
+                    real_damaged().fill(false);
+                    last_applied_real_ids().fill(0);
+                    last_applied_carrier_ids().fill(0);
+                    manual_apply();
+                    pm.save();
+                }
+            }
+            ImGui::EndDisabled();
+            if (ImGui::IsItemHovered())
+                ui_tooltip("Read-only for now -- follows the character you "
+                           "control in-game. Editing another character's "
+                           "preset while controlling someone else is "
+                           "planned (see per-companion-edit memory note).");
+
+            // Body-kind override. Lets body-swap mod users mark e.g.
+            // Kliff as Female so the picker shows the female-body-
+            // token pool. "Auto" defers to the hardcoded default
+            // (Kliff/Oongka = Male, Damiane = Female).
+            //
+            // Saved per character in presets.json. Only affects the
+            // picker filter -- no effect on apply / render behaviour.
+            static constexpr const char *k_bodyItems[] = {
+                "Auto", "Male", "Female", "Both",
+            };
+            constexpr int k_bodyCount =
+                static_cast<int>(sizeof(k_bodyItems) / sizeof(k_bodyItems[0]));
+
+            const std::string currentBody =
+                pm.body_kind_of(pm.active_character());
+            int bodyIdx = 0;
+            for (int i = 0; i < k_bodyCount; ++i)
+            {
+                if (currentBody == k_bodyItems[i])
+                {
+                    bodyIdx = i;
+                    break;
+                }
+            }
+            ImGui::SameLine(0.0f, 24.0f);
+            ImGui::SetNextItemWidth(140.0f);
+            if (ImGui::Combo("Body##body_kind",
+                             &bodyIdx,
+                             k_bodyItems,
+                             k_bodyCount))
+            {
+                pm.set_body_kind_of(pm.active_character(),
+                                    k_bodyItems[bodyIdx]);
+            }
+            if (ImGui::IsItemHovered())
+                ui_tooltip("Override the body type used for picker "
+                           "filtering. Use if you run a body-swap "
+                           "mod that changes this character's "
+                           "skeleton (e.g. Kliff -> Female).");
+        }
+    }
 
     ImGui::Separator();
 
@@ -634,7 +856,7 @@ static void draw_overlay_content()
         }
 
         if (count == 0)
-            ui_text_disabled("No presets — use Append to create one");
+            ui_text_disabled("No presets -- use Append to create one");
 
         ImGui::Spacing();
 
@@ -644,16 +866,42 @@ static void draw_overlay_content()
             pm.append_from_state();
             manual_apply();
         }
+        if (ImGui::IsItemHovered())
+            ui_tooltip("Capture your currently-worn real armor as a "
+                       "new preset, then apply it.");
 
         ImGui::SameLine();
 
-        if (ImGui::Button("Replace") && count > 0)
-            pm.replace_current_from_state();
+        // Copy: like Append but skips capture_outfit -- forks the
+        // current slot-mapping state (loaded from the active preset +
+        // any edits you made in the rows) into a brand-new preset.
+        // Useful for duplicating an existing preset and tweaking the
+        // fork without overwriting the source.
+        if (ImGui::Button("Copy"))
+        {
+            pm.append_from_state();
+            manual_apply();
+        }
+        if (ImGui::IsItemHovered())
+            ui_tooltip("Duplicate the current slot rows into a new "
+                       "preset (without re-capturing real armor), "
+                       "then apply it. Use after selecting a preset "
+                       "and tweaking the rows to fork it.");
 
         ImGui::SameLine();
 
         if (ImGui::Button("Remove") && count > 0)
+        {
             pm.remove_current();
+            // remove_current auto-selects a neighbouring preset.
+            // Apply it so the visible outfit matches the new active
+            // preset instead of leaving the old (now-deleted) one on
+            // screen.
+            if (pm.preset_count() > 0)
+                manual_apply();
+            else
+                manual_clear();
+        }
 
         ImGui::SameLine();
 
@@ -686,7 +934,7 @@ static void draw_overlay_content()
         const bool tableReady = table.ready();
 
         if (!tableReady)
-            ui_text_disabled("Item catalog not ready — hex entry only.");
+            ui_text_disabled("Item catalog not ready -- hex entry only.");
 
         ui_text_disabled("Toggle which slots the next Apply All will touch.");
 
@@ -799,7 +1047,9 @@ static void draw_overlay_content()
                                               ? std::string("(none)")
                                               : table.name_of(m.targetItemId);
                         const auto cat =
-                            ItemNameTable::classify_slot(name);
+                            (m.targetItemId == 0)
+                                ? TransmogSlot::Count
+                                : table.category_of(m.targetItemId);
                         const char *catName =
                             (m.targetItemId == 0)
                                 ? "clear"
@@ -925,5 +1175,6 @@ static void draw_overlay_content()
     }
 
     ui_text("Active slots: %d / %zu", activeCount, k_slotCount);
-    ui_text("Character: %s", pm.active_character().c_str());
 }
+
+} // anonymous namespace

--- a/CrimsonDesertLiveTransmog/src/part_show_suppress.cpp
+++ b/CrimsonDesertLiveTransmog/src/part_show_suppress.cpp
@@ -98,7 +98,7 @@ namespace Transmog::PartShowSuppress
             {
                 logger.warning(
                     "[dispatch] slot hash missing: '{}' not found in "
-                    "IndexedStringA — suppression for slot {} disabled",
+                    "IndexedStringA -- suppression for slot {} disabled",
                     k_slotNames[i].name, k_slotNames[i].slot);
                 continue;
             }
@@ -151,7 +151,7 @@ namespace Transmog::PartShowSuppress
         if (partHash != 0 &&
             s_hashSeen[idx].exchange(1, std::memory_order_relaxed) == 0)
         {
-            DMK::Logger::get_instance().info(
+            DMK::Logger::get_instance().trace(
                 "[dispatch] PartAddShow unique hash=0x{:08X} low16=0x{:04X} "
                 "a2={:#04x} enabled={} suppress={}",
                 partHash, idx, static_cast<unsigned>(a2), enabled, suppress);

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -48,7 +48,7 @@ namespace Transmog
         else
         {
             DMK::Logger::get_instance().warning(
-                "[preset] item name '{}' not in current catalog — "
+                "[preset] item name '{}' not in current catalog -- "
                 "slot disabled; re-pick in the overlay",
                 s.itemName);
             s.active = false;
@@ -85,13 +85,18 @@ namespace Transmog
         for (auto &p : cp.presets)
             presetsArr.push_back(preset_to_json(p));
 
-        return json{{"activePreset", cp.activePreset}, {"presets", presetsArr}};
+        return json{
+            {"activePreset", cp.activePreset},
+            {"presets", presetsArr},
+            {"bodyKind", cp.bodyKind},
+        };
     }
 
     static CharacterPresets character_from_json(const json &j)
     {
         CharacterPresets cp;
         cp.activePreset = j.value("activePreset", 0);
+        cp.bodyKind = j.value("bodyKind", std::string("Auto"));
 
         if (j.contains("presets") && j["presets"].is_array())
         {
@@ -125,7 +130,7 @@ namespace Transmog
         std::ifstream file(path);
         if (!file.is_open())
         {
-            logger.info("Presets file not found — starting with defaults");
+            logger.info("Presets file not found -- starting with defaults");
 
             // Create default entries for known characters.
             ensure_character("Kliff");
@@ -139,7 +144,12 @@ namespace Transmog
         {
             json root = json::parse(file);
 
-            m_activeCharacter = root.value("activeCharacter", std::string("Kliff"));
+            // `activeCharacter` JSON field is no longer used -- the
+            // runtime active character is driven by the live WS
+            // chain via the char-swap detector. Kept here only to
+            // silently tolerate old presets.json files that still
+            // carry it; the value is discarded.
+            (void)root.value("activeCharacter", std::string{});
 
             if (root.contains("characters") && root["characters"].is_object())
             {
@@ -158,7 +168,7 @@ namespace Transmog
             if (!ItemNameTable::instance().ready())
             {
                 logger.info(
-                    "[preset] item catalog not ready at load time — name "
+                    "[preset] item catalog not ready at load time -- name "
                     "resolution deferred until background scan completes");
             }
         }
@@ -187,7 +197,9 @@ namespace Transmog
         // Schema v3: slots carry only itemName (stable identifier).
         // itemId is resolved at runtime from the item catalog.
         root["version"] = 3;
-        root["activeCharacter"] = m_activeCharacter;
+        // `activeCharacter` is intentionally NOT written -- the live
+        // controlled character drives apply at runtime, so the field
+        // would just be a stale last-viewed-UI hint.
 
         json chars = json::object();
         for (auto &[name, cp] : m_characters)
@@ -227,6 +239,34 @@ namespace Transmog
     {
         m_activeCharacter = name;
         ensure_character(name);
+    }
+
+    std::string PresetManager::body_kind_of(const std::string &charName) const
+    {
+        auto it = m_characters.find(charName);
+        if (it == m_characters.end())
+            return "Auto";
+        return it->second.bodyKind.empty() ? std::string("Auto")
+                                            : it->second.bodyKind;
+    }
+
+    void PresetManager::set_body_kind_of(const std::string &charName,
+                                         const std::string &bodyKind)
+    {
+        auto &cp = ensure_character(charName);
+        // Normalise: accept only known values; anything else collapses
+        // to "Auto" so the JSON stays clean and the picker filter has
+        // a well-defined fallback.
+        if (bodyKind == "Male" || bodyKind == "Female" ||
+            bodyKind == "Both" || bodyKind == "Auto")
+        {
+            cp.bodyKind = bodyKind;
+        }
+        else
+        {
+            cp.bodyKind = "Auto";
+        }
+        save();
     }
 
     // --- Preset management ---
@@ -389,7 +429,7 @@ namespace Transmog
         auto &mappings = slot_mappings();
 
         // NOTE: must NOT touch last_applied_ids() here. lastIds tracks what
-        // apply_all_transmog has actively injected into the game — the diff
+        // apply_all_transmog has actively injected into the game -- the diff
         // logic depends on lastIds holding the PREVIOUS applied state so it
         // can compute drop-masks on preset switching. Writing to lastIds
         // here would pre-populate it with the NEW preset values before the
@@ -413,7 +453,7 @@ namespace Transmog
         {
             p.slots[i].active = mappings[i].active;
             p.slots[i].itemId = mappings[i].targetItemId;
-            // id 0 means "none" — don't resolve a name for it.
+            // id 0 means "none" -- don't resolve a name for it.
             // The catalog's entry at index 0 is a real item
             // (Pyeonjeon_Arrow) and saving that name would cause
             // the preset to load an unintended item on reresolve.
@@ -432,7 +472,7 @@ namespace Transmog
         if (!table.ready())
         {
             logger.warning(
-                "[preset] reresolve_all_names called before catalog ready — "
+                "[preset] reresolve_all_names called before catalog ready -- "
                 "no-op");
             return 0;
         }
@@ -458,7 +498,7 @@ namespace Transmog
                     else
                     {
                         logger.warning(
-                            "[preset] '{}' not in catalog — disabling "
+                            "[preset] '{}' not in catalog -- disabling "
                             "(char='{}' preset='{}')",
                             slot.itemName, charName, preset.name);
                         slot.itemId = 0;

--- a/CrimsonDesertLiveTransmog/src/preset_manager.hpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.hpp
@@ -14,7 +14,7 @@ namespace Transmog
     {
         bool active = false;
         // Runtime-only item id resolved from `itemName` against the
-        // item catalog. Never persisted — rebuilt on every load by
+        // item catalog. Never persisted -- rebuilt on every load by
         // slot_from_json() or reresolve_all_names().
         uint16_t itemId = 0;
         // Stable game-data item name (e.g. "Kliff_PlateArmor_Helm").
@@ -33,6 +33,14 @@ namespace Transmog
     {
         int activePreset = 0;
         std::vector<Preset> presets;
+        /// Body-kind override used by the picker filter. One of:
+        ///   "Auto"   (default) -- fall back to the hardcoded map
+        ///                        (Kliff/Oongka = Male, Damiane = Female)
+        ///   "Male" / "Female" / "Both"
+        /// Lets body-swap mod users mark Kliff as "Female" so his
+        /// picker shows the female-body-token pool. Persisted in
+        /// presets.json per character.
+        std::string bodyKind = "Auto";
     };
 
     class PresetManager
@@ -51,6 +59,14 @@ namespace Transmog
         std::vector<std::string> character_names() const;
         const std::string &active_character() const;
         void set_active_character(const std::string &name);
+
+        /// Get/set the per-character body-kind override. Empty or
+        /// "Auto" falls back to the hardcoded default in
+        /// ItemNameTable::body_kind_for_character(). Values are saved
+        /// to presets.json on set.
+        std::string body_kind_of(const std::string &charName) const;
+        void set_body_kind_of(const std::string &charName,
+                              const std::string &bodyKind);
 
         // --- Preset management (operates on active character) ---
 

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -60,6 +60,42 @@ namespace Transmog
     std::atomic<bool> &in_transmog() { return s_inTransmog; }
     std::atomic<bool> &suppress_vec() { return s_suppressVEC; }
     std::atomic<__int64> &player_a1() { return s_playerA1; }
+
+    // SEH-only helper -- kept in its own no-C++-object function so
+    // MSVC __try/__except doesn't collide with std::string unwinding
+    // (C2712) in callers.
+    static std::uint8_t read_controlled_char_idx_seh() noexcept
+    {
+        const auto wsBase =
+            s_worldSystemPtr.load(std::memory_order_acquire);
+        if (!wsBase)
+            return 0;
+        __try
+        {
+            auto ws = *reinterpret_cast<uintptr_t *>(wsBase);
+            if (ws < 0x10000)
+                return 0;
+            auto am = *reinterpret_cast<uintptr_t *>(ws + 0x30);
+            if (am < 0x10000)
+                return 0;
+            return *reinterpret_cast<uint8_t *>(am + 0x30);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return 0;
+        }
+    }
+
+    std::string current_controlled_character_name() noexcept
+    {
+        switch (read_controlled_char_idx_seh())
+        {
+            case 1: return "Kliff";
+            case 2: return "Damiane";
+            case 3: return "Oongka";
+            default: return {};
+        }
+    }
     std::atomic<uintptr_t> &world_system_ptr() { return s_worldSystemPtr; }
     std::array<bool, k_slotCount> &real_damaged() { return s_realDamaged; }
     std::array<std::uint16_t, 5> &last_applied_real_ids() { return s_lastAppliedRealIds; }

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -13,11 +13,11 @@ namespace Transmog
     struct ResolvedAddresses
     {
         uintptr_t slotPopulator       = 0;
-        uintptr_t mapLookup            = 0; // IndexedStringA::lookup — used to resolve CD_* slot hashes at runtime
-        uintptr_t subTranslator        = 0; // sub_14076D950 — anchor for iteminfo item-name table scan
-        uintptr_t safeTearDown         = 0; // sub_14075FE60 — scene-graph tear-down used by real_part_tear_down
-        uintptr_t indexedStringLookup  = 0; // sub_1402D75D0 — IndexedStringA short->hash; resolved via ItemNameTable chain walk (50+ template siblings prevent direct AOB)
-        uintptr_t charClassBypass      = 0; // 0x141D5F538 — jz byte in CondPrefab evaluator secondary hash check. Toggle 0x74↔0xEB for NPC item support.
+        uintptr_t mapLookup            = 0; // IndexedStringA::lookup -- used to resolve CD_* slot hashes at runtime
+        uintptr_t subTranslator        = 0; // sub_14076D950 -- anchor for iteminfo item-name table scan
+        uintptr_t safeTearDown         = 0; // sub_14075FE60 -- scene-graph tear-down used by real_part_tear_down
+        uintptr_t indexedStringLookup  = 0; // sub_1402D75D0 -- IndexedStringA short->hash; resolved via ItemNameTable chain walk (50+ template siblings prevent direct AOB)
+        uintptr_t charClassBypass      = 0; // 0x141D5F538 -- jz byte in CondPrefab evaluator secondary hash check. Toggle 0x74↔0xEB for NPC item support.
     };
 
     ResolvedAddresses &resolved_addrs();
@@ -57,7 +57,7 @@ namespace Transmog
     // --- Trampoline typedefs ---
 
     // sub_14076C960: Populates slot visual data + calls VisualEquipChange.
-    // This is the KEY function for transmog — it loads meshes and transitions.
+    // This is the KEY function for transmog -- it loads meshes and transitions.
     using SlotPopulatorFn = __int64(__fastcall *)(__int64 a1, unsigned __int16 *a2_itemData, __int64 a3_swapEntry);
     SlotPopulatorFn &slot_populator_fn();
 
@@ -78,6 +78,14 @@ namespace Transmog
 
     /// Last known player a1 (captured from BatchEquip hook / VEC hook).
     std::atomic<__int64> &player_a1();
+
+    /// Returns the currently-controlled character name ("Kliff",
+    /// "Damiane", "Oongka") by reading the 1-based index byte at
+    /// `*(WS+0x30)+0x30` (CE-verified 2026-04-21 on v1.03.01).
+    /// Returns an empty string if the chain is not yet resolved,
+    /// the byte holds an unknown value, or a memory fault is
+    /// caught. Safe to call from any thread.
+    std::string current_controlled_character_name() noexcept;
 
     /// WorldSystem base pointer (game_base + RVA). Atomic because x64
     /// qword stores are naturally atomic on aligned data but the compiler
@@ -107,7 +115,7 @@ namespace Transmog
     /// debounced apply to one slot only, avoiding full-gear flicker.
     /// Last-writer-wins: if manual_apply (full) and manual_apply_slot
     /// race before the worker wakes, only the latest store takes
-    /// effect. This is acceptable — the user's most recent action wins.
+    /// effect. This is acceptable -- the user's most recent action wins.
     std::atomic<std::size_t> &pending_slot_index();
 
     // --- Hot-path utilities ---

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -324,7 +324,7 @@ namespace Transmog
         auto &logger = DMK::Logger::get_instance();
 
         if (!DMK::Memory::init_cache())
-            logger.warning("Memory cache init failed — pointer reads may be slower");
+            logger.warning("Memory cache init failed -- pointer reads may be slower");
 
         // --- Resolve AOB addresses ---
         //
@@ -342,9 +342,9 @@ namespace Transmog
             "SlotPopulator");
 
         if (!addrs.slotPopulator)
-            logger.warning("SlotPopulator AOB scan failed — transmog will not work");
+            logger.warning("SlotPopulator AOB scan failed -- transmog will not work");
 
-        // MapLookup: IndexedStringA::lookup. Not hooked — RIP anchor for
+        // MapLookup: IndexedStringA::lookup. Not hooked -- RIP anchor for
         // scan_indexed_string_table(). Must be resolved before
         // PartShowSuppress::init_slot_hashes.
         addrs.mapLookup = resolve_address(
@@ -365,14 +365,14 @@ namespace Transmog
             else
             {
                 logger.debug(
-                    "[dispatch] IndexedStringA scan returned empty — "
+                    "[dispatch] IndexedStringA scan returned empty -- "
                     "slot hashes unresolved, PartShowSuppress disabled");
             }
         }
         else
         {
             logger.warning(
-                "MapLookup AOB scan failed — cannot resolve CD_* slot hashes, "
+                "MapLookup AOB scan failed -- cannot resolve CD_* slot hashes, "
                 "PartShowSuppress will be inert this session");
         }
 
@@ -408,14 +408,14 @@ namespace Transmog
             else if (result == BR::Deferred)
             {
                 logger.info(
-                    "[nametable] iteminfo global not initialized yet — "
+                    "[nametable] iteminfo global not initialized yet -- "
                     "starting background scan thread");
                 launch_deferred_nametable_scan();
             }
             else // Fatal
             {
                 logger.warning(
-                    "[nametable] address chain resolution failed — "
+                    "[nametable] address chain resolution failed -- "
                     "item-name table disabled this session");
             }
 
@@ -430,7 +430,7 @@ namespace Transmog
         else
         {
             logger.warning(
-                "SubTranslator AOB scan failed — cannot build item-name table, "
+                "SubTranslator AOB scan failed -- cannot build item-name table, "
                 "presets will fall back to raw itemId only");
         }
 
@@ -442,7 +442,7 @@ namespace Transmog
         if (!addrs.safeTearDown)
         {
             logger.warning(
-                "SafeTearDown AOB scan failed — real_part_tear_down will "
+                "SafeTearDown AOB scan failed -- real_part_tear_down will "
                 "be disabled this session");
         }
 
@@ -458,7 +458,7 @@ namespace Transmog
             {
                 logger.warning(
                     "InitSwapEntry resolved to 0x{:X} but prologue byte "
-                    "looks wrong — rejecting",
+                    "looks wrong -- rejecting",
                     iseAddr);
                 iseAddr = 0;
             }
@@ -471,7 +471,7 @@ namespace Transmog
             else
             {
                 logger.warning(
-                    "InitSwapEntry AOB scan failed — transmog apply will "
+                    "InitSwapEntry AOB scan failed -- transmog apply will "
                     "be disabled this session");
             }
         }
@@ -523,11 +523,6 @@ namespace Transmog
             auto &pm = PresetManager::instance();
             pm.load(presetsPath);
             pm.apply_to_state();
-
-            logger.info("Active character: '{}', preset {}/{}",
-                        pm.active_character(),
-                        pm.preset_count() > 0 ? pm.active_preset_index() + 1 : 0,
-                        pm.preset_count());
         }
 
         // --- Install hooks ---
@@ -547,7 +542,7 @@ namespace Transmog
             {
                 logger.warning(
                     "SlotPopulator resolved to 0x{:X} but prologue byte "
-                    "looks wrong — rejecting, transmog apply disabled",
+                    "looks wrong -- rejecting, transmog apply disabled",
                     addrs.slotPopulator);
                 addrs.slotPopulator = 0;
             }
@@ -564,7 +559,7 @@ namespace Transmog
             {
                 logger.warning(
                     "BatchEquip resolved to 0x{:X} but prologue byte "
-                    "looks wrong — rejecting",
+                    "looks wrong -- rejecting",
                     beAddr);
                 beAddr = 0;
             }
@@ -590,7 +585,7 @@ namespace Transmog
             }
             else
             {
-                logger.warning("BatchEquip AOB scan failed — transmog equip trigger disabled");
+                logger.warning("BatchEquip AOB scan failed -- transmog equip trigger disabled");
             }
         }
 
@@ -602,7 +597,7 @@ namespace Transmog
             {
                 logger.warning(
                     "VEC resolved to 0x{:X} but prologue byte looks "
-                    "wrong — rejecting",
+                    "wrong -- rejecting",
                     vecAddr);
                 vecAddr = 0;
             }
@@ -626,7 +621,29 @@ namespace Transmog
             }
         }
 
-        // PartAddShow (sub_14081DC20) inline hook.
+        // PartAddShow (sub_14081DC20) inline hook -- transition-flash polish.
+        //
+        // Auto-skip if CrimsonDesertEquipHide is loaded in-process.
+        // EH installs its own inline hook on the exact same function
+        // for its gliding-fix. Two inline hooks on one address chain
+        // non-deterministically across game launches (DLL load order
+        // isn't fixed), and one side can end up silently bypassed.
+        // LT's hook is cosmetic polish, EH's is user-visible
+        // functionality -- when both are present, yield to EH.
+        // Dual-name check covers both dev two-DLL and release single-
+        // ASI EH layouts.
+        const bool ehPresent =
+            GetModuleHandleA("CrimsonDesertEquipHide_Logic.dll") != nullptr ||
+            GetModuleHandleA("CrimsonDesertEquipHide.asi") != nullptr ||
+            GetModuleHandleA("CrimsonDesertEquipHide.dll") != nullptr;
+        if (ehPresent)
+        {
+            logger.info("[dispatch] PartAddShow hook skipped -- "
+                        "CrimsonDesertEquipHide detected; yielding to "
+                        "its gliding-fix hook to avoid dual-install "
+                        "ordering issues.");
+        }
+        else
         {
             auto pasAddr = resolve_address(
                 k_partAddShowCandidates,
@@ -637,7 +654,7 @@ namespace Transmog
             {
                 logger.warning(
                     "PartAddShow resolved to 0x{:X} but prologue byte "
-                    "looks wrong — rejecting",
+                    "looks wrong -- rejecting",
                     pasAddr);
                 pasAddr = 0;
             }
@@ -658,13 +675,13 @@ namespace Transmog
                 }
                 else
                 {
-                    logger.warning("PartAddShow hook failed: {} — transition flash suppression disabled",
+                    logger.warning("PartAddShow hook failed: {} -- transition flash suppression disabled",
                                    DetourModKit::Hook::error_to_string(result.error()));
                 }
             }
             else
             {
-                logger.warning("[dispatch] PartAddShow AOB scan failed — transition flash suppression disabled");
+                logger.warning("[dispatch] PartAddShow AOB scan failed -- transition flash suppression disabled");
             }
         }
 
@@ -672,7 +689,7 @@ namespace Transmog
         if (!RealPartTearDown::resolve_helpers())
         {
             logger.warning(
-                "[dispatch] tear_down: helper resolution failed — "
+                "[dispatch] tear_down: helper resolution failed -- "
                 "feature disabled");
         }
 
@@ -691,7 +708,7 @@ namespace Transmog
             }
             else
             {
-                logger.warning("WorldSystem AOB failed — load-time transmog disabled");
+                logger.warning("WorldSystem AOB failed -- load-time transmog disabled");
             }
         }
 
@@ -701,7 +718,7 @@ namespace Transmog
         register_hotkeys();
         DMK::InputManager::get_instance().start();
 
-        logger.info("Transmog initialization complete — SlotPopulator {}",
+        logger.info("Transmog initialization complete -- SlotPopulator {}",
                     slot_populator_fn() ? "READY" : "UNAVAILABLE");
 
         return true;
@@ -715,11 +732,11 @@ namespace Transmog
         // Order is load-bearing: workers first, hooks second.
         //
         // Every worker we spawned calls raw game functions under SEH
-        // (apply_all_transmog → SlotPopulator, debounce worker →
-        // RealPartTearDown → safeTearDown). Joining them BEFORE
-        // DMK_Shutdown removes the MinHook trampolines guarantees no
-        // worker is mid-call into game code that the loader is about
-        // to unmap.
+        // (apply_all_transmog -> SlotPopulator, debounce worker ->
+        // RealPartTearDown -> safeTearDown). Joining them BEFORE
+        // DMK_Shutdown removes the SafetyHook trampolines guarantees
+        // no worker is mid-call into game code that the loader is
+        // about to unmap.
 
         stop_load_detect_thread();
         stop_apply_worker();

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -1,6 +1,7 @@
 #include "transmog_apply.hpp"
 #include "item_name_table.hpp"
 #include "part_show_suppress.hpp"
+#include "preset_manager.hpp"
 #include "real_part_tear_down.hpp"
 #include "shared_state.hpp"
 #include "transmog_map.hpp"
@@ -39,12 +40,19 @@ namespace Transmog
         in_transmog().store(false, std::memory_order_relaxed);
     }
 
-    // ── Default carrier set (Kliff PlateArmor) ──────────────────────────
-    // These are valid Kliff-equippable base items resolved by name at
-    // runtime. If a name fails to resolve, the slot falls back to direct
-    // equip (which may silently fail for NPC/variant items).
+    // ── Default carrier set (per character) ─────────────────────────────
+    // Each entry must be a valid item for THAT character in the given
+    // slot -- something the engine's equip class-gate accepts. Kliff and
+    // Oongka share Kliff_PlateArmor_* (Oongka's equip-type matches
+    // Kliff's). Damiane has her own armor namespace (Demian_*) which
+    // Kliff cannot wear, but the engine accepts them on Damiane even
+    // though they are marked PlayerSafe=no in the item catalog. The
+    // PlayerSafe flag reflects Kliff compatibility only.
+    //
+    // If a name fails to resolve the slot falls back to direct equip
+    // (which may silently fail for NPC/variant items).
 
-    static constexpr const char *k_defaultCarrierNames[] = {
+    static constexpr const char *k_kliffCarriers[] = {
         "Kliff_PlateArmor_Helm",   // TransmogSlot::Helm
         "Kliff_PlateArmor_Armor",  // TransmogSlot::Chest
         "Kliff_PlateArmor_Cloak",  // TransmogSlot::Cloak
@@ -52,7 +60,30 @@ namespace Transmog
         "Kliff_Plate_Boots",       // TransmogSlot::Boots
     };
 
-    uint16_t default_carrier_for_slot(TransmogSlot slot)
+    static constexpr const char *k_damianeCarriers[] = {
+        "Demian_PlateArmor_Helm_I",   // TransmogSlot::Helm
+        "Demian_Leather_Armor",       // TransmogSlot::Chest
+        "Demian_Leather_Cloak",       // TransmogSlot::Cloak
+        "Demian_Leather_Gloves_I",    // TransmogSlot::Gloves
+        "Demian_Plate_Boots_III",     // TransmogSlot::Boots
+    };
+
+    // Oongka carriers. Despite sharing 3/4 male-body classifier
+    // tokens with Kliff, the engine rejects Kliff-equip-type (0x0004)
+    // items at Oongka's equip gate -- Oongka's slot class is 0x0001.
+    // Native Oongka_* items pass the gate cleanly; the hybrid then
+    // patches their +0x42 over a Kliff target so Oongka can wear
+    // cross-character armor visuals.
+    static constexpr const char *k_oongkaCarriers[] = {
+        "Oongka_PlateArmor_Helm_II",   // TransmogSlot::Helm
+        "Oongka_Basic_Leather_Armor",  // TransmogSlot::Chest
+        "Oongka_Basic_Leather_Cloak",  // TransmogSlot::Cloak
+        "Oongka_Basic_Leather_Gloves", // TransmogSlot::Gloves
+        "Oongka_PlateArmor_Boots_II",  // TransmogSlot::Boots
+    };
+
+    uint16_t default_carrier_for_slot(
+        TransmogSlot slot, const std::string &charName)
     {
         const auto idx = static_cast<std::size_t>(slot);
         if (idx >= k_slotCount)
@@ -60,18 +91,80 @@ namespace Transmog
         const auto &table = ItemNameTable::instance();
         if (!table.ready())
             return 0;
-        auto id = table.id_of(k_defaultCarrierNames[idx]);
-        return id.value_or(0);
+
+        const char *name = k_kliffCarriers[idx];
+        if (charName == "Damiane")
+            name = k_damianeCarriers[idx];
+        else if (charName == "Oongka")
+            name = k_oongkaCarriers[idx];
+
+        auto id = table.id_of(name);
+        if (id.has_value())
+            return *id;
+
+        // Fallback: if a character-specific carrier name did not
+        // resolve (missing from catalog, renamed), try Kliff's set.
+        if (name != k_kliffCarriers[idx])
+        {
+            auto kliff = table.id_of(k_kliffCarriers[idx]);
+            return kliff.value_or(0);
+        }
+        return 0;
     }
 
-    bool needs_carrier(uint16_t itemId)
+    // Expected equip-type u16 (at desc+0x42) for the given playable
+    // character. CE-verified 2026-04-21:
+    //   Kliff   = 0x0004
+    //   Oongka  = 0x0001
+    //   Damiane = 0x0001
+    // Unknown characters default to Kliff's value so legacy call
+    // paths keep their prior behaviour.
+    static std::uint16_t expected_equip_type_for_char(
+        const std::string &charName) noexcept
+    {
+        if (charName == "Damiane" || charName == "Oongka")
+            return 0x0001;
+        return 0x0004;
+    }
+
+    bool needs_carrier(uint16_t itemId, const std::string &charName)
     {
         const auto &table = ItemNameTable::instance();
         if (!table.ready())
             return false;
-        return table.has_variant_meta(itemId) ||
-               !table.is_player_compatible(itemId) ||
-               table.has_npc_equip_type(itemId);
+
+        // Variant-meta items always need the carrier-patch path so
+        // the NPC variant descriptor gets swapped in for visuals
+        // while a clean carrier supplies the rule list.
+        if (table.has_variant_meta(itemId))
+            return true;
+
+        // Equip-type mismatch: the item's +0x42 slot class doesn't
+        // match what the active character's inventory slot accepts.
+        // Without the carrier path the engine rejects the item at
+        // the equip gate (Oongka picking Kliff's 0x0004 armor, Kliff
+        // picking Damiane's 0x0001 armor, etc.). The hybrid patches
+        // the carrier's equip-type over the target descriptor so
+        // the slot accepts while the target's visuals render.
+        const std::uint16_t expected =
+            expected_equip_type_for_char(charName);
+        const std::uint16_t actual = table.equip_type_of(itemId);
+        // equip_type_of returns 0 if the catalog hasn't resolved this
+        // id yet; fall back to the old broad "is_player_compatible"
+        // gate in that case so we don't silently direct-apply a
+        // cross-class item during the deferred-scan window.
+        if (actual == 0)
+            return !table.is_player_compatible(itemId) ||
+                   table.has_npc_equip_type(itemId);
+
+        return actual != expected;
+    }
+
+    // Legacy wrapper retained for any call sites that still assume
+    // Kliff. Matches the pre-2026-04-21 behaviour exactly.
+    bool needs_carrier(uint16_t itemId)
+    {
+        return needs_carrier(itemId, std::string("Kliff"));
     }
 
     // SEH-safe memory helpers (MSVC: __try cannot coexist with C++
@@ -292,7 +385,7 @@ namespace Transmog
     // Differences from apply_all_transmog:
     //   - Dispatch cache: only clears entries matching this slot's game
     //     tag (by walking the 24-byte stride array). Does NOT reset the
-    //     global count to zero — other slots' entries stay valid.
+    //     global count to zero -- other slots' entries stay valid.
     //   - Tear-down: Phase A (previous fake) and Phase B (real item)
     //     scoped to one slot.
     //   - Apply: single call to apply_transmog or
@@ -319,7 +412,13 @@ namespace Transmog
         auto &lastIds = last_applied_ids();
         auto &m = mappings[slotIdx];
 
-        if (world_system_ptr().load(std::memory_order_acquire))
+        // resolve_player_component() walks WorldSystem → ActorManager
+        // → UserActor → actor, which we confirmed in 2026-04-21 CE
+        // probes always returns Kliff's component regardless of the
+        // currently-controlled character. Using it unconditionally
+        // clobbered per-character a1 values from VEC/BatchEquip hooks.
+        // Keep it ONLY as a fallback when the passed-in a1 is invalid.
+        if (a1 < 0x10000 && world_system_ptr().load(std::memory_order_acquire))
         {
             auto fresh = resolve_player_component();
             if (fresh > 0x10000)
@@ -397,8 +496,11 @@ namespace Transmog
             realId = RealPartTearDown::get_real_item_id(
                 reinterpret_cast<void *>(a1), gameTag);
 
-            // Phase A: tear down previous fake.
-            if (prevId != 0 && prevId != realId)
+            // Phase A: tear down previous fake. Runs even when the
+            // previous fake itemId matches the live real item; we
+            // treat fake and real the same so the tear-down/apply
+            // sequence is always complete.
+            if (prevId != 0)
             {
                 const auto prevCarrier = last_applied_carrier_ids()[slotIdx];
                 const uintptr_t bypassAddr =
@@ -422,8 +524,9 @@ namespace Transmog
                     set_char_class_bypass(bypassAddr, 0x74);
             }
 
-            // Phase B: tear down real item if fake differs.
-            if (targetId != 0 && targetId != realId)
+            // Phase B: tear down the real item. Runs unconditionally
+            // (fake == real is treated the same as fake != real).
+            if (targetId != 0)
             {
                 if (RealPartTearDown::tear_down_real_part(
                         reinterpret_cast<void *>(a1), gameTag))
@@ -435,9 +538,13 @@ namespace Transmog
         if (targetId != 0)
         {
             const auto tmSlot = static_cast<TransmogSlot>(slotIdx);
-            const bool useCarrier = needs_carrier(targetId);
+            const auto &activeChar =
+                PresetManager::instance().active_character();
+            const bool useCarrier = needs_carrier(targetId, activeChar);
             const uint16_t carrierId =
-                useCarrier ? default_carrier_for_slot(tmSlot) : 0;
+                useCarrier
+                    ? default_carrier_for_slot(tmSlot, activeChar)
+                    : 0;
 
             if (useCarrier && carrierId != 0)
             {
@@ -467,7 +574,7 @@ namespace Transmog
             // Clearing this slot. Two cases:
             //  - active + none (checkbox ticked, picker = none): user
             //    wants to show an EMPTY slot (bare head, etc.). Do NOT
-            //    restore the real item — Phase B already tore it down.
+            //    restore the real item -- Phase B already tore it down.
             //  - inactive (!m.active): slot was previously controlled
             //    by us; restore the real item so it reappears.
             const bool showEmpty = m.active;
@@ -525,7 +632,8 @@ namespace Transmog
         auto &mappings = slot_mappings();
         auto &lastIds = last_applied_ids();
 
-        if (world_system_ptr().load(std::memory_order_acquire))
+        // Fallback only -- see apply_single_slot_transmog comment.
+        if (a1 < 0x10000 && world_system_ptr().load(std::memory_order_acquire))
         {
             auto fresh = resolve_player_component();
             if (fresh > 0x10000)
@@ -563,7 +671,7 @@ namespace Transmog
         //
         // Slot tag order here must match k_tearDownSlots inside the
         // tear-down block: Helm(3), Chest(4), Gloves(5), Boots(6),
-        // Cloak(16). TransmogSlot enum indices differ — we translate.
+        // Cloak(16). TransmogSlot enum indices differ -- we translate.
         static constexpr std::uint16_t k_earlyOutSlotTags[5] = {
             0x0003, 0x0004, 0x0005, 0x0006, 0x0010};
         static constexpr TransmogSlot k_earlyOutSlots[5] = {
@@ -606,7 +714,7 @@ namespace Transmog
                 }
             }
 
-            // Check for active "none" slots — these need Phase B
+            // Check for active "none" slots -- these need Phase B
             // tear-down and suppress reinforcement even when nothing
             // else changed (the game may re-equip real items after our
             // initial tear-down during the load sequence).
@@ -665,8 +773,8 @@ namespace Transmog
             // last_applied_real_ids so we compare against the previous
             // state. A slot needs tear-down + re-apply if its preset
             // target changed OR its underlying real item changed.
-            // Unchanged slots are skipped — no tear-down, no cache
-            // clear, no SlotPopulator call — so they don't flicker.
+            // Unchanged slots are skipped -- no tear-down, no cache
+            // clear, no SlotPopulator call -- so they don't flicker.
             //
             // Unticked slots whose real changes ARE still marked: a
             // prior restore via SlotPopulator may have left a dispatch
@@ -687,7 +795,7 @@ namespace Transmog
 
                 // Check if the real item changed for this slot.
                 // Unticked slots still need cache cleanup when their
-                // real changes — an earlier restore via SlotPopulator
+                // real changes -- an earlier restore via SlotPopulator
                 // may have left a dispatch entry that the game's own
                 // unequip flow can't remove.
                 for (std::size_t k = 0; k < 5; ++k)
@@ -732,7 +840,7 @@ namespace Transmog
         //      restore count, which re-exposed previous-preset entries
         //      and caused SlotPopulator's linear search (14076ca7b) to
         //      find an old slotNativeId and *append* a new blob to its
-        //      existing subArray — the stale blob still gets dispatched
+        //      existing subArray -- the stale blob still gets dispatched
         //      to VEC via sub_14076D520, producing the stale helm bug.
         //  (2) Even on a slot we ARE re-populating this frame, the game
         //      never clears subCount, so the previously queued blob
@@ -789,9 +897,9 @@ namespace Transmog
 
         // Two-phase scene-graph tear-down before applying fakes.
         //
-        // Phase A — tear down the previous preset's fake meshes using
+        // Phase A -- tear down the previous preset's fake meshes using
         //   lastIds[] as the itemId source.
-        // Phase B — tear down the REAL item in the auth table for every
+        // Phase B -- tear down the REAL item in the auth table for every
         //   active slot whose new fake differs from the real.
         //
         // Both phases go through sub_14075FE60 which detaches particle
@@ -867,16 +975,9 @@ namespace Transmog
                 const auto prevCarrier = last_applied_carrier_ids()[idx];
                 if (prevId == 0)
                     continue;
-                if (static_cast<std::uint16_t>(prevId) == realItemId[k] &&
-                    prevCarrier == 0)
-                {
-                    logger.trace(
-                        "[dispatch] tear_down_fake slot={:#06x} itemId={:#06x} "
-                        "skipped (matches real, no carrier)",
-                        td.gameTag,
-                        static_cast<std::uint16_t>(prevId));
-                    continue;
-                }
+                // Phase A runs unconditionally: fake and real are
+                // treated equally, so even when the previous fake
+                // matched the live real item we still tear it down.
                 if (prevCarrier != 0 &&
                     prevCarrier != static_cast<std::uint16_t>(prevId))
                 {
@@ -903,9 +1004,11 @@ namespace Transmog
                              "after Phase A tear-down");
             }
 
-            // Phase B: real items for any active slot. Skip slots where
-            // the NEW fake itemId matches the real equipped id AND the
-            // real is still intact. Also skip slots with no work needed.
+            // Phase B: real items for any active slot. Runs
+            // unconditionally -- fake and real are treated equally,
+            // so even when the new fake matches the live real we
+            // still tear down the real part. Only slots that had no
+            // slotNeedsWork flag or are inactive skip.
             for (std::size_t k = 0; k < k_tearDownCount; ++k)
             {
                 const auto &td = k_tearDownSlots[k];
@@ -915,17 +1018,6 @@ namespace Transmog
                 auto &m = mappings[idx];
                 if (!m.active)
                     continue;
-                if (m.targetItemId != 0 &&
-                    static_cast<std::uint16_t>(m.targetItemId) == realItemId[k] &&
-                    !real_damaged()[idx])
-                {
-                    logger.trace(
-                        "[dispatch] tear_down slot={:#06x} itemId={:#06x} "
-                        "skipped (fake matches intact real)",
-                        td.gameTag,
-                        static_cast<std::uint16_t>(m.targetItemId));
-                    continue;
-                }
                 if (RealPartTearDown::tear_down_real_part(
                         reinterpret_cast<void *>(a1), td.gameTag))
                 {
@@ -962,32 +1054,22 @@ namespace Transmog
             if (!m.active || m.targetItemId == 0)
                 continue;
 
-            // Skip SlotPopulator when the fake matches the INTACT live
-            // real item. Once the real has been damaged by a previous
-            // phase-B tear-down, fall through so SlotPopulator can
-            // restore the mesh — the layer-2 effects are already lost.
+            // Fake and real are treated equally -- SlotPopulator runs
+            // unconditionally even when the new fake itemId matches
+            // the intact live real item. The earlier skip-on-match
+            // fast-path was removed per user preference (predictable
+            // apply sequence over incremental CPU savings).
             //
-            // Important: do NOT increment ourWrittenCount on the skip
-            // path. We did not actually write a dispatch cache entry.
-            const std::uint16_t realId = lookup_real_id(i);
-            if (realId != 0 &&
-                static_cast<std::uint16_t>(m.targetItemId) == realId &&
-                !real_damaged()[i])
-            {
-                logger.trace(
-                    "[dispatch] apply_transmog slot={} itemId={:#06x} "
-                    "skipped (fake matches intact real)",
-                    i, m.targetItemId);
-                lastIds[i] = m.targetItemId;
-                continue;
-            }
-
             // Decide: direct apply or carrier-assisted apply.
             const auto tmSlot = static_cast<TransmogSlot>(i);
             const auto targetId = m.targetItemId;
-            const bool useCarrier = needs_carrier(targetId);
+            const auto &activeChar =
+                PresetManager::instance().active_character();
+            const bool useCarrier = needs_carrier(targetId, activeChar);
             const uint16_t carrierId =
-                useCarrier ? default_carrier_for_slot(tmSlot) : 0;
+                useCarrier
+                    ? default_carrier_for_slot(tmSlot, activeChar)
+                    : 0;
 
             if (useCarrier && carrierId != 0)
             {
@@ -1032,7 +1114,7 @@ namespace Transmog
         // previously controlled by us (Phase B tore down the real
         // item). Restore the real item so it reappears.
         // "Active + none" (checkbox ticked, dropdown=none) means
-        // "show empty" — do NOT restore.
+        // "show empty" -- do NOT restore.
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
             const auto &m = mappings[i];
@@ -1041,7 +1123,7 @@ namespace Transmog
                 const std::uint16_t realId = lookup_real_id(i);
                 if (realId != 0)
                 {
-                    logger.info("[dispatch] slot={} unticked — "
+                    logger.info("[dispatch] slot={} unticked -- "
                                 "restoring real item {:#06x}",
                                 slot_name(static_cast<TransmogSlot>(i)),
                                 realId);
@@ -1055,7 +1137,7 @@ namespace Transmog
                     // left a scene-graph mesh entry. Tear it down so
                     // the visual actually disappears. The old real ID
                     // is still in last_applied_real_ids (not yet
-                    // overwritten — moved to end of function).
+                    // overwritten -- moved to end of function).
                     for (std::size_t k = 0; k < k_tearDownCount; ++k)
                     {
                         if (static_cast<std::size_t>(
@@ -1067,7 +1149,7 @@ namespace Transmog
                         {
                             logger.info(
                                 "[dispatch] slot={} unticked + "
-                                "unequipped — tearing down restored "
+                                "unequipped -- tearing down restored "
                                 "mesh {:#06x}",
                                 slot_name(static_cast<TransmogSlot>(i)),
                                 oldReal);
@@ -1109,14 +1191,14 @@ namespace Transmog
             const auto oldReal = last_applied_real_ids()[k];
             if (oldReal == 0)
                 continue;
-            logger.info("[dispatch] slot={} cleanup — tearing down "
+            logger.info("[dispatch] slot={} cleanup -- tearing down "
                         "stale restore mesh {:#06x}",
                         slot_name(td.slot), oldReal);
             RealPartTearDown::tear_down_by_item_id(
                 reinterpret_cast<void *>(a1), oldReal, td.gameTag);
         }
 
-        // Count was NOT zeroed — unchanged slots' entries are still
+        // Count was NOT zeroed -- unchanged slots' entries are still
         // live with their original subCount. Log the final state for
         // diagnostics.
         __try
@@ -1184,7 +1266,8 @@ namespace Transmog
         auto &logger = DMK::Logger::get_instance();
         auto &lastIds = last_applied_ids();
 
-        if (world_system_ptr().load(std::memory_order_acquire))
+        // Fallback only -- see apply_single_slot_transmog comment.
+        if (a1 < 0x10000 && world_system_ptr().load(std::memory_order_acquire))
         {
             auto fresh = resolve_player_component();
             if (fresh > 0x10000)

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.hpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.hpp
@@ -23,13 +23,23 @@ namespace Transmog
     void apply_transmog_with_carrier(
         __int64 a1, std::uint16_t carrierId, std::uint16_t targetId);
 
-    /// Resolve the default carrier itemId for a given transmog slot.
-    /// Returns 0 if no carrier is needed (item is directly equippable)
-    /// or if the carrier name can't be resolved.
-    std::uint16_t default_carrier_for_slot(TransmogSlot slot);
+    /// Resolve the default carrier itemId for a given transmog slot
+    /// and currently-active character. Each character needs carriers
+    /// from its own equippable pool -- Kliff's plate base items are
+    /// rejected by the engine class-gate on Damiane (and vice versa).
+    /// Returns 0 if the name can't be resolved.
+    std::uint16_t default_carrier_for_slot(
+        TransmogSlot slot, const std::string &charName);
 
-    /// Returns true if the given item needs a carrier (has variant meta
-    /// or is not player-compatible).
+    /// Returns true if the given item needs the carrier-patch path
+    /// when applied on the given character. An item needs carrier
+    /// when either it carries NPC variant metadata, or its equip-
+    /// type at desc+0x42 doesn't match the active character's slot
+    /// class (otherwise the engine rejects it at equip time).
+    bool needs_carrier(std::uint16_t itemId, const std::string &charName);
+
+    /// Legacy overload (assumes Kliff). Kept for call sites that
+    /// predate multi-character support.
     bool needs_carrier(std::uint16_t itemId);
 
     /// Single-slot apply: tears down and re-applies only the given slot.

--- a/CrimsonDesertLiveTransmog/src/transmog_hooks.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_hooks.cpp
@@ -16,6 +16,17 @@ namespace Transmog
 
     bool is_player_actor(__int64 a1) noexcept
     {
+        // Originally this checked `*(typeEntry+1) == 1` (role byte).
+        // CE probing on 1.03.01 showed the byte is character-specific
+        // (Kliff=1, Damiane=4, Oongka=?), not a clean player/NPC flag,
+        // so the equality check silently rejected every companion.
+        //
+        // New filter: pointer chain is readable AND typeEntry+8 is a
+        // non-null pointer. For every party member we sampled, this
+        // value is the same ActorManager pointer; for unrelated NPCs
+        // the pointer differs or the chain faults. Good enough for
+        // the transmog hooks -- misclassification just produces a
+        // harmless no-op apply (no presets exist for unknown chars).
         __try
         {
             auto actor = *reinterpret_cast<uintptr_t *>(a1 + 8);
@@ -24,7 +35,8 @@ namespace Transmog
             auto typeEntry = *reinterpret_cast<uintptr_t *>(actor + 0x88);
             if (typeEntry < 0x10000)
                 return false;
-            return *reinterpret_cast<uint8_t *>(typeEntry + 1) == 1;
+            auto actorMgr = *reinterpret_cast<uintptr_t *>(typeEntry + 8);
+            return actorMgr >= 0x10000;
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -44,6 +56,23 @@ namespace Transmog
 
     // --- VEC hook (sub_14076D520) ---
 
+    // Returns true iff a1 matches the controlled-character's actor
+    // component (WS → ActorManager+0x30 → UserActor+0x28 → +0xD8).
+    // Early-outs on mismatch prevent LT from re-running its carrier-
+    // apply on every background companion's equip/VEC event -- each
+    // such unintended apply was mutating scene-graph state for the
+    // wrong actor, accumulating dangling pointers and crashing the
+    // game on later traversals (weapon draw, glide, etc.).
+    static bool is_controlled_actor(__int64 a1) noexcept
+    {
+        if (a1 < 0x10000)
+            return false;
+        const auto controlled = resolve_player_component();
+        if (!controlled)
+            return true; // can't resolve → don't filter
+        return a1 == controlled;
+    }
+
     __int64 __fastcall on_vec(__int64 a1, __int16 slotId, __int16 itemId, __int64 a4)
     {
         // Recursion guard + suppress during clear+apply cycle.
@@ -57,6 +86,12 @@ namespace Transmog
             return ret;
 
         if (flag_player_only().load(std::memory_order_relaxed) && !is_player_actor(a1))
+            return ret;
+
+        // Only schedule apply for the currently-controlled character.
+        // Background companion equip events route through VEC with
+        // their own a1 and must not drive LT's dispatch.
+        if (!is_controlled_actor(a1))
             return ret;
 
         // Skip non-armor slot changes (weapons, rings, etc.). We still
@@ -81,7 +116,8 @@ namespace Transmog
         uint32_t *ret = s_origBatchEquip(a1, a2, a3, a4);
 
         if (flag_enabled().load(std::memory_order_relaxed) &&
-            (!flag_player_only().load(std::memory_order_relaxed) || is_player_actor(a1)))
+            (!flag_player_only().load(std::memory_order_relaxed) || is_player_actor(a1)) &&
+            is_controlled_actor(a1))
         {
             // A save-load or zone transition routes a different a1
             // through this path. Every cached "damaged" flag and

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -21,7 +21,7 @@ namespace Transmog
     // --- Deferred item-name catalog scan ---
     //
     // The game populates the iteminfo global (`qword_145CEF370`) some
-    // time after our DLL init runs — exactly when depends on world load
+    // time after our DLL init runs -- exactly when depends on world load
     // order, so we can't reliably build the catalog in init(). Mirror
     // EquipHide's pattern: a single background thread that sleeps an
     // initial grace period, then retries `ItemNameTable::build` until
@@ -46,7 +46,7 @@ namespace Transmog
 
         using BR = ItemNameTable::BuildResult;
 
-        // Initial grace period — lets the game finish loading its
+        // Initial grace period -- lets the game finish loading its
         // iteminfo container before we start polling.
         for (int slept = 0; slept < k_nametableInitialDelayMs; slept += 250)
         {
@@ -96,7 +96,7 @@ namespace Transmog
             if (result == BR::Fatal)
             {
                 logger.error(
-                    "[nametable] deferred scan hit fatal chain error — "
+                    "[nametable] deferred scan hit fatal chain error -- "
                     "item catalog unavailable, mod disabled");
                 flag_enabled().store(false, std::memory_order_release);
                 return;
@@ -144,23 +144,43 @@ namespace Transmog
         __try
         {
             auto ws = *reinterpret_cast<uintptr_t *>(wsBase);
-            if (ws < 0x10000) return 0;
+            if (ws < 0x10000)
+                return 0;
             auto am = *reinterpret_cast<uintptr_t *>(ws + 0x30);
-            if (am < 0x10000) return 0;
+            if (am < 0x10000)
+                return 0;
             auto user = *reinterpret_cast<uintptr_t *>(am + 0x28);
-            if (user < 0x10000) return 0;
-            auto actor = *reinterpret_cast<uintptr_t *>(user + 0xD0);
-            if (actor < 0x10000) return 0;
+            if (user < 0x10000)
+                return 0;
+            // CE-verified 2026-04-21: `user+0xD8` holds the currently-
+            // controlled character's ClientChildOnlyInGameActor. It
+            // falls back to Kliff's actor when Kliff is the active
+            // character (Kliff's +0xD0 and +0xD8 point to the same
+            // actor), and switches to Damiane/Oongka's actor when one
+            // of them is controlled. Using +0xD0 instead (legacy
+            // offset) would always return Kliff's actor regardless of
+            // who is controlled, which is why the apply pipeline
+            // previously landed all companion presets on Kliff.
+            auto actor = *reinterpret_cast<uintptr_t *>(user + 0xD8);
+            if (actor < 0x10000)
+                return 0;
 
-            // Verify it's the player via type byte.
+            // Verify the chain is walkable -- typeEntry pointer has to
+            // be a readable heap address. The old check required
+            // `typeByte == 1` (Kliff-specific); CE probing showed
+            // Damiane's actor carries typeByte=4 and Oongka's has a
+            // different value again, so gating on that byte silently
+            // rejected companions. Pointer validity is enough.
             auto te = *reinterpret_cast<uintptr_t *>(actor + 0x88);
-            if (te < 0x10000 || *reinterpret_cast<uint8_t *>(te + 1) != 1)
+            if (te < 0x10000)
                 return 0;
 
             auto comp104 = *reinterpret_cast<uintptr_t *>(actor + 104);
-            if (comp104 < 0x10000) return 0;
+            if (comp104 < 0x10000)
+                return 0;
             auto component = *reinterpret_cast<uintptr_t *>(comp104 + 56);
-            if (component < 0x10000) return 0;
+            if (component < 0x10000)
+                return 0;
 
             return static_cast<__int64>(component);
         }
@@ -190,6 +210,33 @@ namespace Transmog
     static std::thread s_applyWorker;
     static std::atomic<bool> s_applyWorkerStarted{false};
 
+    // Apply ALWAYS targets the currently-controlled character; this
+    // helper re-reads the live char via the WS idx byte and, when
+    // PresetManager has a different active character cached, switches
+    // to the live one and rebuilds slot_mappings from its preset.
+    // No __try inside, so std::string usage is fine. Called from
+    // run_debounced_apply (which cannot mix __try with C++ objects).
+    static void sync_active_char_to_live() noexcept
+    {
+        const std::string live = current_controlled_character_name();
+        if (live.empty())
+            return;
+        auto &pm = PresetManager::instance();
+        if (live == pm.active_character())
+            return;
+        pm.set_active_character(live);
+        for (auto &m : slot_mappings())
+        {
+            m.active = false;
+            m.targetItemId = 0;
+        }
+        pm.apply_to_state();
+        last_applied_ids().fill(0);
+        real_damaged().fill(false);
+        last_applied_real_ids().fill(0);
+        last_applied_carrier_ids().fill(0);
+    }
+
     // One apply/clear pass. Pulled out of the worker body so the SEH
     // frame does not share scope with the condition-variable unique_lock
     // (MSVC C2712 forbids __try with objects requiring unwinding).
@@ -202,16 +249,56 @@ namespace Transmog
         const bool do_clear =
             clear_pending().exchange(false, std::memory_order_acq_rel);
 
-        // Re-resolve the player pointer from the WorldSystem chain.
-        // The captured a1 from the triggering hook is not trusted
-        // here — by the time the debounce fires the game may have
-        // reloaded the world and the old pointer points into freed
-        // memory. resolve_player_component returns 0 if the chain
-        // is partially populated (pre-world, loading screen) and
-        // we silently drop the apply in that case.
-        const __int64 a1 = resolve_player_component();
+        // Prefer the hook-captured a1 from player_a1() -- it identifies
+        // the character whose equip event triggered this apply. The
+        // WorldSystem chain resolve_player_component() only ever
+        // returns Kliff's component regardless of currently-controlled
+        // character (verified via CE probes 2026-04-21), so using it
+        // unconditionally applied every companion's preset to Kliff.
+        //
+        // Fall back to resolve_player_component() only when player_a1
+        // is empty or unreadable (post-reload / loading screen). The
+        // original concern about stale pointers after world reload is
+        // addressed by a SEH-guarded actor deref below -- a freed
+        // wrapper faults and we drop the apply, same net behaviour.
+        //
+        // Apply ALWAYS targets the currently-controlled character.
+        // The UI's "active character" is just a view into the JSON
+        // preset list -- a user could pick Oongka in the overlay
+        // while controlling Damiane, but we still want Damiane to
+        // end up wearing Damiane's preset. The helper below syncs
+        // PresetManager + slot_mappings to the live character.
+        // Lives outside this __try-containing function so
+        // std::string destructors don't trip C2712.
+        sync_active_char_to_live();
+        __int64 a1 = player_a1().load(std::memory_order_acquire);
         if (a1 <= 0x10000)
-            return;
+        {
+            a1 = resolve_player_component();
+            if (a1 <= 0x10000)
+                return;
+        }
+
+        // Verify the wrapper still points to a live actor. If the
+        // world reloaded after the last hook capture, *(a1+8) may
+        // fault or yield garbage -- fall back to the WS chain in
+        // that case.
+        __try
+        {
+            const auto actor = *reinterpret_cast<uintptr_t *>(a1 + 8);
+            if (actor < 0x10000)
+            {
+                a1 = resolve_player_component();
+                if (a1 <= 0x10000)
+                    return;
+            }
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            a1 = resolve_player_component();
+            if (a1 <= 0x10000)
+                return;
+        }
 
         // Consume the single-slot index. k_slotCount means "all slots".
         const auto slotIdx =
@@ -256,10 +343,9 @@ namespace Transmog
         std::unique_lock<std::mutex> lk(s_applyCvMtx);
         for (;;)
         {
-            s_applyCv.wait(lk, [] {
-                return shutdown_requested().load(std::memory_order_acquire) ||
-                       s_applyPending.load(std::memory_order_acquire);
-            });
+            s_applyCv.wait(lk, []
+                           { return shutdown_requested().load(std::memory_order_acquire) ||
+                                    s_applyPending.load(std::memory_order_acquire); });
             if (shutdown_requested().load(std::memory_order_acquire))
                 return;
 
@@ -275,12 +361,11 @@ namespace Transmog
 
                 const auto waitFor =
                     std::chrono::milliseconds(deadline - now);
-                s_applyCv.wait_for(lk, waitFor, [&deadline] {
-                    return shutdown_requested().load(
-                               std::memory_order_acquire) ||
-                           s_applyDeadlineTick.load(
-                               std::memory_order_acquire) != deadline;
-                });
+                s_applyCv.wait_for(lk, waitFor, [&deadline]
+                                   { return shutdown_requested().load(
+                                                std::memory_order_acquire) ||
+                                            s_applyDeadlineTick.load(
+                                                std::memory_order_acquire) != deadline; });
                 if (shutdown_requested().load(std::memory_order_acquire))
                     return;
             }
@@ -352,6 +437,7 @@ namespace Transmog
     {
         auto &logger = DMK::Logger::get_instance();
         __int64 prevComp = 0;
+        std::string prevCharName;
 
         while (!shutdown_requested().load(std::memory_order_relaxed))
         {
@@ -359,11 +445,69 @@ namespace Transmog
             if (shutdown_requested().load(std::memory_order_relaxed))
                 return 0;
 
+            // --- Character-swap auto-detect ---
+            //
+            // Reads the controlled-character index byte every tick;
+            // when it changes, switches the UI preset list to the new
+            // character and schedules an apply. The apply path
+            // re-walks the WS chain through `user+0xD8` so it always
+            // resolves the correct per-character wrapper -- no cache
+            // or BatchEquip event required.
+            {
+                const auto liveName = current_controlled_character_name();
+                auto &pm = PresetManager::instance();
+                if (!liveName.empty() && liveName != prevCharName)
+                {
+                    const std::string oldName = prevCharName.empty()
+                                                    ? pm.active_character()
+                                                    : prevCharName;
+                    prevCharName = liveName;
+
+                    if (liveName != pm.active_character())
+                    {
+                        pm.set_active_character(liveName);
+                        for (auto &m : slot_mappings())
+                        {
+                            m.active = false;
+                            m.targetItemId = 0;
+                        }
+                        pm.apply_to_state();
+                        {
+                            std::lock_guard<std::mutex> lk(s_applyCvMtx);
+                            last_applied_ids().fill(0);
+                            real_damaged().fill(false);
+                            last_applied_real_ids().fill(0);
+                            last_applied_carrier_ids().fill(0);
+                        }
+                        logger.info("Char swap detected: {} -> {}",
+                                    oldName, liveName);
+                        if (flag_enabled().load(std::memory_order_relaxed))
+                            schedule_transmog_ms(200);
+                        pm.save();
+                    }
+                }
+            }
+
             auto comp = resolve_player_component();
 
             // Detect change: new component appeared or address changed.
             if (comp > 0x10000 && comp != prevComp)
             {
+                // Safety gate: don't auto-apply until the controlled-
+                // character idx byte is readable (world fully loaded).
+                // run_debounced_apply will sync PresetManager to the
+                // live char itself, but running the retry loop with
+                // an unresolved live char is pointless and noisy.
+                const std::string liveChar =
+                    current_controlled_character_name();
+                if (liveChar.empty())
+                {
+                    logger.trace(
+                        "Load detect: holding auto-apply -- controlled "
+                        "char unresolved (waiting for world)");
+                    continue; // Don't advance prevComp; retry next tick.
+                }
+
                 logger.info("Load detect: player component changed ({:#x} -> {:#x})",
                             static_cast<uint64_t>(prevComp),
                             static_cast<uint64_t>(comp));
@@ -372,7 +516,7 @@ namespace Transmog
 
                 // Reset cached apply state so the early-out in
                 // apply_all_transmog doesn't suppress the re-apply.
-                // The scene graph is fresh after reload — old fake
+                // The scene graph is fresh after reload -- old fake
                 // meshes are gone even though the IDs haven't changed.
                 //
                 // Held under s_applyCvMtx to prevent racing with an
@@ -390,7 +534,7 @@ namespace Transmog
                     continue;
 
                 // Retry through the debounce worker. The game's visual
-                // state isn't ready immediately after load detect — the
+                // state isn't ready immediately after load detect -- the
                 // first attempt often faults because the PartDef array
                 // and scene graph are still being populated. We retry
                 // with exponential backoff up to ~90s total, exiting
@@ -406,15 +550,15 @@ namespace Transmog
                      ++attempt)
                 {
                     const int delayMs =
-                        (attempt < 2) ? 2000 :
-                        (attempt < 3) ? 3000 :
-                        (attempt < 4) ? 4000 : 5000;
+                        (attempt < 2) ? 2000 : (attempt < 3) ? 3000
+                                           : (attempt < 4)   ? 4000
+                                                             : 5000;
                     sleep_interruptible(delayMs);
                     if (shutdown_requested().load(std::memory_order_relaxed))
                         break;
                     schedule_transmog_ms(0);
                     logger.debug("Load detect: scheduled apply (attempt {})",
-                                attempt + 1);
+                                 attempt + 1);
 
                     // Give the worker time to finish, then check result.
                     sleep_interruptible(500);


### PR DESCRIPTION
## Summary
- Per-character presets for **Kliff**, **Damiane**, and **Oongka**. Active preset swaps automatically when the player switches who they control; each character keeps an independent preset list.
- Body-kind (male / female) filter in the picker so mismatched-body armor stays hidden by default, with a per-character override in the overlay for body-swap mod users.
- Display-name table loaded from `CrimsonDesertLiveTransmog_display_names.tsv`. The TSV must ship alongside the `.asi` -- without it the picker falls back to raw item ids.
- `CrimsonDesertLiveTransmog/LICENSE` added (MIT, matches the sibling `CrimsonDesertEquipHide/LICENSE`).
- Documentation refreshed: README feature list, template readme, nexus bbcode, Acknowledgements (+nlohmann/json entry).
- EquipHide + Core: small correctness fixes (module-dir resolution, SEH scope cleanup, shared AOB additions). No behavioural change.

## Verification
- MSVC dev-msvc RelWithDebInfo builds for both `CrimsonDesertLiveTransmog` and `CrimsonDesertEquipHide` complete with zero warnings.
- Manually smoke-tested character swap (Kliff -> Damiane -> Oongka), per-character preset auto-swap, picker body-kind filter and override.
