### PR TITLE
docs(live-transmog): add reverse-engineering knowledge base

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/research/README.md
+++ b/CrimsonDesertLiveTransmog/docs/research/README.md
@@ -1,0 +1,32 @@
+# CrimsonDesertTools -- Reverse-Engineering Knowledge Base
+
+Project knowledge base for mod runtime internals. Each entry is a long-lived reference document anchored to a specific binary version; entries are updated (not replaced) when the game binary shifts.
+
+- Game binary: `BlackDesertCrimson.exe`
+- Current verified version: **Crimson Desert v1.03.01**
+- Image base: `0x140000000`
+
+## CrimsonDesertLiveTransmog
+
+| Document | Role |
+|----------|------|
+| [live-transmog-architecture.md](live-transmog-architecture.md) | Runtime pipeline: hook points, apply state machine, memory write surface, event-driven transitions. Cross-references `CrimsonDesertLiveTransmog/src/` files. |
+| [live-transmog-source-of-truth.md](live-transmog-source-of-truth.md) | Byte-level reference: WS chain offsets, carrier descriptor layout, hook RVAs, `charClassBypass` site, IDA verification log. |
+
+## CrimsonDesertEquipHide
+
+Research artifacts for the EquipHide mod will live under `CrimsonDesertEquipHide/docs/research/` once lifted into this format. Naming convention:
+
+```
+equip-hide-architecture.md       -- runtime pipeline
+equip-hide-source-of-truth.md    -- byte-level anchors
+equip-hide-<topic>.md            -- topic-scoped deep dives
+```
+
+## Conventions
+
+- Entries list semantic role first, then concrete offsets / bytes / AOBs.
+- Every absolute address is paired with an RVA (`CrimsonDesert.exe + 0x...`) so it survives re-basing.
+- IDA verification status goes in a dedicated section near the end.
+- Cross-reference source files by path (`module/src/file.cpp`) with optional line-range hints.
+- No em-dashes; use `--` or restructure.

