### PR TITLE
feat(equip-hide): multi-character support

### DIFF
--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -21,6 +21,11 @@
 - SEH-protected hook callback to prevent crashes if mod is outdated
 - Fully customizable settings via INI configuration
 
+## Requirements
+
+- Crimson Desert (PC, Steam)
+- ASI Loader (e.g. [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases))
+
 ## Installation
 
 ### Step 1: Install an ASI Loader
@@ -203,9 +208,11 @@ If you encounter issues:
 
 Common issues:
 
-- **Mod doesn't load** – Ensure the files are in the correct location and ASI Loader is installed
-- **Toggle doesn't work** – Check log file for AOB pattern errors
-- **Game crashes** – Check log file for errors; try updating to the latest version
+- **Mod doesn't load** -- Ensure the files are in the correct location and ASI Loader is installed
+- **Toggle doesn't work** -- Check log file for AOB pattern errors
+- **Game crashes** -- Check log file for errors; try updating to the latest version
+
+**Important: removing or disabling ASI mods.** Ultimate ASI Loader scans subdirectories recursively. Moving an `.asi` file into a subfolder (e.g. `plugins/backup/`) does **not** prevent it from loading. To fully disable an ASI mod, move it **outside the game's root directory entirely**, or rename the file extension (e.g. `.asi.bak`).
 
 > **Still stuck?** [Open a GitHub issue](https://github.com/tkhquang/CrimsonDesertTools/issues/new?assignees=&labels=bug&template=bug_report.yaml) and include your INI config, log output, and game version.
 
@@ -229,6 +236,47 @@ Parts = CD_Helm, CD_Cloak, CD_Shoulder
 ```
 
 In this example, pressing `V` would still toggle Shields and Masks, but Helm would only respond to `F5` because UserPreset1 owns it.
+
+## Per-Character Parts Overrides
+
+Each category's `Parts` list can be overridden per protagonist by adding a section named `[CategoryName:CharacterName]`. Supported names: `Kliff`, `Damiane`, `Oongka`. Only the `Parts` key is per-character; `Enabled`, `DefaultHidden`, and hotkeys remain global.
+
+Three ways to set a per-character `Parts` value:
+
+| Value | Effect |
+| ----- | ------ |
+| section absent, or `Parts =` (empty) | Inherits the base `[CategoryName]` list |
+| `Parts = CD_Xxx, CD_Yyy, ...` | Uses this explicit list when that character is controlled |
+| `Parts = NONE` | Disables the category for that character (nothing hidden even when the base is enabled) |
+
+### Example: keep the lantern visible on Damiane
+
+```ini
+[Lanterns]
+Enabled = true
+ToggleHotkey = L
+DefaultHidden = true
+Parts = CD_Lantern, CD_Lantern_Ring
+
+[Lanterns:Damiane]
+Parts = NONE
+```
+
+`V`/`L` still toggles the lantern for Kliff and Oongka, but Damiane's lantern is never hidden.
+
+### Example: different weapon sets per character
+
+Kliff has no sheath mesh for 1H axes or maces, but Damiane does:
+
+```ini
+[OneHandWeapons]
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ...
+
+[OneHandWeapons:Damiane]
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L
+```
+
+The active character is detected by walking the live WorldSystem pointer chain to the currently-controlled actor and decoding its built-in identity fields. Switching between protagonists automatically swaps the effective Parts list on the next tick.
 
 ## Compatibility with Replacer Mods
 
@@ -261,8 +309,8 @@ See [CHANGELOG.md](CHANGELOG.md) for a detailed history of updates.
 
 This mod requires:
 
-- [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader) by [**ThirteenAG**](https://github.com/ThirteenAG) – `winmm.dll` recommended (see [Installation](#installation) for alternatives)
-- [DetourModKit](https://github.com/tkhquang/DetourModKit) – A lightweight C++ toolkit for game modding
+- [Ultimate ASI Loader](https://github.com/ThirteenAG/Ultimate-ASI-Loader) by [**ThirteenAG**](https://github.com/ThirteenAG) -- `winmm.dll` recommended (see [Installation](#installation) for alternatives)
+- [DetourModKit](https://github.com/tkhquang/DetourModKit) -- A lightweight C++ toolkit for game modding
 
 ## Building from Source
 
@@ -296,10 +344,10 @@ The loader (`CrimsonDesertEquipHide.asi`) and logic DLL (`CrimsonDesertEquipHide
 
 ## Credits
 
-- [ThirteenAG](https://github.com/ThirteenAG) – for the Ultimate ASI Loader
-- [cursey](https://github.com/cursey) – for SafetyHook
-- [Brodie Thiesfield](https://github.com/brofield) – for SimpleIni
-- Pearl Abyss – for Crimson Desert
+- [ThirteenAG](https://github.com/ThirteenAG) -- for the Ultimate ASI Loader
+- [cursey](https://github.com/cursey) -- for SafetyHook
+- [Brodie Thiesfield](https://github.com/brofield) -- for SimpleIni
+- Pearl Abyss -- for Crimson Desert
 
 ## License
 

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -32,6 +32,40 @@
 ; Comma-separated part names. Move items between categories by cut/paste.
 ; Raw hex IDs (e.g. 0xAE1E) also accepted for unlisted/gap parts.
 ;
+; --- Per-character Parts overrides ---
+; You can override the Parts list for a specific protagonist by creating a
+; section named [CategoryName:CharacterName]. Supported names: Kliff, Damiane,
+; Oongka. The override replaces the base Parts list when that character is
+; controlled.
+;
+; Three ways to set a per-character Parts value:
+;   1. Section absent OR Parts = (empty)  -> inherit the base [CategoryName]
+;   2. Parts = CD_Xxx, CD_Yyy, ...        -> use this explicit list for this character
+;   3. Parts = NONE                       -> disable this category for this character
+;                                            (nothing hidden even when the base is enabled)
+;
+; Example -- hide axes/maces only when playing Damiane (Kliff leaves them
+; alone because they have no sheath mesh on his body):
+;
+;   [OneHandWeapons]
+;   Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ...
+;
+;   [OneHandWeapons:Damiane]
+;   Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L
+;
+; Example -- hide the lantern on Kliff but leave it visible on Damiane:
+;
+;   [Lanterns]
+;   Enabled = true
+;   DefaultHidden = true
+;   Parts = CD_Lantern, CD_Lantern_Ring
+;
+;   [Lanterns:Damiane]
+;   Parts = NONE
+;
+; Only the Parts key is per-character. Enabled / DefaultHidden / hotkeys
+; remain global to the base [CategoryName] section.
+;
 ; --- Other ---
 ; DefaultHidden = true to start hidden on game load.
 ; Enabled = false to disable a category entirely (parts won't be tracked).
@@ -49,7 +83,7 @@ PlayerOnly = true
 ; Safe to leave false if you are not using such mods.
 ForceShow = false
 ; Prevents baldness when hiding helmets/cloaks/masks.
-; The game normally hides hair when a helmet is equipped — this fix keeps
+; The game normally hides hair when a helmet is equipped -- this fix keeps
 ; hair visible when the mod hides the helmet mesh.
 ; Note: Hair/beard may occasionally disappear; re-toggling the helmet
 ; (show then hide) restores it.
@@ -86,9 +120,26 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-; Tip: If daggers appear permanently visible or clip with swords, remove the
-; four CD_MainWeapon_Dagger_* entries from Parts to restore default behaviour.
-Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Bola, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_L, CD_MainWeapon_HandCannon, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux
+; Base list = parts that have a sheath mesh on every protagonist. Per-character
+; sections below extend this with parts that only some characters can safely
+; hide. Parts lacking a sheath mesh on a specific character are omitted from
+; that character's override to avoid floating-mesh clipping when toggled visible.
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux
+
+; Kliff can additionally hide: left-hand daggers, left gauntlet, bola.
+; (Vanilla-hidden for him: R-daggers, 1H axes/maces, right gauntlet, L-fist, handcannon.)
+[OneHandWeapons:Kliff]
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Gauntlet_L, CD_MainWeapon_Bola
+
+; Damiane can additionally hide: left-hand daggers, 1H axes, 1H maces, both gauntlets.
+; (Vanilla-hidden for her: R-dagger, fan, L-fist, handcannon, bola.)
+[OneHandWeapons:Damiane]
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L
+
+; Oongka's vanilla-hidden set has not been verified. Leave empty to inherit
+; the conservative base; fill in once you confirm his sheath meshes.
+[OneHandWeapons:Oongka]
+Parts =
 
 [TwoHandWeapons]
 Enabled = false
@@ -120,7 +171,12 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-Parts = CD_MainWeapon_ArwHead, CD_MainWeapon_CrossBow, CD_MainWeapon_Pistol_R, CD_MainWeapon_Pistol_L, CD_MainWeapon_Musket, CD_MainWeapon_Trap, CD_MainWeapon_Bomb, CD_MainWeapon_Fan, CD_MainWeapon_ThrownSpear_R, CD_MainWeapon_ThrownSpear_L, CD_MainWeapon_Whip_R, CD_MainWeapon_Parachute
+; CD_MainWeapon_Fan is vanilla-hidden on both Kliff and Damiane (no sheath
+; mesh -- it only appears while drawn). Kept out of the base list to avoid
+; floating-mesh clipping when toggled visible. If you want to experiment with
+; showing it, paste into a [UserPresetN]:
+;   CD_MainWeapon_Fan
+Parts = CD_MainWeapon_ArwHead, CD_MainWeapon_CrossBow, CD_MainWeapon_Pistol_R, CD_MainWeapon_Pistol_L, CD_MainWeapon_Musket, CD_MainWeapon_Trap, CD_MainWeapon_Bomb, CD_MainWeapon_ThrownSpear_R, CD_MainWeapon_ThrownSpear_L, CD_MainWeapon_Whip_R, CD_MainWeapon_Parachute
 
 [Tools]
 Enabled = false
@@ -128,7 +184,25 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Saw, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Shooter, CD_Tool_Flute, CD_Tool_FireCan, CD_Tool_Cigarette, CD_Tool_Sprayer, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Torch, CD_Tool_Pan, CD_Tool_Trumpet, CD_Tool_Pipe, CD_Tool_Book
+; Base list = tools with a stowed mesh on every protagonist. Per-character
+; sections below add tools that specific characters can safely hide. Tools
+; without a stowed mesh on a given character are omitted from their override.
+Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book
+
+; Kliff can additionally hide: fire can.
+; (Vanilla-hidden for him: torch, flute, pan, pipe, saw, shooter, sprayer.)
+[Tools:Kliff]
+Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book, CD_Tool_FireCan
+
+; Damiane can additionally hide: saw, pan, shooter.
+; (Vanilla-hidden for her: torch, flute, pipe, sprayer, firecan.)
+[Tools:Damiane]
+Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book, CD_Tool_Saw, CD_Tool_Pan, CD_Tool_Shooter
+
+; Oongka's vanilla-hidden tool set has not been verified. Leave empty to
+; inherit the conservative base.
+[Tools:Oongka]
+Parts =
 
 [Lanterns]
 Enabled = false
@@ -162,7 +236,15 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-Parts = CD_Lowerbody, CD_Lowerbody_Acc, CD_Underwear
+Parts = CD_Lowerbody, CD_Lowerbody_Acc
+
+[Underwear]
+Enabled = false
+ToggleHotkey =
+ShowHotkey =
+HideHotkey =
+DefaultHidden = false
+Parts = CD_Underwear
 
 [Gloves]
 Enabled = false
@@ -248,17 +330,24 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-Parts = CD_Belt, CD_Acc, CD_Bag, CD_Bag_Rocket, CD_Bag_For_Dock, CD_Bag_Belt_For_Dock, CD_Additional_For_Dock, CD_Bag_Small, CD_Bag_Acc, CD_Bag_Belt, CD_Bag_Lantern, CD_Bag_Rack
+; CD_Bag_For_Dock is a dock-transition attachment (wooden frame), not a normal
+; equipped bag. It's absent from the player's <PartInOutSocketInfo> on both
+; Kliff and Damiane in vanilla, so forcing it visible via ShowAll/ShowHotkey
+; triggers a wooden-frame attachment that overrides KukuPack/weapon meshes on
+; the back. Kept out of the base list to avoid that regression.
+; If you want to toggle it anyway, paste into a [UserPresetN]:
+;   CD_Bag_For_Dock
+Parts = CD_Belt, CD_Acc, CD_Bag, CD_Bag_Rocket, CD_Bag_Belt_For_Dock, CD_Additional_For_Dock, CD_Bag_Small, CD_Bag_Acc, CD_Bag_Belt, CD_Bag_Lantern, CD_Bag_Rack
 
 ; ── User Presets ─────────────────────────────────────────────────────
 ; Custom part groups with independent visibility control.
-; When a preset is enabled, it takes full control of its parts —
+; When a preset is enabled, it takes full control of its parts --
 ; built-in category toggles (like V for Shields/Helm/Mask) will NOT
 ; affect parts owned by an active preset. Only the preset's own
 ; hotkey controls them.
 ;
 ; Tip: Set DefaultHidden = true if you want preset parts hidden on startup.
-; Disabled by default — set Enabled = true and add parts to use.
+; Disabled by default -- set Enabled = true and add parts to use.
 
 [UserPreset1]
 Enabled = false

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,4 +1,8 @@
-## Core Refactor
+## Multi-Character Support
 
 - Shared AOB scanning utilities moved into the new `CrimsonDesertCore` static library. No behavioural change ([#33](https://github.com/tkhquang/CrimsonDesertTools/pull/33))
 - Minor post-extraction cleanups in `aob_resolver`, `armor_injection`, `bald_fix`, `equip_hide`, `player_detection`, and `visibility_write`. No user-visible change ([#34](https://github.com/tkhquang/CrimsonDesertTools/pull/34))
+- Per-character Parts overrides. Every category section now accepts `[Section:Kliff]`, `[Section:Damiane]`, and `[Section:Oongka]` subsections; the mod picks the active character's list automatically on in-game swap. Missing subsection inherits from the base `[Section]` list. Use `Parts = NONE` to disable a category for a specific character without affecting the others
+- Bald Fix now works for Kliff, Damiane, and Oongka
+- Fixed: swapping between characters no longer leaves the previous character's hide state stuck on the new character's body (e.g. hiding Oongka's chest parts and then swapping to Kliff no longer leaves Kliff bare-chested)
+- Per-character detection is now robust across saves regardless of party composition

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -17,7 +17,18 @@ This mod allows you to hide equipped gear visually in Crimson Desert using custo
 [size=5]Requirements[/size]
 [list]
 [*] Crimson Desert (Steam version)
+[*] ASI Loader (e.g. [url=https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases]Ultimate ASI Loader[/url])
 [/list]
+
+[color=red][size=5][b]DO NOT INSTALL VIA MOD MANAGERS[/b][/size][/color]
+
+[color=red][b]This mod is manual-install only. Mod managers are NOT supported.[/b][/color]
+
+Mod managers often stage [b].asi[/b] files into their own subfolders. Ultimate ASI Loader scans subdirectories recursively, so the [b].asi[/b] keeps loading even after the manager reports the mod as "disabled" or "uninstalled". Common symptom: gear stays hidden after you think the mod is gone.
+
+[b]Install manually[/b] by following the Installation steps below. [b]To uninstall,[/b] delete [b]CrimsonDesertEquipHide.asi[/b] and [b]CrimsonDesertEquipHide.ini[/b] directly from [b]bin64[/b] (not via the manager). If a manager moved your files into a subfolder like [b]bin64/plugins/[/b] or [b]bin64/backup/[/b], delete them from that subfolder too.
+
+[color=red][b]Issues reported for mod-manager installs will not be investigated. Reproduce on a clean manual install first.[/b][/color]
 
 [size=5]Installation[/size]
 
@@ -32,6 +43,8 @@ Download the [b]x64[/b] build of [url=https://github.com/ThirteenAG/Ultimate-ASI
 [/list]
 
 [b]How to verify:[/b] After completing Step 2, launch the game once. If no [b]CrimsonDesertEquipHide.log[/b] file appears in [b]bin64[/b], the ASI Loader is not loading. Try renaming the DLL to one of the other variants listed above.
+
+[b]Note:[/b] If you are using a newer version of Ultimate ASI Loader and the log file is not generated, try the [b]win64[/b] (x64) build from [url=https://github.com/ThirteenAG/Ultimate-ASI-Loader/releases/tag/v9.1.0]v9.1.0[/url] instead.
 
 [size=4]Step 2: Install the mod[/size]
 1. Download the latest release from the files section
@@ -163,6 +176,45 @@ ToggleHotkey = V,Gamepad_LB+Gamepad_Y
 
 [b]XInput only:[/b] Xbox controllers work natively. For PS4/PS5/Switch controllers, use an XInput translation layer (e.g. DS4Windows, DualSenseX, BetterJoy) or Steam Input to present your controller as XInput. See [url=https://github.com/tkhquang/DetourModKit?tab=readme-ov-file#gamepad-compatibility]Gamepad Compatibility[/url] for details.
 
+[size=5]Per-Character Parts Overrides[/size]
+Each category's [b]Parts[/b] list can be overridden per protagonist by adding a section named [b][CategoryName:CharacterName][/b]. Supported names: [b]Kliff[/b], [b]Damiane[/b], [b]Oongka[/b]. Only the [b]Parts[/b] key is per-character; [b]Enabled[/b], [b]DefaultHidden[/b], and hotkeys remain global to the base section.
+
+Three ways to set a per-character [b]Parts[/b] value:
+[list]
+[*] Section absent, or [b]Parts =[/b] (empty) - inherits the base [b][CategoryName][/b] list
+[*] [b]Parts = CD_Xxx, CD_Yyy, ...[/b] - uses this explicit list when that character is controlled
+[*] [b]Parts = NONE[/b] - disables the category for that character (nothing hidden even when the base is enabled)
+[/list]
+
+[b]Example: keep the lantern visible on Damiane[/b]
+
+[code]
+[Lanterns]
+Enabled = true
+ToggleHotkey = L
+DefaultHidden = true
+Parts = CD_Lantern, CD_Lantern_Ring
+
+[Lanterns:Damiane]
+Parts = NONE
+[/code]
+
+The lantern hotkey still works for Kliff and Oongka, but Damiane's lantern is never hidden.
+
+[b]Example: different weapon sets per character[/b]
+
+Kliff has no sheath mesh for 1H axes or maces, but Damiane does:
+
+[code]
+[OneHandWeapons]
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ...
+
+[OneHandWeapons:Damiane]
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L
+[/code]
+
+The active character is detected by walking the live WorldSystem pointer chain to the currently-controlled actor and decoding its built-in identity fields. Switching between protagonists automatically swaps the effective Parts list on the next tick.
+
 [size=5]Compatibility with Replacer Mods[/size]
 Set [b]ForceShow = true[/b] if you use mods that alter the default visibility of equipment via PAZ patching (e.g. character replacers like "Playing Kliff as Damiane", armor replacers, transmog mods). ForceShow overrides their changes so toggling equipment back to visible still works:
 
@@ -213,6 +265,8 @@ If you encounter issues:
 [*] Check the log file in your game directory ([b]CrimsonDesertEquipHide.log[/b])
 [*] For memory pattern errors, the mod needs an update for the current game version
 [/list]
+
+[b]Important: removing or disabling ASI mods.[/b] Ultimate ASI Loader scans subdirectories recursively. Moving an [b].asi[/b] file into a subfolder (e.g. [b]plugins/backup/[/b]) does [b]not[/b] prevent it from loading. To fully disable an ASI mod, move it [b]outside the game's root directory entirely[/b], or rename the file extension (e.g. [b].asi.bak[/b]).
 
 [size=5]Credits & Source Code[/size]
 Built with [url=https://github.com/tkhquang/DetourModKit]DetourModKit[/url] for core functionality.

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -182,4 +182,67 @@ namespace EquipHide
          ResolveMode::Direct, -0x6F, 0},
     };
 
+    /**
+     * @brief Return-address landmark inside `createPrefabFromPartPrefab`
+     *        (engine-registered profiling label for sub_14261B6C0).
+     *
+     * That function instantiates a renderable prefab from a PartPrefab,
+     * then tail-calls sub_1402E1430(v107) -- inside which the rule-eval
+     * pipeline reaches PostfixEval on the freshly-built instance. The
+     * return address on the byte right after that inner call is the
+     * landmark (match+12, the first byte of the post-call `mov rbx,
+     * [rsp+0x4A0]` epilogue load).
+     *
+     * Player PostfixEval invocations come from the equipment-visibility
+     * update loop elsewhere in the binary and never include this return
+     * address on their stack. bald_fix uses stack presence of this
+     * landmark to reject prefab-instantiation-path calls without caching
+     * ctx pointers or depending on frequency heuristics.
+     *
+     * Instruction window (all three candidates land on the first byte of
+     * the `lea rcx, [rbp+0x210]`; consumer adds +12 to reach the
+     * landmark):
+     *
+     *   48 8D 8D 10 02 00 00        lea rcx, [rbp+0x210]
+     *   E8 ?? ?? ?? ??              call sub_1402E1430
+     *   48 8B 9C 24 A0 04 00 00     mov rbx, [rsp+0x4A0]   ; landmark
+     *   48 81 C4 60 04 00 00        add rsp, 0x460
+     *   41 5F 41 5E 41 5D 41 5C
+     *   5F 5E 5D C3                 pop r15..rbp ; ret
+     *
+     * The `mov rbx, [rsp+0x4A0]` stack-disp is the uniqueness anchor
+     * (wildcarding it drops the scan from one hit to 10+). Every other
+     * immediate is a compiler-movable constant and is wildcarded in P2
+     * and P3 to tolerate stack-frame shifts across builds.
+     */
+    inline constexpr AddrCandidate k_npcPfeReturnAddrCandidates[] = {
+        // P1 -- tight. Both frame offsets retained as literals for the
+        // strictest match on the current build. First to fail if either
+        // the `lea` frame disp or the `mov rbx` stack disp shifts.
+        {"NpcPfeReturnAddr_P1_PostCallLandmark",
+         "48 8D 8D 10 02 00 00 E8 ?? ?? ?? ?? 48 8B 9C 24 A0 04 00 00",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- wildcards the `lea` frame disp so a future build that
+        // adds or removes locals (shifting the `[rbp+var_180]` offset)
+        // still matches, and extends forward through the stack-teardown
+        // `add rsp, <imm>` whose immediate is also wildcarded. Keeps the
+        // landmark `A0 04 00 00` as a literal for uniqueness.
+        {"NpcPfeReturnAddr_P2_LandmarkEpilogue",
+         "48 8D 8D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 9C 24 A0 04 00 00 "
+         "48 81 C4 ?? ?? ?? ??",
+         ResolveMode::Direct, 0, 0},
+
+        // P3 -- P2 extended through the non-volatile-register pop chain
+        // and terminating `ret`. The `41 5F 41 5E 41 5D 41 5C 5F 5E 5D
+        // C3` suffix ties the pattern to this specific callee-saved-set
+        // (r12..r15 + rdi + rsi + rbp). Most resilient to frame-layout
+        // shifts but will break if the compiler changes which registers
+        // the function spills.
+        {"NpcPfeReturnAddr_P3_WiderEpilogueChain",
+         "48 8D 8D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 9C 24 A0 04 00 00 "
+         "48 81 C4 ?? ?? ?? ?? 41 5F 41 5E 41 5D 41 5C 5F 5E 5D C3",
+         ResolveMode::Direct, 0, 0},
+    };
+
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -11,22 +11,57 @@ namespace EquipHide
 {
     static PostfixEvalFn s_originalPostfixEval = nullptr;
 
-    // Single-slot cache of the player's PostfixEval context. A wider
-    // set-based cache (per-protagonist slots) was attempted and
-    // crashed at load -- the game's PostfixEval also fires for NPC
-    // contexts with populated item arrays, and the override code
-    // writes into those items' +0x70 bitmasks. NPC item structs have
-    // different layouts, so the priority-bit write corrupts game
-    // state and crashes on later traversal.
-    //
-    // Current design: single slot, first populated call wins. In
-    // practice this is the character you load in as (typically Kliff).
-    // Swapping to Damiane/Oongka leaves them bald when helm/mask is
-    // hidden. A proper fix requires validating each cached context
-    // belongs to a player character -- e.g. reading an identity byte
-    // off the context struct -- before accepting it into the cache.
-    // See memory note `project_baldfix_multichar_deferred`.
-    static std::atomic<uintptr_t> s_cachedContext{0};
+    // Player-vs-prefab-instantiation identity is decided by a call-graph
+    // landmark: CE capture on 2026-04-22 (Kliff session 194 hits, Oongka
+    // session 173 hits) showed every PostfixEval invocation that came
+    // through the engine's `createPrefabFromPartPrefab` path (sub_14261B6C0,
+    // which IDA confirms allocates the 240-byte prefab instance then
+    // invokes the rule pipeline via sub_1402E1430) carried the
+    // post-call return address at ResolvedAddresses::npcPfeReturnAddr on
+    // its stack. Player-side PostfixEval invocations run from the
+    // equipment-visibility update loop and never include that address
+    // (196/196 player-context hits across both sessions). At hook entry
+    // we scan a small stack window; if the landmark is present, we defer
+    // to the original evaluator without mutating any item bitmasks. No
+    // ctx caching, no frequency threshold, no per-item hash heuristic.
+    static constexpr int k_stackScanDepth = 24;
+
+    // Dedup tables so the trace log fires at most once per ever-seen ctx.
+    // Sized generously: the live build has at most 3 player protagonists
+    // and typically <10 NPC prefab-instantiation contexts per load zone.
+    // Tables never evict; if they saturate, further contexts silently
+    // stop logging. Entries are zero-initialised (0 sentinel = empty).
+    static constexpr int k_logDedupSize = 16;
+    static std::atomic<uintptr_t> s_loggedAcceptCtxs[k_logDedupSize]{};
+    static std::atomic<uintptr_t> s_loggedRejectCtxs[k_logDedupSize]{};
+
+    /* Returns true exactly once per (table, ctx) pair -- on the first
+       call that inserts ctx into a free slot. Safe under contention:
+       compare_exchange distinguishes "we inserted" from "lost the race
+       to the same ctx". Lock-free, no per-call allocation. */
+    static bool log_dedup_claim(std::atomic<uintptr_t> *table, uintptr_t ctx) noexcept
+    {
+        for (int i = 0; i < k_logDedupSize; ++i)
+        {
+            auto v = table[i].load(std::memory_order_relaxed);
+            if (v == ctx)
+                return false;
+            if (v == 0)
+            {
+                uintptr_t expected = 0;
+                if (table[i].compare_exchange_strong(
+                        expected, ctx,
+                        std::memory_order_relaxed,
+                        std::memory_order_relaxed))
+                    return true;
+                /* Race: another thread claimed this slot. If with same
+                   ctx we're done; otherwise keep scanning. */
+                if (expected == ctx)
+                    return false;
+            }
+        }
+        return false;
+    }
 
     void set_postfix_eval_trampoline(PostfixEvalFn original)
     {
@@ -87,11 +122,42 @@ namespace EquipHide
         return mask;
     }
 
+    /* Returns true if the current call stack came through the NPC-side
+       PostfixEval caller. Scans a small window of stack slots looking
+       for resolved_addrs().npcPfeReturnAddr as a return address; the
+       landmark always sits at a predictable depth within the captured
+       window, so bounded scanning is sufficient (and cheap). SEH wraps
+       the walk in case an unusually deep call trimmed the frame. */
+    static bool is_npc_call_stack(uintptr_t landmark) noexcept
+    {
+        if (!landmark)
+            return false;
+
+        auto *frame = static_cast<uintptr_t *>(_AddressOfReturnAddress());
+        __try
+        {
+            for (int i = 0; i < k_stackScanDepth; ++i)
+            {
+                if (frame[i] == landmark)
+                    return true;
+            }
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+        }
+        return false;
+    }
+
     /* Temporarily set bit 19 on items whose category is hidden, call
        the original PostfixEval, then restore.  Only items belonging to
        a hidden headgear category are overridden -- e.g. hiding Mask only
        overrides Mask items (beard stays visible) while Helm items keep
-       their bitmask (hair hidden under helmet as normal). */
+       their bitmask (hair hidden under helmet as normal).
+
+       Per-item SEH guards against mid-walk faults: a context that slips
+       through the validator must not be able to crash the game via a
+       bad deref. Restoration is also SEH-wrapped so a fault on item[N]
+       does not skip restoring item[N+1..]. */
     static __int64 eval_with_priority_override(
         __int64 ruleObj, __int64 context) noexcept
     {
@@ -111,37 +177,52 @@ namespace EquipHide
 
         for (uint32_t i = 0; i < itemCount; ++i)
         {
-            auto item = itemArray[i];
-            if (item < 0x10000)
-                continue;
-            if (*reinterpret_cast<uint8_t *>(item + 0x88) == 0)
-                continue;
+            __try
+            {
+                auto item = itemArray[i];
+                if (item < 0x10000)
+                    continue;
+                if (*reinterpret_cast<uint8_t *>(item + 0x88) == 0)
+                    continue;
 
-            /* Only override items whose part hash belongs to a hidden
-               head-covering category. */
-            auto partHash = *reinterpret_cast<uint32_t *>(item + 0x48);
-            if (!needs_classification(partHash))
-                continue;
-            auto partCat = classify_part(partHash);
-            if ((partCat & hiddenMask) == 0)
-                continue;
+                /* Only override items whose part hash belongs to a hidden
+                   head-covering category. */
+                auto partHash = *reinterpret_cast<uint32_t *>(item + 0x48);
+                if (!needs_classification(partHash))
+                    continue;
+                auto partCat = classify_part(partHash);
+                if ((partCat & hiddenMask) == 0)
+                    continue;
 
-            auto *bm = reinterpret_cast<uint32_t *>(item + 0x70);
-            uint32_t val = *bm;
+                auto *bm = reinterpret_cast<uint32_t *>(item + 0x70);
+                uint32_t val = *bm;
 
-            if (val & k_priorityBit)
-                continue;
+                if (val & k_priorityBit)
+                    continue;
 
-            *bm = (val | k_priorityBit) & ~k_activeBit;
-            patchedItems[patchCount] = item;
-            originalValues[patchCount] = val;
-            ++patchCount;
+                *bm = (val | k_priorityBit) & ~k_activeBit;
+                patchedItems[patchCount] = item;
+                originalValues[patchCount] = val;
+                ++patchCount;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+            }
         }
 
         __int64 result = s_originalPostfixEval(ruleObj, context);
 
         for (int i = 0; i < patchCount; ++i)
-            *reinterpret_cast<uint32_t *>(patchedItems[i] + 0x70) = originalValues[i];
+        {
+            __try
+            {
+                *reinterpret_cast<uint32_t *>(patchedItems[i] + 0x70) =
+                    originalValues[i];
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+            }
+        }
 
         return result;
     }
@@ -154,33 +235,31 @@ namespace EquipHide
             {
                 auto ctx = static_cast<uintptr_t>(context);
 
-                /* Cache the player context on first populated call. */
-                if (s_cachedContext.load(std::memory_order_relaxed) == 0 &&
-                    ctx > 0x10000)
-                {
-                    auto cnt = *reinterpret_cast<const uint32_t *>(ctx + 0x60);
-                    if (cnt > 0)
-                    {
-                        s_cachedContext.store(ctx, std::memory_order_relaxed);
-                        DMK::Logger::get_instance().debug(
-                            "BaldFix: cached context 0x{:X} ({} items)",
-                            ctx, cnt);
-                    }
-                }
-
-                /* Only override for the cached player context + hair-hiding
-                   rules + any head-covering gear hidden. */
-                if (ctx == s_cachedContext.load(std::memory_order_relaxed) &&
+                /* Only consider overrides for hair-hiding rules + any
+                   head-covering gear hidden. These gates are cheap and
+                   ordered first so most calls exit without touching the
+                   stack-walk filter. */
+                if (ctx > 0x10000 &&
                     is_hair_hiding_rule(ruleObj) &&
                     (is_category_hidden(Category::Helm) ||
                      is_category_hidden(Category::Cloak) ||
                      is_category_hidden(Category::Mask)))
                 {
-                    static std::atomic<bool> s_logged{false};
-                    if (!s_logged.exchange(true, std::memory_order_relaxed))
-                        DMK::Logger::get_instance().debug(
-                            "BaldFix: priority override active");
-                    return eval_with_priority_override(ruleObj, context);
+                    auto &logger = DMK::Logger::get_instance();
+                    if (is_npc_call_stack(resolved_addrs().npcPfeReturnAddr))
+                    {
+                        if (log_dedup_claim(s_loggedRejectCtxs, ctx))
+                            logger.trace("BaldFix: filtered prefab-instantiation "
+                                         "call (ctx=0x{:X})", ctx);
+                        /* Fall through to original evaluator untouched. */
+                    }
+                    else
+                    {
+                        if (log_dedup_claim(s_loggedAcceptCtxs, ctx))
+                            logger.trace("BaldFix: override active (ctx=0x{:X})",
+                                         ctx);
+                        return eval_with_priority_override(ruleObj, context);
+                    }
                 }
             }
             __except (EXCEPTION_EXECUTE_HANDLER)

--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -4,6 +4,8 @@
 #include <array>
 #include <cstdint>
 #include <limits>
+#include <mutex>
+#include <string_view>
 #include <vector>
 
 namespace EquipHide
@@ -155,7 +157,7 @@ namespace EquipHide
         // Legs (armor)
         {"CD_Lowerbody",                 Category::Legs},
         {"CD_Lowerbody_Acc",             Category::Legs},
-        {"CD_Underwear",                 Category::Legs},
+        {"CD_Underwear",                 Category::Underwear},
         // Gloves (armor)
         {"CD_Hand",                      Category::Gloves},
         {"CD_Hand_Acc",                  Category::Gloves},
@@ -217,6 +219,51 @@ namespace EquipHide
     /* Written during init (config load) before hooks; read by rebuild_part_lookup()
        on the background scan thread. Hook installation provides happens-before. */
     static std::string s_categoryParts[CATEGORY_COUNT];
+
+    /* Per-character Parts overrides. Empty = inherit from s_categoryParts[cat].
+       Written during config load and never thereafter, so no synchronisation needed
+       beyond the existing s_rebuildMutex guard on rebuild_part_lookup. */
+    static std::string s_categoryPartsPerChar[CATEGORY_COUNT][kCharIdxCount];
+
+    /* Active character index. -1 = use base Parts only (pre-resolution / unknown). */
+    static std::atomic<int> s_activeChar{-1};
+
+    /* Serialises rebuild_part_lookup(): the deferred IndexedStringA scan thread and
+       the player-detection char-swap poll can both trigger rebuilds concurrently. */
+    static std::mutex s_rebuildMutex;
+
+    std::string_view character_name_for_idx(std::size_t idx) noexcept
+    {
+        constexpr std::string_view names[] = {"Kliff", "Damiane", "Oongka"};
+        static_assert(std::size(names) == kCharIdxCount,
+                      "names[] must match kCharIdxCount");
+        return (idx < kCharIdxCount) ? names[idx] : std::string_view{};
+    }
+
+    void set_per_char_parts(Category cat, std::size_t charIdx, std::string partsStr)
+    {
+        if (charIdx >= kCharIdxCount)
+            return;
+        s_categoryPartsPerChar[static_cast<std::size_t>(cat)][charIdx] = std::move(partsStr);
+    }
+
+    int get_active_character() noexcept
+    {
+        return s_activeChar.load(std::memory_order_acquire);
+    }
+
+    /** @brief Pick effective Parts for a category, honouring the active per-char override. */
+    static const std::string& effective_parts_for_category(std::size_t catIdx) noexcept
+    {
+        const int active = s_activeChar.load(std::memory_order_acquire);
+        if (active >= 0 && active < static_cast<int>(kCharIdxCount))
+        {
+            const auto& override_parts = s_categoryPartsPerChar[catIdx][active];
+            if (!override_parts.empty())
+                return override_parts;
+        }
+        return s_categoryParts[catIdx];
+    }
 
     void set_runtime_hashes(std::unordered_map<std::string, uint32_t>&& nameToHash)
     {
@@ -338,9 +385,10 @@ namespace EquipHide
     static constexpr std::size_t k_bitsetWords = 1024;
     static std::array<uint64_t, k_bitsetWords> s_classifyBitsets[2]{};
 
-    void register_parts(Category cat, const std::string& partsStr)
+    void register_parts(Category cat, const std::string& partsStr, bool storeBase)
     {
-        s_categoryParts[static_cast<std::size_t>(cat)] = partsStr;
+        if (storeBase)
+            s_categoryParts[static_cast<std::size_t>(cat)] = partsStr;
 
         auto& logger = DMK::Logger::get_instance();
         auto& writeMap = s_partMaps[1 - s_activeMap.load(std::memory_order_relaxed)];
@@ -364,9 +412,31 @@ namespace EquipHide
             return;
         }
 
+        /* NONE sentinel -- case-insensitive, trimmed -- explicitly disables the
+           category (commonly used in per-character overrides like
+           [Lanterns:Damiane] Parts = NONE). Silent return, no warning. */
+        {
+            auto first = partsStr.find_first_not_of(" \t,");
+            auto last  = partsStr.find_last_not_of(" \t,");
+            if (first != std::string::npos && last != std::string::npos &&
+                (last - first + 1) == 4)
+            {
+                auto ch = [&](std::size_t i) {
+                    char c = partsStr[first + i];
+                    return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : c;
+                };
+                if (ch(0) == 'n' && ch(1) == 'o' && ch(2) == 'n' && ch(3) == 'e')
+                {
+                    logger.debug("{}: NONE (category explicitly disabled for this scope)",
+                                 category_section(cat));
+                    return;
+                }
+            }
+        }
+
         const auto& nameMap = name_to_hash_map();
 
-        // No runtime hashes yet — store names for deferred resolution only.
+        // No runtime hashes yet -- store names for deferred resolution only.
         // rebuild_part_lookup() will re-resolve after the scan completes.
         if (nameMap.empty())
             return;
@@ -540,16 +610,37 @@ namespace EquipHide
 
     void rebuild_part_lookup()
     {
+        std::lock_guard<std::mutex> lock(s_rebuildMutex);
         invalidate_name_to_hash_map();
         s_partMaps[1 - s_activeMap.load(std::memory_order_relaxed)].clear();
 
         for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
         {
-            if (!s_categoryParts[i].empty())
-                register_parts(static_cast<Category>(i), s_categoryParts[i]);
+            const auto& parts = effective_parts_for_category(i);
+            if (!parts.empty())
+                register_parts(static_cast<Category>(i), parts, /*storeBase=*/false);
         }
 
         build_part_lookup();
+    }
+
+    void set_active_character(int newIdx)
+    {
+        const int clamped =
+            (newIdx < -1 || newIdx >= static_cast<int>(kCharIdxCount)) ? -1 : newIdx;
+        const int prev = s_activeChar.exchange(clamped, std::memory_order_acq_rel);
+        if (prev == clamped)
+            return;
+
+        auto& logger = DMK::Logger::get_instance();
+        if (clamped >= 0)
+            logger.info("Active character -> {} (idx={})",
+                        character_name_for_idx(static_cast<std::size_t>(clamped)),
+                        clamped);
+        else
+            logger.info("Active character -> (base, no override)");
+
+        rebuild_part_lookup();
     }
 
     CategoryMask classify_part(uint32_t hash)

--- a/CrimsonDesertEquipHide/src/categories.hpp
+++ b/CrimsonDesertEquipHide/src/categories.hpp
@@ -30,6 +30,7 @@ namespace EquipHide
         Helm,
         Chest,
         Legs,
+        Underwear,
         Gloves,
         Boots,
         Cloak,
@@ -61,7 +62,7 @@ namespace EquipHide
         constexpr std::string_view names[] = {
             "OneHandWeapons", "TwoHandWeapons", "Shields", "Bows",
             "SpecialWeapons", "Tools", "Lanterns",
-            "Helm", "Chest", "Legs", "Gloves", "Boots",
+            "Helm", "Chest", "Legs", "Underwear", "Gloves", "Boots",
             "Cloak", "Shoulder", "Mask", "Glasses",
             "Earrings", "Rings", "Necklace", "Bags",
             "UserPreset1", "UserPreset2", "UserPreset3",
@@ -100,6 +101,7 @@ namespace EquipHide
         case Category::Helm:
         case Category::Chest:
         case Category::Legs:
+        case Category::Underwear:
         case Category::Gloves:
         case Category::Boots:
         case Category::Cloak:
@@ -166,11 +168,34 @@ namespace EquipHide
 
     // --- Part classification ---
 
-    /** @brief Parse a "Parts" string and register all contained IDs for the given category. */
-    void register_parts(Category cat, const std::string &partsStr);
+    /** @brief Parse a "Parts" string and register all contained IDs for the given category.
+     *  @param storeBase If true (default), also caches partsStr as the base Parts for
+     *                   subsequent rebuilds. Set false when applying a per-character
+     *                   override so the base Parts string is preserved. */
+    void register_parts(Category cat, const std::string &partsStr, bool storeBase = true);
 
     /** @brief Finalize the lookup map and compute hash range bounds. Call after all register_parts(). */
     void build_part_lookup();
+
+    // --- Per-character Parts overrides ---
+
+    /** @brief Number of supported protagonist identities for per-char overrides. */
+    inline constexpr std::size_t kCharIdxCount = 3;
+
+    /** @brief Returns human-readable name for a character index (0=Kliff, 1=Damiane, 2=Oongka).
+     *  @return Non-empty string_view for valid indices, empty view otherwise. */
+    std::string_view character_name_for_idx(std::size_t idx) noexcept;
+
+    /** @brief Store a per-character Parts override. Empty = inherit from the base [Section].
+     *  @note Does not rebuild; takes effect on the next set_active_character() or rebuild call. */
+    void set_per_char_parts(Category cat, std::size_t charIdx, std::string partsStr);
+
+    /** @brief Update the active character index. Triggers rebuild_part_lookup() on change.
+     *  @param charIdx 0..kCharIdxCount-1 for Kliff/Damiane/Oongka, or -1 to use only base Parts. */
+    void set_active_character(int charIdx);
+
+    /** @brief Returns the currently active character index, or -1 if using base only. */
+    int get_active_character() noexcept;
 
     /**
      * @brief Re-resolve part names against current runtime hashes and rebuild the lookup map.
@@ -179,7 +204,7 @@ namespace EquipHide
      */
     void rebuild_part_lookup();
 
-    /** @brief Category bitmask type — one bit per category (supports up to 32). */
+    /** @brief Category bitmask type -- one bit per category (supports up to 32). */
     using CategoryMask = uint32_t;
 
     /** @brief Returns a bitmask with only the given category's bit set. */

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -13,6 +13,8 @@
 #include "shared_state.hpp"
 #include "visibility_write.hpp"
 
+#include <cdcore/controlled_char.hpp>
+
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
@@ -96,6 +98,20 @@ namespace EquipHide
 
             DMK::Config::register_string(section, "Parts", section + " Parts", [cat](const std::string &val)
                                          { register_parts(cat, val); }, default_parts_string(cat));
+
+            /* Per-character Parts overrides: [Section:Kliff], [Section:Damiane],
+               [Section:Oongka]. Empty value (section missing) inherits from base. */
+            for (std::size_t charIdx = 0; charIdx < kCharIdxCount; ++charIdx)
+            {
+                const std::string charName{character_name_for_idx(charIdx)};
+                const std::string charSection = section + ":" + charName;
+                const std::string logLabel = section + " Parts (" + charName + ")";
+                DMK::Config::register_string(
+                    charSection, "Parts", logLabel,
+                    [cat, charIdx](const std::string &val)
+                    { set_per_char_parts(cat, charIdx, val); },
+                    "");
+            }
         }
 
         DMK::Config::load(INI_FILE);
@@ -309,6 +325,14 @@ namespace EquipHide
             k_worldSystemCandidates, std::size(k_worldSystemCandidates),
             "WorldSystem");
 
+        // Publish the WorldSystem holder to the Core controlled-character
+        // resolver. Core walks WorldSystem -> ActorManager -> UserActor ->
+        // controlled_actor(+0xD8) -> identity u32s at +0xDC and +0xEC.
+        // Idempotent across consumers: when CrimsonDesertLiveTransmog is
+        // loaded alongside, both publish the same address and the later
+        // writer wins (the intended behaviour after a re-resolve).
+        CDCore::set_world_system_holder(addrs.worldSystem);
+
         addrs.childActorVtbl = resolve_address(
             k_childActorVtblCandidates, std::size(k_childActorVtblCandidates),
             "ChildActorVtbl");
@@ -446,15 +470,28 @@ namespace EquipHide
 
         // Prevents baldness when hiding helmets/cloaks.  The hook temporarily
         // sets bit 19 in item+0x70 bitmasks per-call so PostfixEval sees
-        // inactive priority and hair-hiding rules don't match.  Player
-        // context is cached on first populated call; NPC contexts never match.
+        // inactive priority and hair-hiding rules don't match.  Player vs
+        // NPC invocations are distinguished by a call-graph landmark: NPC
+        // PostfixEval calls always traverse a specific caller whose return
+        // address we resolve via AOB (npcPfeReturnAddr); the hook scans
+        // its own stack window for that landmark and rejects NPC calls.
         if (flag_bald_fix().load(std::memory_order_relaxed))
         {
             auto postfixEvalAddr = resolve_address(
                 k_postfixEvalCandidates, std::size(k_postfixEvalCandidates),
                 "PostfixEval");
 
-            if (postfixEvalAddr)
+            auto npcPfeLandmark = resolve_address(
+                k_npcPfeReturnAddrCandidates,
+                std::size(k_npcPfeReturnAddrCandidates),
+                "NpcPfeReturnAddr");
+            // Landmark sits 12 bytes past the match start (first byte of the
+            // `mov rbx, [rsp+4A0]` right after the call), which is the real
+            // return address on an NPC stack frame.
+            if (npcPfeLandmark)
+                addrs.npcPfeReturnAddr = npcPfeLandmark + 12;
+
+            if (postfixEvalAddr && addrs.npcPfeReturnAddr)
             {
                 PostfixEvalFn trampoline = nullptr;
                 auto result = hookMgr.create_inline_hook(
@@ -465,16 +502,22 @@ namespace EquipHide
                 if (result.has_value())
                 {
                     set_postfix_eval_trampoline(trampoline);
-                    logger.info("PostfixEval inline hook installed at 0x{:X} -- bald fix active",
-                                postfixEvalAddr);
+                    logger.info("PostfixEval inline hook installed at 0x{:X}, "
+                                "npc-caller landmark 0x{:X} -- bald fix active",
+                                postfixEvalAddr, addrs.npcPfeReturnAddr);
                 }
                 else
                     logger.warning("PostfixEval hook failed: {} -- bald fix disabled",
                                    DetourModKit::Hook::error_to_string(result.error()));
             }
-            else
+            else if (!postfixEvalAddr)
             {
                 logger.warning("PostfixEval AOB scan failed -- bald fix disabled");
+            }
+            else
+            {
+                logger.warning("NpcPfeReturnAddr AOB scan failed -- bald fix disabled "
+                               "(refusing to run without the call-graph filter)");
             }
         }
         else

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -1,5 +1,8 @@
 #include "player_detection.hpp"
+#include "categories.hpp"
 #include "shared_state.hpp"
+
+#include <cdcore/controlled_char.hpp>
 
 #include <DetourModKit.hpp>
 
@@ -44,7 +47,10 @@ namespace EquipHide
         // Dedupe on (body, vc): only log when this body resolves to a
         // different vc than last seen. Small fixed LRU sized to the max
         // protagonist count -- any more is not useful for this resolver.
-        struct Entry { uintptr_t body, vc; };
+        struct Entry
+        {
+            uintptr_t body, vc;
+        };
         static Entry s_lru[k_maxProtagonists]{};
         static int s_next = 0;
         for (auto &e : s_lru)
@@ -78,9 +84,96 @@ namespace EquipHide
             auto am = read_ptr_unsafe(ws, 0x30);
             if (!am)
                 return;
+
             auto user = read_ptr_unsafe(am, 0x28);
             if (!user)
                 return;
+
+            /* World-reload invalidation. The UserActor pointer is
+               reallocated on every save load (the ActorManager rewrites
+               it; in-session character swaps only rotate user+0xD8 and
+               leave the singleton itself alone). Comparing the most
+               recently-seen user against the freshly-walked one is
+               therefore a reliable signal for "new world": when it
+               flips, wipe the Core resolver's cache so it does not
+               keep returning the previous save's character while the
+               new save is still populating the engine state. Runs
+               independently of LiveTransmog so EquipHide is self-
+               contained when loaded standalone.
+
+               The prevUser != 0 inner guard suppresses first-boot
+               invalidation: on the very first tick prevUser is zero
+               and curUser is the first valid singleton; invalidating
+               here would wipe a cache the resolver may have just
+               populated against the initial world. Static file scope
+               is fine because player_detection is single-threaded
+               (driven by the background_threads tick). */
+            static std::uintptr_t s_prevUser = 0;
+            if (user != s_prevUser)
+            {
+                if (s_prevUser != 0)
+                {
+                    CDCore::invalidate_controlled_character();
+                }
+                s_prevUser = user;
+            }
+
+            /* Character-swap invalidation. In-session protagonist
+               swaps (Kliff <-> Damiane <-> Oongka) rotate user+0xD8 to
+               point at a different ClientChildOnlyInGameActor without
+               touching the UserActor singleton above, so the first
+               trigger does not catch them. Without this second point
+               the LKG identity cached by CDCore against the prior
+               actor stays valid from Core's perspective and the
+               resolver's torn-read absorption returns the previous
+               character's name on any chain walk that lands on the
+               new wrapper before its +0x60 slot-index byte is
+               populated. Result downstream: set_active_character()
+               gets called with the wrong idx for one or more ticks
+               after the swap and the per-character Parts list
+               switches to the outgoing character's overrides until
+               the next tick re-classifies. Invalidating here costs at
+               most one polling tick of additional latency (the
+               resolver returns Unknown until the chain walk on the
+               new wrapper lands a known identity key) which the
+               caller tolerates by idx=-1 falling back to base Parts.
+
+               The prevControlledActor != 0 guard mirrors the
+               first-boot suppression above: on the very first tick
+               the prior value is zero and the freshly-walked pointer
+               is the initial controlled actor, so invalidating would
+               wipe a cache just populated against it. */
+            auto controlledActor = read_ptr_unsafe(user, 0xD8);
+            static std::uintptr_t s_prevControlledActor = 0;
+            if (controlledActor != s_prevControlledActor)
+            {
+                if (s_prevControlledActor != 0)
+                {
+                    CDCore::invalidate_controlled_character();
+                }
+                s_prevControlledActor = controlledActor;
+            }
+
+            /* Controlled-character identity via the shared Core
+               resolver. Core walks WorldSystem -> ActorManager ->
+               UserActor -> controlled_actor(+0xD8), then decodes the
+               (party_class, char_kind) u32 pair at the actor's +0xDC
+               and +0xEC into a known character. The WorldSystem holder
+               address is published by this module's init in
+               equip_hide.cpp via CDCore::set_world_system_holder, so
+               the resolver is wired up by the time the polling loop
+               first reaches this point. Idempotent across consumers:
+               LiveTransmog publishes the same address and the later
+               writer wins. Resolver returns 0 -> idx=-1 -> disabled
+               override on holder-not-published, faulted chain walk,
+               or unknown identity key. */
+            {
+                const auto idxU32 = CDCore::current_controlled_character_idx();
+                const int idx = (idxU32 >= 1 && idxU32 <= 3)
+                                    ? static_cast<int>(idxU32) - 1
+                                    : -1;
+                set_active_character(idx);
+            }
 
             static constexpr ptrdiff_t k_bodyOffsets[] = {
                 0xD0, 0xD8, 0xE0, 0xE8, 0xF0, 0xF8, 0x100, 0x108};

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -20,6 +20,22 @@ namespace EquipHide
         uintptr_t mapLookup = 0;
         uintptr_t mapInsert = 0;
         uintptr_t indexedStringGlobal = 0;
+        /**
+         * @brief Return-address landmark inside createPrefabFromPartPrefab
+         *        (sub_14261B6C0), on the instruction right after its
+         *        inner `call sub_1402E1430` (through which PostfixEval
+         *        runs for newly-instantiated prefabs).
+         *
+         * CE captures across Kliff (194 hits) and Oongka (173 hits)
+         * sessions on 2026-04-22: every PostfixEval hit that came from
+         * prefab instantiation (NPC creation events at load) had this
+         * return address on its stack; no player-side hit (196/196 for
+         * the two active-protagonist contexts) did. BaldFix uses this
+         * stack-presence check as a deterministic call-graph filter --
+         * no ctx caching, no frequency heuristics. Resolved via an AOB
+         * anchor at mod init.
+         */
+        uintptr_t npcPfeReturnAddr = 0;
     };
 
     ResolvedAddresses &resolved_addrs();
@@ -68,7 +84,7 @@ namespace EquipHide
             .count();
     }
 
-    /** @brief Unsafe pointer read — use ONLY inside SEH-protected hot paths. */
+    /** @brief Unsafe pointer read -- use ONLY inside SEH-protected hot paths. */
     inline uintptr_t read_ptr_unsafe(uintptr_t base, ptrdiff_t off) noexcept
     {
         auto addr = *reinterpret_cast<const uintptr_t *>(base + off);

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -5,8 +5,19 @@
 
 #include <Windows.h>
 
+#include <algorithm>
+#include <vector>
+
 namespace EquipHide
 {
+    /* File-scope scratch buffer reused across apply_direct_vis_write calls.
+       Populated under vis_write_mutex (held for the full duration of the
+       function) so concurrent callers never race. File scope rather than a
+       local inside the __try block both avoids MSVC C2712 (no
+       non-trivially-destructible object sharing scope with __try) and
+       keeps the stack small for game threads with tight stack reserves. */
+    static std::vector<std::uintptr_t> s_touchedVisAddrs;
+
     void apply_direct_vis_write() noexcept
     {
         auto &addrs = resolved_addrs();
@@ -17,6 +28,8 @@ namespace EquipHide
         auto &mtx = vis_write_mutex();
         if (!mtx.try_lock())
             return;
+
+        s_touchedVisAddrs.clear();
 
         __try
         {
@@ -57,6 +70,7 @@ namespace EquipHide
                         continue;
 
                     const auto visAddr = entry + 0x1C;
+                    s_touchedVisAddrs.push_back(visAddr);
                     auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
 
                     if (is_any_category_hidden(mask))
@@ -90,6 +104,51 @@ namespace EquipHide
                     }
                 }
             }
+
+            /* Orphan sweep. An entry lands here when its hash was in the
+               active character's hidden category at a previous apply pass
+               (so we wrote vis=2 and cached the original in origVis) but
+               is no longer in the part map for the current character (or
+               its category stopped being registered). The main loop above
+               iterates only the active character's map, so those orphan
+               entries would otherwise retain vis=2 indefinitely. Since
+               part-mesh names are shared across protagonists (e.g.
+               CD_Upperbody / CD_Vest exist on every humanoid), the
+               leaked vis=2 write from the previous character causes the
+               matching mesh on the new character to render hidden until
+               shutdown triggers cleanup_vis_bytes().
+
+               The touched-address vector is sorted once (cheap: at most a
+               few hundred entries) and orphan membership is resolved via
+               binary_search, giving O((|orig| + |touched|) * log(|touched|))
+               for the sweep. Restored bytes use the same (origVal == 2 ?
+               0 : origVal) mapping the in-map restore branch uses, so the
+               resulting state is indistinguishable from the path a
+               same-character hide-then-show would have taken. */
+            std::sort(s_touchedVisAddrs.begin(), s_touchedVisAddrs.end());
+            int orphanRestored = 0;
+            for (auto it = origVis.begin(); it != origVis.end();)
+            {
+                const auto visAddr = it->first;
+                if (std::binary_search(s_touchedVisAddrs.begin(),
+                                       s_touchedVisAddrs.end(), visAddr))
+                {
+                    ++it;
+                    continue;
+                }
+                auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
+                const auto origVal = it->second;
+                const auto restored = (origVal == 2) ? 0 : origVal;
+                *visPtr = static_cast<uint8_t>(restored);
+                it = origVis.erase(it);
+                ++orphanRestored;
+            }
+            if (orphanRestored > 0)
+                logger.debug(
+                    "DirectWrite: {} orphan vis bytes restored "
+                    "(category or character-swap sweep)",
+                    orphanRestored);
+            restoredCount += orphanRestored;
 
             logger.trace("DirectWrite: {} protagonists, {} hidden, {} restored",
                          n, hiddenCount, restoredCount);

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -39,6 +39,18 @@ Change the visual appearance of your equipped armor [b]in real time[/b] without 
 
 [line]
 
+[color=red][size=5][b]DO NOT INSTALL VIA MOD MANAGERS[/b][/size][/color]
+
+[color=red][b]This mod is manual-install only. Mod managers are NOT supported.[/b][/color]
+
+Mod managers often stage [b].asi[/b] files into their own subfolders. Ultimate ASI Loader scans subdirectories recursively, so the [b].asi[/b] keeps loading even after the manager reports the mod as "disabled" or "uninstalled". Common symptom: transmog still applies after you think the mod is gone.
+
+[b]Install manually[/b] by following the Installation steps below. [b]To uninstall,[/b] delete [b]CrimsonDesertLiveTransmog.asi[/b] and [b]CrimsonDesertLiveTransmog.ini[/b] directly from [b]bin64[/b] (not via the manager). If a manager moved your files into a subfolder like [b]bin64/plugins/[/b] or [b]bin64/backup/[/b], delete them from that subfolder too.
+
+[color=red][b]Issues reported for mod-manager installs will not be investigated. Reproduce on a clean manual install first.[/b][/color]
+
+[line]
+
 [size=5]Installation[/size]
 
 [size=4]Step 1 -Install an ASI Loader[/size]


### PR DESCRIPTION
## Summary

- **Per-character Parts overrides.** Every category accepts `[Section:Kliff]`, `[Section:Damiane]`, and `[Section:Oongka]` sub-sections; the mod auto-switches the effective Parts list when you swap characters in-game. Missing sub-section inherits from the base `[Section]`. `Parts = NONE` disables a category for a specific character.
- **BaldFix now works for all three protagonists** (previously Kliff-only).
- **Fixed character-swap hide-leak.** Swapping between characters could leave the previous character's hide state stuck on the new character's meshes (e.g. hiding Oongka's chest parts and then swapping to Kliff left Kliff bare-chested). The vis-byte writer now sweeps orphaned entries from the previous character.
- **AOB resilience.** `NpcPfeReturnAddr` cascade renamed and extended with `P2` / `P3` alternates that relax frame-disp and stack-adjust wildcards, following the unified `<Role>_P<N>_<Descriptor>` naming convention in the AOB guide.
- **Docs.** Added a Requirements section and the UAL subdirectory-scan caveat to the EH README. Added a prominent no-mod-manager warning on both EH and LT BBCode.

## Test plan

- [x] 3-party save: hide Oongka's chest parts, swap to Kliff -> Kliff renders normally (no bare chest leak)
- [x] Per-character INI: `[Chest:Oongka] Parts = CD_Upperbody` only hides chest for Oongka; Kliff/Damiane unaffected
- [x] `[Lanterns:Damiane] Parts = NONE` leaves Damiane's lantern visible while still toggling for Kliff/Oongka
- [x] BaldFix: helmet hide keeps hair visible on all three protagonists
- [x] Swap timing: rapid character swaps do not hang the vis-byte writer (orphan sweep is bounded, runs under the existing mutex)
