### PR TITLE
feat(live-transmog): auto-apply per controlled character

### DIFF
--- a/CrimsonDesertCore/CMakeLists.txt
+++ b/CrimsonDesertCore/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 
 add_library(CrimsonDesertCore STATIC
     src/aob_resolver.cpp
+    src/controlled_char.cpp
     src/indexed_string_table.cpp
     src/dev_helpers.cpp
 )

--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -1,0 +1,163 @@
+#ifndef CDCORE_CONTROLLED_CHAR_HPP
+#define CDCORE_CONTROLLED_CHAR_HPP
+
+#include <cstdint>
+#include <string_view>
+
+// ---------------------------------------------------------------------------
+// Controlled-character resolver.
+//
+// Walks the live WorldSystem chain on every query and identifies the
+// currently-controlled protagonist via a two-part decode: a structural
+// invariant for Kliff plus a slot-index diff for the two companions.
+//
+//   *(WS holder)           -> WorldSystem instance (session heap)
+//   *(ws   + 0x30)         -> ActorManager singleton
+//   *(am   + 0x28)         -> UserActor singleton (ClientUserActor)
+//   *(user + 0xD0)         -> primary actor slot (always Kliff in the
+//                             current story progression)
+//   *(user + 0xD8)         -> controlled client actor (rotates on swap)
+//
+// Decode rules:
+//   1. If *(user + 0xD0) == *(user + 0xD8), the primary slot coincides with
+//      the controlled slot, which only happens when Kliff is the active
+//      character. This is a pure structural check, independent of any
+//      numeric field that could shift across saves.
+//
+//   2. Otherwise, a companion is controlled. The byte at actor+0x60 is a
+//      per-actor slot index assigned at allocation time in a fixed order
+//      (Kliff, Damiane, Oongka). The absolute value varies per save (the
+//      slot-index pool is shared with other actors), but WITHIN any given
+//      save:
+//          Damiane.slot == Kliff.slot + 1
+//          Oongka.slot  == Kliff.slot + 2
+//      Using Kliff's slot (always at user+0xD0) as the anchor, the diff
+//      against the controlled actor's slot uniquely identifies the
+//      companion.
+//
+// Previous decode attempts -- (party_class, char_kind) at +0xDC/+0xEC -- are
+// NOT used. Both values shift with party composition (e.g. Damiane in a
+// 3-party save and Oongka in the same save both read (party_class=3,
+// char_kind=2), making the key structurally ambiguous).
+//
+// To absorb transient torn reads (the controlled-actor pointer can be
+// briefly stale during a swap event) the resolver keeps a last-known-good
+// cache: any decode that does not match one of the three known identities
+// returns the cached value instead, and the cache refreshes whenever a
+// fresh known-identity decode succeeds.
+//
+// The resolver requires the consumer to publish the WorldSystem holder
+// static address once (typically right after that mod's own AOB scan
+// resolves it). Until set_world_system_holder() has been called, every
+// query returns Unknown. This avoids duplicating the WorldSystem AOB scan
+// across every consumer.
+//
+// Known assumption: character allocation order is always Kliff, Damiane,
+// Oongka. A save containing only Kliff + Oongka (no Damiane) would allocate
+// Oongka at Kliff+1 and would be decoded as Damiane. No such save has been
+// observed in the current game content; if one arises, the consumer mod's
+// overlay allows manual override and the misdetection is a UX hiccup, not a
+// correctness failure.
+//
+// Thread safety:
+//   - set_world_system_holder() is safe from any thread; later writers win,
+//     which is the intended behaviour if a consumer re-resolves on reload.
+//   - current_controlled_character() is non-blocking and SEH-guarded; safe
+//     to call from any thread including the rendering thread.
+// ---------------------------------------------------------------------------
+
+namespace CDCore
+{
+    /**
+     * @brief Identifies one of the three controlled playable characters.
+     * @details The Unknown sentinel is returned before
+     *          set_world_system_holder() has been called, before the chain
+     *          walk yields a known identity (very early in the loading
+     *          screen), and after invalidate_controlled_character() until
+     *          the next chain walk observes one of the three known keys
+     *          and refreshes the cache.
+     */
+    enum class ControlledCharacter : std::uint8_t
+    {
+        Unknown,
+        Kliff,
+        Damiane,
+        Oongka,
+    };
+
+    /**
+     * @brief Publish the WorldSystem holder static address to the
+     *        controlled-character resolver.
+     * @details Both consumer mods (CrimsonDesertEquipHide and
+     *          CrimsonDesertLiveTransmog) AOB-scan for the WorldSystem
+     *          holder during their own init. Whichever resolves first
+     *          should hand the address to Core via this call so the
+     *          resolver does not need its own AOB scan. Subsequent calls
+     *          overwrite the previous value, which is the intended
+     *          behaviour when a consumer re-scans.
+     * @param holderAddr Absolute address of the WorldSystem holder slot
+     *                   (the static qword whose dereference yields the
+     *                   live WorldSystem instance pointer). Pass 0 to
+     *                   disable the resolver.
+     */
+    void set_world_system_holder(std::uintptr_t holderAddr) noexcept;
+
+    /**
+     * @brief Resolve the currently-controlled character.
+     * @details Walks WorldSystem -> ActorManager -> UserActor, reads both
+     *          the primary actor at user+0xD0 and the controlled actor at
+     *          user+0xD8 plus the slot-index byte at +0x60 on each. Decodes
+     *          Kliff by the structural invariant
+     *          `*(user+0xD0) == *(user+0xD8)` and the two companions by
+     *          the diff between the controlled slot and the primary slot
+     *          (Damiane = primary + 1, Oongka = primary + 2). When the
+     *          decode does not match a known identity (faulted chain walk,
+     *          torn read across a swap transition, unrecognised future
+     *          slot offset) the resolver returns the previously-cached
+     *          identity instead, so transient drift does not flap the
+     *          controlled character.
+     * @return The identified character, or ControlledCharacter::Unknown
+     *         when the WorldSystem holder has not been published yet,
+     *         when the chain walk faults, or when neither the live decode
+     *         nor the last-known-good cache yields a known value.
+     */
+    [[nodiscard]] ControlledCharacter current_controlled_character() noexcept;
+
+    /**
+     * @brief Short display name for a controlled character.
+     * @return A static string view ("Kliff" / "Damiane" / "Oongka") or
+     *         an empty view for Unknown.
+     */
+    [[nodiscard]] std::string_view controlled_character_name(
+        ControlledCharacter ch) noexcept;
+
+    /**
+     * @brief Convenience wrapper that returns the live name.
+     * @return Short name of the controlled character, or an empty view if
+     *         unknown.
+     */
+    [[nodiscard]] std::string_view current_controlled_character_name() noexcept;
+
+    /**
+     * @brief One-based index of the controlled character.
+     * @return 1 for Kliff, 2 for Damiane, 3 for Oongka, or 0 for unknown.
+     *         The zero sentinel matches the game's own pre-world value so
+     *         consumers can treat it uniformly.
+     */
+    [[nodiscard]] std::uint32_t current_controlled_character_idx() noexcept;
+
+    /**
+     * @brief Clear the last-known-good identity cache.
+     * @details Call on world-reload transitions (save load, return to
+     *          title) so the resolver does not keep returning the
+     *          previous save's character while the new save is still
+     *          populating the engine state. After invalidation the
+     *          resolver returns Unknown until the next chain walk observes
+     *          one of the three known keys and refreshes the cache. Safe
+     *          to call from any thread; non-blocking.
+     */
+    void invalidate_controlled_character() noexcept;
+
+} // namespace CDCore
+
+#endif // CDCORE_CONTROLLED_CHAR_HPP

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -1,0 +1,354 @@
+#include <cdcore/controlled_char.hpp>
+
+#include <DetourModKit.hpp>
+
+#include <Windows.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+
+namespace CDCore
+{
+    namespace
+    {
+        // s_wsHolder holds the absolute address of the WorldSystem holder
+        // static, published by a consumer's init code. While zero every
+        // resolver query short-circuits to Unknown so the mod degrades
+        // gracefully when the consumer has not yet completed its own AOB
+        // scan (or that scan fails on a future patch).
+        std::atomic<std::uintptr_t> s_wsHolder{0};
+
+        // s_lastGoodChar caches the most recent known identity. The chain
+        // walk can land mid-swap when the engine is rewriting user+0xD8 and
+        // produce garbage; the cache absorbs those torn reads so the
+        // resolver does not flap between Unknown and a known character
+        // within a single swap. Stored as the underlying enum value to keep
+        // the atomic lock-free on x64.
+        std::atomic<std::uint8_t> s_lastGoodChar{
+            static_cast<std::uint8_t>(ControlledCharacter::Unknown)};
+
+        // Walk offsets starting at the WorldSystem holder static:
+        //
+        //   *(holder)            -> WorldSystem instance (session heap)
+        //   *(ws   + 0x30)       -> ActorManager singleton
+        //   *(am   + 0x28)       -> UserActor singleton (ClientUserActor)
+        //   *(user + 0xD0)       -> primary actor slot (always Kliff in the
+        //                           current story progression; this value
+        //                           is the structural Kliff anchor)
+        //   *(user + 0xD8)       -> controlled client actor (rotates on swap)
+        //
+        // The UserActor pointer is stable for the lifetime of a save: only
+        // user+0xD8 rotates when the player switches which body they
+        // control. When Kliff is the controlled character, user+0xD0 and
+        // user+0xD8 reference the same actor; this coincidence is the
+        // structural Kliff detector used below.
+        constexpr std::ptrdiff_t k_wsToActorMgrOffset          = 0x30;
+        constexpr std::ptrdiff_t k_actorMgrToUserOffset        = 0x28;
+        constexpr std::ptrdiff_t k_userToPrimaryActorOffset    = 0xD0;
+        constexpr std::ptrdiff_t k_userToControlledActorOffset = 0xD8;
+
+        // Per-actor slot-index byte at actor+0x60. The engine assigns this
+        // byte at actor allocation time in a fixed character order
+        // (Kliff < Damiane < Oongka). The ABSOLUTE value varies across
+        // saves because the slot-index pool is shared with other actors,
+        // but within any given save the companions are always at
+        // (Kliff's value + 1) and (Kliff's value + 2) respectively.
+        //
+        // Observed across two distinct saves on Crimson Desert v1.03.01:
+        //   save with 2 protagonists    Kliff=1, Damiane=2             diff=1
+        //   save with 3 protagonists    Kliff=6, Damiane=7, Oongka=8   diff=1,2
+        //
+        // The byte stays stable when a character is backgrounded (verified
+        // by reading a backgrounded Oongka actor after the user swapped
+        // away from him), so the decode works for all in-session lookups
+        // regardless of which character is currently controlled.
+        //
+        // Assumption: the character allocation order is always
+        // Kliff, Damiane, Oongka. A save with only Kliff and Oongka (no
+        // Damiane) would allocate Oongka at Kliff+1 and would be decoded
+        // as Damiane. This combination has not been observed in-game; if
+        // it arises the user can override the detected character via the
+        // overlay in each consumer mod and the misdetection becomes a
+        // one-time UX hiccup rather than a correctness failure.
+        constexpr std::ptrdiff_t k_actorSlotIndexByteOffset = 0x60;
+        constexpr int k_damianeSlotDiff = 1;
+        constexpr int k_oongkaSlotDiff  = 2;
+
+        // Lower bound for "looks like a heap pointer". Any value below the
+        // 64 KiB Windows guard region is treated as null/invalid; this
+        // catches both real null pointers and the small enum-shaped values
+        // an uninitialised slot may carry before the singleton is wired up.
+        constexpr std::uintptr_t k_minValidPtr = 0x10000;
+
+        // One chain walk yields enough structural data to decode identity.
+        // Populated fully only when the walk completes without faulting; on
+        // any fault `valid` stays false and the numeric fields carry zero.
+        struct ChainProbe
+        {
+            std::uintptr_t primaryActor;
+            std::uintptr_t controlledActor;
+            std::uint8_t   primarySlot;
+            std::uint8_t   controlledSlot;
+            bool           valid;
+        };
+
+        // SEH-isolated chain walk. Lives in its own function because MSVC
+        // rejects the combination of __try and any C++ object with a
+        // non-trivial destructor in the same scope (C2712). Each
+        // intermediate pointer is rejected if it falls below the guard
+        // region so a half-torn chain cannot reach the final byte reads
+        // with garbage state.
+        //
+        // Reads BOTH user+0xD0 (primary actor, Kliff anchor) and
+        // user+0xD8 (controlled actor) plus the +0x60 slot-index byte on
+        // each actor. The two byte reads cost negligible cache traffic
+        // because the actor was just dereferenced and is already in cache.
+        ChainProbe walk_chain_seh(std::uintptr_t holder) noexcept
+        {
+            ChainProbe out{};
+            if (holder < k_minValidPtr)
+            {
+                return out;
+            }
+            __try
+            {
+                const auto ws =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(holder);
+                if (ws < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto am =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(
+                        ws + k_wsToActorMgrOffset);
+                if (am < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto user =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(
+                        am + k_actorMgrToUserOffset);
+                if (user < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto primary =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(
+                        user + k_userToPrimaryActorOffset);
+                if (primary < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto controlled =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(
+                        user + k_userToControlledActorOffset);
+                if (controlled < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto primarySlot =
+                    *reinterpret_cast<const volatile std::uint8_t *>(
+                        primary + k_actorSlotIndexByteOffset);
+                const auto controlledSlot =
+                    *reinterpret_cast<const volatile std::uint8_t *>(
+                        controlled + k_actorSlotIndexByteOffset);
+                out.primaryActor    = primary;
+                out.controlledActor = controlled;
+                out.primarySlot     = primarySlot;
+                out.controlledSlot  = controlledSlot;
+                out.valid           = true;
+                return out;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return out;
+            }
+        }
+
+        // Decode identity from a completed chain probe using the
+        // structural D0==D8 invariant for Kliff and the slot-index diff
+        // for companions. Returns Unknown when the probe is not valid or
+        // the slot diff falls outside the expected {1, 2} range.
+        ControlledCharacter decode_probe(const ChainProbe &probe) noexcept
+        {
+            if (!probe.valid)
+            {
+                return ControlledCharacter::Unknown;
+            }
+            if (probe.controlledActor == probe.primaryActor)
+            {
+                return ControlledCharacter::Kliff;
+            }
+            const int diff = static_cast<int>(probe.controlledSlot) -
+                             static_cast<int>(probe.primarySlot);
+            if (diff == k_damianeSlotDiff)
+            {
+                return ControlledCharacter::Damiane;
+            }
+            if (diff == k_oongkaSlotDiff)
+            {
+                return ControlledCharacter::Oongka;
+            }
+            return ControlledCharacter::Unknown;
+        }
+
+        // Diagnostic: log each unique (controlledSlot - primarySlot) diff
+        // observed from a valid probe, at most once per process. Four slots
+        // covers the three expected values plus one transient anomaly.
+        // Logs both the raw slot bytes and the computed diff so a future
+        // patch that alters the offset layout is immediately visible.
+        std::array<std::atomic<std::uint32_t>, 4> s_seenProbes{};
+
+        constexpr std::uint32_t k_probeSentinel = 0xFFFFFFFFu;
+
+        std::uint32_t pack_probe_signature(const ChainProbe &probe) noexcept
+        {
+            // primary in low byte, controlled in next byte, leaves the
+            // high half zero. Guaranteed distinct from k_probeSentinel
+            // because bit 31 is never set.
+            return static_cast<std::uint32_t>(probe.primarySlot) |
+                   (static_cast<std::uint32_t>(probe.controlledSlot) << 8);
+        }
+
+        void log_first_seen_probe(const ChainProbe &probe,
+                                  ControlledCharacter decoded) noexcept
+        {
+            const auto sig = pack_probe_signature(probe);
+            for (auto &slot : s_seenProbes)
+            {
+                auto prev = slot.load(std::memory_order_relaxed);
+                if (prev != 0 && (prev ^ k_probeSentinel) == sig)
+                {
+                    return;
+                }
+                if (prev == 0)
+                {
+                    const auto stamp = sig ^ k_probeSentinel;
+                    if (slot.compare_exchange_strong(
+                            prev, stamp,
+                            std::memory_order_relaxed,
+                            std::memory_order_relaxed))
+                    {
+                        const int diff =
+                            static_cast<int>(probe.controlledSlot) -
+                            static_cast<int>(probe.primarySlot);
+                        // Prefer the short character name when the decode
+                        // matched one of the three known identities.
+                        // Unknown falls back to a literal "Unknown" label
+                        // because controlled_character_name() returns an
+                        // empty view for that case and we want a
+                        // self-describing log line even for anomalies.
+                        const auto name = controlled_character_name(decoded);
+                        DMK::Logger::get_instance().info(
+                            "ControlledChar: probe primary_slot={} "
+                            "controlled_slot={} diff={} -> {}",
+                            static_cast<unsigned>(probe.primarySlot),
+                            static_cast<unsigned>(probe.controlledSlot),
+                            diff,
+                            name.empty() ? std::string_view{"Unknown"}
+                                         : name);
+                        return;
+                    }
+                    if ((prev ^ k_probeSentinel) == sig)
+                    {
+                        return;
+                    }
+                }
+            }
+            // Seen-set exhausted. The resolver stays functional; only the
+            // diagnostic log is silently dropped for additional unknown
+            // probe signatures.
+        }
+
+    } // anonymous namespace
+
+    void set_world_system_holder(std::uintptr_t holderAddr) noexcept
+    {
+        s_wsHolder.store(holderAddr, std::memory_order_release);
+
+        if (holderAddr != 0)
+        {
+            DMK::Logger::get_instance().info(
+                "ControlledChar: WorldSystem holder published at 0x{:X}",
+                static_cast<std::uint64_t>(holderAddr));
+        }
+    }
+
+    ControlledCharacter current_controlled_character() noexcept
+    {
+        const auto holder = s_wsHolder.load(std::memory_order_acquire);
+        if (holder == 0)
+        {
+            return ControlledCharacter::Unknown;
+        }
+
+        const auto probe   = walk_chain_seh(holder);
+        const auto decoded = decode_probe(probe);
+
+        if (probe.valid)
+        {
+            log_first_seen_probe(probe, decoded);
+        }
+
+        // A known-identity decode refreshes the last-known-good cache.
+        // Anything else (invalid probe from a faulted chain walk, torn
+        // read mid-swap that lands on an unexpected slot diff, or an
+        // unrecognised future slot offset) is rejected and the
+        // previously-cached identity is reused instead. When the cache
+        // itself is empty (pre-world, post-invalidation) the final return
+        // falls through to Unknown.
+        if (decoded != ControlledCharacter::Unknown)
+        {
+            s_lastGoodChar.store(static_cast<std::uint8_t>(decoded),
+                                 std::memory_order_release);
+            return decoded;
+        }
+
+        return static_cast<ControlledCharacter>(
+            s_lastGoodChar.load(std::memory_order_acquire));
+    }
+
+    std::string_view controlled_character_name(
+        ControlledCharacter ch) noexcept
+    {
+        switch (ch)
+        {
+            case ControlledCharacter::Kliff:   return "Kliff";
+            case ControlledCharacter::Damiane: return "Damiane";
+            case ControlledCharacter::Oongka: return "Oongka";
+            case ControlledCharacter::Unknown: return {};
+        }
+        return {};
+    }
+
+    std::string_view current_controlled_character_name() noexcept
+    {
+        return controlled_character_name(current_controlled_character());
+    }
+
+    std::uint32_t current_controlled_character_idx() noexcept
+    {
+        switch (current_controlled_character())
+        {
+            case ControlledCharacter::Kliff:   return 1;
+            case ControlledCharacter::Damiane: return 2;
+            case ControlledCharacter::Oongka: return 3;
+            case ControlledCharacter::Unknown: return 0;
+        }
+        return 0;
+    }
+
+    void invalidate_controlled_character() noexcept
+    {
+        // Release ordering pairs with the acquire load in
+        // current_controlled_character() so any reader that subsequently
+        // observes the Unknown sentinel also observes side effects the
+        // caller performed before invalidating (e.g. clearing per-character
+        // preset caches in preparation for a save-load transition).
+        s_lastGoodChar.store(
+            static_cast<std::uint8_t>(ControlledCharacter::Unknown),
+            std::memory_order_release);
+    }
+
+} // namespace CDCore

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,8 @@
-## [Title for next release]
+## Load-Time Auto-Apply Robustness
 
-- New feature
-- Bug fix
-- Improvement
+- Character-swap auto-detect now uses a 1 second settle window so the engine's load-time party rotation (Kliff -> Oongka -> Damiane) collapses into a single transition instead of three back-to-back applies
+- Load-detect retry loop now runs a cheap actor-readiness probe before each scheduled apply, suppressing the noisy SEH-faulted log spam previously produced when the engine parked the player wrapper on a placeholder during long world loads
+- Load-detect retry loop now aborts mid-budget if the engine swaps the player wrapper beneath it (placeholder -> real actor), handing off to the outer loop instead of burning the remainder of a ~95 second retry budget against a dead pointer
+- Cuts the visible-mismatch window after a slow load from up to ~95 seconds down to ~3-7 seconds on affected systems
+- Fixed: switching characters could apply the previous character's preset onto the new actor when the controlled-char resolver's last-known-good cache had not yet caught up to the swap (e.g. swapping to Damiane on a save with no Oongka could briefly render Oongka's transmog). The cache is now invalidated on every player-component change, not only on save load
+- Fixed: auto-apply could fail entirely on saves whose Kliff actor was constructed with different metadata (e.g. a chapter where Kliff reads as `(party_class=3, char_kind=3)` instead of the previously-verified `(4, 3)`). The controlled-character resolver now identifies Kliff via the structural invariant `*(user+0xD0) == *(user+0xD8)` and the two companions via the slot-index byte at `actor+0x60` (Damiane = primary slot + 1, Oongka = primary slot + 2), making detection robust across saves regardless of party composition

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -220,10 +220,6 @@ If you encounter issues:
 
 [size=5]Credits & Source Code[/size]
 
-[b]Author:[/b] tkhquang ([url=https://github.com/tkhquang]GitHub[/url] / [url=https://next.nexusmods.com/profile/tkhquang]Nexus[/url])
-[b]Source:[/b] [url=https://github.com/tkhquang/CrimsonDesertTools]github.com/tkhquang/CrimsonDesertTools[/url]
-[b]Report issues:[/b] [url=https://github.com/tkhquang/CrimsonDesertTools/issues]GitHub Issues[/url] or the Bugs tab on this Nexus page
-
 Built with [url=https://github.com/tkhquang/DetourModKit]DetourModKit[/url] for core functionality (AOB scanning, hook management, logging, input).
 
 [b]Third-party libraries:[/b]

--- a/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
+++ b/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
@@ -17,11 +17,11 @@ namespace Transmog::RealPartTearDown
         // Helper function pointer types. Addresses come from
         // Transmog::resolved_addrs() (populated elsewhere in init()):
         //
-        // sub_14075FE60 — Safe scene-graph tear-down.
+        // sub_14075FE60 -- Safe scene-graph tear-down.
         //   Calls sub_1425EBAE0 internally. Does NOT mutate the
         //   authoritative equip table at *(a1+0x78).
         //
-        // sub_1402D75D0 — IndexedStringA short->hash lookup. Takes the
+        // sub_1402D75D0 -- IndexedStringA short->hash lookup. Takes the
         //   address of a uint16_t slot id; returns a pointer whose
         //   first DWORD is the descriptor hash used by the rest of the
         //   equip pipeline.
@@ -117,6 +117,54 @@ namespace Transmog::RealPartTearDown
     bool is_ready() noexcept
     {
         return g_ready.load(std::memory_order_acquire);
+    }
+
+    bool is_actor_apply_ready(void *a1Raw) noexcept
+    {
+        const auto a1 = reinterpret_cast<std::uintptr_t>(a1Raw);
+        if (a1 < 0x10000)
+            return false;
+
+        // Mirrors the preamble of `tear_down_real_part` exactly. Layout
+        // constants are file-scope (not exported), so the probe lives in
+        // this TU and is exposed via the namespace function only. SEH-
+        // wrapped because the placeholder wrapper that the engine parks
+        // user+0xD8 on during world load faults at the container deref --
+        // that fault is the primary signal we are filtering on.
+        __try
+        {
+            const auto container =
+                *reinterpret_cast<volatile std::uintptr_t *>(
+                    a1 + k_containerPtrOffset);
+            if (container < 0x10000)
+                return false;
+
+            const auto arrayBase =
+                *reinterpret_cast<volatile std::uintptr_t *>(
+                    container + k_containerArrayBaseOffset);
+            if (arrayBase < 0x10000)
+                return false;
+
+            const auto count =
+                *reinterpret_cast<volatile std::uint32_t *>(
+                    container + k_containerCountOffset);
+
+            // count is the slot-entry count, not the equipped-item count
+            // (the iteration in tear_down_real_part visits all indices
+            // 0..count and skips empty slots via primary==0xFFFF and
+            // gate==0 inside the loop). A naked character still reports
+            // a full slot count -- empty slots persist as 0xFFFF
+            // sentinels. Therefore count==0 with a readable container
+            // signals an actor whose container struct is allocated but
+            // whose slot entries are not yet populated -- placeholder or
+            // mid-wiring. The upper bound rejects torn reads that would
+            // otherwise pass the lower bound by accident.
+            return count >= 1 && count <= k_maxPlausibleEntries;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return false;
+        }
     }
 
     bool resolve_helpers() noexcept
@@ -224,7 +272,7 @@ namespace Transmog::RealPartTearDown
         {
             logger.warning(
                 "[dispatch] tear_down: slot tag {:#06x} outside plausible "
-                "range [{:#x}..{:#x}] — rejecting",
+                "range [{:#x}..{:#x}] -- rejecting",
                 gameSlotTag, k_minPlausibleSlotTag, k_maxPlausibleSlotTag);
             return false;
         }
@@ -252,13 +300,13 @@ namespace Transmog::RealPartTearDown
             {
                 logger.warning(
                     "[dispatch] tear_down: container sanity failed "
-                    "(arrayBase=0x{:X} count={}) — layout may have shifted",
+                    "(arrayBase=0x{:X} count={}) -- layout may have shifted",
                     static_cast<std::uint64_t>(arrayBase), count);
                 return false;
             }
 
             // First-entry sanity log, once per session. Warns loudly if
-            // the gate qword is zero — that would mean the struct
+            // the gate qword is zero -- that would mean the struct
             // reshaped and every subsequent walk is reading garbage.
             bool expected = false;
             if (g_loggedFirstEntry.compare_exchange_strong(
@@ -286,7 +334,7 @@ namespace Transmog::RealPartTearDown
                 if (g0 == 0)
                 {
                     logger.warning(
-                        "[dispatch] tear_down: first-entry gate is zero — "
+                        "[dispatch] tear_down: first-entry gate is zero -- "
                         "PartDef struct layout may have shifted, all "
                         "subsequent walks are suspect");
                 }
@@ -338,7 +386,7 @@ namespace Transmog::RealPartTearDown
                 itemWord = *reinterpret_cast<volatile std::uint16_t *>(
                     foundEntry + k_entryPrimaryWordOffset);
 
-            // Copy to a stable local — the lookup fn takes the ADDRESS of a
+            // Copy to a stable local -- the lookup fn takes the ADDRESS of a
             // short and may dereference it multiple times.
             std::uint16_t localWord = itemWord;
             void *hashPtr = lookupFn(&localWord);

--- a/CrimsonDesertLiveTransmog/src/real_part_tear_down.hpp
+++ b/CrimsonDesertLiveTransmog/src/real_part_tear_down.hpp
@@ -47,4 +47,35 @@ namespace Transmog::RealPartTearDown
     // True iff resolve_helpers() succeeded. Used by callers to gate the
     // feature without re-checking individual function pointers.
     bool is_ready() noexcept;
+
+    /** @brief Cheap read-only probe for "is this actor ready to receive
+     *         tear_down/apply".
+     *  @details Walks the same container chain that `tear_down_real_part`
+     *           dereferences, but issues no engine calls and writes
+     *           nothing -- just verifies that `*(a1+0x78) -> container`,
+     *           `container+0x08 -> arrayBase`, and `container+0x10 ->
+     *           count` all read cleanly under SEH and that `count` is in
+     *           a plausible range (`[1, k_maxPlausibleEntries]`).
+     *
+     *           Designed for the load-detect retry loop. During world
+     *           load the engine briefly parks `user+0xD8` on a placeholder
+     *           wrapper whose actor part-registry is not yet wired; on
+     *           low-end PCs that placeholder can persist for 90+ seconds.
+     *           Calling `apply_all_transmog` against a placeholder
+     *           consistently SEH-faults inside engine calls and produces
+     *           dozens of log lines per attempt. Probing readiness first
+     *           lets the retry loop skip those attempts at microsecond
+     *           cost without shrinking the overall retry budget.
+     *
+     *           A real actor's container has a non-empty entry array
+     *           (the protagonist always has at least one equipped slot in
+     *           practice; a hypothetical naked save would be filtered
+     *           briefly until the engine swaps the wrapper). A placeholder
+     *           either faults on container deref or returns sentinel
+     *           garbage that fails the count sanity check.
+     *
+     *  @param a1 Player wrapper pointer (`*(actor+0x68)+0x38` shape, the
+     *            same value the apply pipeline accepts as `a1`).
+     *  @returns true if the chain reads cleanly and count is plausible. */
+    bool is_actor_apply_ready(void *a1) noexcept;
 }

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -1,5 +1,7 @@
 #include "shared_state.hpp"
 
+#include <cdcore/controlled_char.hpp>
+
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
@@ -61,40 +63,15 @@ namespace Transmog
     std::atomic<bool> &suppress_vec() { return s_suppressVEC; }
     std::atomic<__int64> &player_a1() { return s_playerA1; }
 
-    // SEH-only helper -- kept in its own no-C++-object function so
-    // MSVC __try/__except doesn't collide with std::string unwinding
-    // (C2712) in callers.
-    static std::uint8_t read_controlled_char_idx_seh() noexcept
-    {
-        const auto wsBase =
-            s_worldSystemPtr.load(std::memory_order_acquire);
-        if (!wsBase)
-            return 0;
-        __try
-        {
-            auto ws = *reinterpret_cast<uintptr_t *>(wsBase);
-            if (ws < 0x10000)
-                return 0;
-            auto am = *reinterpret_cast<uintptr_t *>(ws + 0x30);
-            if (am < 0x10000)
-                return 0;
-            return *reinterpret_cast<uint8_t *>(am + 0x30);
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            return 0;
-        }
-    }
-
     std::string current_controlled_character_name() noexcept
     {
-        switch (read_controlled_char_idx_seh())
-        {
-            case 1: return "Kliff";
-            case 2: return "Damiane";
-            case 3: return "Oongka";
-            default: return {};
-        }
+        // Delegates to the shared Core resolver, which walks the live
+        // WorldSystem chain to the controlled actor and decodes its
+        // identity u32s. Returns an empty string when the WorldSystem
+        // holder has not been published yet or the chain walk yields
+        // an unknown key with no cached fallback.
+        const auto name = CDCore::current_controlled_character_name();
+        return std::string(name);
     }
     std::atomic<uintptr_t> &world_system_ptr() { return s_worldSystemPtr; }
     std::array<bool, k_slotCount> &real_damaged() { return s_realDamaged; }

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -14,6 +14,8 @@
 #include "transmog_map.hpp"
 #include "transmog_worker.hpp"
 
+#include <cdcore/controlled_char.hpp>
+
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
@@ -695,7 +697,11 @@ namespace Transmog
 
         // --- Input ---
 
-        // Resolve WorldSystem pointer for player detection on load.
+        // Resolve WorldSystem pointer for player detection on load and
+        // publish the same address to the Core controlled-character
+        // resolver. Core walks WorldSystem -> ActorManager -> UserActor ->
+        // controlled_actor(+0xD8) -> identity u32s at +0xDC and +0xEC;
+        // unresolved holder degrades to Unknown without crashing.
         {
             auto wsAddr = resolve_address(
                 k_worldSystemCandidates,
@@ -705,10 +711,13 @@ namespace Transmog
             {
                 world_system_ptr().store(wsAddr, std::memory_order_release);
                 logger.info("WorldSystem pointer at 0x{:X}", wsAddr);
+                CDCore::set_world_system_holder(wsAddr);
             }
             else
             {
-                logger.warning("WorldSystem AOB failed -- load-time transmog disabled");
+                logger.warning(
+                    "WorldSystem AOB failed -- load-time transmog and "
+                    "per-character presets disabled");
             }
         }
 

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -2,9 +2,12 @@
 #include "constants.hpp"
 #include "item_name_table.hpp"
 #include "preset_manager.hpp"
+#include "real_part_tear_down.hpp"
 #include "shared_state.hpp"
 #include "transmog.hpp"
 #include "transmog_apply.hpp"
+
+#include <cdcore/controlled_char.hpp>
 
 #include <DetourModKit.hpp>
 
@@ -152,25 +155,24 @@ namespace Transmog
             auto user = *reinterpret_cast<uintptr_t *>(am + 0x28);
             if (user < 0x10000)
                 return 0;
-            // CE-verified 2026-04-21: `user+0xD8` holds the currently-
-            // controlled character's ClientChildOnlyInGameActor. It
-            // falls back to Kliff's actor when Kliff is the active
-            // character (Kliff's +0xD0 and +0xD8 point to the same
-            // actor), and switches to Damiane/Oongka's actor when one
-            // of them is controlled. Using +0xD0 instead (legacy
-            // offset) would always return Kliff's actor regardless of
-            // who is controlled, which is why the apply pipeline
-            // previously landed all companion presets on Kliff.
+            // user+0xD8 holds the currently-controlled character's
+            // ClientChildOnlyInGameActor. It coincides with user+0xD0
+            // (the "primary" slot, always Kliff) when Kliff is the
+            // active character, and rotates to Damiane's or Oongka's
+            // actor when one of them is controlled. Reading +0xD0
+            // unconditionally would land all companion applies on
+            // Kliff's actor, which is why the apply pipeline always
+            // walks +0xD8.
             auto actor = *reinterpret_cast<uintptr_t *>(user + 0xD8);
             if (actor < 0x10000)
                 return 0;
 
-            // Verify the chain is walkable -- typeEntry pointer has to
-            // be a readable heap address. The old check required
-            // `typeByte == 1` (Kliff-specific); CE probing showed
-            // Damiane's actor carries typeByte=4 and Oongka's has a
-            // different value again, so gating on that byte silently
-            // rejected companions. Pointer validity is enough.
+            // Pointer-validity check on the typeEntry slot. The byte at
+            // typeEntry+1 is role-based (controlled vs backgrounded)
+            // and not stable per-character, so it cannot gate the chain
+            // walk; rejecting on it would silently drop companion
+            // applies. A readable typeEntry pointer is sufficient
+            // structural evidence that the actor is alive.
             auto te = *reinterpret_cast<uintptr_t *>(actor + 0x88);
             if (te < 0x10000)
                 return 0;
@@ -210,12 +212,12 @@ namespace Transmog
     static std::thread s_applyWorker;
     static std::atomic<bool> s_applyWorkerStarted{false};
 
-    // Apply ALWAYS targets the currently-controlled character; this
-    // helper re-reads the live char via the WS idx byte and, when
-    // PresetManager has a different active character cached, switches
-    // to the live one and rebuilds slot_mappings from its preset.
-    // No __try inside, so std::string usage is fine. Called from
-    // run_debounced_apply (which cannot mix __try with C++ objects).
+    // Apply ALWAYS targets the currently-controlled character. This
+    // helper re-reads the live character via the Core resolver and,
+    // when PresetManager has a different active character cached,
+    // switches to the live one and rebuilds slot_mappings from its
+    // preset. Holds no __try block so std::string usage is fine; called
+    // from run_debounced_apply (which cannot mix __try with C++ objects).
     static void sync_active_char_to_live() noexcept
     {
         const std::string live = current_controlled_character_name();
@@ -250,26 +252,20 @@ namespace Transmog
             clear_pending().exchange(false, std::memory_order_acq_rel);
 
         // Prefer the hook-captured a1 from player_a1() -- it identifies
-        // the character whose equip event triggered this apply. The
-        // WorldSystem chain resolve_player_component() only ever
-        // returns Kliff's component regardless of currently-controlled
-        // character (verified via CE probes 2026-04-21), so using it
-        // unconditionally applied every companion's preset to Kliff.
-        //
-        // Fall back to resolve_player_component() only when player_a1
-        // is empty or unreadable (post-reload / loading screen). The
-        // original concern about stale pointers after world reload is
-        // addressed by a SEH-guarded actor deref below -- a freed
-        // wrapper faults and we drop the apply, same net behaviour.
+        // the character whose equip event triggered this apply. Fall
+        // back to resolve_player_component() only when player_a1 is
+        // empty or unreadable (post-reload / loading screen). The
+        // SEH-guarded actor deref below catches a stale wrapper after
+        // world reload by dropping the apply.
         //
         // Apply ALWAYS targets the currently-controlled character.
         // The UI's "active character" is just a view into the JSON
-        // preset list -- a user could pick Oongka in the overlay
-        // while controlling Damiane, but we still want Damiane to
-        // end up wearing Damiane's preset. The helper below syncs
-        // PresetManager + slot_mappings to the live character.
-        // Lives outside this __try-containing function so
-        // std::string destructors don't trip C2712.
+        // preset list -- a user can pick Oongka in the overlay while
+        // controlling Damiane, but we still want Damiane to end up
+        // wearing Damiane's preset. The helper below syncs
+        // PresetManager + slot_mappings to the live character. Lives
+        // outside this __try-containing function so std::string
+        // destructors do not trip MSVC C2712.
         sync_active_char_to_live();
         __int64 a1 = player_a1().load(std::memory_order_acquire);
         if (a1 <= 0x10000)
@@ -433,11 +429,68 @@ namespace Transmog
         }
     }
 
+    // SEH-isolated walk of WorldSystem -> ActorManager -> UserActor.
+    // The UserActor pointer is stable for the lifetime of a save: the
+    // singleton itself is never swapped when the player changes which
+    // body they control (only user+0xD8 rotates between actor slots).
+    // A change of the UserActor pointer is therefore a reliable signal
+    // for "new world loaded" -- distinct from an in-session character
+    // swap, which does NOT reallocate this singleton.
+    //
+    // Returns 0 on any fault or on an unresolved chain; callers treat 0
+    // as "chain not yet ready" and defer the save-load branch.
+    static std::uintptr_t read_user_actor_ptr_seh() noexcept
+    {
+        const auto wsBase =
+            world_system_ptr().load(std::memory_order_acquire);
+        if (!wsBase)
+            return 0;
+        __try
+        {
+            auto ws = *reinterpret_cast<uintptr_t *>(wsBase);
+            if (ws < 0x10000)
+                return 0;
+            auto am = *reinterpret_cast<uintptr_t *>(ws + 0x30);
+            if (am < 0x10000)
+                return 0;
+            auto user = *reinterpret_cast<uintptr_t *>(am + 0x28);
+            if (user < 0x10000)
+                return 0;
+            return user;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return 0;
+        }
+    }
+
+    /** @brief Settle window for the character-swap detector.
+     *  @details During world load the engine rotates `user+0xD8` through
+     *           the party members as it wires each actor (e.g. Kliff ->
+     *           Oongka -> Damiane on a Damiane save). Each rotation is a
+     *           genuine engine state, so the resolver reports the
+     *           transient identities; firing the swap immediately would
+     *           apply the wrong character's preset and incur ~3x wasted
+     *           apply work plus a brief visual flicker. Requiring the new
+     *           identity to remain stable across this window before
+     *           committing the swap collapses the load-time churn into
+     *           a single transition while still propagating real
+     *           user-initiated swaps after a 1s delay. */
+    static constexpr std::uint64_t k_charSwapSettleMs = 1000;
+
     static DWORD WINAPI load_detect_thread_fn(LPVOID)
     {
         auto &logger = DMK::Logger::get_instance();
         __int64 prevComp = 0;
+        std::uintptr_t prevUser = 0;
         std::string prevCharName;
+
+        // Settle-window state for the swap detector below. pendingCharName
+        // is empty when no candidate is in flight; otherwise it holds the
+        // candidate name observed since pendingFirstSeenTick. The swap
+        // commits only when (now - pendingFirstSeenTick) >= settle window.
+        std::string pendingCharName;
+        std::uint64_t pendingFirstSeenTick = 0;
 
         while (!shutdown_requested().load(std::memory_order_relaxed))
         {
@@ -445,23 +498,91 @@ namespace Transmog
             if (shutdown_requested().load(std::memory_order_relaxed))
                 return 0;
 
+            // --- Save-load invalidation ---
+            //
+            // The Core controlled-character resolver caches the most
+            // recent known identity key. On a save load the previous
+            // world's actor pool is freed and reallocated; without
+            // invalidation the resolver could keep returning the prior
+            // save's character until the chain walk first observes the
+            // new actor's identity u32s.
+            //
+            // Use the UserActor pointer as the save-load signal: the
+            // ActorManager rewrites it on world load but leaves it
+            // alone during in-session character swaps (only
+            // user+0xD8 rotates on swap). Invalidating on every comp
+            // change would wipe the cache during normal swaps and add
+            // a full 1s tick of latency before the char-swap detector
+            // below could confirm the new name.
+            //
+            // Runs BEFORE the char-swap block so a save-load event
+            // routes through the retry loop further down instead of
+            // firing a spurious "swap detected" log against a stale
+            // cached name.
+            {
+                const auto curUser = read_user_actor_ptr_seh();
+                if (curUser != 0 && curUser != prevUser)
+                {
+                    if (prevUser != 0)
+                    {
+                        logger.info(
+                            "Load detect: UserActor swapped "
+                            "({:#x} -> {:#x}); invalidating controlled-"
+                            "char cache for save-load transition",
+                            static_cast<uint64_t>(prevUser),
+                            static_cast<uint64_t>(curUser));
+                        CDCore::invalidate_controlled_character();
+                        prevCharName.clear();
+                        pendingCharName.clear();
+                    }
+                    prevUser = curUser;
+                }
+            }
+
             // --- Character-swap auto-detect ---
             //
-            // Reads the controlled-character index byte every tick;
-            // when it changes, switches the UI preset list to the new
-            // character and schedules an apply. The apply path
-            // re-walks the WS chain through `user+0xD8` so it always
-            // resolves the correct per-character wrapper -- no cache
-            // or BatchEquip event required.
+            // Reads the controlled-character name every tick; when it
+            // changes AND remains stable for k_charSwapSettleMs, switches
+            // the UI preset list to the new character and schedules an
+            // apply. The apply path re-walks the WS chain through
+            // user+0xD8 so it always resolves the correct per-character
+            // wrapper without needing a BatchEquip event.
+            //
+            // The settle window absorbs load-time wiring churn where the
+            // engine briefly rotates user+0xD8 through party members
+            // before settling on the save's controlled actor. See the
+            // k_charSwapSettleMs declaration above for the rationale.
             {
                 const auto liveName = current_controlled_character_name();
                 auto &pm = PresetManager::instance();
-                if (!liveName.empty() && liveName != prevCharName)
+
+                // Branch on three states:
+                //   1. liveName empty / matches prevCharName -- no
+                //      transition; clear any pending candidate so a
+                //      back-and-forth (A -> B -> A within settle window)
+                //      does not commit a phantom swap to B.
+                //   2. liveName differs from pendingCharName -- new
+                //      candidate; restart the settle clock.
+                //   3. liveName matches pendingCharName -- candidate
+                //      held; commit when the elapsed time crosses the
+                //      settle threshold.
+                if (liveName.empty() || liveName == prevCharName)
+                {
+                    pendingCharName.clear();
+                }
+                else if (liveName != pendingCharName)
+                {
+                    pendingCharName = liveName;
+                    pendingFirstSeenTick = GetTickCount64();
+                }
+                else if (GetTickCount64() - pendingFirstSeenTick >=
+                         k_charSwapSettleMs)
                 {
                     const std::string oldName = prevCharName.empty()
                                                     ? pm.active_character()
                                                     : prevCharName;
                     prevCharName = liveName;
+                    pendingCharName.clear();
 
                     if (liveName != pm.active_character())
                     {
@@ -493,11 +614,43 @@ namespace Transmog
             // Detect change: new component appeared or address changed.
             if (comp > 0x10000 && comp != prevComp)
             {
-                // Safety gate: don't auto-apply until the controlled-
-                // character idx byte is readable (world fully loaded).
-                // run_debounced_apply will sync PresetManager to the
-                // live char itself, but running the retry loop with
-                // an unresolved live char is pointless and noisy.
+                // Advance prevComp BEFORE the controlled-char gate so
+                // the worker does not re-observe the same change every
+                // tick while the world is still loading. The next
+                // genuine component change is still detected because
+                // prevComp tracks the most recent observed value, not
+                // the most recent successfully-applied one.
+                logger.info("Load detect: player component changed ({:#x} -> {:#x})",
+                            static_cast<uint64_t>(prevComp),
+                            static_cast<uint64_t>(comp));
+                prevComp = comp;
+
+                // Wipe the controlled-character LKG cache so the gate
+                // below decides on a fresh chain walk instead of stale
+                // identity from a previous controlled actor. A
+                // player_component change always means user+0xD8 now
+                // points at a different ClientChildOnlyInGameActor; the
+                // LKG identity from the prior actor is no longer
+                // applicable, but the resolver's torn-read absorption
+                // would otherwise return that stale name on any chain
+                // walk that lands on the new wrapper before its slot
+                // fields (actor+0x60 slot-index byte used by the
+                // companion diff) have been populated. That stale name
+                // would route the auto-apply pipeline through
+                // PresetManager::set_active_character() with the wrong
+                // character, committing the previous character's
+                // preset onto the new actor. Invalidating here costs
+                // at most one outer-loop tick of latency (the gate
+                // defers until the chain walk lands a known key) and
+                // is the only correctness-preserving choice on a swap.
+                CDCore::invalidate_controlled_character();
+
+                // Safety gate: do not auto-apply until the resolver
+                // returns a known character. With LKG invalidated
+                // immediately above, liveChar comes back empty until
+                // the chain walk on the new wrapper lands a known
+                // identity; the retry loop below tolerates that by
+                // design (next outer-loop tick re-evaluates).
                 const std::string liveChar =
                     current_controlled_character_name();
                 if (liveChar.empty())
@@ -505,13 +658,9 @@ namespace Transmog
                     logger.trace(
                         "Load detect: holding auto-apply -- controlled "
                         "char unresolved (waiting for world)");
-                    continue; // Don't advance prevComp; retry next tick.
+                    continue;
                 }
 
-                logger.info("Load detect: player component changed ({:#x} -> {:#x})",
-                            static_cast<uint64_t>(prevComp),
-                            static_cast<uint64_t>(comp));
-                prevComp = comp;
                 player_a1().store(comp, std::memory_order_release);
 
                 // Reset cached apply state so the early-out in
@@ -543,8 +692,29 @@ namespace Transmog
                 // Backoff schedule: 2s, 2s, 3s, 4s, 5s, 5s, 5s, ...
                 // This gives fast feedback when the game loads quickly
                 // but doesn't burn CPU during longer load screens.
+                //
+                // Each iteration runs a cheap actor-readiness probe
+                // (RealPartTearDown::is_actor_apply_ready) before
+                // scheduling a full apply. The probe walks the same
+                // container chain that tear_down dereferences but
+                // performs no engine calls; on a placeholder wrapper
+                // (engine still wiring during world load) the probe
+                // returns false at microsecond cost and the iteration
+                // skips the full apply, avoiding ~5 SEH-faulted
+                // tear_down log lines plus an apply fault per attempt.
+                // The 20-attempt budget is preserved for low-end PCs
+                // where wiring legitimately takes >60s; the probe just
+                // makes the wait silent and cheap.
+                //
+                // The probe is suppressed on attempt 0 so first-load
+                // fast-paths (e.g. the engine warmed before we got
+                // scheduled) still fire an apply immediately without
+                // an extra delay.
                 static constexpr int k_maxAutoApplyAttempts = 20;
                 s_lastApplyOk.store(false, std::memory_order_release);
+
+                int notReadyStreak = 0;
+                bool wrapperChanged = false;
 
                 for (int attempt = 0; attempt < k_maxAutoApplyAttempts;
                      ++attempt)
@@ -556,6 +726,58 @@ namespace Transmog
                     sleep_interruptible(delayMs);
                     if (shutdown_requested().load(std::memory_order_relaxed))
                         break;
+
+                    // Mid-retry wrapper-change abort. The engine
+                    // sometimes parks user+0xD8 on a placeholder wrapper
+                    // for 60+ seconds before deallocating it and
+                    // allocating the real character actor at a different
+                    // address. Without this check the retry loop would
+                    // burn the rest of its budget on the dead placeholder
+                    // and only notice the new wrapper when the outer
+                    // load-detect tick runs again post-loop. Re-resolving
+                    // the component here lets us bail within one
+                    // attempt's delay of the swap; the outer loop's next
+                    // iteration will see comp != prevComp and start a
+                    // fresh retry budget against the new wrapper.
+                    {
+                        const auto curComp = resolve_player_component();
+                        if (curComp > 0x10000 && curComp != comp)
+                        {
+                            logger.info(
+                                "Load detect: wrapper changed mid-retry "
+                                "({:#x} -> {:#x}), aborting current budget",
+                                static_cast<uint64_t>(comp),
+                                static_cast<uint64_t>(curComp));
+                            wrapperChanged = true;
+                            break;
+                        }
+                    }
+
+                    if (attempt > 0 &&
+                        !RealPartTearDown::is_actor_apply_ready(
+                            reinterpret_cast<void *>(comp)))
+                    {
+                        // Log once per fault streak so the deferral is
+                        // visible in the log without filling it. The
+                        // streak resets when a probe finally passes or
+                        // when the wrapper changes (next outer-loop
+                        // iteration).
+                        if (notReadyStreak == 0)
+                            logger.debug(
+                                "Load detect: actor not ready -- deferring "
+                                "apply (attempt {})", attempt + 1);
+                        ++notReadyStreak;
+                        continue;
+                    }
+
+                    if (notReadyStreak > 0)
+                    {
+                        logger.debug(
+                            "Load detect: actor became ready after {} "
+                            "deferred attempts", notReadyStreak);
+                        notReadyStreak = 0;
+                    }
+
                     schedule_transmog_ms(0);
                     logger.debug("Load detect: scheduled apply (attempt {})",
                                  attempt + 1);
@@ -570,7 +792,11 @@ namespace Transmog
                         break;
                     }
                 }
-                if (!s_lastApplyOk.load(std::memory_order_acquire))
+                // Suppress the failure warning when we aborted because
+                // the wrapper changed -- that path is a planned hand-off
+                // to the outer loop, not a failure.
+                if (!wrapperChanged &&
+                    !s_lastApplyOk.load(std::memory_order_acquire))
                     logger.warning(
                         "Load detect: auto-apply failed after {} attempts",
                         k_maxAutoApplyAttempts);

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -11,7 +11,7 @@ Project knowledge base for mod runtime internals. Each entry is a long-lived ref
 | Document | Role |
 |----------|------|
 | [live-transmog-architecture.md](live-transmog-architecture.md) | Runtime pipeline: hook points, apply state machine, memory write surface, event-driven transitions. Cross-references `CrimsonDesertLiveTransmog/src/` files. |
-| [live-transmog-source-of-truth.md](live-transmog-source-of-truth.md) | Byte-level reference: WS chain offsets, carrier descriptor layout, hook RVAs, `charClassBypass` site, IDA verification log. |
+| [live-transmog-source-of-truth.md](live-transmog-source-of-truth.md) | Byte-level reference: WS chain offsets, carrier descriptor layout, hook RVAs, `charClassBypass` site, IDA verification log. §1.3 also covers the `CDCore::current_controlled_character()` resolver shared with EquipHide (chain walk, `+0xDC`/`+0xEC` identity layout, LKG cache, save-load invalidation contract). |
 
 ## CrimsonDesertEquipHide
 

--- a/docs/research/live-transmog-source-of-truth.md
+++ b/docs/research/live-transmog-source-of-truth.md
@@ -39,13 +39,125 @@ WS holder          : 0x145D2AEE8           (scanned via AOB at init)
 
 `user+0xD8` falls back to Kliff's actor when Kliff is the active character (so `+0xD0` and `+0xD8` coincide). Reading `+0xD8` unconditionally is therefore safe for all three playable characters.
 
-### 1.3 Character index byte
+### 1.3 Controlled-character resolver (`CDCore`)
 
-```
-ActorManager +0x30 (first byte, u8)  :  1 = Kliff, 2 = Damiane, 3 = Oongka
+Authoritative reference for the resolver implemented in `CrimsonDesertCore/src/controlled_char.cpp`. The resolver answers a single question: *"which of the three playable protagonists is the user currently controlling?"* It returns one of `Kliff`, `Damiane`, `Oongka`, or `Unknown`. Two consumer mods (`CrimsonDesertLiveTransmog`, `CrimsonDesertEquipHide`) drive per-character behaviour off the result.
+
+#### 1.3.1 Chain walk
+
+The resolver walks five pointer dereferences plus two byte reads on every query. No caching of intermediate pointers; the chain is cheap and any heap pointer in it can be invalidated by a save load or character swap, so re-walking is the only correctness-preserving strategy.
+
+```text
+WorldSystem holder static    : 0x145D2AEE8         (= CrimsonDesert.exe + 0x05D2AEE8)
+  +0x00 (qword)              -> WorldSystem instance        [session heap]
+    +0x30 (qword)            -> ActorManager singleton
+      +0x28 (qword)          -> UserActor singleton (ClientUserActor)
+        +0xD0 (qword)        -> primary actor slot           [always Kliff]
+        +0xD8 (qword)        -> controlled client actor      [rotates on swap]
+          +0x60 (u8)         -> per-actor slot-index byte    [allocation order]
 ```
 
-This byte is the single cheapest signal for "who is controlled right now". The mod reads it in `read_controlled_char_idx_seh()` (`shared_state.cpp`) and polls it once per second in `load_detect_thread_fn` (`transmog_worker.cpp`).
+Notes on each step:
+
+* **`0x145D2AEE8`** is the WorldSystem holder static slot. Its qword contents are session-dependent (allocated during world load). The consumer mods AOB-scan for this address and hand it to Core via `set_world_system_holder()`; Core does not scan for it itself.
+* **`ws + 0x30`** is the ActorManager singleton. Reallocated on every save load.
+* **`am + 0x28`** is the UserActor singleton (RTTI class `.?AVClientUserActor@pa@@`). The pointer at this slot is stable for the lifetime of a save: in-session character swaps do NOT rewrite it. Save loads do reallocate it; consumers use the change of this pointer as the trigger for cache invalidation.
+* **`user + 0xD0`** is the "primary" actor slot. Always points at Kliff's actor in the current story progression, regardless of which character is currently controlled. This is a structural invariant that the decode below relies on.
+* **`user + 0xD8`** is the currently-controlled client actor (RTTI class `.?AVClientChildOnlyInGameActor@pa@@`). Coincides with `user + 0xD0` when Kliff is controlled, and rotates to a Damiane or Oongka slot when one of them is controlled.
+
+Every intermediate pointer is rejected if it falls below the 64 KiB guard region (`k_minValidPtr = 0x10000`). The whole walk runs inside a single `__try` block; any access fault returns an invalid probe which the caller treats as "no live identity, fall back to cache".
+
+#### 1.3.2 Decode rules (verified 2026-04-22)
+
+**Rule 1 -- Kliff via structural invariant.** When `*(user + 0xD0) == *(user + 0xD8)` the primary slot coincides with the controlled slot, which only happens when Kliff is controlled. This is a pure pointer comparison with no dependence on numeric fields that could shift across saves or patches. Verified across three distinct saves controlling Kliff.
+
+**Rule 2 -- companions via slot-index diff.** When the two slots differ, a companion is controlled. The byte at `actor + 0x60` is a per-actor slot index assigned at allocation time in a fixed character order (Kliff, then Damiane, then Oongka). The absolute value varies per save because the slot-index pool is shared with other actors, but within any given save the diff between the controlled slot and the primary slot uniquely identifies the companion:
+
+| Companion diff | Character |
+|----------------|-----------|
+| `+1`           | Damiane   |
+| `+2`           | Oongka    |
+| anything else  | Unknown   |
+
+#### 1.3.3 Verified observations (v1.03.01)
+
+| Save shape       | Kliff `+0x60` | Damiane `+0x60` | Oongka `+0x60` |
+|------------------|---------------|-----------------|----------------|
+| Kliff + Damiane  | `1`           | `2`             | (absent)       |
+| 3 protagonists   | `6`           | `7`             | `8`            |
+
+The `+0x60` byte stays stable when a character is backgrounded -- verified by reading it on Oongka after the user swapped away from him; the value remained `8` across the swap. So the decode produces the same result regardless of which character is currently controlled, as long as the primary slot stays Kliff.
+
+#### 1.3.4 What was tried and rejected
+
+The previous resolver attempted to identify characters via a packed `(party_class << 32) | char_kind` key reading the u32s at `actor + 0xDC` and `+0xEC`. That approach was disproved on 2026-04-22:
+
+* `(party_class, char_kind)` shifts with party composition. The same Damiane reads `(4, 2)` in a 3-party save and `(3, 2)` in a save without Oongka.
+* Damiane and Oongka in the **same** 3-party save BOTH read `(3, 2)`, so the key is structurally ambiguous.
+* `char_kind = 3` did consistently identify Kliff across all four observations, but the structural `D0 == D8` check is more robust and was preferred to avoid depending on a numeric value that may also drift on a future patch.
+
+The qwords at `actor + 0xD8` and `actor + 0xE8` carry control-state in their LOW u32s (controlled vs backgrounded) and the rejected identity bits in their HIGH u32s. They are documented here so a future RE pass does not re-test them.
+
+#### 1.3.5 Known assumption
+
+The decode assumes the engine's character allocation order is always `Kliff, Damiane, Oongka`. A save containing only Kliff + Oongka (no Damiane) would allocate Oongka at `Kliff + 1` and would be decoded as Damiane. No such save has been observed in the current game content; if one arises, the consumer mod's overlay allows manual override and the misdetection is a UX hiccup, not a correctness failure.
+
+#### 1.3.6 Last-known-good cache
+
+The resolver keeps one atomic `s_lastGoodKey` that holds the most recent identity key matching one of the three known values. Each query:
+
+1. Walks the chain (SEH-isolated).
+2. If the resulting key is one of `{Kliff, Damiane, Oongka}`, refresh `s_lastGoodKey` with it and use it as the effective key.
+3. Otherwise (zero from a faulted walk, torn read mid-swap, unknown future value) ignore the live key and use whatever is currently in `s_lastGoodKey`. The cache may itself be empty (zero), in which case the resolver returns `Unknown`.
+
+The cache exists to absorb torn reads at the moment the engine is rewriting `user + 0xD8` during a swap. Without it, a query that landed mid-rewrite would briefly resolve to `Unknown` and any consumer holding state per-character (preset selection, parts override) would flap.
+
+`invalidate_controlled_character()` zeroes the cache. Consumers MUST call it on save-load transitions:
+
+* **Trigger:** the UserActor pointer at `am + 0x28` changes value.
+* **Why:** the previous save's identity key may still reflect the old character whose actor lived in heap that has just been freed and reallocated.
+* **Why not on character swap:** the UserActor pointer does not change on swaps; only `user + 0xD8` rotates. Invalidating on swap would wipe a cache the resolver could have re-populated within the same query.
+
+Both `transmog_worker.cpp` (LiveTransmog load-detect thread) and `player_detection.cpp` (EquipHide background tick) implement this trigger. The first-boot path is gated by a `prevUser != 0` check so the very first tick after world load does not invalidate a cache the resolver may have just populated.
+
+#### 1.3.7 Consumer init contract
+
+The Core resolver does not own its own AOB scan. Consumers AOB-scan for the WorldSystem holder (each mod has a `WorldSystem` AOB candidate set in its own `aob_resolver.hpp`) and publish the resolved address via:
+
+```cpp
+CDCore::set_world_system_holder(addrs.worldSystem);
+```
+
+Both consumers can publish the same address; later writers win, which is the intended behaviour after a re-resolve. Until at least one consumer has called `set_world_system_holder()` with a non-zero address, every resolver query short-circuits to `Unknown`.
+
+The first call also emits a single info log line:
+
+```text
+ControlledChar: WorldSystem holder published at 0x145D2AEE8
+```
+
+A separate one-shot diagnostic logs each unique probe signature (the `(primary_slot, controlled_slot)` pair) the resolver observes:
+
+```text
+ControlledChar: probe primary_slot=6 controlled_slot=8 diff=2 -> Oongka
+```
+
+The trailing name is the decoded character (`Kliff` / `Damiane` / `Oongka` / `Unknown`). This is the only signal that the resolver is wired up correctly on a future patch; the four-slot seen-set covers the three expected diff combinations plus one transient anomaly without log spam.
+
+#### 1.3.8 Reproducing the verification
+
+To re-verify against a future game patch:
+
+1. Attach Cheat Engine to `CrimsonDesert.exe` after a save is loaded with Kliff controlled.
+2. Read the qword at the WorldSystem holder static (the consumer's AOB-scanned address; `0x145D2AEE8` on v1.03.01) -- this yields the WorldSystem instance pointer.
+3. Walk `+0x30 -> +0x28` to land on the UserActor singleton.
+4. Read the qwords at `user + 0xD0` (primary) and `user + 0xD8` (controlled). They MUST be equal -- this is the structural Kliff invariant. RTTI on the resolved actor must be `pa::ClientChildOnlyInGameActor`.
+5. Read the byte at `controlled_actor + 0x60`. Record the value -- call it `K` (Kliff's slot index for this save).
+6. Swap to a companion via the in-game character picker. Re-walk the chain. `user + 0xD0` MUST still hold Kliff's actor pointer; `user + 0xD8` MUST now hold a different pointer. The byte at the new controlled actor's `+0x60` MUST equal `K + 1` for Damiane or `K + 2` for Oongka.
+7. Background the companion and re-walk. The byte at `+0x60` on the now-backgrounded companion MUST stay at the same value (slot index is allocation-time and survives control-state changes).
+8. Repeat for the third protagonist if available. The diff from `K` MUST be the documented value (1 or 2).
+
+If steps 4-7 still hold on a new patch, the resolver requires no changes. If they break, the structural invariant has shifted (most likely candidates: the engine moved the primary slot off `+0xD0`, or the slot-index byte moved off `+0x60`). In either case the offsets in `controlled_char.cpp` need updating, but the algorithm shape (`D0 == D8` for Kliff plus slot-diff for companions) does not.
 
 ### 1.4 How the mod resolves `a1` at apply time
 
@@ -88,6 +200,8 @@ Every armor's rule list (`desc+0x248`, stride `0x38`, count at `desc+0x250`) con
 Any token `>= 0x1000` is classified by the mod as **non-humanoid** (`k_nonHumanoidTokenThreshold` in `item_name_table.cpp`). Humanoid tokens observed so far all fit below `0x0400`.
 
 ### 2.2 Role byte -- NOT a reliable identifier
+
+The `typeEntry+1` byte is role-based (controlled vs backgrounded), not character-based. Companion actors share the same typeEntry pool slot when controlled, so multiple characters decode to the same byte value and cannot be distinguished here. Identity decoding belongs to the resolver documented in §1.3, which compares the primary and controlled actor pointers at `user+0xD0` and `user+0xD8` for the Kliff case and uses the allocation-order slot-index byte at `actor+0x60` to disambiguate companions.
 
 `*(actor+0x88)+1` is **not** a player/NPC flag despite older code treating it as one. Observed values:
 
@@ -279,11 +393,67 @@ Color tiers on rows:
 
 Implemented in `transmog_worker.cpp :: load_detect_thread_fn`.
 
-1. Poll `read_controlled_char_idx_seh()` once per second.
-2. On change between known characters, call `pm.set_active_character(live)`, wipe `slot_mappings`, run `apply_to_state()` so `slot_mappings` reflects the live character's active preset, reset drop-detection state, save.
-3. Schedule a transmog apply if the mod is enabled.
+1. Poll `CDCore::current_controlled_character_name()` once per second (resolver internals in §1.3).
+2. Apply a **settle window** (`k_charSwapSettleMs = 1000`): a candidate identity must remain stable across at least one full second of polling before the swap commits. The first tick that observes a new candidate records `(pendingCharName, pendingFirstSeenTick)`; subsequent ticks confirm the candidate, and the swap fires when `GetTickCount64() - pendingFirstSeenTick >= 1000`. A back-and-forth (A -> B -> A) within the window cancels the pending candidate, so phantom commits do not leak through.
+3. On confirmed change between known characters, call `pm.set_active_character(live)`, wipe `slot_mappings`, run `apply_to_state()` so `slot_mappings` reflects the live character's active preset, reset drop-detection state, save.
+4. Schedule a transmog apply if the mod is enabled.
+
+The settle window exists because the engine rotates `user+0xD8` through party members during world-load wiring (observed sequence on a Damiane save: Kliff -> Oongka -> Damiane over ~30 seconds). Each rotation is a real engine state, but only the final identity is the user's intended controlled character; firing the swap on each transition would commit the wrong preset and incur ~3x wasted apply work plus a brief visual flicker. 1s is chosen to coalesce sub-second torn reads at the cost of an equal amount of latency on real user-initiated swaps. Multi-second engine wiring sequences (like the load-time rotation above) are not coalesced -- the user will still see one transmog apply per stable identity -- but the immediately-after-load Kliff->random-companion->target-companion churn that arises when the engine briefly parks on the primary slot before rotating is suppressed.
+
+A separate save-load detector observes the `am+0x28` UserActor pointer; when it changes the worker calls `CDCore::invalidate_controlled_character()` so the resolver's last-known-good cache does not return the previous save's character against freshly-reallocated heap. The settle-window state (`pendingCharName`, `pendingFirstSeenTick`) is also cleared on this transition so a stale candidate from the previous save cannot commit against the new world.
+
+The same `CDCore::invalidate_controlled_character()` is called when `player_component` changes (not just on UserActor change). A character swap rotates `user+0xD8` to a different `ClientChildOnlyInGameActor` without touching the UserActor singleton; the LKG identity from the previous controlled actor is no longer applicable to the new wrapper. Without this second invalidation point the resolver's torn-read absorption returns the prior character's name on any chain walk that lands on the new wrapper before its `+0x60` slot-index byte has been written, and the load-detect retry path commits the prior character's preset onto the new actor. Cost: at most one outer-loop tick (~1 second) of additional latency on swaps where the chain walk transiently returns Unknown right after the rotation; the safety-gate defers until the chain lands on a known identity.
 
 `run_debounced_apply` additionally calls `sync_active_char_to_live()` at the start of every apply pass so that even UI-driven applies (preset clicks, character picker) target the correct character regardless of what `pm.active_character()` was momentarily set to by the UI.
+
+### 6.1 Actor-readiness probe (placeholder-wrapper filter)
+
+When `Load detect: player component changed` fires, the load-detect retry loop schedules up to 20 attempts (backoff 2s, 2s, 3s, 4s, then 5s × 16 -> ~95s total). The 20-attempt budget exists because **on low-end PCs the engine takes 60+ seconds to fully wire the controlled actor's part-registry after a save load**, and a shorter budget would give up before legitimate slow loads complete.
+
+The cost of that budget on machines where the engine parks `user+0xD8` on a *placeholder* wrapper for the entire load was ~5 SEH-faulted `tear_down` log lines plus an apply fault per attempt -- ~100 noisy faults until the engine swaps the wrapper to the real actor. Mitigation: a cheap actor-readiness probe in front of each scheduled apply.
+
+**Probe** (`RealPartTearDown::is_actor_apply_ready`):
+
+```text
+SEH-guarded read-only chain on a1 (the player wrapper):
+  *(a1 + 0x78) -> container         (must be >= 0x10000)
+    +0x08 -> arrayBase              (must be >= 0x10000)
+    +0x10 -> count (u32)            (must be in [1, 0x1000])
+```
+
+The chain mirrors the preamble of `tear_down_real_part` exactly. On a placeholder wrapper the `*(a1+0x78)` read SEH-faults (the placeholder's container slot is unallocated). On a real actor the chain reads cleanly and `count` is the live PartDef entry count (14 in a representative reproduction; the protagonist always has at least one equipped slot once wiring completes).
+
+**Wiring in the retry loop:**
+
+* Attempt 0 always invokes the apply path (so a fast-load case where the actor was already wired at the moment load-detect fired still applies immediately, with no probe-only delay).
+* Attempts 1+ run the probe first. If the probe returns false, log one `Load detect: actor not ready -- deferring apply (attempt N)` line, increment a `notReadyStreak` counter, and continue. Subsequent failed probes within the same streak are silent (no log spam).
+* On the first probe that passes after a streak, log `Load detect: actor became ready after N deferred attempts`, reset the streak, and proceed to schedule a real apply.
+
+**Result:** on a slow load where the engine holds the placeholder for 90+ seconds, the log shows two debug lines (defer + recovery) instead of ~100 SEH-fault traces, and the eventual apply still fires on the first attempt after the engine swaps the wrapper. The 20-attempt budget itself is unchanged so legitimate slow-but-in-place wiring is still tolerated.
+
+**Why `count >= 1` is safe even for a naked character:** `count` is the slot-entry count (helm/chest/cloak/gloves/boots/weapons/accessories/...), NOT the equipped-item count. Empty slots persist as `primary == 0xFFFF` sentinels and are skipped *inside* the iteration loop, not by lowering `count`. A naked save still reports a full slot count (the representative reproduction shows `count = 14` even for slots that turned out empty during the walk). `count == 0` with a readable container only occurs during the brief window where the container struct is allocated but its slot entries have not yet been initialised -- which is exactly the placeholder/mid-wiring state we want to filter out.
+
+### 6.2 Mid-retry wrapper-change abort
+
+The retry loop also re-resolves the player component at the top of every attempt and aborts the current budget when the wrapper has been swapped beneath us:
+
+```cpp
+const auto curComp = resolve_player_component();
+if (curComp > 0x10000 && curComp != comp)
+{
+    logger.info("Load detect: wrapper changed mid-retry "
+                "({:#x} -> {:#x}), aborting current budget",
+                comp, curComp);
+    wrapperChanged = true;
+    break;
+}
+```
+
+The engine sometimes parks `user+0xD8` on a *placeholder* wrapper for 60+ seconds before deallocating it and allocating the real character actor at a different address. Without this check the inner retry loop would burn its full ~95s budget against the dead placeholder, then return to the outer load-detect tick which would only then notice the new wrapper and start a *second* full retry budget. Net delay until the real wrapper got a transmog apply: 95s + (1s outer-loop tick) + (2s first-attempt delay) = ~98s of visible-mismatch render.
+
+With the abort the inner loop bails within at most one attempt's delay (2-5s) of the swap. The outer loop's next 1s tick observes `comp != prevComp`, advances `prevComp` and starts a fresh 20-attempt budget against the real wrapper -- which typically succeeds on attempt 1 because the freshly-allocated real actor is already wired by the time the engine swaps to it. End-to-end visible-mismatch window collapses from ~95s to ~3-7s.
+
+The "auto-apply failed after N attempts" warning is suppressed when the inner loop exits via `wrapperChanged = true`: that exit is a planned hand-off to the outer loop, not a failure.
 
 ---
 


### PR DESCRIPTION
## Summary

- New `CDCore::current_controlled_character` resolver. Kliff is identified via the structural invariant `*(user+0xD0) == *(user+0xD8)`; companions via the slot-index byte at `actor+0x60` (Damiane = primary + 1, Oongka = primary + 2). Replaces the prior `(party_class, char_kind)` packed key, which was disproved on multi-party saves where Damiane and Oongka can both read `(3, 2)`.
- LiveTransmog consumes the resolver to auto-switch the active preset on world load and on in-game character swap. A 1 second settle window coalesces the engine's load-time party rotation (Kliff -> Oongka -> Damiane) into a single apply.
- Load-time robustness:
  - Actor-readiness probe filters placeholder wrappers. Silences the ~100 SEH-fault log lines per slow load while keeping the 20-attempt retry budget for low-end PCs that need it.
  - Mid-retry wrapper-change abort hands off to the outer loop the moment the engine swaps `user+0xD8` to the real actor. Cuts the visible-mismatch window from up to ~95s down to ~3-7s.
  - LKG invalidation on every player-component change (not only on save load) prevents a stale cached identity from committing the wrong preset during a swap.
- Docs: `docs/research/live-transmog-source-of-truth.md` §1.3 rewritten (new chain walk + decode rules + "what was tried and rejected" + reproducing the verification). §6.1 "Actor-readiness probe" and §6.2 "Mid-retry wrapper-change abort" added. NEXT_CHANGELOG entry for LiveTransmog.

## Test plan

- [x] Kliff-only save: auto-apply fires within 3 attempts on a fast load
- [x] Multi-party save: all three protagonists correctly identified on swap (no Damiane-as-Oongka mis-detection)
- [x] Slow load that parks wrapper on placeholder: log shows silent deferrals (no SEH-fault spam) and apply fires once the engine swaps to the real wrapper
- [x] Rapid character swaps during load: single "Char swap detected" log per settled identity, not one per transient engine state