--- a/CrimsonDesertLiveTransmog/docs/research/live-transmog-architecture.md
+++ b/CrimsonDesertLiveTransmog/docs/research/live-transmog-architecture.md
@@ -1,0 +1,281 @@
+# Live Transmog -- Runtime Architecture
+
+Reverse-engineering reference for the Live Transmog mod's runtime pipeline, verified against **Crimson Desert v1.03.01** (PC binary, image base `0x140000000`). This document maps the apply pipeline to concrete functions, offsets, and source locations; byte-level anchors (AOBs, struct offsets) live in `live-transmog-source-of-truth.md`.
+
+---
+
+## 1. Pipeline summary
+
+The engine owns its own rules for which visual mesh is drawn per armor slot (helm, chest, cloak, gloves, boots). Live Transmog does not rewrite those rules. It operates by:
+
+1. Asking the engine to remove the real armor's mesh from the live scene graph (SafeTearDown path).
+2. Asking the engine to run its own "show this item" path (`SlotPopulator`) with a substituted item id.
+
+The auth table at `a1+0x78` (what is actually equipped, and what is serialised to the save file) is never mutated. Mod state lives in DLL memory and is released on quit.
+
+---
+
+## 2. Terminology
+
+| Term | Plain English | Technical meaning |
+|------|---------------|-------------------|
+| **Real item** | Whatever the character actually has equipped in the inventory screen. | Entry in the auth table at `a1+0x78`. Written to save file. |
+| **Fake item** | The mesh the mod is asking the engine to draw instead. | `slot_mappings[i].targetItemId` in mod memory. Not persisted. |
+| **Carrier** | Helper item the mod uses to pass the engine's class check. | Member of `k_kliffCarriers` / `k_oongkaCarriers` / `k_damianeCarriers`. |
+| **Auth table** | Authoritative equipment record (server-synced). | Stride-`0xC8` array at `*(a1+0x78)+0x08`, count at `+0x10`. |
+| **PartDef / scene graph cache** | Live in-RAM list of meshes the renderer walks this frame. | Dispatch cache at `a1+0x1B8` (ptr), `+0x1C0` (count), `+0x1C4` (cap). |
+| **Tear-down** | Scene-graph remove ("stop drawing this mesh"). | Call path passing through `sub_14075F9E0` (internal label `SafeTearDown` at `+0x14075FE60`). |
+| **a1** | Equip-wrapper pointer passed back into engine functions. | Player-component pointer; engine reads many offsets from it. |
+| **Dispatch** | One full tear-down-and-reapply pass. | Body of `apply_all_transmog()` in `transmog_apply.cpp`. |
+
+---
+
+## 3. End-to-end lifecycle
+
+```mermaid
+flowchart TD
+    A[Game loads the world] --> B[Load-detect thread wakes<br/>every 1000 ms]
+    B --> C{WS chain resolves<br/>a valid component?}
+    C -- no --> B
+    C -- yes --> D[Char-swap poll reads<br/>ActorManager +0x30 byte<br/>Kliff=1 Damiane=2 Oongka=3]
+    D --> E{Current char differs from<br/>PresetManager active?}
+    E -- yes --> F[Switch UI preset list<br/>rebuild slot_mappings<br/>reset drop-detection]
+    E -- no --> G[Idle]
+    F --> H[Schedule a transmog pass]
+    G --> H
+
+    subgraph userActions [user triggers]
+        U1[User equips gear<br/>BatchEquip hook fires]
+        U2[User toggles a preset<br/>in the overlay]
+        U3[User hotkey: apply]
+    end
+    U1 --> H
+    U2 --> H
+    U3 --> H
+
+    H --> W[Debounce worker wakes<br/>~125 ms later]
+    W --> X[sync_active_char_to_live<br/>reads live char byte<br/>rebuilds mappings if needed]
+    X --> Y[apply_all_transmog a1]
+    Y --> Z[Tear-down + apply pipeline<br/>see section 4]
+    Z --> B
+```
+
+Components:
+
+- **Load-detect thread** (`transmog_worker.cpp :: load_detect_thread_fn`). Wakes once per second. Resolves the player component via the static `WS -> ActorManager -> UserActor -> +0xD8` chain, and reads the character-index byte to swap the active preset on in-game character switches.
+- **Hooks** (`transmog_hooks.cpp`). Two apply triggers: `BatchEquip` at `+0x007605B0` and `VisualEquipChange (VEC)` at `+0x007733B0`. On fire, they record the passed-in `a1` and schedule a pass.
+- **Debounce worker** (`transmog_worker.cpp :: run_debounced_apply`). Single thread consuming scheduled apply requests, coalescing bursts.
+
+The rest of this document focuses on one apply pass (node `Y`).
+
+---
+
+## 4. One apply pass
+
+`apply_all_transmog()` in `transmog_apply.cpp` executes as a short state machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Guard
+    Guard: Enter guarded region
+    Guard: in_transmog = true
+    Guard: suppress_vec = true
+    Guard --> SnapshotReal
+
+    SnapshotReal: Snapshot real item ids per slot
+    SnapshotReal: walks auth table at a1+0x78
+    SnapshotReal: realItemId[k] filled via IndexedStringLookup
+    SnapshotReal --> ClearCache
+
+    ClearCache: Clear dispatch cache entries
+    ClearCache: a1+0x1B8 array, reset subCount for our slots only
+    ClearCache: leaves other slots untouched
+    ClearCache --> PhaseA
+
+    PhaseA: Phase A tear-down previous fake
+    PhaseA: for every slot that had a fake applied before
+    PhaseA: call tear_down_by_item_id(a1, prevFakeId, slotTag)
+    PhaseA: if the previous fake used a carrier also tear down the carrier
+    PhaseA: briefly flips charClassBypass 0x74 to 0xEB so the NPC item resolves
+    PhaseA --> PhaseB
+
+    PhaseB: Phase B tear-down real item
+    PhaseB: for every active slot
+    PhaseB: call tear_down_real_part(a1, slotTag)
+    PhaseB: marks real_damaged[slot] = true
+    PhaseB --> Apply
+
+    Apply: Apply the fake
+    Apply: for each active slot with a target item
+    Apply: decide direct apply or carrier-patch
+    Apply: call SlotPopulator(a1, itemData, swapEntry)
+    Apply --> Restore
+
+    Restore: Restore real items for unticked slots
+    Restore: if user unticked a slot that we had torn down
+    Restore: call apply_transmog(a1, realId) to put the mesh back
+    Restore --> SuppressSetup
+
+    SuppressSetup: Arm PartAddShow suppression mask
+    SuppressSetup: bit per slot where fake differs from real
+    SuppressSetup: stops glide-exit and landing anims from showing real helm
+    SuppressSetup --> Unguard
+
+    Unguard: Exit guarded region
+    Unguard: suppress_vec = false
+    Unguard: in_transmog = false
+    Unguard --> [*]
+```
+
+The `__finally` around this state machine clears `in_transmog` and `suppress_vec` even if a step throws an SEH exception; without it, a fault would leave hooks gagged permanently and no further equip events would fire through the mod.
+
+### 4.1 Phase A -- "forget the old fake"
+
+When the mod applies a new preset, the previous preset is still on screen. Phase A walks the slots the mod wrote to last time (`last_applied_ids`) and asks the engine to remove those meshes from the scene graph:
+
+```
+tear_down_by_item_id(a1, prevFakeId, slotTag)
+  -> IndexedStringLookup(&prevFakeId)           // descriptor hash
+  -> SafeTearDown(a1, hash, slotTag)            // label at 0x14075FE60
+                                                // (inside sub_14075F9E0)
+       -> internal detach path at 0x1425EBAE0   // inside sub_1425EACA0
+                                                // detaches mesh, particle
+                                                // emitters, anim controllers
+                                                // from the scene
+```
+
+No write to `a1+0x78` (auth table). No server-side notification. Save file bytes unchanged across the call. SafeTearDown is a scene-graph operation only -- it removes the mesh from the render list and drops the renderer's internal refs.
+
+If the previous apply used a carrier, the mod briefly flips `charClassBypass` at `0x141D5F538` from `0x74` (`jz short`) to `0xEB` (`jmp short`) so the engine's class check accepts the NPC carrier during tear-down. The byte is restored to `0x74` the moment tear-down returns.
+
+### 4.2 Phase B -- remove the real mesh so the fake can take its place
+
+Phase B calls a different tear-down path that walks the auth table directly:
+
+```
+tear_down_real_part(a1, slotTag)
+  -> container = *(a1 + 0x78)
+  -> base     = *(container + 0x08)              // stride 0xC8 entries
+  -> count    = *(container + 0x10)
+  -> for i in 0..count
+       -> entry = base + i * 0xC8
+       -> if *(entry + 0xC0) == slotTag          // slot tag match
+              realItemId = *(entry + 0x88)       // alt first
+              if realItemId == 0xFFFF:
+                  realItemId = *(entry + 0x08)   // fall back to primary
+              -> IndexedStringLookup(&realItemId)
+              -> SafeTearDown(a1, hash, slotTag)
+```
+
+1. The walk **reads** entries to find the real item id. It does not write to any entry.
+2. Tear-down is a renderer-side operation. The engine's belief about what is equipped is unchanged.
+
+After Phase B, `real_damaged[slotIdx] = true` records that the real mesh is currently missing from the scene graph. That flag is consulted in Restore if the user unticks a slot in the overlay.
+
+### 4.3 Apply -- draw the fake mesh
+
+For every active slot with a target item, the mod calls SlotPopulator (the same function the engine itself uses to attach armor). Two flavours:
+
+**Direct apply** when the fake is something the active character can normally wear:
+
+```
+apply_transmog(a1, targetItemId)
+  itemData = { word targetId at +0, defaults elsewhere }
+  swapEntry = zero-initialised via InitSwapEntry
+  SlotPopulator(a1, &itemData, &swapEntry)
+```
+
+**Carrier-patch apply** when the fake belongs to another character or an NPC. The engine's equip gate checks a `u16` at `desc+0x42` (equip-type, `0x0004` for Kliff, `0x0001` for Oongka/Damiane/NPCs). If the fake's byte does not match the active character's expected value, direct apply is rejected. The mod builds a hybrid descriptor:
+
+```mermaid
+flowchart LR
+    T[Target descriptor<br/>0x400 bytes total] -->|memcpy| H[Hybrid buffer<br/>VirtualAlloc'd]
+    C[Carrier descriptor] -->|overlay +0x42 u16| H
+    H -->|InterlockedExchange64<br/>into carrier slot| Slot[Carrier slot pointer<br/>in catalog]
+    Slot --> SP[SlotPopulator<br/>reads target meshes<br/>sees carrier equip-type]
+    SP -->|on return<br/>InterlockedExchange64| Restore[Original carrier<br/>descriptor pointer]
+    Restore --> Free[VirtualFree hybrid buffer]
+```
+
+Exactly one field is patched: the equip-type at `+0x42`. Every other byte in the hybrid comes from the target (meshes, textures, tints, rule classifiers). SlotPopulator reads the patched byte during its visual-config matching loop (label `+0x14076CAED` inside `sub_14076C7F0`), accepts the carrier's class identity, then renders the target's visual data.
+
+During the call, the `charClassBypass` byte is again flipped to `0xEB` so any deeper class check also passes. Bypass and descriptor pointer are both restored inside a `__finally` so an SEH fault cannot leave the catalog corrupted. The hybrid buffer is freed immediately after.
+
+Source: `CrimsonDesertLiveTransmog/src/transmog_apply.cpp` (`k_descBufSize = 0x400` constant, `charClassBypass` flip at line ~359 and ~507; hybrid assembly around lines ~320--342).
+
+### 4.4 Restore -- put the real item back if the user unticked
+
+If the user turns off a slot in the overlay, the mod needs to put the real mesh back. This is a SlotPopulator call with the real item id the mod snapshotted during the real-id sweep at the top of the dispatch.
+
+### 4.5 PartAddShow suppression
+
+The engine occasionally bypasses the regular scene-graph path and calls `PartAddShow` directly, most notably during glide exits, horse dismounts, and some action-chart landings. If that happens while the mod has torn down the real mesh, the real helm flashes visible for a frame or two. The mod hooks PartAddShow and keeps a small table of suppressed part hashes; while a slot is in the torn-down state, any add-show call for one of that slot's part hashes returns zero immediately without touching the scene graph.
+
+Source: `CrimsonDesertLiveTransmog/src/part_show_suppress.cpp`.
+
+---
+
+## 5. Memory write surface
+
+Every absolute write the mod performs:
+
+| Address | Size | Frequency | Reason | Restore |
+|---------|------|-----------|--------|---------|
+| `0x141D5F538` | 1 byte | during carrier-apply / tear-down | Flip `JZ` (`0x74`) to `JMP` (`0xEB`) so NPC carriers pass the class check | Restored within the same function under `__finally` |
+| `a1 +0x1B8..+0x1C4` (dispatch cache) | ~16 bytes per slot | during apply | Invalidate stale cache entries for mod-owned slots | Natural overwrite by SlotPopulator on the next apply |
+| Mod-allocated heap buffer (`VirtualAlloc`) | `0x400` bytes per carrier apply | during carrier-apply | Build hybrid descriptor | Freed via `VirtualFree` before the function returns |
+| Carrier slot pointer in item catalog | 8 bytes via `InterlockedExchange64` | during carrier-apply | Redirect catalog lookup to the hybrid for one call | Swapped back to original within the same function under `__finally` |
+
+No writes to the auth table at `a1+0x78` or its entries. No writes to save-file-backed state. On DLL unload, all mod-side arrays are released; the hybrid buffer is freed; `charClassBypass` is `0x74` because every flip is paired with a restore in a `__finally`.
+
+---
+
+## 6. Event-driven state transitions
+
+| Event | What the mod sees | Mod response |
+|-------|-------------------|--------------|
+| Zone transition | `BatchEquip` hook fires with a different `a1`. | Wipes `real_damaged` and `last_applied_real_ids` (arrays referenced previous world's memory). Schedules a fresh dispatch. |
+| Save-load | Same as zone transition. Server resends auth table, BatchEquip fires, mod re-applies. | Preset file unchanged. Real gear unchanged. Fake gear re-applies within a second. |
+| Character control swap (Kliff -> Damiane) | Load-detect thread reads a different value from `ActorManager + 0x30`. The controlled actor at `UserActor + 0xD8` now points to Damiane. | Switch UI preset list, rebuild `slot_mappings` from Damiane's active preset, clear drop-detection, schedule a dispatch. |
+| World reload (death, fast travel, manual reload) | `resolve_player_component()` returns a new component pointer. | Same flow as zone transition. |
+| Uninstall the mod | DLL unloaded on next launch. | No-op. Save file was never touched. |
+
+Source: `CrimsonDesertLiveTransmog/src/transmog_worker.cpp` (`resolve_player_component` around line 139).
+
+---
+
+## 7. Recursion guards
+
+`in_transmog` and `suppress_vec` look similar but serve different scopes.
+
+- **`in_transmog`** is scoped to a single SlotPopulator call. Set true on entry, cleared on return. Without it, SlotPopulator's own internal equip-event fan-out would re-enter the VEC hook, which would schedule another apply, which would call SlotPopulator again. One guard, one call, ~50 ms.
+- **`suppress_vec`** wraps the entire dispatch. Set true at the top of `apply_all_transmog`, cleared at the bottom. A dispatch touches multiple slots and therefore calls SlotPopulator multiple times. Each SlotPopulator call can fire VEC internally. Without the outer guard, each VEC fire would schedule another dispatch behind the current one, producing visible flicker and cascading applies that never converge.
+
+Both guards are `std::atomic<bool>` in `shared_state.cpp` and are paired with `__finally` restores so a fault during apply cannot leave them stuck muted.
+
+---
+
+## 8. Verification checklist
+
+To confirm the mod does not touch persistent state:
+
+1. **Compare saves.** Make a save while transmogged. Quit. Remove the mod. Relaunch. Load the save. Real gear is present; transmog mesh is gone. Save-on-disk bytes are identical to a save made with the mod never installed.
+2. **Inspect the auth table in Cheat Engine.** Walk `a1 +0x78 +0x08`, stride `0xC8`, and compare the item word at `+0x08` / `+0x88` before and after an apply. Bytes are identical. Only the scene graph at `a1 +0x1B8` and the renderer-side mesh refs change.
+3. **Read the log.** With `LogLevel = Trace` in the INI, every dispatch prints the source and target of every tear-down and every apply call, the carrier ids used, and the hybrid descriptor writes.
+
+---
+
+## 9. Patch-migration anchors
+
+If the game binary shifts, the highest-churn items are:
+
+- SlotPopulator / BatchEquip / VEC entry points (`+0x007727F0`, `+0x007605B0`, `+0x007733B0`). Re-scan via the AOBs in `aob_resolver.hpp` / `constants.hpp`.
+- The `charClassBypass` JZ byte at `0x141D5F538`. Look for a `movzx eax,[...]; cmp al,<class>; jz short` pattern in the equip path (verified via `sub_141D5F470`).
+- Auth-table stride `0xC8` and slot-tag offset `+0xC0`.
+- Descriptor byte `+0x42` (equip-type). If the engine starts gating equip on additional bytes, the patch list in `k_carrierPatches` will need to grow.
+
+---
+
+## 10. Related modules
+
+CrimsonDesertEquipHide research will land under `CrimsonDesertEquipHide/docs/research/` once that mod's RE artifacts are lifted into the shared knowledge base format. This document and its sibling `live-transmog-source-of-truth.md` are the pattern to follow.

--- a/CrimsonDesertLiveTransmog/docs/research/live-transmog-source-of-truth.md
+++ b/CrimsonDesertLiveTransmog/docs/research/live-transmog-source-of-truth.md
@@ -1,0 +1,325 @@
+# Live Transmog -- Source of Truth
+
+Byte-level reference for every address, offset, and AOB the Live Transmog mod depends on in the Crimson Desert binary. Structured so that when a game patch shifts an address the hook point can be re-found from surrounding byte patterns. Each section lists the semantic role first, then the concrete offsets / bytes / AOBs.
+
+Verified against **Crimson Desert v1.03.01** (image base `0x140000000`). IDA anchors spot-checked 2026-04-21 (see §8).
+
+---
+
+## 1. WorldSystem chain -- resolving the currently-controlled actor
+
+### 1.1 Static entry point
+
+The mod scans for the WorldSystem global-pointer holder via `signatures::WORLD_SYSTEM_P1_SmallFunc` and its fallbacks. On v1.03.01 the holder resolves to:
+
+```
+WS holder : CrimsonDesert.exe + 0x05D2AEE8   (absolute 0x145D2AEE8)
+```
+
+`*WS_holder` -> `WorldSystem` instance pointer (lives on the game heap; value changes per session).
+
+### 1.2 Chain to the currently-controlled character actor
+
+```
+WS holder          : 0x145D2AEE8           (scanned via AOB at init)
+  +0x30            -> ActorManager          (singleton, updated on world load)
+    +0x28          -> UserActor             (singleton, ClientUserActor class;
+                                             the POINTER itself does NOT swap
+                                             when the player switches chars)
+      +0xD0        -> "primary" body actor  (stable = Kliff in the current
+                                             story progression)
+      +0xD8        -> CURRENTLY-CONTROLLED  (this is the useful one --
+                     body actor            switches when user swaps char)
+        +0x68      -> sub-component
+          +0x38    -> wrapper / "player component"
+                    (what the apply pipeline accepts as `a1`)
+        +0x88      -> typeEntry pointer
+          +1 (u8)  -> role byte (see §2.2)
+```
+
+`user+0xD8` falls back to Kliff's actor when Kliff is the active character (so `+0xD0` and `+0xD8` coincide). Reading `+0xD8` unconditionally is therefore safe for all three playable characters.
+
+### 1.3 Character index byte
+
+```
+ActorManager +0x30 (first byte, u8)  :  1 = Kliff, 2 = Damiane, 3 = Oongka
+```
+
+This byte is the single cheapest signal for "who is controlled right now". The mod reads it in `read_controlled_char_idx_seh()` (`shared_state.cpp`) and polls it once per second in `load_detect_thread_fn` (`transmog_worker.cpp`).
+
+### 1.4 How the mod resolves `a1` at apply time
+
+```cpp
+// transmog_worker.cpp :: resolve_player_component() (around line 139)
+ws       = *(0x145D2AEE8)
+am       = *(ws  + 0x30)
+user     = *(am  + 0x28)
+actor    = *(user + 0xD8)              // <-- per-character
+te       = *(actor + 0x88)             // pointer-valid check only
+sub1     = *(actor + 0x68)
+a1       =  *(sub1 + 0x38)             // passes into SlotPopulator
+```
+
+The pre-2026-04-21 version walked `+0xD0` and rejected actors whose role byte was not `1` -- both wrong for companions. If the binary shifts and offsets change, start by re-finding the chain via:
+
+* `WORLD_SYSTEM_P*` AOBs in `constants.hpp` / `aob_resolver.hpp` (shared with CrimsonDesertCore).
+* The RTTI class name on the singleton at `am+0x28` should read `.?AVClientUserActor@pa@@`.
+* `user+0xD0` / `+0xD8` slots both hold `.?AVClientChildOnlyInGameActor@pa@@` pointers.
+
+---
+
+## 2. Character identification
+
+### 2.1 Body-kind classifier sets (CE-verified 2026-04-21)
+
+Every armor's rule list (`desc+0x248`, stride `0x38`, count at `desc+0x250`) contains classifier arrays (ptr `rule+0x20`, count `rule+0x28`, u16 tokens). The tokens partition the catalog into disjoint body families:
+
+| Role                   | Token set                                 |
+|------------------------|-------------------------------------------|
+| **Male humanoid**      | `0x0018, 0x0058, 0x02E3`                  |
+| **Female humanoid**    | `0x0072, 0x0382, 0x0300`                  |
+| Kliff-specific         | `0x0015, 0x039D`                          |
+| Oongka-specific        | `0x0028`                                  |
+| Damiane/Demian-specific| `0x0021`                                  |
+| Horse family           | `0x142B, 0x0037, 0x14A5, 0x14D6, 0x1501`  |
+| Pet cat                | `0x183F, 0x22C7, 0x22B4, 0x22BA, 0x22AE`  |
+| Pet dog                | `0x0D69, 0x4397, 0x2214, 0x0D74`          |
+
+Any token `>= 0x1000` is classified by the mod as **non-humanoid** (`k_nonHumanoidTokenThreshold` in `item_name_table.cpp`). Humanoid tokens observed so far all fit below `0x0400`.
+
+### 2.2 Role byte -- NOT a reliable identifier
+
+`*(actor+0x88)+1` is **not** a player/NPC flag despite older code treating it as one. Observed values:
+
+| Character state                                  | Byte        |
+|--------------------------------------------------|-------------|
+| Kliff, controlled (ClientUserActor)              | 0           |
+| Kliff, backgrounded (ClientChildOnlyInGameActor) | 1           |
+| Damiane, controlled                              | 0           |
+| Damiane, backgrounded                            | 4           |
+| Oongka                                           | also varies |
+
+Treat pointer-validity as the only safe gate. The in-hook filter (`is_player_actor` in `transmog_hooks.cpp`) accepts the byte being in `{0, 1}` since both forms of the same humanoid actor show up on hook paths; deeper filters use the classifier-token sets above.
+
+### 2.3 Equip-type byte at `desc+0x42` (u16)
+
+| Character | Expected equip-type |
+|-----------|---------------------|
+| Kliff     | `0x0004`            |
+| Oongka    | `0x0001`            |
+| Damiane   | `0x0001`            |
+| Most NPCs | `0x0001`            |
+
+An item whose equip-type differs from the active character's expected value needs the carrier-patch path (see §3). This is what `needs_carrier(itemId, charName)` checks in `transmog_apply.cpp`.
+
+### 2.4 Picker body-kind UI classification
+
+```
+BodyKind::Generic      -- no classifier tokens (rule-less cosmetics)
+BodyKind::Male         -- has >=1 male-body token, no female/non-humanoid
+BodyKind::Female       -- has >=1 female-body token, no male/non-humanoid
+BodyKind::Both         -- rare: both male AND female tokens
+BodyKind::Ambiguous    -- has humanoid-range tokens but none in male/female
+                          set (e.g. Antumbra/Badran/Luka gloves with
+                          only `0x012F`). Picker colors these amber;
+                          render fidelity is inconsistent.
+BodyKind::NonHumanoid  -- any token >= 0x1000 (horse, pet, wagon, etc.).
+                          Never rendered on a human body.
+```
+
+Derivation lives in `item_name_table.cpp :: item_body_bits()`.
+
+---
+
+## 3. Carrier system (cross-character transmog)
+
+### 3.1 Why carriers exist
+
+The game's equip pipeline rejects an item that does not match the active character's equip-type / classifier rules. To render an NPC or cross-character visual, the mod uses a **carrier** (an item the active character CAN equip) and patches its descriptor to substitute the target's visuals while keeping the carrier's class signature at `desc+0x42`.
+
+### 3.2 Hybrid descriptor patch
+
+```
+hybrid        = copy of target descriptor   (target's rule list, meshes, etc.)
+hybrid[+0x42] = carrier[+0x42]              (equip-type -- the only gated field)
+```
+
+Stride between descriptors observed at `0x400` bytes (see `k_descBufSize` in `transmog_apply.cpp`, line ~199). Buffer is SEH-guarded; the mod over-reads a full page and the engine only cares about the bytes actually read.
+
+### 3.3 Per-character carrier sets
+
+Defined in `transmog_apply.cpp`:
+
+```cpp
+k_kliffCarriers    = { Kliff_PlateArmor_Helm, _Armor, _Cloak, _Gloves, Kliff_Plate_Boots }
+k_oongkaCarriers   = { Oongka_PlateArmor_Helm_II, Oongka_Basic_Leather_Armor,
+                       Oongka_Basic_Leather_Cloak, Oongka_Basic_Leather_Gloves,
+                       Oongka_PlateArmor_Boots_II }
+k_damianeCarriers  = { Demian_PlateArmor_Helm_I, Demian_Leather_Armor,
+                       Demian_Leather_Cloak, Demian_Leather_Gloves_I,
+                       Demian_Plate_Boots_III }
+```
+
+Kliff and Oongka share three male-body tokens but the engine still rejects Kliff's equip-type `0x0004` at Oongka's slot gate, so Oongka needs his own carrier set matching his `0x0001` type. Falling back to `k_kliffCarriers` is the last-chance path when a character-specific name fails to resolve.
+
+### 3.4 `charClassBypass` byte toggle
+
+```
+Address   : resolved via signatures::CharClassBypass_P1_MovzxCmpLoop
+            (observed absolute on v1.03.01 = 0x141D5F538)
+Original  : 0x74  (jz short -- class check required)
+Bypass    : 0xEB  (jmp short -- class check skipped, forces acceptance)
+```
+
+IDA verification (2026-04-21): the instruction at `0x141D5F538` is `jz short loc_141D5F542` inside a `cmp r9w,[r8+rcx*2]; jz; inc ecx; cmp ecx,edx; jb` classifier-scan loop (host function `sub_141D5F470`).
+
+Toggled during Phase A tear-down (in `RealPartTearDown::tear_down_by_item_id` via `carrier_swap_and_call`) so carrier-bearing fakes can be torn down on characters whose class normally rejects the carrier item. Restored to `0x74` immediately after. The mod sanity-checks the byte on resolve (`byte=0x74 OK` log line); if the landed byte is anything else the mod refuses to install.
+
+If a patch shifts this address:
+* Re-scan for the `movzx eax,[...]; cmp al,<class>; jz <short>` loop.
+* The `jz`'s 2-byte jump is the toggle site; the first byte (`0x74` opcode) is what we overwrite.
+
+---
+
+## 4. Hook points
+
+### 4.1 BatchEquip (game-side inventory commit)
+
+```
+Signature  : signatures::BatchEquip_P1_FullPrologue
+Resolved   : CrimsonDesert.exe + 0x007605B0   (IDA: sub_1407605B0, size 0x87A)
+Arg0 (rcx) : a1       (equip wrapper; *(a1+8) = actor)
+Purpose    : fires when the game commits a batch of equipment changes;
+             the mod captures `a1` into shared_state::player_a1().
+```
+
+Filter: `is_player_actor(a1)` gate in `transmog_hooks.cpp` -- checks `*(a1+8) -> +0x88 -> +1` byte is in `{0, 1}` and the typeEntry pointer is readable. Any humanoid controlled/backgrounded actor passes.
+
+### 4.2 VisualEquipChange (VEC)
+
+```
+Signature  : signatures::VisualEquipChange_P1_FullPrologue
+Resolved   : CrimsonDesert.exe + 0x007733B0   (IDA: sub_1407733B0, size 0x42A)
+Args (rcx, dx, r8w, r9)
+           = (a1, slotId, itemId, unused)
+Purpose    : fires on every visual-equip transition. Captures `a1`,
+             filters to armor slot tags, schedules a transmog pass.
+```
+
+Armor slot tags the mod cares about (CE-verified via HW BP on `sub_148EB6700`):
+
+```
+0x0003 = Helm
+0x0004 = Chest
+0x0005 = Gloves
+0x0006 = Boots
+0x0010 = Cloak
+```
+
+Other tags (weapons, rings, shoulders, belts) are captured as `a1` but do not trigger a transmog pass.
+
+### 4.3 SlotPopulator (direct call, not hooked)
+
+```
+Signature  : signatures::SlotPopulator_P1_FullPrologue
+Resolved   : CrimsonDesert.exe + 0x007727F0   (IDA: sub_1407727F0, size 0x367)
+Prototype  : __int64 slotPop(__int64 a1, uint16_t* itemData, __int64 swapEntry)
+```
+
+The mod calls this directly to push a target/carrier item through the visual pipeline. Sanity: if this address is wrong, expect immediate CTD on first apply. The resolver logs `SlotPopulator resolved via '...' at 0x...` at init.
+
+### 4.4 InitSwapEntry
+
+```
+Signature : signatures::InitSwapEntry_P1_FullPrologue
+Resolved  : CrimsonDesert.exe + 0x01D56620    (IDA: sub_141D56620, size 0xB3)
+Role      : zero-init a SlotPopulator "swap entry" before passing it
+            into slotPop.
+```
+
+### 4.5 PartAddShow, SafeTearDown, SubTranslator, MapLookup
+
+Support hooks for the tear-down / name-lookup pipeline. See the `[dispatch] tear_down helpers resolved` line at init for resolved addresses. Signatures in `constants.hpp` / `aob_resolver.hpp`.
+
+SafeTearDown call label sits at `0x14075FE60` inside `sub_14075F9E0` (size `0x5CD`). The internal detach path at `0x1425EBAE0` sits inside `sub_1425EACA0` (size `0xEC6`). These are internal call labels, not function starts -- resolve via the AOB, not by address.
+
+---
+
+## 5. Item filter rules (picker UI)
+
+Implemented in `overlay_ui.inl`. An item shows in the slot picker when:
+
+1. **Slot match** (if "Exact" toggle is on) -- `category_of(itemId)` reads the canonical item-type code at `desc+0x44` captured at catalog-build time:
+   ```
+   0x04 -> Helm    0x05 -> Chest    0x06 -> Gloves
+   0x07 -> Boots   0x45 -> Cloak
+   ```
+Every other code (shields `0x20`, horse armor `0x53`, quest `0xFFFF`, etc.) maps to `TransmogSlot::Count` and the item is hidden as non-equipment. No name parsing is performed; the engine itself uses this byte as the item category so we trust it.
+
+2. **Not flagged non-humanoid** -- `BodyKind::NonHumanoid` items are always hidden (no toggle to show them; they never render on a humanoid skeleton).
+
+3. **Body-kind match** (if "Hide cross-body" toggle is on -- default): item's `BodyKind` matches the active character's body (Male for Kliff/Oongka, Female for Damiane), OR is Generic / Both. Per-char override available in the overlay Body dropdown.
+
+4. **Variant / incompatibility** filters -- existing `hideIncompatible` and `hideVariants` checkboxes still apply; the former is now equivalent to "hide non-humanoid + non-slot-matched".
+
+Color tiers on rows:
+
+| Color   | Condition                              | Meaning                          |
+|---------|----------------------------------------|----------------------------------|
+| red     | `!bodyMatches && !hasVariantMeta`      | Crash risk -- engine rejects     |
+| orange  | `!bodyMatches && hasVariantMeta`       | Carrier path works but body      |
+|         |                                        | mismatch; mesh may break         |
+| amber   | `BodyKind::Ambiguous && hasVariantMeta`| Render outcome inconsistent      |
+| blue    | `hasVariantMeta && body matches`       | Normal NPC-variant carrier       |
+| default | everything else                        | Clean base item                  |
+
+---
+
+## 6. Character-swap auto-detect
+
+Implemented in `transmog_worker.cpp :: load_detect_thread_fn`.
+
+1. Poll `read_controlled_char_idx_seh()` once per second.
+2. On change between known characters, call `pm.set_active_character(live)`, wipe `slot_mappings`, run `apply_to_state()` so `slot_mappings` reflects the live character's active preset, reset drop-detection state, save.
+3. Schedule a transmog apply if the mod is enabled.
+
+`run_debounced_apply` additionally calls `sync_active_char_to_live()` at the start of every apply pass so that even UI-driven applies (preset clicks, character picker) target the correct character regardless of what `pm.active_character()` was momentarily set to by the UI.
+
+---
+
+## 7. Known caveats
+
+* `UserActor+0xD8` was verified on three characters only; if Pearl Abyss adds a fourth playable party member, the slot may or may not extend to `+0xE0`, `+0xE8`, etc. Worth re-probing after any DLC / major patch.
+* The role byte at `typeEntry+1` is **per-character**, not a clean player/NPC flag. Do not gate on specific values.
+* Heap-pool addresses (`ActorManager`, `UserActor`, wrappers) change per session -- never hard-code them. Always resolve via the static `WS_holder` chain or a fresh AOB scan.
+* `charClassBypass` is a single `JZ` byte; if the game ever moves it to a `CMOV` or uses IBT-hardened code, that instruction may change size/encoding. Watch for resolve-time `CharClassBypass byte mismatch` warnings.
+
+---
+
+## 8. IDA verification status (2026-04-21)
+
+Spot-checked against the v1.03.01 IDB:
+
+| Anchor | Status |
+|--------|--------|
+| BatchEquip `+0x007605B0` (`sub_1407605B0`, size 0x87A) | VERIFIED |
+| VisualEquipChange `+0x007733B0` (`sub_1407733B0`, size 0x42A) | VERIFIED |
+| SlotPopulator `+0x007727F0` (`sub_1407727F0`, size 0x367) | VERIFIED |
+| InitSwapEntry `+0x01D56620` (`sub_141D56620`, size 0xB3) | VERIFIED |
+| `charClassBypass` at `0x141D5F538` original byte `0x74` | VERIFIED (bytes `74 08 FF C1`; `jz short loc_141D5F542` inside `sub_141D5F470`) |
+| `WS holder` at `0x145D2AEE8` | Address in `.data` confirmed; live pointer value session-dependent |
+| SafeTearDown call label `0x14075FE60` | INTERNAL LABEL (inside `sub_14075F9E0`, size 0x5CD). Not a function entry; resolve via AOB. |
+| Scene-graph detach label `0x1425EBAE0` | INTERNAL LABEL (inside `sub_1425EACA0`, size 0xEC6). Not a function entry. |
+| SlotPopulator visual-config match label `0x14076CAED` | INTERNAL LABEL (inside `sub_14076C7F0`, size 0x71B). Not a function entry. |
+
+Deferred verification (not spot-checked this pass -- recommend a follow-up if any of these are edited):
+
+* AOB strings inside `constants.hpp` / `aob_resolver.hpp`.
+* Auth-table stride `0xC8`, slot-tag offset `+0xC0`, primary/alt item id offsets `+0x08` / `+0x88`.
+* Dispatch cache layout at `a1+0x1B8..+0x1C4`.
+* Descriptor `+0x42` equip-type byte semantics (Kliff 0x0004 vs others 0x0001) -- rely on in-code `needs_carrier()` truth.
+* Rule list layout `desc+0x248` stride `0x38` count `desc+0x250`.
+
+---
+
+Maintained alongside the source; bump the "Verified game version" line at the top whenever an address or AOB is re-probed against a new patch.


### PR DESCRIPTION
## Summary
Adds `CrimsonDesertLiveTransmog/docs/research/` as the project knowledge base for mod runtime internals.

- **[live-transmog-architecture.md](CrimsonDesertLiveTransmog/docs/research/live-transmog-architecture.md)** -- runtime pipeline: hook points, apply state machine, memory write surface, event-driven transitions. Cross-references `CrimsonDesertLiveTransmog/src/` files.
- **[live-transmog-source-of-truth.md](CrimsonDesertLiveTransmog/docs/research/live-transmog-source-of-truth.md)** -- byte-level reference: WS chain offsets, carrier descriptor layout, hook RVAs, `charClassBypass` site, IDA verification log.
- **[research/README.md](CrimsonDesertLiveTransmog/docs/research/README.md)** -- index. Reserves a slot for future `CrimsonDesertEquipHide/docs/research/equip-hide-*.md` entries under the same convention.

All anchors verified against **Crimson Desert v1.03.01** (PC binary, image base `0x140000000`). Spot-checked 9 load-bearing function / byte anchors via IDA; 6 confirmed, 3 annotated as internal call labels rather than function entries.

## Non-goals
- No code changes.
- No behaviour changes.
- No EquipHide research (reserved for a follow-up).
