### PR TITLE
fix(live-transmog): support Crimson Desert game version 1.04.00

### DIFF
--- a/CrimsonDesertCore/include/cdcore/indexed_string_table.hpp
+++ b/CrimsonDesertCore/include/cdcore/indexed_string_table.hpp
@@ -3,10 +3,8 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 // ---------------------------------------------------------------------------
 // IndexedStringA table scanner.
@@ -19,13 +17,9 @@
 //
 // The scanner locates the `48 8B 05 <disp32>` instruction inside the first
 // 0x40 bytes of mapLookupFunc (patch-proof against compiler shuffles),
-// walks the chain, then enumerates the configured hash range and returns
-// every entry whose string starts with cfg.prefix.
-//
-// Optional wide-scan fallback: if cfg.getUnresolved is set, after the
-// primary range scan the scanner calls it with the partial map and
-// searches the extended range [1, cfg.wideScanMax) for the returned
-// unresolved names (skipping the primary range to avoid redundant work).
+// walks the chain, then enumerates the configured hash range end-to-end
+// in a single pass and returns every entry whose string starts with
+// cfg.prefix.
 // ---------------------------------------------------------------------------
 
 namespace CDCore
@@ -36,27 +30,19 @@ namespace CDCore
         // are skipped). "CD_" matches every Crimson Desert slot part name.
         const char *prefix = "CD_";
 
-        // Primary hash range -- entries in this range are always scanned.
-        std::uint32_t tableScanMin = 0xAC00;
-        std::uint32_t tableScanMax = 0xCFFF;
-
-        // Approximate number of matching entries on v1.02.00. Used only to
-        // colour the end-of-scan log line ("expected ~N entries").
-        std::uint32_t expectedEntries = 600;
+        // Hash range to sweep. The default covers the full observed bucket
+        // space; callers should only narrow it when a specific patch is
+        // known to keep the relevant entries inside a tighter window and
+        // scan cost is a concern. Per-version bucket drift (seen between
+        // v1.02.00, v1.03.01 and v1.04.00) means any narrow default has
+        // to be revisited every major patch; keeping it wide is the
+        // self-healing choice.
+        std::uint32_t tableScanMin = 1;
+        std::uint32_t tableScanMax = 0x1FFFF;
 
         // Offset of the table_array pointer inside the globalPtr struct.
         // Runtime-data layout, resolved by IDA on v1.02.00. No AOB.
         std::ptrdiff_t tableArrayOffset = 0x58;
-
-        // Optional wide-scan fallback. If set AND wideScanMax > 0, the
-        // scanner calls getUnresolved(primaryResults) after the primary
-        // range pass; each returned name is then probed across the
-        // extended range [1, wideScanMax) (skipping the primary range).
-        // Leave unset to disable the fallback.
-        std::uint32_t wideScanMax = 0;
-        std::function<std::vector<std::string>(
-            const std::unordered_map<std::string, std::uint32_t> &)>
-            getUnresolved;
 
         // Label used in log lines. Change it to distinguish per-mod scans
         // in the shared log stream.

--- a/CrimsonDesertCore/src/aob_resolver.cpp
+++ b/CrimsonDesertCore/src/aob_resolver.cpp
@@ -121,6 +121,14 @@ namespace CDCore
 
         // Blacklist: reject known poison, accept anything else. See
         // header comment for the full rationale and history.
+        //
+        // JMP opcodes (E9/EB/FF 25) are NOT rejected: sibling mods
+        // (EquipHide + LiveTransmog both hook VEC/BatchEquip) legitimately
+        // patch these prologues and the resolver must still succeed so
+        // SafetyHook can layer its trampoline on top of the existing one.
+        // SafetyHook handles pre-hooked targets by decoding the existing
+        // JMP into the new trampoline; refusing here would break the
+        // second mod's init entirely.
         if (b0 == 0x00 || b0 == 0xCC || b0 == 0xC2 || b0 == 0xC3)
             return false;
 

--- a/CrimsonDesertCore/src/indexed_string_table.cpp
+++ b/CrimsonDesertCore/src/indexed_string_table.cpp
@@ -120,8 +120,7 @@ namespace CDCore
             cfg.tableScanMin, cfg.tableScanMax);
 
         const auto t0 = std::chrono::steady_clock::now();
-        std::uint32_t primaryEntries = 0;
-        std::uint32_t probeHits = 0;
+        std::uint32_t entries = 0;
         char buf[k_maxStringLen + 1];
 
         for (std::uint32_t hash = cfg.tableScanMin;
@@ -135,44 +134,7 @@ namespace CDCore
                 continue;
 
             nameToHash[std::string(buf, len)] = hash;
-            ++primaryEntries;
-        }
-
-        // Optional wide-scan fallback for entries that fell outside the
-        // primary bucket range. Skips the primary range to avoid
-        // redundant work.
-        if (cfg.getUnresolved && cfg.wideScanMax > 0)
-        {
-            auto unresolved = cfg.getUnresolved(nameToHash);
-            for (std::uint32_t h = 1;
-                 h < cfg.wideScanMax && !unresolved.empty(); ++h)
-            {
-                if (h >= cfg.tableScanMin && h <= cfg.tableScanMax)
-                    continue;
-
-                const auto len = read_table_entry(
-                    tableArray, h, buf, sizeof(buf));
-                if (len == 0 || len >= k_maxStringLen)
-                    continue;
-                if (!matches_prefix(buf, len, cfg.prefix))
-                    continue;
-
-                for (auto it = unresolved.begin();
-                     it != unresolved.end(); ++it)
-                {
-                    if (len == it->size() &&
-                        std::memcmp(buf, it->c_str(), len) == 0)
-                    {
-                        nameToHash[*it] = h;
-                        ++probeHits;
-                        logger.trace(
-                            "{}: wide-scan {} found at 0x{:X}",
-                            cfg.logLabel, *it, h);
-                        unresolved.erase(it);
-                        break;
-                    }
-                }
-            }
+            ++entries;
         }
 
         const auto t1 = std::chrono::steady_clock::now();
@@ -180,33 +142,22 @@ namespace CDCore
             std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0)
                 .count();
 
-        const auto totalEntries = primaryEntries + probeHits;
-        if (totalEntries == 0)
+        if (entries == 0)
         {
             logger.warning(
                 "{}: 0 entries matching prefix '{}' found in range "
-                "0x{:X}..0x{:X} (expected ~{} on v1.02.00) -- hash bucket "
-                "layout may have shifted, deferring feature",
+                "0x{:X}..0x{:X} -- table not yet populated or prefix "
+                "missing from this build; deferring feature",
                 cfg.logLabel, cfg.prefix ? cfg.prefix : "",
-                cfg.tableScanMin, cfg.tableScanMax, cfg.expectedEntries);
-        }
-        else if (probeHits > 0)
-        {
-            logger.info(
-                "{}: {} entries ({} primary, {} wide-probe) for prefix "
-                "'{}' in {}ms",
-                cfg.logLabel, totalEntries, primaryEntries, probeHits,
-                cfg.prefix ? cfg.prefix : "", ms);
+                cfg.tableScanMin, cfg.tableScanMax);
         }
         else
         {
             logger.info(
                 "{}: {} entries for prefix '{}' in range 0x{:X}..0x{:X} "
-                "(expected ~{}) in {}ms",
-                cfg.logLabel, totalEntries,
-                cfg.prefix ? cfg.prefix : "",
-                cfg.tableScanMin, cfg.tableScanMax,
-                cfg.expectedEntries, ms);
+                "in {}ms",
+                cfg.logLabel, entries, cfg.prefix ? cfg.prefix : "",
+                cfg.tableScanMin, cfg.tableScanMax, ms);
         }
 
         return nameToHash;

--- a/CrimsonDesertEquipHide/src/dllmain.cpp
+++ b/CrimsonDesertEquipHide/src/dllmain.cpp
@@ -31,7 +31,22 @@ static DWORD WINAPI lifecycle_thread(LPVOID /*param*/)
     EquipHide::Version::logVersionInfo();
 
     std::wstring runtimeDirW = DMK::Filesystem::get_runtime_directory();
-    std::string runtimeDir(runtimeDirW.begin(), runtimeDirW.end());
+    std::string runtimeDir;
+    if (!runtimeDirW.empty())
+    {
+        int needed = WideCharToMultiByte(
+            CP_UTF8, 0,
+            runtimeDirW.data(), static_cast<int>(runtimeDirW.size()),
+            nullptr, 0, nullptr, nullptr);
+        if (needed > 0)
+        {
+            runtimeDir.resize(static_cast<std::size_t>(needed));
+            WideCharToMultiByte(
+                CP_UTF8, 0,
+                runtimeDirW.data(), static_cast<int>(runtimeDirW.size()),
+                runtimeDir.data(), needed, nullptr, nullptr);
+        }
+    }
     logger.info("DLL loaded, runtime dir: {}", runtimeDir);
 
     if (!CDCore::Dev::acquire_instance_mutex(

--- a/CrimsonDesertEquipHide/src/indexed_string_table.cpp
+++ b/CrimsonDesertEquipHide/src/indexed_string_table.cpp
@@ -1,5 +1,4 @@
 #include "indexed_string_table.hpp"
-#include "categories.hpp"
 
 #include <cdcore/indexed_string_table.hpp>
 
@@ -10,16 +9,6 @@ namespace EquipHide
     {
         CDCore::IndexedStringScanConfig cfg;
         cfg.logLabel = "IndexedStringA scan [EH]";
-        // Wide-scan fallback: any CD_ part declared in categories.hpp
-        // that didn't land in the primary bucket range gets probed over
-        // the extended range. Keeps us resilient to future hash-bucket
-        // reshuffles that move a category name outside 0xAC00..0xCFFF.
-        cfg.wideScanMax = 0x20000;
-        cfg.getUnresolved =
-            [](const std::unordered_map<std::string, std::uint32_t> &primary) {
-                return get_unresolved_parts(primary);
-            };
-
         return CDCore::scan_indexed_string_table(mapLookupFunc, cfg);
     }
 

--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -110,9 +110,11 @@ If you run into issues, check the OptiScaler documentation for DLL naming and co
 3. Use the search box to filter by name
 4. Select an item - changes stay **pending** until you click **Apply All**
 5. Click **Apply All** to commit all slot changes at once
-6. Use **Append** in the Presets section to save your current look
-7. Use **Prev** / **Next** to cycle through saved presets
-8. Press **Home** again to close the overlay
+6. Use **Append** in the Presets section to create a fresh preset with every slot ticked and set to (none) -- a hide-all starting point you can fill in from the pickers
+7. Use **Copy** to duplicate the current preset (including any unsaved picker edits) into a new slot you can tweak without touching the source
+8. **Save** commits unsaved picker edits back into the active preset. The button turns orange with a `*` marker and a `[UNSAVED -- click Save]` banner appears in the header whenever your edits differ from the stored preset
+9. Use **Prev** / **Next** to cycle through saved presets
+10. Press **Home** again to close the overlay
 
 > **Tip:** Enable **Instant Apply** in the overlay to preview items on hover without needing to click Apply All.
 

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_display_names.tsv
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_display_names.tsv
@@ -2,18 +2,6 @@ Aant_PlateArmor_Helm	Awrain Plate Helm
 Abacus	Abacus
 Abidon_Fabric_Helm	Pailunese Hat
 Abidon_Fabric_Helm_T5_QA	Abidon Fabric Helm T5 QA
-Abyss_Artifact	Abyss Artifact
-Abyss_InfiniteStat_Hp30	Vitality of the Abyss
-Abyss_InfiniteStat_Mp2	Spirit of the Abyss
-Abyss_InfiniteStat_Sp3	Breath of the Abyss
-Abyss_Surreal_Human_Fabric_Boots	Rabbit Cloth Boots
-Abyss_Surreal_Human_Leather_Armor	Rabbit Leather Coat
-Abyss_Surreal_Human_Leather_Helm	Rabbit Leather Mask
-Abyss_Surreal_Wolf_Leather_Armor	Jester Leather Coat
-Abyss_Surreal_Wolf_Leather_Cloak	Jester Leather Cloak
-Abyss_Surreal_Wolf_Leather_Gloves	Jester Leather Gloves
-Abyss_Surreal_Wolf_Leather_Helm	Jester Leather Mask
-Abyss_Surreal_Wolf_Necklace	Surreal Necklace
 AbyssGear_Epistle	White Crow's Letter
 AbyssReward_Desert_OneHandMace	Desert Hammer
 AbyssReward_Dragon_TwoHandGiantHammer	Aeserion Greathammer
@@ -30,8 +18,20 @@ AbyssReward_Titan_TwoHandSpear	Reckoning
 AbyssReward_WhiteHorn_Ring	White Horn's Ring
 AbyssRuinsCreatureCore	Abyss Cell
 AbyssStone_Seed	Abyssal Seed
+Abyss_Artifact	Abyss Artifact
+Abyss_InfiniteStat_Hp30	Vitality of the Abyss
+Abyss_InfiniteStat_Mp2	Spirit of the Abyss
+Abyss_InfiniteStat_Sp3	Breath of the Abyss
+Abyss_Surreal_Human_Fabric_Boots	Rabbit Cloth Boots
+Abyss_Surreal_Human_Leather_Armor	Rabbit Leather Coat
+Abyss_Surreal_Human_Leather_Helm	Rabbit Leather Mask
+Abyss_Surreal_Wolf_Leather_Armor	Jester Leather Coat
+Abyss_Surreal_Wolf_Leather_Cloak	Jester Leather Cloak
+Abyss_Surreal_Wolf_Leather_Gloves	Jester Leather Gloves
+Abyss_Surreal_Wolf_Leather_Helm	Jester Leather Mask
+Abyss_Surreal_Wolf_Necklace	Surreal Necklace
 Acembel_Leather_Gloves	Essembel Leather Gloves
-Acid_Spider_Poison	Acidic Spider Venom
+Acid_Spider_Poison	Acid Spider Venom
 Acorn	Acorn
 Acquirs_Wood_OneHandShield	Rising Arrow Shield
 Adeion_Leather_Boots	Adeion Leather Boots
@@ -54,12 +54,12 @@ Alida_Restraint_OneHandPistol	Shadow of the Past Pistol
 Allbit_Leather_Boots	Alvitt Leather Boots
 Alpein_Fabric_Armor	Alphen Cloth Armor
 Alsace_Fabric_Armor	Alsace Cloth Armor
-Alustin_Journal_Book_I	Archive Record: Ch. 1
-Alustin_Journal_Book_II	Archive Record: Ch. 2
-Alustin_Journal_Book_III	Archive Record: Ch. 3
-Alustin_Journal_Book_IV	Archive Record: Ch. 4
-Alustin_Journal_Book_V	Archive Record: Ch. 5
-Alustin_Journal_Book_VI	Archive Record: Final Chapter
+Alustin_Journal_Book_I	Archive Records: Vol. I
+Alustin_Journal_Book_II	Archive Records: Vol. II
+Alustin_Journal_Book_III	Archive Records: Vol. III
+Alustin_Journal_Book_IV	Archive Records: Vol. IV
+Alustin_Journal_Book_V	Archive Records: Vol. V
+Alustin_Journal_Book_VI	Archive Records: Vol. VI
 Ama	Flax
 Amanas_ChainMail_Armor	Amanas Chain Mail
 Amanta_PlateArmor_Armor	Amanta Plate Armor
@@ -105,8 +105,8 @@ Apenzel_OneHandRapier	Fallen Kingdom's Rapier
 Apothecary_BackPack_I	Apothecary's Pack
 Apothecary_BackPack_II	Apothecary's Pack
 Apple	Apple
-Apple_BackPack	Apple Pack
 AppleTree_Seed	Apple Seed
+Apple_BackPack	Apple Pack
 Arandhal_Fabric_Armor	Arandhal Cloth Armor
 Arcalu_PlateArmor_Armor	Arcalu Plate Armor
 Archaia_OneHandMace	Spine of the Earth
@@ -191,11 +191,13 @@ Ballet_Leather_Gloves	Barre Leather Gloves
 Balthazar_BackPack	Wyvernflames Captain's Pack
 Baltimer_Leather_Armor	Baltimier Leather Armor
 Balton_OneHandMace	Balton Hammer
+Bamboo_Branch_01	Bamboo Stalk
+Bamboo_Branch_02	Sturdy Bamboo Stalk
 Bamboo_TwoHandSpear	Bamboo Spear
 Banana_Bread	Fruit Bread
 Bandit_Leather_Boots	Bandit's Leather Greaves
 Bandit_Leather_Boots_II	Bandit's Leather Greaves
-Bandit_Leather_Gloves_I	Bandit Leather Gloves
+Bandit_Leather_Gloves_I	Bandit's Leather Gloves
 Bandit_Leather_Gloves_II	Orc Bandit's Leather Gloves
 Bandit_Leather_Gloves_III	Bandit's Scale Leather Gloves
 Baraccuro_Fabric_Armor	Baraccuro Cloth Armor
@@ -220,8 +222,6 @@ Barndid_Fabric_Armor	Bandide Cloth Armor
 Barnia_ChainMail_Boots	Varnian Chain Boots
 Barnia_Fabric_Armor	Varnia Cloth Armor
 Barnia_Fabric_Helm	Varnia Cloth Cap
-barnia_Flag_I	Small Varnian Banner Pike
-barnia_Flag_II	Medium Varnian Banner Pike
 Barnia_Leather_Gloves	Varnian Leather Gloves
 Barnia_Soldier_General_Fabric_Armor	Varnian Guard Captain's Cloth Armor
 Barnia_Soldier_General_Fabric_Cloak	Varnian Guard Captain's Cloth Cloak
@@ -232,13 +232,13 @@ Bastion_OneHandMace	Mace of Ambition
 Bastion_OneHandShield	Black Sun
 Bastion_PlateArmor_Armor	Bastier Armor
 Batangka_Leather_Armor	Batangka Leather Armor
-BattleSticky_FlowerBomb	Sticky Flower Bomb
 BattleStickyBomb	Sticky Bomb
+BattleSticky_FlowerBomb	Sticky Flower Bomb
 Battmen_Fabric_Armor	Bartmun Cloth Armor
 Batz_OneHandDagger	Kylus Dagger
-Batz_Plate_Boots	Batz Plate Boots
 Batz_PlateArmor_Gloves	Batz Plate Gloves
 Batz_PlateArmor_Gloves_I	Batz Plate Gloves I
+Batz_Plate_Boots	Batz Plate Boots
 Bayur_Fabric_Armor	The Faceless's Cloth Armor
 Bayur_Leather_Boots	Bayer Leather Boots
 Bayur_PlateArmor_Helm	Bayer Plate Helm
@@ -265,6 +265,7 @@ Begill_Leather_Boots	Begill Leather Boots
 Begonia	Begonia
 Bekker_OneHandAxe	Bekker Axe
 Bekker_OneHandSword	Alabaster Curved Sword
+Beldrak_WarthogArmor_Armor	Warthog Beldrak Armor
 Bell_BackPack	Bell Pack
 Bell_Flower	Lily of the Valley
 Bellac_HorseArmor_Helm	Velok Champron
@@ -298,7 +299,7 @@ Bessenette_Leather_Boots	Bessett Leather Boots
 Bessenette_PlateArmor_Gloves	Bessett Plate Gloves
 Bessenette_PlateArmor_Helm	Besnet Plate Helm
 Bethel_Leather_Boots	Bethel Leather Boots
-Betty_Leather_Boots	Beattie Leather Boots
+Betty_Leather_Boots	Bettie Leather Boots
 Betty_Leather_Gloves	Bettie Leather Gloves
 Beverly_PlateArmor_Armor	Beverly Plate Armor
 Bhetert_TwoHandAxe	Fan-Blade Greataxe
@@ -325,19 +326,19 @@ Birdish_Leather_Armor	Verdesh Leather Armor
 Birdish_Leather_Gloves	Verdesh Leather Gloves
 Biryghton_Leather_Gloves	Viraiton Leather Gloves
 Biryghton_OneHandMace	Wells Mace
+BismuthOre	Bismuth Ore
 Bismuth_CannonBall_Errant	Crude Bismuth Cannonball
 Bismuth_TwoHandCannon_I	Bismuth Cannon
 Bismuth_TwoHandSpear	Bismuth Spear
-BismuthOre	Bismuth Ore
+BlackBear_Leather_Gloves	Black Bear Leather Gloves
+BlackOath_OneHandShield	Black Oath Shield
 Black_Horse_Report	Sighting of Rokade
 Black_Lion_Earring	Black Lion Earring
 Blackbear_Flag_I	Small Black Bears Banner Pike
 Blackbear_Flag_II	Medium Black Bears Banner Pike
 Blackbear_Flag_IV	Black Bears Banner Pike with Tassel
-BlackBear_Leather_Gloves	Black Bear Leather Gloves
 Blackberry	Blackberry
 Blackburn_PlateArmor_Armor	Blackburn Plate Armor
-BlackOath_OneHandShield	Black Oath Shield
 Blady_ChainMail_Armor	Blandry Chain Mail
 Blank_Book	Empty Book
 Bleann_Leather_Armor	Blin Leather Armor
@@ -352,8 +353,8 @@ Bleed_Flag_III	Medium Bleed Bandits Banner Pike
 Bloatte_Leather_Armor	Blaine Leather Armor
 BloodyFarmhouse_Book	Quarry Manager's Log
 Blowin_Leather_Armor	Bleawin Leather Armor
-Blueberry	Blueberry
 BlueStone	Azurite
+Blueberry	Blueberry
 Blyan_Leather_Gloves	Blyne Leather Bracers
 BoardPaperBundle	Posters
 Boboten_Leather_Boots	Bourveten Leather Boots
@@ -368,15 +369,17 @@ Bolton_PlateArmor_Armor	Bolton Plate Armor
 Bolton_PlateArmor_Cloak	Bolton Plate Cloak
 Bolton_PlateArmor_Helm	Keredeg Plate Helm
 Bolzers_Leather_Armor	Bolzers Leather Armor
+BombSpider_CannonBall	Mine Spider Cannonball
 Bomb_Arrow	Explosive Arrow
 Bomb_Smoke	Smoke Bomb
-BombSpider_CannonBall	Mine Spider Cannonball
 BoneCollectorWagon_Book	Skull Collector's Journal
+Book_Azerian_Diary	Azerian's Journal
 Book_Battle_ATT_Alfonso	Spear Manual of House Alfonso, Vol. 2
 Book_Battle_DEF_Alfonso	Spear Manual of House Alfonso, Vol. 1
 Book_Battle_EXP_Alfonso	Spear Manual of House Alfonso, Vol. 3
 Book_Beighen_Diary	Journal
 Book_DrugFactory	Equipment Manual
+Book_Dusty_Diary	Dusty Journal
 Book_FruitofGreed	Investigative Log: Harvest of Greed
 Book_GoldleafGuildhouse_Clue	Horse Hire Ledger
 Book_GoldleafGuildhouse_Clue_I	Empty Ledger
@@ -385,10 +388,17 @@ Book_Hernand_story	Tales of Sunset Valley
 Book_HyperSpace	Old Research Journal
 Book_Investigation_GoldleafGuildhouse	Investigative Log: Extinguish the Flames
 Book_Investigation_Log	Investigative Log: Shadows in the Village
+Book_Marni_Tech_Book	A book of Marni's skills passed down from Marshell.
 Book_Misappropriation_Log	Investigative Log: Ambition in the Ruins
+Book_Octabus_Research_Diary	Octavius's Research Log
+Book_Old_Kliff_Diary	Goyen's Journal
 Book_RedfoxTradePost_Questioning	Investigative Log: Broken Silence
 Book_ScholarLibrary_Knowledge_Knowledge_PlateArmor_Helm	The Knowledge Helm
+Book_Tax_Collection_Ledger	Tax Collection Ledger
+Book_Traitor_Hit_List	Traitor Hit List
 Book_TruthontheSand	Investigative Log: Truth on the Sands
+Book_Urdavah_Research_Book	Urdavah Book
+Book_Vordis_Research_Diary	Bordis's Research Log
 Book_WeightOfKnowledge	Investigative Log: The Weight of Knowledge
 Bopet_PlateArmor_Helm	Bobfett Plate Helm
 Borman_Fabric_Armor	Borman Cloth Armor
@@ -402,7 +412,7 @@ Boss_Reward_BountyReduction	Shadow Contract
 Boss_Reward_CatFishMap	Voyages of Sir Catfish
 Boss_Reward_DelesyianNode	REN-X Surveillance Record
 Boss_Reward_DragonParts	Golden Star's Component
-Boss_Reward_Efficiency	Golden Beer
+Boss_Reward_Efficiency_Charm	Golden Beer
 Boss_Reward_FishMap	Mossy Secret Map
 Boss_Reward_GoldVeinMap	Gold Vein Map
 Boss_Reward_Graymanes	Seal of Devotion
@@ -417,15 +427,15 @@ Boss_Reward_MerchantKing_SaltroadTradePost	Seal of Greed - Saltroad Trading Post
 Boss_Reward_MerchantKing_SilvermoonTroll	Seal of Greed - Silvermoon Trade Group
 Boss_Reward_MiraculousRecovery	Bloodstained Blessing
 Boss_Reward_Npc01Intimacy	Mysterious Gift
-Boss_Reward_QuickLearner	Sage's Eye
+Boss_Reward_QuickLearner_Charm	Sage's Eye
 Boss_Reward_ReturnCamp	Memory of a Fallen Kingdom
 Boss_Reward_StatsCrime	Chalice of Corruption
 Boss_Reward_StatsMp	T'rukan's Fighting Spirit
 Boss_Reward_StatsStamina	Dark Red Goblet
 Boss_Reward_SummonMerchant	Hologram Projector
-Boss_Reward_Supercarrot	Giant Brown Sugar Cube
 Boss_Reward_SuperSkill	Blessing of the Immortal
 Boss_Reward_SuperWeapon	Axe of the Apocalypse
+Boss_Reward_Supercarrot	Giant Brown Sugar Cube
 Boss_Reward_Survivors	The Ivory Messenger
 Boss_Reward_Tracker	Leebur's Soul
 BountyHunter_Fabric_Armor	Bounty Hunter's Cloth Armor
@@ -453,17 +463,17 @@ BountyHunter_Leather_Boots_I	Strapped Bounty Hunter's Leather Boots
 BountyHunter_Leather_Gloves	Ringed Leather Gloves
 BountyHunter_Leather_Gloves_I	Tough Hunter's Leather Gloves
 BountyHunter_Leather_Gloves_II	Thick Hunter's Leather Gloves
-BountyHunter_Leather_Helm_I	Bounty Hunter's Scale Helm
-BountyHunter_Leather_Helm_II	Bounty Hunter's Leather Helm
+BountyHunter_Leather_Helm_I	Bounty Hunter's Scale Hat
+BountyHunter_Leather_Helm_II	Bounty Hunter's Leather Cap
+BountyHunter_PlateArmor_Gloves_I	Bounty Hunter's Plate Gloves
+BountyHunter_PlateArmor_Helm	Horned Bounty Hunter's Plate Helm
+BountyHunter_PlateArmor_Helm_I	Bounty Hunter's Plate Helm
+BountyHunter_PlateArmor_Helm_II	Crow Bounty Plate Helm
 BountyHunter_Plate_Armor	Bounty Hunter's Plate Armor
 BountyHunter_Plate_Armor_I	Bounty Hunter's Plate Armor
 BountyHunter_Plate_Armor_II	Bounty Hunter's Plate Armor
 BountyHunter_Plate_Armor_III	Bounty Hunter's Plate Armor
 BountyHunter_Plate_Boots	Bounty Hunter's Plate Boots
-BountyHunter_PlateArmor_Gloves_I	Bounty Hunter's Plate Gloves
-BountyHunter_PlateArmor_Helm	Horned Bounty Hunter's Plate Helm
-BountyHunter_PlateArmor_Helm_I	Bounty Hunter's Plate Helm
-BountyHunter_PlateArmor_Helm_II	Crow Bounty Plate Helm
 Bourgogne_OneHandMace	Sorcerer's Massage Stick
 Braised_Fish	Braised Fish
 Braised_Fish_Large	Satisfying Braised Fish
@@ -511,13 +521,11 @@ Bulga_Leather_Armor	Bulga Leather Armor
 Bullet	Bullet
 Bunce_Leather_Gloves	Bunce Leather Gloves
 Burimen_PlateArmor_Armor	Breemen Plate Armor
-burrowingtoad	Burrowing Toad
 Bydan_Fabric_Gloves	Baidan Cloth Gloves
 ByeorSeungja_Chongtong_TwoHandCannon_I	Gamma Barrel Cannon
 Cabbage	Cabbage
 CabinDeathMystery_Book	Journal at the Cabin
 Cacao	Cacao
-cacao_Seed	Cacao Seed
 Cacheco_Leather_Boots	Catcheta Leather Boots
 Cadwallon_ChainMail_Helm	Kadallon Chain Coif
 Cadwallon_Leather_Boots	Kadallon's Leather Boots
@@ -533,9 +541,9 @@ Caliburn_Engineer_Leather_Gloves	Caliburn's Combat Engineer Leather Gloves
 Caliburn_Flag	Small Caliburn's Banner Pike
 Caliburn_Flag_I	Small Caliburn's Banner Pike
 Caliburn_Flag_II	Medium Caliburn's Banner Pike
-Caliburn_Plate_Boots	Caliburn's Plate Boots
 Caliburn_PlateArmor_Armor	Caliburn's Plate Armor
 Caliburn_PlateArmor_Gloves	Caliburn's Plate Gloves
+Caliburn_Plate_Boots	Caliburn's Plate Boots
 Caliburn_Report	Investigative Report
 Caliburn_Tolerance_OneHandPistol	Caliburn's Mercy Pistol
 Caliburn_TwoHandSword	Righteous Verdict
@@ -589,7 +597,6 @@ Caviden_Leather_Gloves	Caviden Leather Gloves
 Caviden_Wood_OneHandShield	Sydmon Kite Shield
 Cebro_Fabric_Gloves	Serbello Cloth Gloves
 Cecilia_Kokes_OneHandMace	Acorn Mace
-centipede	Centipede
 Ceremonial_OneHandDagger	Ator's Finger
 Cernos_HorseArmor_Armor	Cernos Barding
 Ceruon_PlateArmor_Armor	Cerruan Plate Armor
@@ -629,8 +636,8 @@ Cigrymon_Plate_Boots	Sigremon Plate Boots
 Cigrymon_TwoHandAxe	Sigremon Greataxe
 Cilantro_Leather_Boots	Sillau Leather Boots
 CircusMachine_Sphere	Circus Machine Sphere
-Claire_Leather_Gloves	Claire Leather Gloves
 ClaireHill_Leather_Boots	Clarille Leather Boots
+Claire_Leather_Gloves	Claire Leather Gloves
 Clays_Leather_Boots	Clays Leather Boots
 Clays_Leather_Boots_I	Desert Clays Leather Boots
 Clays_Leather_Boots_II	Large Clays Leather Boots
@@ -646,12 +653,6 @@ Cog_Pack	Cogwheel
 Colatte_Leather_Armor	Colatte Leather Armor
 Colbern_Leather_Boots	Colbern Leather Boots
 Colbill_Leather_Armor_I	Colbill Leather Armor
-Collection_gemstone_lamp_0001	Icy White Processed Crystal
-Collection_gemstone_lamp_0001_index01	Twilight Processed Crystal
-Collection_gemstone_lamp_0001_index02	Lilac Processed Crystal
-Collection_gemstone_lamp_0002	Icy White Crystal
-Collection_gemstone_lamp_0002_index01	Twilight Crystal
-Collection_gemstone_lamp_0002_index02	Lilac Crystal
 Collection_Lamp_Candle_0001	Icy White Glass Lamp
 Collection_Lamp_Candle_0001_index01	Twilight Glass Lamp
 Collection_Lamp_Candle_0001_index02	Lilac Glass Lamp
@@ -667,7 +668,7 @@ Collection_Lamp_Candle_0004_index02	Lilac Hexagonal Lamp
 Collection_Prop_Bismuthornament_0001	Broken Bismuth Ornament
 Collection_Prop_Bismuthornament_0002	Angular Bismuth Ornament
 Collection_Prop_Bismuthornament_0003	Round Bismuth Ornament
-Collection_Prop_Bottle_0001	Blue-Green Glass Water Bottle
+Collection_Prop_Bottle_0001	Crimson Glass Container
 Collection_Prop_Bottle_0002	Wooden Container
 Collection_Prop_Bottle_0003	Portable Wooden Container
 Collection_Prop_Bottle_0004	Blue Round Water Bottle
@@ -746,7 +747,7 @@ Collection_Prop_Bowl_0023	Wooden Beaker
 Collection_Prop_Bowl_0024	Oak Beaker
 Collection_Prop_Bowl_0025	Two-Handled Bronze Cup
 Collection_Prop_Bowl_0026	Pot
-Collection_Prop_Bowl_0027	Ceremonial Bowl
+Collection_Prop_Bowl_0027	Large Ceremonial Bowl
 Collection_Prop_Candle_0001	Twin Candles
 Collection_Prop_Candle_0002	Candle
 Collection_Prop_Candle_0003	Plain Candle
@@ -757,11 +758,11 @@ Collection_Prop_Candle_0007	Iron Cup Candle
 Collection_Prop_Candle_0008	Iron Candle
 Collection_Prop_Candle_0009	Tripod Candle
 Collection_Prop_Candle_0010	Four-Candle Candelabra
-Collection_Prop_Candle_0011	Tarnished Four Candle Candelabra
+Collection_Prop_Candle_0011	Tarnished Four-Candle Candelabra
 Collection_Prop_Ceramic_0001	Blue Patterned Ceramic
 Collection_Prop_Ceramic_0002	Slim Celadon Bottle
 Collection_Prop_Ceramic_0003	Freshly Fired Celadon Vase
-Collection_Prop_Ceramic_0004	Medicine Ceramic Jar
+Collection_Prop_Ceramic_0004	Ceramic for Medicinal Use
 Collection_Prop_Ceramic_0005	Multipurpose Jar
 Collection_Prop_Ceramic_0006	Medicine Jar
 Collection_Prop_Ceramic_0007	Round Jar
@@ -796,6 +797,10 @@ Collection_Prop_Ceramic_0052	Old Round Jar
 Collection_Prop_Ceramic_0053	Brown Round Jar
 Collection_Prop_Ceramic_0054	Old Water Pot
 Collection_Prop_Ceramic_0055	Light Brown Water Pot
+Collection_Prop_Ceramic_0056	Flower Bird Glass Pottery
+Collection_Prop_Ceramic_0057	Blue Gilded Handle Ceramic
+Collection_Prop_Ceramic_0058	Blue Ceramic Container
+Collection_Prop_Ceramic_0059	The Blue Mirage
 Collection_Prop_Chest_0001	Strongbox
 Collection_Prop_Chest_0002	Document Storage
 Collection_Prop_Chest_0003	Sturdy Wooden Box
@@ -984,6 +989,7 @@ Collection_Prop_Picture_0066	Study - Emptiness
 Collection_Prop_Picture_0067	Study - Gathering Genius
 Collection_Prop_Picture_0068	Study - Discovering Genius
 Collection_Prop_Picture_0069	Study - Contemplative Genius
+Collection_Prop_Picture_0070	Acclaimed - Stefan Lanford
 Collection_Prop_Plate_0001	Large Wooden Plate
 Collection_Prop_Plate_0002	Bright Wooden Plate
 Collection_Prop_Plate_0003	Concave Wooden Plate
@@ -1020,12 +1026,18 @@ Collection_Prop_Trophy_0002	Trophy - Unarmed Duel
 Collection_Prop_Trophy_0003	Trophy - Wrestling Match
 Collection_Prop_Trophy_0004	Trophy - Spear Duel
 Collection_Prop_Trophy_0005	Trophy - Sword Duel
-Collection_Prop_viewingstone_0001	Blue Dragon Scale Decorative Stone
-Collection_Prop_viewingstone_0002	Ancient's Decorative Stone
-Collection_Prop_viewingstone_0003	Red Fire Decorative Stone
 Collection_Prop_WeaponBox_0001	Firearms Box
 Collection_Prop_WeaponBox_0002	Swords Box
 Collection_Prop_WeaponBox_0003	Weapons Box
+Collection_Prop_viewingstone_0001	Blue Dragon Scale Decorative Stone
+Collection_Prop_viewingstone_0002	Ancient's Decorative Stone
+Collection_Prop_viewingstone_0003	Red Fire Decorative Stone
+Collection_gemstone_lamp_0001	Icy White Processed Crystal
+Collection_gemstone_lamp_0001_index01	Twilight Processed Crystal
+Collection_gemstone_lamp_0001_index02	Lilac Processed Crystal
+Collection_gemstone_lamp_0002	Icy White Crystal
+Collection_gemstone_lamp_0002_index01	Twilight Crystal
+Collection_gemstone_lamp_0002_index02	Lilac Crystal
 Colossus_Boots	Giant's Boots
 Commander_PlateArmor_Gloves	Dulone Plate Gloves
 Common_Flag_I	Double-Sided Banner Pike
@@ -1043,8 +1055,8 @@ Contribution_Hernandian	Hernandian Contribution
 Contribution_Pailunese	Pailunese Contribution
 Contribution_Tashkalpan	Tashkalp Contribution
 Cooking_Oil	Cooking Oil
-Copper_Pack	Modest Copper Pouch
 CopperOre	Copper Ore
+Copper_Pack	Modest Copper Pouch
 Corey_Fabric_Armor	Corey Cloth Armor
 Corn	Corn
 Corn_seed	Corn Seed
@@ -1053,19 +1065,16 @@ Corvo_PlateArmor_Cloak	Icewing Plate Cloak
 Corvo_PlateArmor_Gloves	Icewing Plate Gloves
 Corvo_PlateArmor_Gloves_II	Corvo Plate Gloves
 Cotton	Cotton
-cotton_BackPack	Cotton Pack
 Cournantry_Fabric_Armor	Conentry Cloth Armor
 Cournantry_Leather_Boots	Conentry Leather Boots
 Cradbahn_Leather_Armor	Cradbahn Leather Armor
-Crafting_Blizzard_Necklace	Blizzard Crystal Necklace
-Crafting_WhiteHorn_OneHandShield	Frostbone Shield
 CraftingRecipe_Demian_Leather_Armor_V	Elegant Carmine Armor Blueprint
 CraftingRecipe_Demian_Leather_Cloak_I	Elegant Carmine Cloak Blueprint
 CraftingRecipe_Demian_PlateArmor_Gloves_VI	Elegant Carmine Gloves Blueprint
 CraftingRecipe_Demian_PlateArmor_Helm_XIII	Elegant Carmine Helm Blueprint
 CraftingRecipe_Demian_Pure_White_Plate_Boots_II	Fluttering Radiance Plate Boots
 CraftingRecipe_Dragon_Weapon	Aeserion Gear Blueprint
-CraftingRecipe_Kuku_Golden999K	Kuku Communicative Pack Blueprint
+CraftingRecipe_Kuku_Golden999K	Kuku Transmission Pack Blueprint
 CraftingRecipe_Kuku_Pot_Arms_Book	Kuku Gear Special Blueprint
 CraftingRecipe_Kuku_Pot_Backpack_Book	Kuku Pack Special Blueprint
 CraftingRecipe_Kuku_Pot_Book	Kuku Pot Special Blueprint
@@ -1076,6 +1085,8 @@ CraftingRecipe_Oongka_PlateArmor_Boots_III	Belkandor Boots Blueprint
 CraftingRecipe_Oongka_PlateArmor_Cloak_III	Belkandor Cloak Blueprint
 CraftingRecipe_Oongka_PlateArmor_Gloves_III	Belkandor Gloves Blueprint
 CraftingRecipe_Oongka_PlateArmor_Helm_III	Belkandor Helm Blueprint
+Crafting_Blizzard_Necklace	Blizzard Crystal Necklace
+Crafting_WhiteHorn_OneHandShield	Frostbone Shield
 Crail_PlateArmor_Armor	Crail Plate Armor
 Crail_PlateArmor_Armor_I	Crail Plate Armor
 Criminal_DropItem	Note with a Suspicious Symbol
@@ -1085,12 +1096,13 @@ Crocodile_Skin	Sturdy Hide
 Croden_Leather_Armor	Croden Leather Armor
 Croton	Croton
 Croton_Red	Red Croton
+CrowMan_PlateArmor_Helm	Blackwing Mask
 Crow_Bell	Bells
 Crow_Bomb	Crow Bomb
 Crow_Charm	Talisman
 Crow_PlateArmor_Helm	Crow Plate Helm
 Crow_Thurible	Censer
-CrowMan_PlateArmor_Helm	Blackwing Mask
+Crowman_Eyepatch	Crow Eyepatch
 Crude_Devil_Mask	Crude Devil Mask
 Crudell_OneHandAxe	Timberham Axe
 Crudil_Leather_Boots	Crudil Leather Boots
@@ -1107,13 +1119,18 @@ Cyton_Leather_Armor	Cyton Leather Armor
 Dadnion_PlateArmor_Armor	Dardnion Plate Armor
 Daeil_Band	Axiom Bracelet
 Daibeads_Leather_Armor	Davis Leather Armor
-dain_Leather_Gloves	Dane Leather Bands
 Daine_Leather_Boots	Daine Leather Boots
 Dakahbern_Fabric_Armor	Dahkavan Cloth Armor
 Dallaban_Leather_Gloves	Dallaban Leather Gloves
 Dallabici_PlateArmor_Armor	Demeniss Honor Armor
 Dallabici_PlateArmor_Armor_I	Dalbich Plate Armor
 Dalton_Leather_Gloves	Dalton Leather Gloves
+DamianOnly_Leather_Boots_II	Low-Heeled Leather Boots
+DamianOnly_Leather_Boots_III	White Bloodwind Leather Boots
+DamianOnly_Leather_Boots_IV	Autumn Banquet Leather Boots
+DamianOnly_Leather_Boots_V	Official Knight's Leather Boots
+DamianOnly_Leather_Boots_VI	Wanderer of Faith Leather Boots
+DamianOnly_Leather_Boots_VII	Leather Boots of Earth's Honor
 Damian_Daeil_Band	Damiane's Axiom Bracelet
 Damian_Demeniss_Elite_Uniform_Leather_Armor	Demenissian Elite Uniform Leather Armor
 Damian_Demeniss_Elite_Uniform_Leather_Boots	Demeniss Elite Uniform Leather Boots
@@ -1127,12 +1144,6 @@ Damian_OneHandShield_IV	Demenissian Silver-Decorated Shield
 Damian_OneHandShield_VI	Artisan's Ornamented Shield
 Damian_OneHandShield_VII	Shield of Radiance
 Damian_OneHandShield_VIII	Golden Kerria Shield
-DamianOnly_Leather_Boots_II	Low-heeled Leather Boots
-DamianOnly_Leather_Boots_III	White Bloodwind Leather Boots
-DamianOnly_Leather_Boots_IV	Autumn Banquet Leather Boots
-DamianOnly_Leather_Boots_V	Official Knight's Leather Boots
-DamianOnly_Leather_Boots_VI	Wanderer of Faith Leather Boots
-DamianOnly_Leather_Boots_VII	Leather Boots of Earth's Honor
 Danda_ChainMail_Armor	Danda Chain Mail
 Danda_Fabric_Helm	Danda Cloth Cap
 Danda_Leather_Gloves	Danda Leather Gloves
@@ -1140,13 +1151,13 @@ Danekoche_Leather_Boots	Dannoche Leather Boots
 Danid_PlateArmor_Helm	Deland Plate Helm
 Daraz_Fabric_Armor	Daraz Cloth Armor
 Darbaran_Leather_Armor	Darbaran Leather Armor
-Dark_King_Fabric_Armor	Antumbra Cloth Armor
-Dark_King_Metal_OneHandShield	Mirror of Night
-Dark_King_Plate_Boots	Antumbra Plate Boots
 DarkLeader_OneHandDagger	Dagger of Dark Pursuit
 DarkLeader_TwoHandGiantSpear	Thorn of Dark Pursuit
 DarkLeader_TwoHandSword	Vessel of Dark Pursuit
 DarkLeader_TwoHandWarHammer	Guidance of Dark Pursuit
+Dark_King_Fabric_Armor	Antumbra Cloth Armor
+Dark_King_Metal_OneHandShield	Mirror of Night
+Dark_King_Plate_Boots	Antumbra Plate Boots
 DarknessKing_PlateArmor_Armor	Plate Armor of the Shadows
 DarknessKing_PlateArmor_Boots	Plate Boots of the Shadows
 DarknessKing_PlateArmor_Cloak	Plate Cloak of the Shadows
@@ -1172,6 +1183,12 @@ Dealinger_OneHandTowerShield	Mass-Produced Large Rekel Shield
 Deboros_Leather_Armor	Deboros Leather Armor
 Decoy_Human_I	Fake Silver Pouch
 Deekz_Fabric_Armor	Diggs Cloth Armor
+DeerAntler_Fruit_Tea	Antler Tea
+DeerAntler_Soup	Longhorn Soup
+DeerAntler_Soup_Large	Satisfying Longhorn Soup
+DeerAntler_Soup_Medium	Filling Longhorn Soup
+DeerAntler_Soup_XLarge	Hearty Longhorn Soup
+DeerKing_Lantern	Fancy Flame-Patterned Lantern
 Deer_Antler	Long Horn
 Deer_King_Follower_Cloak_I	Yrkabel Cloth Cloak
 Deer_King_Follower_Leather_Armor	Staglord Acolyte's Leather Armor
@@ -1187,19 +1204,11 @@ Deer_King_Metal_OneHandShield	Staglord's Shield
 Deer_King_OneHandSword	Survivor's Solitude
 Deer_Leather	Short Hair Hide
 Deer_Porter_BackPack	Deer Pack
-DeerAntler_Fruit_Tea	Antler Tea
-DeerAntler_Soup	Longhorn Soup
-DeerAntler_Soup_Large	Satisfying Longhorn Soup
-DeerAntler_Soup_Medium	Filling Longhorn Soup
-DeerAntler_Soup_XLarge	Hearty Longhorn Soup
-deerking_Flag_I	Small Staglord Banner Pike
-deerking_Flag_II	Medium Staglord Banner Pike
-DeerKing_Lantern	Fancy Flame-Patterned Lantern
 Deerking_Leather_Armor	Leather Armor of the Fallen Kingdom
 Deerking_Leather_Armor_T4_QA	Deerking Leather Armor T4 QA
 Deerking_Leather_Cloak	Leather Cloak of the Fallen Kingdom
-Deerking_Plate_Boots	Plate Boots of the Fallen Kingdom
 Deerking_PlateArmor_Gloves	Plate Gloves of the Fallen Kingdom
+Deerking_Plate_Boots	Plate Boots of the Fallen Kingdom
 Deernil_Leather_Gloves	Delinell's Leather Gloves
 Deernil_Leather_Gloves_I	Delinell's Leather Gloves
 Deerprice_Leather_Armor	Dyrfrith Leather Armor
@@ -1210,8 +1219,8 @@ Degah_Fabric_Armor	Dega Cloth Armor
 Deidre_Leather_Boots	Deidre Leather Boots
 Dein_OneHandShotgun	Dane Shotgun
 Dekcher_Leather_Armor	Dekter Leather Armor
-Dekcher_Leather_Boots	Dreiger Leather Boots
-Dekcher_Leather_Helm	Dekter Leather Helm
+Dekcher_Leather_Boots	Dekter Leather Boots
+Dekcher_Leather_Helm	Dekter Leather Cap
 Del_Prison_Room_Key	Delesyia Prison Key
 Delegation_Leather_Helm	Delegation Leather Hat
 Delesian_Friend_Boss_TwoHandSword	Delesyian Longsword
@@ -1263,12 +1272,6 @@ Demeniss_Soldier_Kitee_Metal_OneHandShield_I	Demenissian Shield of Valor
 Demeniss_Soldier_Kitee_Metal_OneHandShield_II	Demenissian Shield of Loyalty
 Demeniss_Soldier_Kitee_Metal_OneHandShield_III	Demenissian Shield of Obedience
 Demeniss_Soldier_OneHandTowerShield	Demenissian Soldier's Large Shield
-demenissnobility_Flag_I	Small Demenissian Noble's Banner
-demenissnobility_Flag_II	Small Demenissian Noble's Banner
-demenissnobility_Flag_III	Small Demenissian Noble's Banner
-demenissnobility_Flag_IV	Medium Demenissian Noble's Banner Pike
-demenissnobility_Flag_V	Medium Demenissian Noble's Banner Pike
-demenissnobility_Flag_VI	Medium Demenissian Noble's Banner Pike
 Demian_Earring_I	Light of the Battlefield Earring
 Demian_Fabric_Armor	Demian Fabric Armor
 Demian_Fabric_Cloak_I	Light of the Battlefield Cloth Cloak
@@ -1277,6 +1280,7 @@ Demian_Fabric_Cloak_III	Autumn Banquet Cloth Cloak
 Demian_Fabric_Cloak_IV	Official Knight's Cloth Cloak
 Demian_Fabric_Cloak_V	Demian Fabric Cloak V
 Demian_Greyfur_Fabric_Cloak	Grey Wolf Cloth Cloak
+Demian_Greyfur_Fabric_Cloak_I	Greymane Cloth Cloak
 Demian_Leather_Armor	Leather Armor of Earth's Honor
 Demian_Leather_Armor_III	White Bloodwind Leather Armor
 Demian_Leather_Armor_IV	Autumn Banquet Leather Armor
@@ -1290,10 +1294,6 @@ Demian_Leather_Gloves_II	Leather Gloves of Earth's Honor
 Demian_Leather_Gloves_III	Autumn Banquet Leather Gloves
 Demian_Leather_Gloves_IV	Wanderer of Faith Leather Gloves
 Demian_OneHandRapier	White Wind Rapier
-Demian_Plate_Boots_III	Goldlight Plate Boots
-Demian_Plate_Boots_IV	Elegant Carmine Plate Boots
-Demian_Plate_Boots_V	Executioner of Darkness Plate Boots
-Demian_Plate_Boots_VI	Light of the Battlefield Plate Boots
 Demian_PlateArmor_Armor_II	Light of the Battlefield Plate Armor
 Demian_PlateArmor_Armor_VI	Official Knight's Plate Armor
 Demian_PlateArmor_Cloak_III	Goldlight Plate Cloak
@@ -1312,6 +1312,10 @@ Demian_PlateArmor_Helm_VII	Official Knight's Plate Helm
 Demian_PlateArmor_Helm_VIII	Light of the Battlefield Plate Helm
 Demian_PlateArmor_Helm_XI	Executioner of Darkness Plate Helm
 Demian_PlateArmor_Helm_XIII	Elegant Carmine Plate Helm
+Demian_Plate_Boots_III	Goldlight Plate Boots
+Demian_Plate_Boots_IV	Elegant Carmine Plate Boots
+Demian_Plate_Boots_V	Executioner of Darkness Plate Boots
+Demian_Plate_Boots_VI	Light of the Battlefield Plate Boots
 Demian_Pure_White_Plate_Boots_I	Radiant Plate Boots
 Demian_Pure_White_Plate_Boots_II	Fluttering Radiance Plate Boots
 Demian_Skirt_Fabric_Armor	Demian Skirt Fabric Armor
@@ -1367,6 +1371,10 @@ Dev_Growth_Ring_VI	Dev Growth Ring VI
 Dev_Growth_Ring_VII	Dev Growth Ring VII
 Dev_Growth_Ring_VIII	Dev Growth Ring VIII
 Dev_Growth_Ring_X	Dev Growth Ring X
+Dev_QA0	[QA] Profiling (Hernand)
+Dev_QA1	[QA] Profiling (Hernand-Demeniss 60)
+Dev_QA2	[QA] Profiling (Hernand-Demeniss 20)
+Dev_QA3	[QA] Profiling (Hernand-Demeniss 2.5)
 Dev_QA_demtodel_run	[QA] Profiling (Demeniss-Delesyia 20)
 Dev_QA_demtodel_walk	[QA] Profiling (Demeniss-Delesyia 2.5)
 Dev_QA_demtovar_run	[QA] Profiling (Demeniss-Varnia 20)
@@ -1374,10 +1382,6 @@ Dev_QA_demtovar_walk	[QA] Profiling (Demeniss-Varnia 2.5)
 Dev_QA_her_loop	[QA] Repeated movement within Hernand (Speed 15)
 Dev_QA_hertopail_run	[QA] Profiling (Hernand-Pailune 20)
 Dev_QA_hertopail_walk	[QA] Profiling (Hernand-Pailune 2.5)
-Dev_QA0	[QA] Profiling (Hernand)
-Dev_QA1	[QA] Profiling (Hernand-Demeniss 60)
-Dev_QA2	[QA] Profiling (Hernand-Demeniss 20)
-Dev_QA3	[QA] Profiling (Hernand-Demeniss 2.5)
 Dev_Red_Dragon_HorseArmor_Armor	Dev Red Dragon HorseArmor Armor
 Dev_Red_Dragon_HorseArmor_Helm	Dev Red Dragon HorseArmor Helm
 Dev_Red_Dragon_HorseArmor_Saddle	Dev Red Dragon HorseArmor Saddle
@@ -1406,11 +1410,10 @@ Diencia_Fabric_Boots	Diencia Cloth Boots
 Diencia_TwoHandAlebard	Lambert Halberd
 Diencia_TwoHandAxe	Iris Greataxe
 Diencia_TwoHandedWarHammer	Arlem Warhammer
-diereuben_Leather_Gloves	Dirrebin Leather Gloves
 Dikkahn_Fabric_Helm	Deccain Cloth Headband
 Diknanteu_Fabric_Armor	Decanteau Cloth Armor
-Dimfeld_Leather_Boots	Driseld Leather Boots
-Dimfeld_Leather_Helm	Dimfeld Leather Helm
+Dimfeld_Leather_Boots	Dimfeld Leather Boots
+Dimfeld_Leather_Helm	Dimfeld Leather Hat
 Dimfeld_PlateArmor_Gloves	Dimfeld Plate Gloves
 Dimphelt_Wood_OneHandShield	Dewhaven Shield
 Dinon_Leather_Armor	Dannon Leather Armor
@@ -1439,6 +1442,7 @@ Douglas_Leather_Gloves	Blackwing Leather Gloves
 Douglas_Leather_Gloves_T5_QA	Douglas Leather Gloves T5 QA
 Doventry_Leather_Armor	Doventry Leather Armor
 Dowsampton_Leather_Armor	Dowsampton Leather Armor
+DragonSlayerLeader_OneHandCannon	Wyvern Blaster
 Dragon_Armor_01	Abyssal Dragon Armor
 Dragon_Armor_Material	Abyssal Fusion
 Dragon_Knight_Archer_PlateArmor_Gloves	Dragon Knight Archer's Plate Gloves
@@ -1456,11 +1460,8 @@ Dragon_Slayer_Leather_Boots	Flame Knight's Leather Boots
 Dragon_Slayer_Ohyoon_PlateArmor_Helm	Cassius Morten's Plate Helm
 Dragon_TwoHandAlebard	Aeserion Halberd
 Dragon_TwoHandAxe	Aeserion Greataxe
-Dragon_TwoHandedWarHammer	Aeserion Warhammer
 Dragon_TwoHandSword	Aeserion Longsword
-dragonkiller_Flag_I	Small Flame Knights Banner Pike
-dragonkiller_Flag_II	Medium Flame Knights Banner Pike
-DragonSlayerLeader_OneHandCannon	Wyvern Blaster
+Dragon_TwoHandedWarHammer	Aeserion Warhammer
 Draiga_PlateArmor_Gloves	Draiga Plate Gloves
 Drakhan_OneHandMace	Drakhan Hammer
 Dreenah_Fabric_Helm	Drina Cloth Cap
@@ -1487,13 +1488,13 @@ Ducca_Leather_Armor	Ducca Leather Armor
 Duebell_Leather_Armor	Duvelle Leather Armor
 Dueblone_Plated_Boots	Dulone Plate Boots
 Duemeniss_Fabric_Armor	Dumenis Cloth Armor
-Duemeniss_Leather_Boots	Dumas Leather Boots
-Duemeniss_Plate_Boots	Dumenis Plate Boots
-Duemeniss_Plate_Boots_I	Blacksteel Dumenis Plate Boots
-Duemeniss_Plate_Boots_II	Dumenis Plate Boots II
+Duemeniss_Leather_Boots	Dumenis Leather Boots
 Duemeniss_PlateArmor_Gloves	Dumenis Plate Gloves
 Duemeniss_PlateArmor_Helm	Demenissian Soldier Plate Helm
 Duemeniss_PlateArmor_Helm_I	Dumenis Plate Helm
+Duemeniss_Plate_Boots	Dumenis Plate Boots
+Duemeniss_Plate_Boots_I	Blacksteel Dumenis Plate Boots
+Duemeniss_Plate_Boots_II	Dumenis Plate Boots II
 Dueroin_Fabric_Gloves	Duroin Cloth Gloves
 Duilker_Fabric_Armor	Dwelker Cloth Armor
 Dukesan_OneHandDagger	Delesyian Dagger
@@ -1524,6 +1525,8 @@ Dylanka_Fabric_Armor	Dilanka Cloth Armor
 Dyran_Fabric_Armor	Dyran Cloth Armor
 Dyrania_Fabric_Armor	Direnya Cloth Armor
 Dyrill_Leather_Armor	Dyrel Leather Armor
+EMP_BackPack	Disruptor
+EMP_TwoHandSpear	Disruptor Spear
 Earring_Tier1_I	Worn Earring
 Earring_Tier2_I	Faded Earring
 Earring_Tier3_I	Green Coral Reef Earring
@@ -1553,8 +1556,6 @@ Ellachic_Leather_Gloves	Elashe Leather Gloves
 Elliot_Leather_Armor	Elliot Leather Armor
 Elsiguo_Leather_Gloves	Ellisco Leather Bracers
 Emil_PlateArmor_Armor	Emil Plate Armor
-EMP_BackPack	Disruptor
-EMP_TwoHandSpear	Disruptor Spear
 Empty_BackPack	Empty Pack
 Empty_Bottle	Empty Bottle
 Endnion_PlateArmor_Armor	Endnion Plate Armor
@@ -1592,6 +1593,7 @@ Equip_Rake	Rake
 Equip_Saw	Saw
 Equip_Shovel	Shovel
 Equip_Stick	Walking Cane
+Equip_Sturdy_Broom	Sturdy Broom
 Equip_TriRake	Wooden Pitchfork
 Equip_Trumpet	Trumpet
 Equip_WoodRake	Wooden Rake
@@ -1615,13 +1617,14 @@ Faded_Necklace	Tarnished Necklace
 Faded_Ring	Tarnished Ring
 Faience_Fabric_Armor	Faians Cloth Armor
 Falcone_OneHandPistol	Falconne Pistol
-Falstaff_Fabric_Helm	Falstaff Cloth Helm
+Falstaff_Fabric_Helm	Falstaff's Cloth Cap
+Family_Crest_Surcoat	A Surcoat Embroidered with a Family Crest
 Fang	Fang
-Farmer_BackPack_I	Farmer's Pack
-Farmer_BackPack_II	Farmer's Pack
 FarmSlot_Expansion_1	Small Livestock Capacity Increase
 FarmSlot_Expansion_2	Medium Livestock Capacity Increase
 FarmSlot_Expansion_3	Large Livestock Capacity Increase
+Farmer_BackPack_I	Farmer's Pack
+Farmer_BackPack_II	Farmer's Pack
 Feather	Feather
 Feather_Pen	Feather Pen
 Fennel	Fennel
@@ -1638,11 +1641,11 @@ Finraysen_Leather_Armor	Finneron Leather Armor
 Fiore_Fabric_Armor	Fiore Cloth Armor
 Fiore_Fabric_Helm	Fiore Cloth Cap
 Fiore_Leather_Boots	Fiore Leather Boots
+FireFly_Lantern	Firefly Lantern
 Fire_Arrow	Fire Arrow
 Fire_Bomb	Bomb
 Fire_Boots	Fire Walk Boots
 Fire_staff_spear_TwoHandSpear	Flame Spear
-FireFly_Lantern	Firefly Lantern
 First_Artifact	The First Artifact
 Fish_BackPack_I	Angler's Pack
 Fish_BackPack_II	Angler's Pack
@@ -1677,12 +1680,12 @@ Fish_Vegetable_Porridge_XLarge	Hearty Vegetable and Seafood Porridge
 FishingRod	Fishing Rod
 FishingRod_II	Fine Fishing Rod
 FishingRod_III	Pororin Fishing Rod
-Flame_Knights_PlateArmor_Helm	Flame Knight's Plate Helm
+FlameThrower	Electromagnetic Flamespitter
+Flame_Knights_PlateArmor_Helm	Elite Flame Knights Plate Helm
 Flame_Knights_PlateArmor_Helm_I	Flame Knight's Plate Helm
-Flame_staff_spear_TwoHandSpear	Blazing Spear
 Flame_SwordMan_PlateArmor_Gloves	Flame Swordsman Plate Gloves
 Flame_SwordMan_TwoHandHammer	Greathammer of Fire
-FlameThrower	Electromagnetic Flamespitter
+Flame_staff_spear_TwoHandSpear	Blazing Spear
 FlatBasket	Wide Basket
 Flolin_BackPack	Pororin Pack
 Flolin_BackPack_FlowerDrone_I	Florindale Flower Bomb Pack
@@ -1699,8 +1702,8 @@ Food_Bass_I	Bass
 Food_Bass_II	Yellow Bass
 Food_Benjari	Threeline Grunt
 Food_Beyaz	Small Rasbora
-Food_Blackbrow_Bleak	Small Blackbrow Bleak
 Food_BlackSeaBream	Blackhead Seabream
+Food_Blackbrow_Bleak	Small Blackbrow Bleak
 Food_BlueCrab	Blue Crab
 Food_Burbot	Burbot
 Food_Carp	Carp
@@ -1718,8 +1721,8 @@ Food_Fish_Meat	Fish Fillet
 Food_GiantMudfish	Giant Pond Loach
 Food_GiantRedSeaBream	Giant Red Seabream
 Food_GoldCarp	Golden Carp
-Food_Golden_Coelacanth	Golden Coelacanth
 Food_GoldTenchi	Golden Tench
+Food_Golden_Coelacanth	Golden Coelacanth
 Food_HexeFish	Hexe Earthen Fish
 Food_Lenok	Lenok
 Food_LightCrotch	Anglerfish
@@ -1730,11 +1733,10 @@ Food_MechanicFish	Clockwork Fish
 Food_Mudfish	Pond Loach
 Food_Perch	Perch
 Food_Pikefish	Northern Pike
+Food_RedSnapper	Crimson Opaleye
 Food_Red_Seabream	Red Seabream
 Food_Red_Snapper	Opaleye
-Food_RedSnapper	Crimson Opaleye
 Food_Ricefish	Ricefish
-Food_river_Crab	Freshwater Crab
 Food_Rock_Bream	Barred Knifejaw
 Food_Sailfish	Sailfish
 Food_Salmon	Salmon
@@ -1751,19 +1753,14 @@ Food_Starfish	Starfish
 Food_Sturgeon	Sturgeon
 Food_Tenchi	Tench
 Food_Trout	Trout
-Forest_Fairy_Leather_Armor	Forest Fae Armor
+Food_river_Crab	Freshwater Crab
 ForestFairy_TwoHandedWarHammer	Shadowleaf Soul Branch
+Forest_Fairy_Leather_Armor	Forest Fae Armor
 Forgotten_General_TwoHandAlebard	Awakened Spirit
 Formosa_Leather_Armor	Formosa Leather Armor
+FortMoru_Key	Fort Anvil Key
 Fort_Flag_02	Small Halberd of Carnage's Banner Pike
 Fort_Flag_03	Medium Halberd of Carnage's Banner Pike
-fort_Flag_I	Small Dusksongs Banner Pike
-fort_Flag_II	Small Faceless Banner Pike
-fort_Flag_III	Small Twilight Messengers Banner Pike
-fort_Flag_IV	Medium Dusksongs Banner Pike
-fort_Flag_V	Medium Faceless Banner Pike
-fort_Flag_VI	Medium Twilight Messengers Banner Pike
-FortMoru_Key	Fort Anvil Key
 FoxBean_Flower	Dunbaria
 Freshly_Grilled_Bird	Grilled Bird Meat
 Freshly_Grilled_Bird_Large	Satisfying Grilled Bird Meat
@@ -1781,14 +1778,13 @@ Fri_PlateArmor_Armor	Prix Plate Armor
 Friendly_Legendary_Animal_Book	Black Lion Observation Log
 Friendly_Legendary_Hunter	The Legendary Hunter's Whereabouts
 Frinyl_PlateArmor_Helm	Ferenna Plate Helm
-frog	Poison Frog
 FrontierMilitia_OneHandShield	Flame Knights Shield
+FruitTea	Fruit Tea
 Fruit_Porridge	Fruit Punch
 Fruit_Porridge_Large	Satisfying Fruit Punch
 Fruit_Porridge_Medium	Filling Fruit Punch
 Fruit_Porridge_XLarge	Hearty Fruit Punch
 Fruit_Wine	Wine
-FruitTea	Fruit Tea
 Full_Course_of_Braised_Fish	Assorted Braised Fish
 Full_Course_of_Braised_Fish_Large	Satisfying Assorted Braised Fish
 Full_Course_of_Braised_Fish_Medium	Filling Assorted Braised Fish
@@ -1800,8 +1796,8 @@ Gadherish_Fabric_Armor	Gadereich Cloth Armor
 Gadherish_Fabric_Gloves	Gadereich Cloth Gloves
 Gadherish_Fabric_Helm	Gadereich Cloth Cap
 Gael_Fabric_Armor	Gael Cloth Armor
-Gaeljude_Plate_Boots	Golden Greed Plate Boots
 Gaeljude_PlateArmor_Gloves	Golden Greed Plate Gloves
+Gaeljude_Plate_Boots	Golden Greed Plate Boots
 Gahlatain_OneHandAxe	Ring of the Earth
 Gaimeon_Leather_Gloves	Gaiman Leather Gloves
 Gainarre_OneHandAxe	Leofric Double-Headed Axe
@@ -1829,20 +1825,14 @@ Gerano_Leather_Armor	Gerano Leather Armor
 Germion_PlateArmor_Armor	Jerrinmarne Plate Armor
 Ghaltain_Fabric_Helm	Ghaltain Cloth Cap
 Ghost_TwohandSword	Invisible Longsword
+GiantBallista_Book	Pailunese Guard's Journal
 Giant_Copper_Drill	Copper Knuckledrill
 Giant_ReiGhis_TwoHandGiantAxe	Gorthak Greataxe
 Giant_Warriors_TwoHandGiantAxe	Patterned Stone Greataxe
-GiantBallista_Book	Pailunese Guard's Journal
 Gias_Leather_Armor	Giath's Leather Armor
 Gias_OneHandSword	Savage Sawblade
 Gilded_OneHandShield	Gilded Shield
 Gilded_OneHandTowerShield	Large Gilded Shield
-gimmick_tool_kinetic_barbell_0001	Kinetic Counterweight
-gimmick_tool_kinetic_barbell_0002	Kinetic Knight
-gimmick_tool_kinetic_boat_0001	Kinetic Boat
-gimmick_tool_kinetic_circle_0001	Kinetic Circle
-gimmick_tool_kinetic_dolphin_0001	Kinetic Dolphin Family
-gimmick_tool_kinetic_dolphin_0002	Kinetic Dolphin
 Ginseng_Seed	Wild Ginseng Seed
 Girrin_PlateArmor_Armor	Guilan Plate Armor
 Gladiator_Fabric_Armor	Gladiator's Cloth Armor
@@ -1854,13 +1844,13 @@ Gladiator_Fabric_Gloves_I	Gladiator Cloth Gloves
 Gladiator_Leather_Armor	Gladiator Leather Armor
 Gladiator_Leather_Boots	Troll Gladiator's Leather Boots
 Gladiator_Leather_Boots_II	Gladiator's Leather Boots
-Gladiator_Plate_Boots	Gladiator Plate Boots
 Gladiator_PlateArmor_Gloves_I	Gladiator Plate Gloves
+Gladiator_Plate_Boots	Gladiator Plate Boots
 Gladiator_Stigma_TwoHandSpear	Slave Gladiator Branding Spear
 Glaville_Leather_Armor	Glaville Leather Armor
 Glosope_Leather_Armor	Glosope Leather Armor
-Glow_Fruit	Shineberry
 GlowFlower_Seed	Luminous Seed
+Glow_Fruit	Shineberry
 Goat_Horn_Potion	Mysterious Elixir
 Gobialthai_Fabric_Armor	Gobialta Cloth Armor
 Gobialthai_Leather_Gloves	Gobialta Leather Gloves
@@ -1868,62 +1858,54 @@ Goblin_Boss_OneHandSword	Lightningblade of Greed
 Goblin_Director_House_Key	Overseer's House Key
 Goblin_Fight_PlateArmor_Gloves	Goblin Dueling Plate Gloves
 Goblin_Merchant_Fabric_Armor_V	Goldleaves' Cloth Armor
-Goblin_Merchant_Fabric_Armor_���	Goldleaves' Cloth Armor
-Goblin_Merchant_Fabric_Armor_���	Goldleaves' Cloth Armor
-Goblin_Merchant_Fabric_Armor_���	Nibrak Cloth Armor
-Goblin_Merchant_Fabric_Cloak_���	Goldleaves' Cloth Cloak
-Goblin_Merchant_Fabric_Cloak_���	Goldleaves' Cloth Cloak
 Goblin_Merchant_Fabric_Helm	Goldleaf Soldier Cloth Headband
 Goblin_Merchant_PlateArmor_Gloves_I	Goblin Merchant Guild's Plate Gloves
 Goblin_Merchant_Soldier_Leather_Boots	Goldleaves' Short Leather Boots
 Goblin_Merchant_Soldier_Leather_Boots_I	Goldleaves' Leather Boots
-Goblin_Merchant_Soldier_Leather_Helm_I	Goldleaves' Cone Leather Helm
-Goblin_Merchant_Soldier_Leather_Helm_II	Goldleaves' Leather Helm
+Goblin_Merchant_Soldier_Leather_Helm_I	Goldleaves' Cone Leather Cap
+Goblin_Merchant_Soldier_Leather_Helm_II	Goldleaves' Leather Cap
 Goblin_Pot	Goldleaf Censer
-Goblin_Pumpkin_Helm_I	Goblin Pumpkin Helm
+Goblin_Pumpkin_Helm_I	Pumpkin Head
 Godhehart_ChainMail_Gloves	Goldheart Chain Gloves
 Gohol_Leather_Boots	Gohol Leather Boots
+GoldArmor_OneHandSword	Sword of Greed
+GoldBar	Gold Bar
+GoldBar_Fake	Crude Gold Bar
+GoldOre	Gold Ore
 Gold_Apple	Golden Apple
 Gold_Armor_OneHandShield	Golden Shield
 Gold_Plating_Lantern	Shroud Lantern
-GoldArmor_OneHandSword	Sword of Greed
-GoldBar	Gold Bar
+GoldenGoose_Egg	Golden Goose Egg
 Golden_OneHandSword	Golden Sword
 Golden_PlateArmor_Armor	Golden Greed Plate Armor
 Golden_PlateArmor_Cloak	Golden Greed Plate Cloak
 Golden_PlateArmor_Helm	Golden Greed Plate Helm
-GoldenGoose_Egg	Golden Goose Egg
-GoldOre	Gold Ore
 Goldur_Leather_Armor	Goldur Leather Armor
 Goloduan_PlateArmor_Gloves	Demenissian Elite Plate Gloves
 Gomel_Leather_Armor	Gomel Leather Armor
 Goorba_OneHandMace	Saltroad Mace
-Grace_Blueprint	Cloudcart Blueprint
-Grace_Fabric_Gloves	Runae Cloth Gloves
-Grace_Plate_Boots	Canta Plate Boots
-Grace_PlateArmor_Helm	Grace Plate Helm
 GraceMansion_MetalDoor_Key	Glenbright Manor Key
 GraceMansion_RoomDoor_Key	Glenbright Manor Basement Key
+Grace_Blueprint	Cloudcart Blueprint
+Grace_Fabric_Gloves	Runae Cloth Gloves
+Grace_PlateArmor_Helm	Grace Plate Helm
+Grace_Plate_Boots	Canta Plate Boots
 Grape	Grape
-grape_BackPack	Grape Pack
-grape_Seed	Grape Seed
 GraveRobber_Leather_Armor_I	Grave Robber's Leather Armor
 GraveRobber_Leather_Armor_II	Grave Robber's Leather Armor
 GraveRobber_Leather_Armor_III	Grave Robber's Leather Armor
 GraveRobber_Leather_Armor_IV	Grave Robber's Leather Armor
-graymane_Flag_I	Tiny Greymane Banner Pike
-graymane_Flag_II	Small Greymane Banner Pike
-graymane_Flag_III	Medium Greymane Banner Pike
 Graymane_Token	Greymane's Token
-Greeney_Leather_Armor	Greeney Leather Armor
-greenfrog	Tree Frog
 GreenOrc_TwoHandedWarHammer	Gorthak Warhammer
 GreenStone	Epidote
+Greeney_Leather_Armor	Greeney Leather Armor
 Gregor_OneHandShield	Khaled Shield
 Gregrick_TwoHandSword	Dewhaven Longsword
 Grenvar_HorseArmor_Armor	Grenbar Cloth Barding
+GreyWolf_OneHandBow	Grey Wolf Bow
 Greyfur_Fabric_Armor	Balder's Cloth Armor
 Greyfur_Fabric_Armor_C	Ronald's Cloth Armor
+Greyfur_Fabric_Armor_CI	Greymane Cloth Armor
 Greyfur_Fabric_Armor_D	Fritz's Cloth Armor
 Greyfur_Fabric_Armor_I	Matilda's Cloth Armor
 Greyfur_Fabric_Armor_III	Devan's Cloth Armor
@@ -1949,10 +1931,10 @@ Greyfur_Fabric_Armor_XL	Wybert's Cloth Armor
 Greyfur_Fabric_Armor_XX	Anders's Cloth Armor
 Greyfur_Fabric_Armor_XXX	Fred's Cloth Armor
 Greyfur_Fabric_Gloves	Greymane Cloth Gloves
-Greyfur_Fabric_Helm	Colton's Cloth Helm
-Greyfur_Fabric_Helm_I	Arnold's Cloth Helm
-Greyfur_Fabric_Helm_II	Wybert's Cloth Helm
-Greyfur_Fabric_Helm_III	Fritz's Cloth Helm
+Greyfur_Fabric_Helm	Colton's Cloth Cap
+Greyfur_Fabric_Helm_I	Arnold's Cloth Cap
+Greyfur_Fabric_Helm_II	Wybert's Cloth Cap
+Greyfur_Fabric_Helm_III	Fritz's Cloth Cap
 Greyfur_Fabric_Helm_IV	Shane's Cloth Headband
 Greyfur_Leather_Armor	Greymanes' Leather Armor
 Greyfur_Leather_Armor_I	Greymanes' Leather Armor
@@ -1990,11 +1972,10 @@ Greyfur_Leather_Gloves_I	Vernon's Leather Gloves
 Greyfur_Leather_Gloves_II	Laurent's Leather Gloves
 Greyfur_Leather_Helm	Matilda's Leather Headband
 Greyfur_Leather_Helm_I	Jian's Leather Helm
-Greyfur_Leather_Helm_II	Greymane Leather Helm
+Greyfur_Leather_Helm_II	Greymanes' Leather Helm
 Greyfur_Necklace	Greymane Necklace
 Greyfur_PlateArmor_Gloves_I	Darren Plate Gloves
 Greymane_Nobility_Degree_I	Greymane Signet
-GreyWolf_OneHandBow	Grey Wolf Bow
 Grilled_Big_Fish	Large Grilled Fish
 Grilled_Big_Fish_Large	Satisfying Large Grilled Fish
 Grilled_Big_Fish_Medium	Filling Large Grilled Fish
@@ -2028,8 +2009,8 @@ Grommet_Leather_Armor	Grommet Leather Armor
 Gronerd_Leather_Armor	Gronerd Leather Armor
 Groucca_Leather_Armor	Groucca Leather Armor
 Gruun_Fabric_Armor	Gruun Cloth Armor
-Guardian_PlateArmor_Armor	Guardian Plate Armor
 GuardianTree_Pear	Fruit of Life
+Guardian_PlateArmor_Armor	Guardian Plate Armor
 Guff_Leather_Armor	Guff Leather Armor
 Gun_OneHandShield	Shotgun Shield
 Gun_Powder	Gunpowder
@@ -2118,6 +2099,8 @@ Herween_Leather_Armor	Herwin Leather Armor
 Hewlette_Fabric_Armor	Hewlette Cloth Armor
 Hexe_Archer_OneHandBow	Bow of the Fleeting
 Hexe_Earring	Witch's Earring
+Hexe_Marie_Boy_Toy	Doll or Toy made by Hexe Marie
+Hexe_Ring	Hexe Marie's Ring
 Hexe_Soldier_OneHandMace	Mace of the Fleeting
 Hexe_Soldier_OneHandShield	Shell of the Fleeting
 Hexe_Soldier_OneHandSword	Sword of the Fleeting
@@ -2145,9 +2128,9 @@ Hodges_Leather_Armor	Hodges Leather Armor
 HolyWater	Holy Water
 Home_Key	Key
 Honey	Honey
-Honey_Tea	Honey Tea
 HoneyComb	Beehive
 HoneyComb_OneHandMace	Beehive Club
+Honey_Tea	Honey Tea
 Hooburn_Leather_Boots	Hauvern Leather Boots
 Hoobus_Fabric_Helm	Hubus Cloth Cap
 Hoobus_Leather_Armor	Hubus Leather Armor
@@ -2160,7 +2143,6 @@ HorseFeed_Speed_Potion	Horse Stimulant
 HorseFeed_Sugar_Beet	Sugar Beet
 HorseShoe_HorseArmor_Brass_horseshoe_II	Bronze Horseshoes
 HorseShoe_HorseArmor_Clover_Horseshoe_II	Four-Leaf Horseshoes
-HorseShoe_HorseArmor_marquel_Stirrup	Marcello Stirrups
 HorseShoe_HorseArmor_Shabby_horseshoe_II	Shabby Horseshoes
 HorseShoe_HorseArmor_Shoe	Silver Iron Horseshoes
 HorseShoe_HorseArmor_Shoe_I	Ironstone Horseshoes
@@ -2171,9 +2153,10 @@ HorseShoe_HorseArmor_Steel_Horseshoe_II	Steel Horseshoes
 HorseShoe_HorseArmor_Stirrup	Crude Stirrups
 HorseShoe_HorseArmor_Stirrup_I	Wells Military Stirrups
 HorseShoe_HorseArmor_Stirrup_II	Decorative Dragon Head Stirrups
-HorseShoe_HorseArmor_Stirrup_III	Gold-Decorated Stirrups
+HorseShoe_HorseArmor_Stirrup_III	Gilded Stirrups
 HorseShoe_HorseArmor_Stirrup_IV	Fine Leather Stirrups
 HorseShoe_HorseArmor_Stirrup_V	Exclaire Stirrups
+HorseShoe_HorseArmor_marquel_Stirrup	Marcello Stirrups
 Hound_Flag_I	Small Hellhounds Banner Pike
 Hound_Flag_II	Medium Hellhounds Banner Pike
 Huge_TwoHandGiantAxe	Inquisitor's Greataxe
@@ -2195,9 +2178,9 @@ Hymns_of_Dusk_PlateArmor_Armor_I	Dusksongs Plate Armor
 Hymns_of_Dusk_PlateArmor_Gloves_I	Dusksongs Plate Gloves
 Hyosi_Arrow	Whistling Arrow
 Hysilda_Fabric_Armor	Hysilda Cloth Armor
-Ice_Arrow	Chill Arrow
 IceStrandedShip_Book	Shipwreck Voyage Log
 IceThrower	Electromagnetic Frostspitter
+Ice_Arrow	Chill Arrow
 Ignir_TwoHandSword	Ignir
 Iguana_Rider_Leather_Boots	Iguana Rider Leather Boots
 Iguana_Rider_Leather_Cloak_III	Lizard Leather Cloak
@@ -2212,10 +2195,10 @@ Immediate_SubLevel_Mp	Spirit Amplification
 Immediate_SubLevel_Stamina	Stamina Amplification
 IncreaseSwimmingSpeed_Plate_Boots	Tidebreaker Boots
 Insect_Collect_BackPack	Kuku Insect Gatherer's Pack
+InstallationBomb	Deployable Explosive
 Installation_01_key	Valvegard Garrison Key
 Installation_02_key	Marni's Laboratorium Key
 Installation_03_key	Aeronautical Research Base Key
-InstallationBomb	Deployable Explosive
 Intacuttar_PlateArmor_Helm	Intaka Plate Helm
 Inventory_Expansion_1	Small Bag
 Inventory_Expansion_2	Medium Bag
@@ -2232,13 +2215,13 @@ Inytium_Leather_Armor	Ynitium Leather Armor
 Inytium_Leather_Boots	Ynitium Leather Boots
 Inytium_Leather_Cloak	Ynitium Leather Cloak
 Inytium_Leather_Gloves	Ynitium Leather Gloves
-Ironfist_Boss_Knuckle	Iron Fists Gauntlet
 IronStone	Iron Ore
+Ironfist_Boss_Knuckle	Iron Fists Gauntlet
 Isilon_Leather_Boots	Isilon Leather Boots
 Itano_CannonBall	Itano Cannonball
 Itano_CannonBall_Errant	Crude Itano Cannonball
+ItemCatch_FishingRod	The Claw
 Item_88_Butterfly	Eighty-eight Butterfly
-Item_Abyss_Artifact_Maker	Abyss Artifact Fabricator
 Item_AbyssGear_SKill_Lv1_Box	Unidentified Abyss Gear
 Item_AbyssGear_SKill_Lv2_Box	Unidentified Abyss Gear
 Item_AbyssGear_SKill_Lv3_Box	Unidentified Abyss Gear
@@ -2246,19 +2229,42 @@ Item_AbyssGear_Special_Box	Unidentified Abyss Gear
 Item_AbyssGear_Stat_Lv1_Box	Unidentified Abyss Gear
 Item_AbyssGear_Stat_Lv2_Box	Unidentified Abyss Gear
 Item_AbyssGear_Stat_Lv3_Box	Unidentified Abyss Gear
+Item_Abyss_Artifact_Maker	Abyss Artifact Fabricator
 Item_Axolotl	Axolotl
 Item_Baby_Hedgehog	Baby Hedgehog
 Item_BackPackChocolate	Cacao Snack
+Item_Background_Breakable_Wood_230	Large Bright Table
+Item_Background_Breakable_Wood_257	Dark Pillared Side Table
+Item_Background_Breakable_Wood_280	Mechanical Clockwork Chair
+Item_Background_Breakable_Wood_281	Antler Chair
+Item_Background_Breakable_Wood_285	Double-Patterned Chair
+Item_Background_Breakable_Wood_290	Blue Fabric Chair
+Item_Background_Breakable_Wood_293	Round-Legged Chair
+Item_Background_Breakable_Wood_294	Crown-Adorned Chair
+Item_Background_Breakable_Wood_295	Red Fabric Chair
+Item_Background_Breakable_Wood_297	Adorned Storage Chest
+Item_Background_Breakable_Wood_302	Mirrored Wooden Dresser
+Item_Background_Breakable_Wood_303	Luxurious Gilded Table
+Item_Background_Breakable_Wood_304	Bright Pillared Side Table
+Item_Background_Breakable_Wood_308	Luxurious Whitesand Table
+Item_Background_Breakable_Wood_309	Bright Lion Head Table
+Item_Background_Breakable_Wood_310	Round Red Fabric Table
+Item_Background_Breakable_Wood_311	Large Round Red Fabric Table
+Item_Background_Breakable_Wood_313	Side Table
+Item_Background_Breakable_Wood_320	Timber Nightstand
+Item_Background_Breakable_Wood_323	Small Timberton Table
+Item_Background_Breakable_Wood_323_index01	Small Bright Timberton Table
+Item_Background_Breakable_Wood_363	Round Table
 Item_BananaSpider	Yellow Garden Spider
 Item_Banded_Peacock	Banded Peacock Butterfly
 Item_Bee	Honeybee
 Item_Beetle	Beetle
 Item_Beighen_Enchant_Coin	Beighen Refinement Token
-Item_Black_Centipede	Black Centipede
 Item_BlackTail_Flycatcher	Desert Wheatear
+Item_Black_Centipede	Black Centipede
+Item_BlueJay	Blue Jay
 Item_Blue_Copper	Blue Lycaenid Butterfly
 Item_Blue_Pansy_Butterfly	Southern Blue Peacock Butterfly
-Item_BlueJay	Blue Jay
 Item_Bumblebee	Bumblebee
 Item_Bunting_Bird	Meadow Bunting
 Item_Butterfly	Meadow Butterfly
@@ -2268,6 +2274,7 @@ Item_Checkered_White	Checkered White Butterfly
 Item_Chocolate	Chocolate
 Item_Cockroach	Cockroach
 Item_Colias_Nastes	Green Sulphur Butterfly
+Item_Collection_Prop_Statue_0002	The Sitting Lion
 Item_Common_Buckeye	Buckeye Butterfly
 Item_Common_Green_Birdwing	Green Birdwing Butterfly
 Item_Common_Nawab	Nawab Butterfly
@@ -2277,14 +2284,13 @@ Item_Dem_Enchant_Coin	Demeniss Refinement Token
 Item_Desert_Orange_tip	Scarlet Leafwing Butterfly
 Item_DiademSpider	Golden Silk Spider
 Item_Diana_Fritillary	Diana Fritillary Butterfly
-Item_dragonfly	Dragonfly
-Item_Eastern_Comma	Yellow Comma Butterfly
-Item_Eastern_Tailed_Blue	Blue Tailed Butterfly
-Item_Eastern_Tiger_Swallowtail	Swallowtail
 Item_ETC_CooltimeReduce_ATAG	A.T.A.G. Emergency Power Device
 Item_ETC_CooltimeReduce_ATAGII	A.T.A.G. Power Module
 Item_ETC_CooltimeReduce_Dragon	Dragon Claw Horn
 Item_ETC_CooltimeReduce_DragonII	Narima's Horn
+Item_Eastern_Comma	Yellow Comma Butterfly
+Item_Eastern_Tailed_Blue	Blue Tailed Butterfly
+Item_Eastern_Tiger_Swallowtail	Swallowtail
 Item_Firefly	Firefly
 Item_Fist_Damian	Ordinary Gloves
 Item_Fist_Kliff	Ordinary Gloves
@@ -2292,119 +2298,6 @@ Item_Fist_Oongka	Ordinary Gloves
 Item_Flying_Squirrel	Flying Squirrel
 Item_Frilled_Lizard	Frilled-neck Lizard
 Item_Giant_Salamander	Burrowing Salamander
-Item_gimmick_abyss_quest_kuku_seal_01	Magnetic Power Core
-Item_gimmick_abysscore_0001	Abyss Cell: No. 1
-Item_gimmick_abysscore_0002	Abyss Cell: No. 2
-Item_gimmick_abyssruins_useartifact_01_attach_part	Abyss Transporter
-Item_gimmick_attach_abyss_core_01	Power Core - Gate of Collapse
-Item_gimmick_attach_abyss_core_02	Power Core - Ore of Resipiscence
-Item_gimmick_attach_abyss_core_03	Power Core - Casket of Illusions
-Item_gimmick_attach_abyss_core_04	Power Core - Crown of Shadows
-Item_gimmick_attach_abyss_core_05	Power Core - Spire of Defiance
-Item_gimmick_attach_abyss_core_06	Power Core - Verse of Sowing
-Item_gimmick_attach_marni_machinetank_backpack_01	Marni's Mecha Leap Pack
-Item_gimmick_attach_marni_machinetank_backpack_02	Marni's Mecha Laser Pack
-Item_gimmick_attach_marni_machinetank_backpack_03	Marni's Mecha Blade Pack
-Item_gimmick_attach_marni_machinetank_backpack_04	Marni's Mecha Rocket Pack
-Item_gimmick_attach_marni_machinetank_backpack_05	Marni's Mecha Booster Pack
-Item_gimmick_attach_marni_machinetank_backpack_06	Dreadnought Booster Pack
-Item_gimmick_attach_marni_machinetank_backpack_07	Dreadnought Missile Pack
-Item_gimmick_attach_mechanical_powerplant_0001	Electrical Component
-Item_gimmick_attach_nuclear_fusion_core_01	Tenebrum Magnetic Core
-Item_gimmick_nature_rock_dissolve_stone_core_01	Abyss Cell: No. 0
-Item_gimmick_puzzle_antumbra_tokamak_01_parts01	Fusion Reactor Core: I-I
-Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index01	Fusion Reactor Core: XI-I
-Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index03	Fusion Reactor Core: XI-III
-Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index04	Fusion Reactor Core: XI-IV
-Item_gimmick_puzzle_antumbra_tokamak_01_parts02	Fusion Reactor Core: I-II
-Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index01	Fusion Reactor Core: XII-I
-Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index03	Fusion Reactor Core: XII-III
-Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index04	Fusion Reactor Core: XII-IV
-Item_gimmick_puzzle_antumbra_tokamak_01_parts03	Fusion Reactor Core: I-III
-Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index01	Fusion Reactor Core: XIII-I
-Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index03	Fusion Reactor Core: XIII-III
-Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index04	Fusion Reactor Core: XIII-IV
-Item_gimmick_puzzle_antumbra_tokamak_01_parts04	Fusion Reactor Core: I-IV
-Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index01	Fusion Reactor Core: XIV-I
-Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index03	Fusion Reactor Core: XIV-III
-Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index04	Fusion Reactor Core: XIV-IV
-Item_gimmick_puzzle_antumbra_tokamak_01_parts20	Core of Penitence
-Item_gimmick_puzzle_antumbra_tokamak_01_parts21	Core of Renunciation
-Item_gimmick_puzzle_antumbra_tokamak_01_parts22	Core of Expiation
-Item_gimmick_puzzle_antumbra_tokamak_01_parts23	Core of Oblation
-Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index01	Fusion Reactor Core: XXI-I
-Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index03	Fusion Reactor Core: XXI-III
-Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index04	Fusion Reactor Core: XXI-IV
-Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index01	Fusion Reactor Core: XXII-I
-Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index03	Fusion Reactor Core: XXII-III
-Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index04	Fusion Reactor Core: XXII-IV
-Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index01	Fusion Reactor Core: XXIII-I
-Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index03	Fusion Reactor Core: XXIII-III
-Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index04	Fusion Reactor Core: XXIII-IV
-Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index01	Fusion Reactor Core: XXIV-I
-Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index03	Fusion Reactor Core: XXIV-III
-Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index04	Fusion Reactor Core: XXIV-IV
-Item_gimmick_puzzle_antumbra_tokamak_02_parts20	Core of Mortification
-Item_gimmick_puzzle_antumbra_tokamak_02_parts21	Core of Faith
-Item_gimmick_puzzle_antumbra_tokamak_02_parts22	Core of Benediction
-Item_gimmick_puzzle_antumbra_tokamak_02_parts23	Core of Absolution
-Item_gimmick_puzzle_antumbra_tokamak_03_parts01	Fusion Reactor Core: III-I
-Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index02	Fusion Reactor Core: XXXI-II
-Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index04	Fusion Reactor Core: XXXI-IV
-Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index06	Fusion Reactor Core: XXXI-VI
-Item_gimmick_puzzle_antumbra_tokamak_03_parts02	Fusion Reactor Core: III-II
-Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index02	Fusion Reactor Core: XXXII-II
-Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index04	Fusion Reactor Core: XXXII-IV
-Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index06	Fusion Reactor Core: XXXII-VI
-Item_gimmick_puzzle_antumbra_tokamak_03_parts03	Fusion Reactor Core: III-III
-Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index02	Fusion Reactor Core: XXXIII-II
-Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index04	Fusion Reactor Core: XXXIII-IV
-Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index06	Fusion Reactor Core: XXXIII-VI
-Item_gimmick_puzzle_antumbra_tokamak_03_parts04	Fusion Reactor Core: III-IV
-Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index02	Fusion Reactor Core: XXXIV-II
-Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index04	Fusion Reactor Core: XXXIV-IV
-Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index06	Fusion Reactor Core: XXXIV-VI
-Item_gimmick_puzzle_antumbra_tokamak_03_parts20	Core of Solace
-Item_gimmick_puzzle_antumbra_tokamak_03_parts21	Core of Revelation
-Item_gimmick_puzzle_antumbra_tokamak_03_parts22	Core of Temperance
-Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index01	Fusion Reactor Core: LI-I
-Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index02	Fusion Reactor Core: LI-II
-Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index04	Fusion Reactor Core: LI-IV
-Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index05	Fusion Reactor Core: LI-VI
-Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index01	Fusion Reactor Core: LII-I
-Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index02	Fusion Reactor Core: LII-II
-Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index04	Fusion Reactor Core: LII-IV
-Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index05	Fusion Reactor Core: LII-VI
-Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index01	Fusion Reactor Core: LIII-I
-Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index02	Fusion Reactor Core: LIII-II
-Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index04	Fusion Reactor Core: LIII-IV
-Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index05	Fusion Reactor Core: LIII-VI
-Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index01	Fusion Reactor Core: LIV-I
-Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index02	Fusion Reactor Core: LIV-II
-Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index04	Fusion Reactor Core: LIV-IV
-Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index05	Fusion Reactor Core: LIV-VI
-Item_gimmick_puzzle_antumbra_tokamak_05_parts20	Core of Atonement
-Item_gimmick_puzzle_antumbra_tokamak_05_parts21	Core of Deliverance
-Item_gimmick_puzzle_antumbra_tokamak_05_parts22	Core of Exaltation
-Item_gimmick_puzzle_antumbra_tokamak_05_parts23	Core of Veneration
-Item_gimmick_puzzle_antumbra_tokamak_05_parts24	Core of Devotion
-Item_gimmick_puzzle_antumbra_tokamak_parts01	Fusion Reactor Core: I
-Item_gimmick_puzzle_antumbra_tokamak_parts02	Fusion Reactor Core: II
-Item_gimmick_puzzle_antumbra_tokamak_parts03	Fusion Reactor Core: III
-Item_gimmick_puzzle_antumbra_tokamak_parts04	Fusion Reactor Core: IV
-Item_gimmick_puzzle_antumbra_tokamak_parts05	Fusion Reactor Core: V
-Item_gimmick_puzzle_antumbra_tokamak_parts06	Fusion Reactor Core: VI
-Item_gimmick_puzzle_antumbra_tokamak_parts07	Fusion Reactor Core: VII
-Item_gimmick_puzzle_antumbra_tokamak_parts08	Fusion Reactor Core: VIII
-Item_gimmick_puzzle_antumbra_tokamak_parts09	Fusion Reactor Core: IX
-Item_gimmick_puzzle_antumbra_tokamak_parts10	Fusion Reactor Core: X
-Item_gimmick_puzzle_antumbra_tokamak_parts11	Fusion Reactor Core: XI
-Item_gimmick_puzzle_antumbra_tokamak_parts12	Fusion Reactor Core: XII
-Item_gimmick_puzzle_antumbra_tokamak_parts13	Fusion Reactor Core: XIII
-Item_gimmick_puzzle_antumbra_tokamak_parts14	Fusion Reactor Core: XIV
-Item_gimmick_puzzle_antumbra_tokamak_parts15	Fusion Reactor Core: XV
-Item_gimmick_puzzle_antumbra_tokamak_parts16	Fusion Reactor Core: XVI
-Item_gimmick_snake_boss_scales_01	Aeserion's Scale
 Item_Gnat	Fruit Fly
 Item_GnatWide	Medium Fly
 Item_Goanna	Goanna
@@ -2421,10 +2314,10 @@ Item_Iguana	Iguana
 Item_Jewel_Beetle	Jewel Beetle
 Item_JijeongLeaf_Insect	Palmar Beetle
 Item_Kallima_Inachus	Orange Oakleaf Butterfly
+Item_KuKu_Small_ATAG	Small Kuku A.T.A.G.
 Item_Kuku_Egg	Kuku Bird's Egg
 Item_Kuku_Pot	Kuku Pot
 Item_Kuku_Pot_02	Enhanced Kuku Pot
-Item_KuKu_Small_ATAG	Small Kuku A.T.A.G.
 Item_Little_Metalmark	Little Metalmark Butterfly
 Item_Little_Wood_Satyr	Little Wood Satyr Butterfly
 Item_Longhorn_Beetle	Longhorn Beetle
@@ -2451,19 +2344,11 @@ Item_Pipevine_Swallowtail	Pipevine Swallowtail Butterfly
 Item_Polydamas_Swallowtail	Polydamas Swallowtail Butterfly
 Item_Possum	Opossum
 Item_Purple_Emperor	Purple Emperor Butterfly
-Item_puzzle_troll_lake_pillar_01_part_01	Kharonso Ruins Pillar: No. 1
-Item_puzzle_troll_lake_pillar_02_part_01	Kharonso Ruins Pillar: No. 2
-Item_puzzle_troll_lake_pillar_03_part_01	Kharonso Ruins Pillar: No. 3
-Item_puzzle_troll_lake_pillar_04_part_01	Kharonso Ruins Pillar: No. 4
-Item_Rare_Collect_amaranth	Amaranth
 Item_Rare_Collect_Chaya	Chaya
-Item_Rare_Collect_chlorella	Green Algae
 Item_Rare_Collect_Dulse	Red Seaweed
 Item_Rare_Collect_Ensete	Enset
-Item_Rare_Collect_jijeongta_leaf	Palmar Leaf
 Item_Rare_Collect_Kudzu	Skyroot
 Item_Rare_Collect_Mercury	Mercury
-Item_Rare_Collect_opuntia	Prickly Pear
 Item_Rare_Collect_Platinum	Platinum
 Item_Rare_Collect_RazorClam	Razor Clam
 Item_Rare_Collect_RazorClam_01	Freshwater Clam
@@ -2471,6 +2356,10 @@ Item_Rare_Collect_Rubber	Rubber
 Item_Rare_Collect_Stalactites	Stalactite
 Item_Rare_Collect_SulfurStone	Brimstone
 Item_Rare_Collect_Taro	Taro
+Item_Rare_Collect_amaranth	Amaranth
+Item_Rare_Collect_chlorella	Green Algae
+Item_Rare_Collect_jijeongta_leaf	Palmar Leaf
+Item_Rare_Collect_opuntia	Prickly Pear
 Item_Rat	Rat
 Item_Red_Spotted_Purple	Red-spotted Purple Butterfly
 Item_Red_Squirrel	Red Squirrel
@@ -2507,22 +2396,25 @@ Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_PlateArmor_LV3	Shatter III
 Item_Skill_AbyssGear_AddFrendly_LV1	Solidarity I
 Item_Skill_AbyssGear_AddFrendly_LV2	Solidarity II
 Item_Skill_AbyssGear_AddFrendly_LV3	Solidarity III
-Item_Skill_AbyssGear_AdditionalThief_LV1	Ledgermain I
-Item_Skill_AbyssGear_AdditionalThief_LV2	Ledgermain II
-Item_Skill_AbyssGear_AdditionalThief_LV3	Ledgermain III
 Item_Skill_AbyssGear_AddKillSkillLevel_LV1	Energy Drain I
 Item_Skill_AbyssGear_AddKillSkillLevel_LV2	Energy Drain II
 Item_Skill_AbyssGear_AddKillSkillLevel_LV3	Energy Drain III
 Item_Skill_AbyssGear_AddMoneyDropRate_LV1	Fortune I
 Item_Skill_AbyssGear_AddMoneyDropRate_LV2	Fortune II
 Item_Skill_AbyssGear_AddMoneyDropRate_LV3	Fortune III
+Item_Skill_AbyssGear_AdditionalThief_LV1	Ledgermain I
+Item_Skill_AbyssGear_AdditionalThief_LV2	Ledgermain II
+Item_Skill_AbyssGear_AdditionalThief_LV3	Ledgermain III
 Item_Skill_AbyssGear_Antumbra_Spear	Warden of Darkness
 Item_Skill_AbyssGear_Antumbra_TwoHandRod	Dark Crescent
 Item_Skill_AbyssGear_ArrowRain_LV1	Arrow Rain
 Item_Skill_AbyssGear_AtorDrone_LV1	Ator's Orb
 Item_Skill_AbyssGear_Attack_HPRecover_LV1	Life Transference
+Item_Skill_AbyssGear_Attack_HPRecover_LV2	Sanguine Transference
 Item_Skill_AbyssGear_Attack_MPRecover_LV1	Spirit Transference
+Item_Skill_AbyssGear_Attack_MPRecover_LV2	Verdant Transference
 Item_Skill_AbyssGear_Attack_SPRecover_LV1	Stamina Transference
+Item_Skill_AbyssGear_Attack_SPRecover_LV2	Celestial Transference
 Item_Skill_AbyssGear_Bastier	Flames of Judgment
 Item_Skill_AbyssGear_BlockAmmoConsume_LV1	Infinite Arrows I
 Item_Skill_AbyssGear_BlockAmmoConsume_LV2	Infinite Arrows II
@@ -2580,15 +2472,15 @@ Item_Skill_AbyssGear_DarkenRobe_LV1	Wound of Darkness
 Item_Skill_AbyssGear_DogClaw_LV1	Hound's Claws
 Item_Skill_AbyssGear_EnergyBurst_LV1	Kinetic Burst
 Item_Skill_AbyssGear_EnlightenmentWave_LV1	Karmic Pulse
+Item_Skill_AbyssGear_EquipDropRate_LV1	Disarm I
+Item_Skill_AbyssGear_EquipDropRate_LV2	Disarm II
+Item_Skill_AbyssGear_EquipDropRate_LV3	Disarm III
 Item_Skill_AbyssGear_Equip_AddHorseExp_LV1	Equestrian I
 Item_Skill_AbyssGear_Equip_AddHorseExp_LV2	Equestrian II
 Item_Skill_AbyssGear_Equip_AddHorseExp_LV3	Equestrian III
 Item_Skill_AbyssGear_Equip_AddPetFriendly_LV1	Companionship I
 Item_Skill_AbyssGear_Equip_AddPetFriendly_LV2	Companionship II
 Item_Skill_AbyssGear_Equip_AddPetFriendly_LV3	Companionship III
-Item_Skill_AbyssGear_EquipDropRate_LV1	Disarm I
-Item_Skill_AbyssGear_EquipDropRate_LV2	Disarm II
-Item_Skill_AbyssGear_EquipDropRate_LV3	Disarm III
 Item_Skill_AbyssGear_FireBreath_LV1	Volcanic Eruption
 Item_Skill_AbyssGear_FlashCombo_LV1	Slashing Reeds
 Item_Skill_AbyssGear_FoodSkillLevelUp_LV1	Gourmet I
@@ -2602,8 +2494,8 @@ Item_Skill_AbyssGear_Hyena_PoisonImmune	Heart of the Serpent
 Item_Skill_AbyssGear_Immune_Bismuth	Heart of Stone
 Item_Skill_AbyssGear_ImpBoss	Howling of Chaos
 Item_Skill_AbyssGear_Karanda	Pillar of Wind
-Item_Skill_AbyssGear_LandMash_LV1	Groundsurge
 Item_Skill_AbyssGear_LanFord	Parting Gift
+Item_Skill_AbyssGear_LandMash_LV1	Groundsurge
 Item_Skill_AbyssGear_Leebur	Shadow Claw
 Item_Skill_AbyssGear_LightningBreath_LV1	Orbs of Lightning
 Item_Skill_AbyssGear_LightningStab_LV1	Storm Fang
@@ -2693,17 +2585,248 @@ Item_Stat_AbyssGear_SwimSpeedRate_LV3	Surge III
 Item_Theona_Checkerspot	Theona Checkerspot Butterfly
 Item_Tiger_Mimic_Queen	Tiger Mimic Queen Butterfly
 Item_Tomaso_Enchant_Coin	Tommaso Refinement Token
-Item_troll_academy_Core	Dimensional Fusion Experimental Power Core
 Item_Varnia_Enchant_Coin	Varnia Refinement Token
 Item_Viceroy	Commander Butterfly
 Item_WaterStrider	Water Strider
+Item_WhiteWing_Flycatcher	White-winged Redstart
 Item_White_M_Hairstreak	White Streaked butterfly
 Item_White_Peacock	White Peacock Butterfly
-Item_WhiteWing_Flycatcher	White-winged Redstart
 Item_Wood_Pecker	Three-Toed Woodpecker
 Item_Zebra_Heliconian	Zebra Longwing Butterfly
 Item_Zebra_Swallowtail	Zebra Swallowtail
-ItemCatch_FishingRod	The Claw
+Item_bookcase_0001	Whitesand Bookshelf
+Item_bookcase_02	Dark Timberton Bookshelf
+Item_bookcase_02_index01	Bright Timberton Bookshelf
+Item_cabinet_0001	Whitesand Gold Display Cabinet
+Item_cabinet_0002	Small Whitesand Cabinet
+Item_cabinet_0003	Whitesand Display Cabinet
+Item_cabinet_02	Dark Crest Triangular Cabinet
+Item_cabinet_02_index01	Bright Crest Triangular Cabinet
+Item_cabinet_03	Dark Crest Display Cabinet
+Item_cabinet_03_index01	Bright Crest Display Cabinet
+Item_cabinet_05	Small Dark Timberton Cabinet
+Item_cabinet_05_index01	Small Bright Timberton Cabinet
+Item_cabinet_11	Small Dark Crest Cabinet
+Item_cabinet_11_index01	Small Bright Crest Cabinet
+Item_cabinet_12	Full Bloom Cabinet
+Item_cabinet_14	Large Timberton Wardrobe
+Item_cabinet_15	Delesyian Metal Lock Cabinet
+Item_cabinet_19	Royal Gold Display Cabinet
+Item_cabinet_19_index01	Sacred Gold Display Cabinet
+Item_cabinet_23	Small Crest Drawer
+Item_cd_ex_dpf_flowerpot_16_housing	Palm Tree Pot
+Item_cd_ex_dpf_flowerpot_21_housing	Small Wooden Flower Pot
+Item_cd_ex_dpf_flowerpot_23_housing	Laurel Pot
+Item_cd_ex_dpf_flowerpot_24_housing	Large Alocasia Pot
+Item_cd_ex_dpf_flowerpot_37_housing	Desert Cactus Pot
+Item_cd_ex_dpf_flowerpot_61_housing	Apple Tree Pot
+Item_cd_lamp_hanger_legendanimal_0002	Twisted Nightmare Lamp
+Item_closet_01	Large Dark Timberton Wardrobe
+Item_closet_01_index01	Large Bright Timberton Wardrobe
+Item_closet_02	Timberham Wardrobe
+Item_craft_medicine_01_housing	Cauldron
+Item_dff_luxuryfurniture_bed_0001	Whitesand Bed
+Item_dff_luxuryfurniture_bed_01	Cozy Bed
+Item_dff_luxuryfurniture_bed_02	Crimson Bed
+Item_dff_luxuryfurniture_bed_03	White Bed
+Item_dff_luxuryfurniture_bed_04	Lord's Bed
+Item_dragonfly	Dragonfly
+Item_dresser_0001	Whitesand Drawer
+Item_dresser_01	Crest Drawer
+Item_dresser_01_index01	Timberton Drawer
+Item_dresser_03	Dark Timberton Cabinet
+Item_dresser_03_index01	Bright Timberton Cabinet
+Item_dresser_04	Timberham Drawer
+Item_gimmick_abyss_quest_kuku_seal_01	Magnetic Power Core
+Item_gimmick_abysscore_0001	Abyss Cell: No. 1
+Item_gimmick_abysscore_0002	Abyss Cell: No. 2
+Item_gimmick_abyssruins_useartifact_01_attach_part	Abyss Transporter
+Item_gimmick_alchemy_globe_0001	Medium Rotating Globe
+Item_gimmick_alchemy_globe_0002	Large Rotating Globe
+Item_gimmick_attach_abyss_core_01	Power Core - Gate of Collapse
+Item_gimmick_attach_abyss_core_02	Power Core - Ore of Resipiscence
+Item_gimmick_attach_abyss_core_03	Power Core - Casket of Illusions
+Item_gimmick_attach_abyss_core_04	Power Core - Crown of Shadows
+Item_gimmick_attach_abyss_core_05	Power Core - Spire of Defiance
+Item_gimmick_attach_abyss_core_06	Power Core - Verse of Sowing
+Item_gimmick_attach_marni_machinetank_backpack_01	Marni's Mecha Leap Pack
+Item_gimmick_attach_marni_machinetank_backpack_02	Marni's Mecha Laser Pack
+Item_gimmick_attach_marni_machinetank_backpack_03	Marni's Mecha Blade Pack
+Item_gimmick_attach_marni_machinetank_backpack_04	Marni's Mecha Rocket Pack
+Item_gimmick_attach_marni_machinetank_backpack_05	Marni's Mecha Booster Pack
+Item_gimmick_attach_marni_machinetank_backpack_06	Dreadnought Booster Pack
+Item_gimmick_attach_marni_machinetank_backpack_07	Dreadnought Missile Pack
+Item_gimmick_attach_mechanical_powerplant_0001	Electrical Component
+Item_gimmick_attach_nuclear_fusion_core_01	Tenebrum Magnetic Core
+Item_gimmick_basecamp_warehouse_box_0002	Private Storage
+Item_gimmick_birdfeeder_0001	Sotdae of Bond
+Item_gimmick_collection_prop_Ceramic_0021	Ocher Jar
+Item_gimmick_collection_prop_Ceramic_0023	Milky White Jar
+Item_gimmick_collection_prop_Ceramic_0033	Patterned Long-Necked Jar
+Item_gimmick_collection_prop_Ceramic_0034	Dark Earthen Jar
+Item_gimmick_collection_prop_Ceramic_0036	Patterned Jar
+Item_gimmick_collection_prop_Ceramic_0040	String-Wrapped Jar
+Item_gimmick_collection_prop_Ceramic_0042	Bright Flat Jar
+Item_gimmick_collection_prop_Ceramic_0043	Dark Flat Jar
+Item_gimmick_collection_prop_Ceramic_0044	Round-Handled Jar
+Item_gimmick_collection_prop_Ceramic_0048	Reddish-Brown Jar
+Item_gimmick_collection_prop_Ceramic_0049	Earth-Colored Jar
+Item_gimmick_collectionstorage_0001	Collectibles Chest
+Item_gimmick_craft_cook_oven_03_housing	Cooking Pot
+Item_gimmick_craft_cook_oven_04_housing	Cooking Griddle
+Item_gimmick_dff_luxuryfurniture_cabinet_0001	Whitesand Storage
+Item_gimmick_dff_luxuryfurniture_cabinet_01	Intricate Floral Vine Cabinet
+Item_gimmick_dff_luxuryfurniture_cabinet_02	Brave Warrior's Storage
+Item_gimmick_dff_luxuryfurniture_chair_01	Decorative Spire Chair
+Item_gimmick_dff_luxuryfurniture_chair_02	Lion-Crested Chair
+Item_gimmick_dff_luxuryfurniture_chair_03	Arched Chair
+Item_gimmick_dff_luxuryfurniture_chair_04	Gilded Red Fabric Chair
+Item_gimmick_dff_luxuryfurniture_chair_troll_03	Large Arched Chair
+Item_gimmick_dff_luxuryfurniture_sofa_01	Luxurious Red Leather Sofa
+Item_gimmick_dff_luxuryfurniture_sofa_02	Luxury Gilded Sofa
+Item_gimmick_dff_luxuryfurniture_stool_01	Luxurious Gilded Side Chair
+Item_gimmick_dff_luxuryfurniture_table_0001	Whitesand Arched Corridor Decorative Table
+Item_gimmick_dff_luxuryfurniture_table_01	Arched Corridor Table
+Item_gimmick_dff_luxuryfurniture_table_02	Dark Lion Head Table
+Item_gimmick_foodstorage_0001	Kuku Cooler
+Item_gimmick_foodstorage_0002	Enhanced Kuku Cooler
+Item_gimmick_gemstone_hanger_top_chandelier_0103	Icy White Chandelier
+Item_gimmick_gemstone_hanger_top_chandelier_0103_index01	Twilight Chandelier
+Item_gimmick_gemstone_hanger_top_chandelier_0103_index02	Lilac Chandelier
+Item_gimmick_hanger_side_lamp_0001	Icy White Wall Lantern
+Item_gimmick_hanger_side_lamp_0001_index01	Twilight Wall Lantern
+Item_gimmick_hanger_side_lamp_0001_index02	Lilac Wall Lantern
+Item_gimmick_hanger_top_lamp_0001	Icy White Lampshade
+Item_gimmick_hanger_top_lamp_0001_index01	Twilight Lampshade
+Item_gimmick_hanger_top_lamp_0001_index02	Lilac Lampshade
+Item_gimmick_hanger_top_lamp_0003	Icy White Drop Light
+Item_gimmick_hanger_top_lamp_0003_index01	Twilight Drop Light
+Item_gimmick_hanger_top_lamp_0003_index02	Lilac Drop Light
+Item_gimmick_in_dff_chair_0002	Double-Patterned Whitesand Chair
+Item_gimmick_in_dff_chair_0003	Whitesand Fabric Chair
+Item_gimmick_in_dff_desk_0001	Whitesand Side Table
+Item_gimmick_in_dff_dressingtable_0001	Mirrored Whitesand Dresser
+Item_gimmick_in_dff_set_chair_0001	Whitesand Fabric Chair
+Item_gimmick_in_dff_stand_0001	Small Whitesand Table
+Item_gimmick_in_dff_table_0002	Large Whitesand Fabric Table
+Item_gimmick_in_dpf_stool_0001	Arched Whitesand Table
+Item_gimmick_item_tool_book_0001	Book
+Item_gimmick_item_tool_bookstand_0001	Book Stand
+Item_gimmick_nature_rock_dissolve_stone_core_01	Abyss Cell: No. 0
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01	Sanctum of Penitence Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index01	Sanctum of Expiation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index03	Sanctum of Renunciation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts01_index04	Sanctum of Oblation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02	Sanctum of Penitence Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index01	Sanctum of Expiation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index03	Sanctum of Renunciation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts02_index04	Sanctum of Oblation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03	Sanctum of Penitence Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index01	Sanctum of Expiation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index03	Sanctum of Renunciation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts03_index04	Sanctum of Oblation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04	Sanctum of Penitence Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index01	Sanctum of Expiation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index03	Sanctum of Renunciation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts04_index04	Sanctum of Oblation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_01_parts20	Core of Penitence
+Item_gimmick_puzzle_antumbra_tokamak_01_parts21	Core of Renunciation
+Item_gimmick_puzzle_antumbra_tokamak_01_parts22	Core of Expiation
+Item_gimmick_puzzle_antumbra_tokamak_01_parts23	Core of Oblation
+Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index01	Sanctum of Benediction Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index03	Sanctum of Absolution Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts01_index04	Sanctum of Mortification Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index01	Sanctum of Benediction Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index03	Sanctum of Absolution Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts02_index04	Sanctum of Mortification Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index01	Sanctum of Benediction Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index03	Sanctum of Absolution Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts03_index04	Sanctum of Mortification Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index01	Sanctum of Benediction Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index03	Sanctum of Absolution Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts04_index04	Sanctum of Mortification Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_02_parts20	Core of Mortification
+Item_gimmick_puzzle_antumbra_tokamak_02_parts21	Core of Faith
+Item_gimmick_puzzle_antumbra_tokamak_02_parts22	Core of Benediction
+Item_gimmick_puzzle_antumbra_tokamak_02_parts23	Core of Absolution
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01	Sanctum of Temperance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index02	Sanctum of Solace Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index04	Sanctum of Faith Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts01_index06	Sanctum of Revelation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02	Sanctum of Temperance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index02	Sanctum of Solace Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index04	Sanctum of Faith Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts02_index06	Sanctum of Revelation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03	Sanctum of Temperance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index02	Sanctum of Solace Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index04	Sanctum of Faith Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts03_index06	Sanctum of Revelation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04	Sanctum of Temperance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index02	Sanctum of Solace Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index04	Sanctum of Faith Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts04_index06	Sanctum of Revelation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_03_parts20	Core of Solace
+Item_gimmick_puzzle_antumbra_tokamak_03_parts21	Core of Revelation
+Item_gimmick_puzzle_antumbra_tokamak_03_parts22	Core of Temperance
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index01	Sanctum of Atonement Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index02	Sanctum of Exaltation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index04	Sanctum of Devotion Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts01_index05	Sanctum of Deliverance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index01	Sanctum of Atonement Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index02	Sanctum of Exaltation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index04	Sanctum of Devotion Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts02_index05	Sanctum of Deliverance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index01	Sanctum of Atonement Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index02	Sanctum of Exaltation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index04	Sanctum of Devotion Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts03_index05	Sanctum of Deliverance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index01	Sanctum of Atonement Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index02	Sanctum of Exaltation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index04	Sanctum of Devotion Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts04_index05	Sanctum of Deliverance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_05_parts20	Core of Atonement
+Item_gimmick_puzzle_antumbra_tokamak_05_parts21	Core of Deliverance
+Item_gimmick_puzzle_antumbra_tokamak_05_parts22	Core of Exaltation
+Item_gimmick_puzzle_antumbra_tokamak_05_parts23	Core of Veneration
+Item_gimmick_puzzle_antumbra_tokamak_05_parts24	Core of Devotion
+Item_gimmick_puzzle_antumbra_tokamak_parts01	Sanctum of Penitence Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts02	Sanctum of Temperance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts03	Sanctum of Atonement Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts04	Sanctum of Deliverance Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts05	Sanctum of Benediction Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts06	Sanctum of Absolution Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts07	Sanctum of Expiation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts08	Sanctum of Mortification Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts09	Sanctum of Revelation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts10	Sanctum of Renunciation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts11	Sanctum of Faith Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts12	Sanctum of Oblation Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts13	Sanctum of Veneration Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts14	Sanctum of Devotion Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts15	Sanctum of Solace Fusion Reactor Core
+Item_gimmick_puzzle_antumbra_tokamak_parts16	Sanctum of Exaltation Fusion Reactor Core
+Item_gimmick_resourcestorage_0001	Sturdy Gatherables Chest
+Item_gimmick_snake_boss_scales_01	Aeserion's Scale
+Item_gimmick_tumbleweed_0001	Tumbleweed
+Item_in_dff_bed_06	Dark Timberham Bed
+Item_in_dff_bed_06_dem	Bright Timberham Bed
+Item_puzzle_troll_lake_pillar_01_part_01	Kharonso Ruins Pillar: No. 1
+Item_puzzle_troll_lake_pillar_02_part_01	Kharonso Ruins Pillar: No. 2
+Item_puzzle_troll_lake_pillar_03_part_01	Kharonso Ruins Pillar: No. 3
+Item_puzzle_troll_lake_pillar_04_part_01	Kharonso Ruins Pillar: No. 4
+Item_troll_academy_Core	Dimensional Fusion Experimental Power Core
+Itemgimmick_lamp_side_candle_0001	Icy White Twin Wall Lamp
+Itemgimmick_lamp_side_candle_0001_index01	Twilight Twin Wall Lamp
+Itemgimmick_lamp_side_candle_0001_index02	Lilac Twin Wall Lamp
+Itemgimmick_lamp_side_candle_0002	Icy White Twin Octagonal Lanterns
+Itemgimmick_lamp_side_candle_0002_index01	Twilight Twin Octagonal Lantern
+Itemgimmick_lamp_side_candle_0002_index02	Lilac Twin Octagonal Lanterns
+Itemgimmick_lamp_side_candle_0003	Icy White Octagonal Lantern
+Itemgimmick_lamp_side_candle_0003_index01	Twilight Octagonal Lantern
+Itemgimmick_lamp_side_candle_0003_index02	Lilac Octagonal Lantern
+Itemgimmick_lamp_stand_candlestick_0001	Icy White Candlestick Lamp
+Itemgimmick_lamp_stand_candlestick_0001_index01	Twilight Candlestick Lamp
+Itemgimmick_lamp_stand_candlestick_0001_index02	Lilac Candlestick Lamp
 Ivano_Fabric_Armor	Bleed Cloth Armor
 Ivory	Ivory
 Iyratti_Fabric_Armor	Eyratt Cloth Armor
@@ -2733,9 +2856,9 @@ Johnnycolo_Leather_Armor	Janiklo Leather Armor
 Johnnycolo_Leather_Gloves	Janiklo Leather Gloves
 Joseph_PlateArmor_Armor	Yosef Plate Armor
 Juden_Fabric_Armor	Juden Cloth Armor
-Judge_Plate_Boots	Inquisitor's Plate Boots
 Judge_PlateArmor_Armor	Inquisitor's Plate Armor
 Judge_PlateArmor_Gloves	Inquisitor's Plate Gloves
+Judge_Plate_Boots	Inquisitor's Plate Boots
 Judge_TwoHandSpear	Alfonso Spear
 Juman_Leather_Boots	Juman Leather Boots
 JumpUp_Boots	Kuku Breeze-Step Boots
@@ -2797,8 +2920,8 @@ Ketlan_ChainMail_Armor	Ketlan Chain Mail
 Khadiac_TwoHandAxe	Troll Hook Greataxe
 Khadiac_TwoHandSpear	Kylus Spear
 Khadion_TwoHandAlebard	Gilliam Halberd
-Khadion_TwoHandedWarHammer	Arlen Warhammer
 Khadion_TwoHandSword	Iris Longsword
+Khadion_TwoHandedWarHammer	Arlen Warhammer
 Khalbydan_Fabric_Armor	Khalbdan Cloth Armor
 Khalbydan_Leather_Gloves	Khalbdan Leather Gloves
 Khanoa_OneHandBow	Sydmon Bow
@@ -2812,9 +2935,6 @@ Kimbap	Battered Harvest Roll
 Kimbap_Large	Satisfying Battered Harvest Roll
 Kimbap_Medium	Filling Battered Harvest Roll
 Kimbap_XLarge	Hearty Battered Harvest Roll
-king_LostPeople_PlateArmor_Armor	Frostcursed Plate Armor
-king_LostPeople_PlateArmor_Armor_Upgrade	Kuku Ice-Resistant Armor
-king_LostPeople_PlateArmor_Cloak	Frostcursed Plate Cloak
 Kinloch_PlateArmor_Armor	Kinloch Plate Armor
 Kinloch_PlateArmor_Armor_I	Kinloch Plate Armor
 Kinov_Fabric_Armor	Keanoff Cloth Armor
@@ -2827,11 +2947,11 @@ Kliff_Earring	Greymane's Earring
 Kliff_Glasses	Master Du's Circlet
 Kliff_Mask	Mask
 Kliff_OneHandShotgun	Pailunese Shotgun
-Kliff_Plate_Boots	Kairos Plate Boots
 Kliff_PlateArmor_Armor	Kairos Plate Armor
 Kliff_PlateArmor_Cloak	Kairos Cloak
 Kliff_PlateArmor_Gloves	Kairos Plate Gloves
 Kliff_PlateArmor_Helm	Kairos Plate Helm
+Kliff_Plate_Boots	Kairos Plate Boots
 Knight_King_OneHandSword	Knightlord's Sword
 Knowledge_PlateArmor_Helm	Helm of Knowledge
 Konkhar_Fabric_Armor	Concarr Cloth Armor
@@ -2848,22 +2968,22 @@ Kritha_HorseArmor_Saddle	Exclaire Saddle
 Kritha_HorseArmor_Stirrup	Calphadean Stirrups
 Ktan_Fabric_Armor	Kithan Cloth Armor
 Ktian_Fabric_Armor	Ketian Cloth Armor
+KuKu_Bismuth_TwoHandSpear	Kuku Bismuth Spear
+KuKu_EMP_TwoHandSpear	Kuku Disruptor Spear
+KuKu_Fire_staff_spear_TwoHandSpear	Kuku Flame Spear
+KuKu_Golden999K	Kuku Transmission 999K Pack
+KuKu_Lightning_TwoHandSpear	Kuku Lightning Spear
+KuKu_Pot_TwoHandSpear	Kuku Spear
+KuKu_Wind_TwoHandSpear	Kuku Propeller Spear
 Kudzu_seed	Skyroot Seed
 Kukan_PlateArmor_Armor	Coogan Plate Armor
 Kukan_PlateArmor_Armor_I	Blacksteel Coogan Plate Armor
-KuKu_Bismuth_TwoHandSpear	Kuku Bismuth Spear
 Kuku_Drone_Backpack	Kuku Watcher Pack
-Kuku_EMP_Enhance_BackPack	Kuku Enhanced Disruptor
-KuKu_EMP_TwoHandSpear	Kuku Disruptor Spear
-KuKu_Fire_staff_spear_TwoHandSpear	Kuku Flame Spear
+Kuku_EMP_Enhance_BackPack	Enhanced Kuku Disruptor
 Kuku_FlameThrower	Kuku Flamespitter
-KuKu_Golden999K	Kuku Transmission 999K Pack
 Kuku_IceThrower	Kuku Frostspitter
-KuKu_Lightning_TwoHandSpear	Kuku Lightning Spear
 Kuku_LightningThrower	Kuku Boltspitter
 Kuku_Pot_BackPack	Kuku Pack
-KuKu_Pot_TwoHandSpear	Kuku Spear
-KuKu_Wind_TwoHandSpear	Kuku Propeller Spear
 Kuku_YamatoCannon_TwoHandSpear	Kuku Laser Cannon Spear
 Kunan_PlateArmor_Armor	Kunan Plate Armor
 Kunan_PlateArmor_Armor_I	Kunan Plate Armor
@@ -2947,7 +3067,7 @@ Lavender_yellow	Yellow Lavender
 Laviren_Fabric_Armor	Ravirun Cloth Armor
 Laviren_Fabric_Armor_1	Bandit Cloth Armor
 Laviren_Fabric_Cloak_I	Bandit Cloth Cloak
-Laviren_Fabric_Helm	Ravirun Cloth Helm
+Laviren_Fabric_Helm	Ravirun Cloth Cap
 Laviren_Leather_Armor	Ravirun Leather Armor
 Lavrak_Fabric_Helm	Labrak Cloth Cap
 Lawncheta_Leather_Gloves	Lawson Leather Gloves
@@ -2965,9 +3085,9 @@ Leeksia_OneHandSword	Dekarr Sword
 Legend_Black_Lion_Report	Sighting of the Black Lion
 Legend_Coelacanth_Report	Sighting of the Coelacanth
 Legend_Giant_Bull_Report	Giant White Bison Sighting
-Legend_Golden_Coelacanth_Report	Sighting of the Golden Coelacanth
 Legend_GoldenCarp_Report	Sighting of the Golden Carp
 Legend_GoldenTench_Report	Golden Tench Sighting
+Legend_Golden_Coelacanth_Report	Sighting of the Golden Coelacanth
 Legend_LeeburtheShadowWolf_Report	Sighting of the Black Fang
 Legend_Phoenix_Wild_Report	Sighting of the Phoenix
 Legend_PureWhite_Bion_Report	Sighting of the White Bison
@@ -2990,8 +3110,8 @@ Legendary_Animal_Redriver_hog	Chalice of Devouring
 Legendary_Animal_Vined_Deer	Aged Branch
 Legendary_Animal_White_Moose	Beckoning Forest
 Legendary_Animal_White_Stag	The Beholder
-Legendary_Antumbra_TwoHandedWarHammer	Antumbra's Eye
 Legendary_Antumbra_TwoHandGiantBastard	Darkbringer
+Legendary_Antumbra_TwoHandedWarHammer	Antumbra's Eye
 Legendary_BridieGu_TwoHandGiantAxe	Wheel of the Last Toll
 Legendary_Caliburn_OneHandRapier	Royal Oath
 Legendary_CaptainGoblin_OneHandAxe	Double-Headed Axe of Greed
@@ -2999,14 +3119,13 @@ Legendary_CrimsonScorpion_TwoHandHammer	Rune-Engraved Rock
 Legendary_Deer_Leather_Gloves	Counterweight Leather Gloves
 Legendary_Deer_Leather_Gloves_T4_QA	Legendary Deer Leather Gloves T4 QA
 Legendary_DemenisMusket_OneHandMusket	Demenissian Hero's Musket
+Legendary_DragonSlayer_OneHandSword	Nazk Sword
 Legendary_Dragon_OneHandSword	Aeserion Sword
 Legendary_Dragon_TwoHandGiantSpear	Aeserion Spear
-Legendary_DragonSlayer_OneHandSword	Nazk Sword
 Legendary_GoldStar_OneHandCannon	Golden Fire
 Legendary_HexeMarie_Earring	Earring of Dark Magic
 Legendary_Kings_OneHandDagger	King's Dagger
 Legendary_Korea_OneHandBow	Noble Man's Bow
-Legendary_Marni_OneHandCannon	Blaster No. 8
 Legendary_MarniDragon_OneHandCannon	Mechanical Clockwork Blaster
 Legendary_MarniGolem_Plate_Armor	Frozen Heart Plate Armor
 Legendary_MarniGolem_Plate_Boots	Frozen Heart Plate Boots
@@ -3014,6 +3133,7 @@ Legendary_MarniGolem_Plate_Cloak	Frozen Heart Plate Cloak
 Legendary_MarniRegion_OneHandMace	Marni Devotee's Mace
 Legendary_MarniTank_OneHandCannon	Marni Tank Blaster
 Legendary_MarniTank_OneHandShield	Delesyian Ornamental Shield
+Legendary_Marni_OneHandCannon	Blaster No. 8
 Legendary_Moonhead_01_TwoHandGiantSpear	Diverging Moon
 Legendary_Moonhead_02_TwoHandGiantSpear	Circling Moon
 Legendary_Moonhead_TwoHandGiantSpear	Grasping Moon
@@ -3030,9 +3150,9 @@ Legendary_Titan_Ring	Ring of Lightning
 Legendary_WhiteHorn_OneHandSword	Chillfallen Sword
 Legendary_WhiteWolf_Leather_Helm	Silver Fang Helm
 Leinstead_OneHandSword	Glenmore Sword
-Lekia_Leather_Boots	Regglia Leather Boots
+Lekia_Leather_Boots	Rekhia Leather Boots
+Lekia_PlateArmor_Helm	Baltheon Plate Helm
 Lekia_Plate_Boots	Unyielding Warrior's Plate Boots
-Lekia_PlateArmor_Helm	Rekhia Plate Helm
 Lentils	Lentils
 Leone_OneHandRapier	Leonne Rapier
 Leontain_Leather_Boots	Leontyne Leather Boots
@@ -3053,15 +3173,16 @@ License_Operation_HernandBank	Personal Strongbox Permit
 Lickla_PlateArmor_Armor	Ricla Plate Armor
 Liculu_Leather_Gloves	Ricrau Leather Gloves
 Licuna_Leather_Boots	Leguna Leather Boots
-Light_Arrowhead_Fabric_Armor_I	Blinding Arrows Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_II	Blinding Arrows Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_III	Blinding Arrows Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_IV	Blinding Arrows Rider's Cloth Armor
-Light_Arrowhead_Fabric_Armor_V	Blinding Arrows Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_VI	Blinding Arrows Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_VII	Blinding Arrows Scout's Cloth Armor
-Light_Arrowhead_Fabric_Cloak_I	Blinding Arrow Cloth Cloak
-Light_Arrowhead_Fabric_Helm_V	Blinding Arrows' Cloth Cap
+LightSaber_TwoHandSword	LightSaber TwoHandSword
+Light_Arrowhead_Fabric_Armor_I	Blinding Arrow Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_II	Blinding Arrow Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_III	Blinding Arrow Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_IV	Blinding Arrow Rider's Cloth Armor
+Light_Arrowhead_Fabric_Armor_V	Blinding Arrow Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_VI	Blinding Arrow Scout's Cloth Armor
+Light_Arrowhead_Fabric_Armor_VII	Blinding Arrow Scout's Cloth Armor
+Light_Arrowhead_Fabric_Cloak_I	Blinding Arrow's Cloth Cloak
+Light_Arrowhead_Fabric_Helm_V	Blinding Arrow's Cloth Cap
 Light_Arrowhead_Leader_OneHandBow	Tormented Soul Bow
 Light_Arrowhead_Leather_Armor_I	Blinding Arrow's Leather Armor
 Light_Arrowhead_Leather_Armor_II	Blinding Arrow's Leather Armor
@@ -3070,24 +3191,22 @@ Light_Arrowhead_Leather_Armor_IV	Blinding Arrow's Leather Armor
 Light_Arrowhead_Leather_Armor_IX	Blinding Arrow's Leather Armor
 Light_Arrowhead_Leather_Armor_V	Blinding Arrow's Leather Armor
 Light_Arrowhead_Leather_Armor_VI	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Armor_VII	Blinding Arrows Scout's Leather Armor
-Light_Arrowhead_Leather_Armor_VIII	Blinding Arrows Scout's Leather Armor
+Light_Arrowhead_Leather_Armor_VII	Blinding Arrow Scout's Leather Armor
+Light_Arrowhead_Leather_Armor_VIII	Blinding Arrow Scout's Leather Armor
 Light_Arrowhead_Leather_Armor_X	Blinding Arrow's Leather Armor
 Light_Arrowhead_Leather_Boots_I	Blinding Arrow's Leather Boots
 Light_Arrowhead_Leather_Boots_II	Blinding Arrow's Leather Boots
 Light_Arrowhead_Leather_Gloves	Blinding Arrow's Leather Gloves
 Light_Of_Giant_Lantern	Shiny Blue Sea Lantern
 Light_Thorn_OneHandTowerShield	Rekel Large Spiked Shield
+LightningThrower	Electromagnetic Boltspitter
 Lightning_Arrow	Blitz Arrow
 Lightning_TwoHandSpear	Lightning Spear
-LightningThrower	Electromagnetic Boltspitter
-LightSaber_TwoHandSword	LightSaber TwoHandSword
 Ligtning_TwoHandHammer_I	Lightning Greathammer
 Likarz_Fabric_Armor	Rikkas Cloth Armor
 Likenin_Leather_Gloves	Lennigen Leather Gloves
 Likua_PlateArmor_Helm	Longia Plate Helm
 Likua_PlateArmor_Helm_I	Blacksteel Longia Plate Helm
-lilian_Leather_Boots	Lilian Leather Boots
 Limerhen_TwoHandSpear	Traitor's Spear
 Limerick_ChainMail_Armor	Lemerick Chain Mail
 Liornia_Fabric_Armor	Liorna Cloth Armor
@@ -3103,7 +3222,7 @@ Logger_BackPack_III	Woodcutter's Pack
 Logger_BackPack_IV	Woodcutter's Pack
 Londel_Leather_Boots	Scorchflame Leather Boots
 Londel_Leather_Gloves	Rondel Leather Gloves
-Londel_Leather_Helm	Rondel Leather Helm
+Londel_Leather_Helm	Rondel Leather Cap
 Londel_PlateArmor_Gloves	Scorchflame Plate Gloves
 Londel_PlateArmor_Helm	Scorchflame Plate Helm
 LongBeak_OneHandSword	Varnian Sword
@@ -3129,7 +3248,7 @@ Lotas_PlateArmor_Helm	Lotas Plate Helm
 Lotas_PlateArmor_Helm_I	Blacksteel Lotas Plate Helm
 Lotunsau_Leather_Armor	Rotunso Leather Armor
 Louis_Fabric_Armor	Louis Cloth Armor
-Lower_ChainMail_Armor	Lauer Chain Mail
+Lower_ChainMail_Armor	Flame Knights Chain Mail
 Lowuti_Leather_Boots	Loutte Leather Boots
 Lucan_OneHandTowerShield	Lucon Large Shield
 Lucion_ChainMail_Armor	Lucion Chain Mail
@@ -3138,7 +3257,7 @@ Lucky_Letter	Letter of Fortune
 Luconek_Fabric_Helm	Rueconec Cloth Cap
 Luconek_Leather_Boots	Rueconec Leather Boots
 Luconek_Leather_Gloves	Rueconec Leather Gloves
-Luconek_Leather_Helm	Rueconec Leather Helm
+Luconek_Leather_Helm	Rueconec Leather Hat
 Luconek_PlateArmor_Helm	Rueconec Plate Helm
 Luconek_PlateArmor_Helm_I	Demenissian Guard's Plate Helm
 Luconek_PlateArmor_Helm_II	Inquisitor's Plate Helm
@@ -3151,7 +3270,7 @@ Ludvic_Leather_Cloak	Hungering Fang Leather Cloak
 Ludvic_Leather_Gloves	Hungering Fang Leather Gloves
 Ludvic_Leather_Gloves_II	Jackals' Leather Gloves
 Ludvic_Necklace	Crossroads Necklace
-Ludvic_OneArmed_Leather_Armor	One-Armed Jackals' Leather Armor
+Ludvic_OneArmed_Leather_Armor	One-Armed Jackal's Leather Armor
 Ludvic_OneArmed_Leather_Cloak	One-Armed Jackal's Leather Cloak
 Ludvig_OneHandSword	Red Rage
 Ludynn_Fabric_Gloves	Ludynn Cloth Gloves
@@ -3174,11 +3293,11 @@ Lunosier_Fabric_Armor	Pailunese Attire
 Lunosier_Fabric_Cloak	Pailunese Cloak
 Lunpherd_Leather_Armor	Lunpherd Leather Armor
 Lunther_PlateArmor_Gloves	Luthor Plate Gloves
-Luon_Plate_Boots	Luon Plate Boots
 Luon_PlateArmor_Armor	Luon Plate Armor
 Luon_PlateArmor_Cloak	Luon Plate Cloak
 Luon_PlateArmor_Gloves	Luon Plate Gloves
 Luon_PlateArmor_Helm	Luon Plate Helm
+Luon_Plate_Boots	Luon Plate Boots
 Luon_TwoHandAlebard	Golden Vanguard
 Lusek_Giant_TwoHandGiantBastard	Lusec Greatsword
 Lutia_Leather_Boots	Lutia Leather Boots
@@ -3207,8 +3326,8 @@ Maeve_Leather_Gloves	Maeve Leather Gloves
 Maeve_OneHandAxe	Maeve Axe
 Maeve_OneHandMace	Marching Baton
 MagicBullet	Magic Bullet
-MagicBullet_Dark_IceSpear	Dark Ice Spear Magic Bullet
 MagicBullet_DarkBall	Dark Magic Bullet
+MagicBullet_Dark_IceSpear	Dark Ice Spear Magic Bullet
 MagicBullet_Electric	Lightning Magic Bullet
 MagicBullet_Fire	Fire Magic Bullet
 MagicBullet_Ice	Ice Magic Bullet
@@ -3236,6 +3355,13 @@ Mark_PlateArmor_Armor	Marc Plate Armor
 Markman_PlateArmor_Armor	Markman Plate Armor
 Markna_Leather_Gloves	Markna Leather Gloves
 Markris_Plate_Boots	Marcris Plate Boots
+MarniDragon_DemenissLetter	Caliburn's Orders
+MarniDragon_GoldenStar	Golden Star Blueprint
+MarniDragon_MarniRen	Careful Observation of H.A.L.L.
+MarniDragon_Visione	The Features of the Visione
+MarniMachineDrill	Marni Drill Component
+MarniMachineLaser	Marni Laser Component
+MarniTower_Key	Spire of Clockwork Key
 Marni_ChainMail_Boots	Marni's Chain Boots
 Marni_ChainMail_Gloves	Marni's Chain Gloves
 Marni_Devotee_PlateArmor_Helm	Visione
@@ -3244,8 +3370,6 @@ Marni_Devotee_PlateArmor_Helm_II	Guard Visione
 Marni_Devotee_PlateArmor_Helm_III	Military Visione
 Marni_Devotee_PlateArmor_Helm_IV	Prototype Visione
 Marni_Fabric_Armor	Marni's Cloth Armor
-marni_Flag_I	Small Marni Banner Pike
-marni_Flag_II	Medium Marni Banner Pike
 Marni_HorseArmor_Armor	Exclaire Barding
 Marni_HorseArmor_Helm	Wells Military Champron
 Marni_HorseArmor_Stirrup	Marni Stirrups
@@ -3255,13 +3379,6 @@ Marni_MachineFish_Report	Sighting of the Clockwork Fish
 Marni_MachineKnight_TwoHandSpear	Electro-Mecha Spear
 Marni_MachineKnight_TwoHandSword	Electro-Mecha Longsword
 Marni_Special_CannonBall	Disruptor Cannonball
-MarniDragon_DemenissLetter	Caliburn's Orders
-MarniDragon_GoldenStar	Golden Star Blueprint
-MarniDragon_MarniRen	Careful Observation of H.A.L.L.
-MarniDragon_Visione	The Features of the Visione
-MarniMachineDrill	Marni Drill Component
-MarniMachineLaser	Marni Laser Component
-MarniTower_Key	Spire of Clockwork Key
 Marozzo_OneHandRapier	Elemore Rapier
 Marqueeluon_Fabric_Armor	Maquealon Cloth Armor
 Marthana_Leather_Armor	Matana Leather Armor
@@ -3270,9 +3387,9 @@ Martin_Leather_Boots	Martin's Leather Boots
 Martindue_Fabric_Armor	Marindo Cloth Armor
 Martins_Leather_Boots	Matrinne Leather Boots
 Mask_Liberator_TwoHandedWarHammer	Oblivion of the Past
-Master_Key	Master Key
-MasterDoo_Scroll	Master Du's Message
 MastKey_Gloves	MastKey Gloves
+MasterDoo_Scroll	Master Du's Message
+Master_Key	Master Key
 Masty_PlateArmor_Gloves	Masti Plate Gloves
 Mataka_Leather_Boots	Matahka Leather Boots
 Matar_Leather_Boots	Matar Leather Boots
@@ -3347,11 +3464,10 @@ Medikit_BackPack_VIII	Healer's Pack
 Mediratu_Leather_Gloves	Merridew Leather Gloves
 Melina_Fabric_Armor	Melina Cloth Armor
 Melvin_Leather_Gloves	Melvin Leather Gloves
-Melvin_Leather_Helm	Melvin Leather Helm
+Melvin_Leather_Helm	Melvin Leather Cap
 Memo_ButlerLeftMemo	A Butler's Note
 Memo_CabinLeftMemo	Note in the Cabin
 Memo_Judgment	Warning of Judgment
-Memo_lightningstriketree	Lightning-struck Tree
 Memo_Proceedings	Supply Delivery Log
 Memo_RuinedChapel	Mysterious Note
 Memo_SebastianMemo	Mapmaker's Note
@@ -3367,6 +3483,7 @@ Memo_Serkis_Piece_1	Piece from Oakenshield Manor
 Memo_Serkis_Piece_2	Piece from Lioncrest Watchtower
 Memo_Serkis_Piece_3	Piece from Duskwood
 Memo_Serkis_Piece_4	Piece from St. Halssius
+Memo_lightningstriketree	Lightning-Struck Tree
 Meravan_Fabric_Armor	Meravan Cloth Armor
 Meravan_Fabric_Helm	Meravan Cloth Cap
 Meravan_Leather_Boots	Meravan Leather Boots
@@ -3424,16 +3541,17 @@ Money_Pearl	Pearl
 Monita_OneHandTowerShield	Balton Large Shield
 Montellanico_Leather_Armor	Montlanico Leather Armor
 Monterima_Fabric_Armor	Monterima Cloth Armor
-Moonhead_Plate_Boots	Half Moon Reaper Plate Boots
-Moonhead_Plate_Boots_Full	Full Moon Reaper Plate Boots
-Moonhead_Plate_Boots_Waning	New Moon Reaper Plate Boots
+Moon_Blade_TwoHandSword	Woldo
 Moonhead_PlateArmor_Armor	Half Moon Reaper Plate Armor
 Moonhead_PlateArmor_Armor_Full	Full Moon Reaper Plate Armor
 Moonhead_PlateArmor_Armor_Waning	New Moon Reaper Plate Armor
-Moonhead_PlateArmor_Gloves	Lunar Reapers' Plate Gloves
+Moonhead_PlateArmor_Gloves	Lunar Reaper Plate Gloves
 Moonhead_PlateArmor_Helm	Half Moon Reaper Plate Helm
 Moonhead_PlateArmor_Helm_Full	Full Moon Reaper Plate Helm
 Moonhead_PlateArmor_Helm_Waning	New Moon Reaper Plate Helm
+Moonhead_Plate_Boots	Half Moon Reaper Plate Boots
+Moonhead_Plate_Boots_Full	Full Moon Reaper Plate Boots
+Moonhead_Plate_Boots_Waning	New Moon Reaper Plate Boots
 Morgren_Fabric_Armor	Morgren Cloth Armor
 Mornington_Fabric_Gloves	Mornington Cloth Gloves
 Mornington_Leather_Boots	Mornington Leather Boots
@@ -3460,13 +3578,11 @@ Muscan_Ghost_Fist	Muskan's Upper Body Clone
 Muscan_Ghost_Fist_I	Muskan's Lower Body Clone
 Muscan_PlateArmor_Armor	Muskan Armor
 Muscan_PlateArmor_Gloves	Combat God's Plate Gloves
-musket_Flag_I	Small Musket of Demeniss Banner Pike
-musket_Flag_II	Medium Musket of Demeniss Banner Pike
 Mynein_OneHandRapier	Gilliam Rapier
 Myrenenn_Fabric_Armor	Myrnen Cloth Armor
 Mysterm_Leather_Boots	Mistum Leather Boots
 Mysterm_Leather_Gloves	Mistum Leather Gloves
-Myurdin_Leather_Armor_II	Myurdin Leather Armor
+Myurdin_Leather_Armor_II	Myurdin's Leather Armor
 Myurdin_Leather_Boots	Myurdin's Leather Boots
 NahabVillage_Pendant	Nahab Pendant
 Nahu_ChainMail_Helm	Nahu Chain Coif
@@ -3492,9 +3608,12 @@ Nevin_Leather_Boots	Nevin Leather Boots
 Nickna_Leather_Boots	Northern Fighter's Leather Boots
 Nihrutte_Leather_Armor	Nehrut Leather Armor
 Nihrutte_Leather_Boots	Nehrut Leather Shoes
+NoName_Wiseman_Leather_Armor	Nameless Sage's Leather Armor
+NoName_Wiseman_Leather_Cloak	Nameless Sage's Leather Cloak
+NoName_Wiseman_Leather_Gloves_I	Nameless Sage's Leather Gloves
 Noble_Fabric_Armor	Noble Cloth Armor
 Noble_Leather_Helm	Noble's Hat
-Noble_Retainer_Leather_Gloves	Noble Private Soldier's Leather Gloves
+Noble_Retainer_Leather_Gloves	Private Soldier's Leather Gloves
 Noble_Retainer_PlateArmor_Armor	Sungrove Standard Plate Armor
 Noble_Retainer_PlateArmor_Armor_I	Marshell Soldier's Plate Armor
 Noble_Retainer_PlateArmor_Armor_II	Marshell Soldier's Plate Armor
@@ -3512,9 +3631,6 @@ Noble_Retainer_PlateArmor_Armor_XIV	Private Soldier's Plate Armor
 Noble_Retainer_PlateArmor_Armor_XV	Private Soldier's Plate Armor
 Nocburn_Leather_Gloves	Nocburn Leather Gloves
 Noname_OneHandDagger	Varnian Dagger
-NoName_Wiseman_Leather_Armor	Nameless Sage's Leather Armor
-NoName_Wiseman_Leather_Cloak	Nameless Sage's Leather Cloak
-NoName_Wiseman_Leather_Gloves_I	Nameless Sage's Leather Gloves
 Norman_Leather_Boots	Norman Leather Boots
 Norswitch_Leather_Armor	Norswich Leather Armor
 North_Mercenary_Fabric_Cloak_I	Jackal Cloth Cloak
@@ -3548,6 +3664,48 @@ NoticePaper_Her_LostCow	Missing Cows
 NoticePaper_Her_StolenGoatHorn	Horn Thief
 NoticePaper_Hyenamolar	Bounty Notice - Skevald, the Carrion King
 NoticePaper_MudWalkerLutemir	Bounty on the Mud Monster
+NoticePaper_Skill_Charge_Shot	Hernand Anonymous Jottings No. 34
+NoticePaper_Skill_CloneAttack	Tribunal Warning Notice No. 52367
+NoticePaper_Skill_CrowWing_Dash	Hernand Anonymous Jottings No. 61
+NoticePaper_Skill_Damian_LungeCatch	Hernand Anonymous Jottings No. 63
+NoticePaper_Skill_Damian_QuickReload	Hernand Anonymous Jottings No. 72
+NoticePaper_Skill_Damian_SpinningKick	Call for Challengers: Master of Kicks
+NoticePaper_Skill_Damian_TurnBash_II	Circus Invitation
+NoticePaper_Skill_DoubleJump	Random Note No. 2
+NoticePaper_Skill_DoubleKick_I	Hernand Anonymous Jottings No. 42
+NoticePaper_Skill_DropKick	Hernand Anonymous Jottings No. 45
+NoticePaper_Skill_EvadeExplosionShot	Hernand Constabulary Warning Notice No. 77
+NoticePaper_Skill_EvadeShot	Pailune Warning Notice No. 66
+NoticePaper_Skill_Greywolf_Detect	Anonymous Note No. 2
+NoticePaper_Skill_Greywolf_Detect_Unleash	Random Note No. 3
+NoticePaper_Skill_JiJeongTa_Deep	Anonymous Note No. 4
+NoticePaper_Skill_JiJeongTa_I	Anonymous Note No. 3
+NoticePaper_Skill_JumpStep	Request from the Merchant Guild
+NoticePaper_Skill_Lift	Hernand Anonymous Jottings No. 52
+NoticePaper_Skill_LungeCombination	Hernand Constabulary Warning Notice No. 66
+NoticePaper_Skill_Mabongpa	Hernand Anonymous Jottings No. 57
+NoticePaper_Skill_MoveCutting_II	Hernand Anonymous Jottings No. 32
+NoticePaper_Skill_MpFire	White Crow's Letter
+NoticePaper_Skill_MpIce	White Crow's Letter
+NoticePaper_Skill_MpLightning	White Crow's Letter
+NoticePaper_Skill_MpWind	White Crow's Letter
+NoticePaper_Skill_MultiShot	Random Note No. 1
+NoticePaper_Skill_Oongka_AimExplosionShot	Anonymous Note No. 6
+NoticePaper_Skill_Oongka_Dash	Hernand Anonymous Jottings No. 23
+NoticePaper_Skill_Oongka_GroundSmash_II	Random Note No. 4
+NoticePaper_Skill_Oongka_RotationBash_II	A man's plea
+NoticePaper_Skill_Oongka_Wrestle_Combo	Troll Wrestling Invitation
+NoticePaper_Skill_RollCancel	Hernand Anonymous Jottings No. 48
+NoticePaper_Skill_RotationBash_II	Hernand Constabulary Warning Notice No. 84
+NoticePaper_Skill_ShieldJustGuard_Attack	An old man's request
+NoticePaper_Skill_SkyKick	Anonymous Note No. 1
+NoticePaper_Skill_SwordRush	Kailok's Request
+NoticePaper_Skill_Tathagata_mini	Anonymous Note No. 5
+NoticePaper_Skill_TurnBash_II	Hernand Anonymous Jottings No. 27
+NoticePaper_Skill_UnArmedCombination	Request from the Communal Training Grounds
+NoticePaper_Skill_Wrestle_AirBodySlam	Hernand Constabulary Warning Notice No. 103
+NoticePaper_Skill_Wrestle_GrabSpinThrow	Pailune Anonymous Jottings No. 77
+NoticePaper_Skill_Wrestle_Lariat	Call for Challengers: Black Bear
 NoticePaper_Village_Muiquun	Request to Punish Outlaws in Muiquun
 Noyvarn_Leather_Armor	Noyvarn Leather Armor
 Nureumjeok	Mixed Skewers
@@ -3557,6 +3715,7 @@ Nureumjeok_XLarge	Hearty Mixed Skewers
 Nusiran_Fabric_Armor	Nuslan Cloth Armor
 Nusiran_Leather_Armor	Nuslan Leather Armor
 Nysron_Fabric_Armor	Neslan Cloth Armor
+OOngka_Daeil_Band	Oongka's Axiom Bracelet
 Oakleyman_PlateArmor_Armor	Oakley Plate Armor
 Oakten_Leather_Boots	Oakten Leather Boots
 Oathring_OneHandShield	Oath Ring Shield
@@ -3568,10 +3727,10 @@ Oil_Barrel	Oil Barrel
 Oil_Sprayer_BackPack	Lubricant Sprayer
 Old_HorseArmor_Saddle	Shabby Horse Saddle
 Old_Kliff_OneHandSword	Fated Shadow
-Old_Kliff_Plate_Boots	Goyen's Plate Boots
 Old_Kliff_PlateArmor_Armor	Goyen's Plate Armor
 Old_Kliff_PlateArmor_Cloak	Goyen's Cloak
 Old_Kliff_PlateArmor_Gloves	Goyen's Plate Gloves
+Old_Kliff_Plate_Boots	Goyen's Plate Boots
 Old_Necklace	Worn Necklace
 Old_Ring	Worn Ring
 Old_Wood_Doll_II	Old Wooden Doll
@@ -3583,8 +3742,6 @@ Onion	Onion
 Oongka_Basic_Leather_Armor	Ashen Wolf's Leather Armor
 Oongka_Basic_Leather_Cloak	Ashen Wolf's Leather Cloak
 Oongka_Basic_Leather_Gloves	Ashen Wolf's Leather Gloves
-OOngka_Daeil_Band	Oongka's Axiom Bracelet
-Oongka_Plate_Glove	Brass Warden's Plate Gloves
 Oongka_PlateArmor_Armor_II	Valortread Plate Armor
 Oongka_PlateArmor_Armor_III	Belkandor Plate Armor
 Oongka_PlateArmor_Boots_II	Valortread Plate Boots
@@ -3595,8 +3752,9 @@ Oongka_PlateArmor_Gloves_II	Valortread Plate Gloves
 Oongka_PlateArmor_Gloves_III	Belkandor Plate Gloves
 Oongka_PlateArmor_Helm_II	Valortread Plate Helm
 Oongka_PlateArmor_Helm_III	Belkandor Plate Helm
+Oongka_Plate_Glove	Brass Warden's Plate Gloves
 Oongka_Rocket_BackPack	Kuku Rocket Pack
-Oongka_Rocket_Helm	KuKu Rocket Helmet - Equipped by Default
+Oongka_Rocket_Helm	Kuku Rocket Helmet - Equipped by Default
 Ophenber_PlateArmor_Helm	Offenberg Plate Helm
 Optionary_Beekeeping_Cloak	Beekeeping Cloak
 Optionary_Beekeeping_Cloth	Beekeeping Suit
@@ -3616,33 +3774,30 @@ Optionary_Ent_Helm	Shadowleaf Helm
 Optionary_Florin_Cloth	Pororin Cloth Attire
 Optionary_Hernand_Party_Cloak	Hernandian Banquet Cloak
 Optionary_Hernand_Party_Cloth	Hernandian Attire
-Optionary_Monk_cloak	St. Halssius Priest's Cloak
 Optionary_Monk_Cloth	St. Halssius Priest Attire
 Optionary_Monk_Necklace	Saint's Necklace
+Optionary_Monk_cloak	St. Halssius Priest's Cloak
 Optionary_NonSlip_Boots	Stirrups of the Open Sky
 Optionary_NonSlip_Gloves	Reins of Open Sky
-Optionary_Scholar_Stone_cloak	Scholastone Cloak
 Optionary_Scholar_Stone_Cloth	Scholastone Uniform
+Optionary_Scholar_Stone_cloak	Scholastone Cloak
 Opuntia_seed	Prickly Pear Seed
 Orange	Orange
-orange_BackPack	Orange Pack
-orange_Seed	Orange Seed
 Orbs_Fabric_Armor	Orbus Cloth Armor
 Orc_Flag_I	Small Ironflame Orcs Banner Pike
 Orc_Flag_II	Medium Ironflame Orcs Banner Pike
 Orc_OneHandCannon	Orc Blaster
 Orc_Warrior_OneHandMace	Octarr's Legacy
-orchids_BackPack	Dendrobium Orchid Pack
-OrcuMer_Fabric_Armor	Trukan Cloth Armor
-OrcuMer_Fabric_Boots	Trukan Cloth Boots
-OrcuMer_Fabric_Cloak	Trukan Cloth Cloak
-OrcuMer_Fabric_Gloves	Trukan Cloth Gloves
-Orcumer_Helm	Wooden Mask of Lost Justice
-OrcuMer_Plate_Boots	Odeck's Protector Plate Boots
+OrcuMer_Fabric_Armor	T'rukan's Cloth Armor
+OrcuMer_Fabric_Boots	T'rukan's Cloth Boots
+OrcuMer_Fabric_Cloak	T'rukan's Cloth Cloak
+OrcuMer_Fabric_Gloves	T'rukan's Cloth Gloves
 OrcuMer_PlateArmor_Armor	Odeck's Protector Plate Armor
 OrcuMer_PlateArmor_Cloak	Odeck's Protector Plate Cloak
 OrcuMer_PlateArmor_Gloves	Odeck's Protector Plate Gloves
 OrcuMer_PlateArmor_Helm	Odeck's Protector Plate Helm
+OrcuMer_Plate_Boots	Odeck's Protector Plate Boots
+Orcumer_Helm	Wooden Mask of Lost Justice
 Orient_Monk_BackPack	Eastern Monk Pack
 Orjekel_HorseArmor_Armor	Varnian Barding
 Orjekel_HorseArmor_Helm	Varnian Champron
@@ -3663,8 +3818,7 @@ Owls_of_the_Mist_Leather_Cloak	Mistcloaked Owl Leather Cloak
 Owls_of_the_Mist_PlateArmor_Helm	Mistcloaked Owl Plate Helm
 Owls_of_the_Mist_PlateArmor_Helm_II	Mistcloaked Owl Plate Helm
 Paijal_PlateArmor_Helm	Paizel Bone Helm
-pailloon_Flag_I	Small Pailunese Banner Pike
-pailloon_Flag_II	Medium Pailunese Banner Pike
+Pail_Cup_Oath	Pailunese Chalice of Oaths
 Pailoon_OneHandMace	Savage Woodland Spirit Killer
 Pailune_Contribution_Flag	Pailunese Contribution Banner Pike
 Pailune_Necklace	Blue Fang Necklace
@@ -3735,40 +3889,73 @@ Pan_fried_Vegetable_Pancake_XLarge	Hearty Battered Vegetables
 Pansy	Pansy
 Pantafe_Fabric_Armor	Pantafe Cloth Armor
 Paper_Adelina	Adrina's Note
+Paper_Adelina_1	Adrina's Note
 Paper_Adelina_I	Carpenter's Note
 Paper_Adelina_II	Training Field Note
+Paper_Adelina_II_1	Training Field Note
+Paper_Adelina_I_1	Carpenter's Note
 Paper_Aldred	Eldred's Note
+Paper_Aldred_1	Eldred's Note
 Paper_Aldred_I	Farmer's Note
 Paper_Aldred_II	Provisioner's Shop Note
+Paper_Aldred_II_1	Provisioner's Shop Note
+Paper_Aldred_I_1	Farmer's Note
 Paper_Beatrice	Bea's Note
+Paper_Beatrice_1	Bea's Note
 Paper_BoundbyLies	Wronged Man's Note
+Paper_BoundbyLies_1	Wronged Man's Note
 Paper_BoundbyLies_I	Note at a Man's House
+Paper_BoundbyLies_I_1	Note at a Man's House
 Paper_BraveToLove	A Man's Note
+Paper_BraveToLove_1	A Man's Note
 Paper_Bruna	Bruna's Note
+Paper_Bruna_1	Bruna's Note
 Paper_Bruna_I	Saddler's Note
 Paper_Bruna_II	Royal Trading Post Note
+Paper_Bruna_II_1	Royal Trading Post Note
+Paper_Bruna_I_1	Saddler's Note
 Paper_Castiel	Castiel's Note
+Paper_Castiel_1	Castiel's Note
 Paper_Castiel_I	Stained Work Log
+Paper_Castiel_I_1	Stained Work Log
 Paper_DelesyiaInstitute_Clue_ResearchPaper	Research Suspension Warning
 Paper_Doni	Donny's Note
+Paper_Doni_1	Donny's Note
 Paper_Doni_I	Flower Shop Customer's Note
+Paper_Doni_I_1	Flower Shop Customer's Note
 Paper_Drianna	Driana's Note
+Paper_Drianna_1	Driana's Note
 Paper_Drianna_I	Watchtower Note
+Paper_Drianna_I_1	Watchtower Note
 Paper_Eliza	Elise's Note
-Paper_Eliza_I	Note from the Street Shop
+Paper_Eliza_1	Elise's Note
+Paper_Eliza_I	Note from the Shopping Street
+Paper_Eliza_I_1	Note from the Shopping Street
 Paper_FieldVoice	Excavation Site Manager's Note
+Paper_FieldVoice_1	Excavation Site Manager's Note
 Paper_FieldVoice_I	Foreman's Note
+Paper_FieldVoice_I_1	Foreman's Note
 Paper_Find_Tolstein	Report on Beighen
 Paper_Fiona	Fiona's Note
+Paper_Fiona_1	Fiona's Note
 Paper_Fiona_I	Chief Trainer's Journal
+Paper_Fiona_I_1	Chief Trainer's Journal
 Paper_Flint	Flint's Note
+Paper_Flint_1	Flint's Note
 Paper_Flint_I	Potter's Journal
+Paper_Flint_I_1	Potter's Journal
 Paper_Forex	Forrex's Note
+Paper_Forex_1	Forrex's Note
 Paper_Forex_I	Arms Scholar's Note
 Paper_Forex_II	Windrose Farm Note
+Paper_Forex_II_1	Windrose Farm Note
+Paper_Forex_I_1	Arms Scholar's Note
 Paper_FriendNews	Merchant's Note
+Paper_FriendNews_1	Merchant's Note
 Paper_FriendNews_I	Duskway Camp Note
 Paper_FriendNews_II	Note Found at the Fence
+Paper_FriendNews_II_1	Note Found at the Fence
+Paper_FriendNews_I_1	Duskway Camp Note
 Paper_FromYann	Yann's Letter
 Paper_GoldleafGuildhouse_Clue_I	Feed Purchase Receipt
 Paper_GoldleafGuildhouse_Clue_II	Trade Schedule Log
@@ -3779,29 +3966,49 @@ Paper_GoldleafGuildhouse_Clue_VI	Guard's Letter
 Paper_GoldleafGuildhouse_Clue_VII	Merchant Delivery Seal
 Paper_GoldleafGuildhouse_Clue_VIII	Proof of Stay
 Paper_Harveston	Haverson's Note
+Paper_Harveston_1	Haverson's Note
 Paper_Harveston_I	Baker's Note
 Paper_Harveston_II	Church Note
+Paper_Harveston_II_1	Church Note
+Paper_Harveston_I_1	Baker's Note
 Paper_Kuku_Pot	Mysterious Pot Crafting Contract
 Paper_Lenard	Leonard's Note
+Paper_Lenard_1	Leonard's Note
 Paper_Lenard_I	Assistant's Note
+Paper_Lenard_I_1	Assistant's Note
 Paper_Maiden	Maidon's Note
+Paper_Maiden_1	Maidon's Note
 Paper_Maiden_I	Harbor Manager's Note
 Paper_Maiden_II	Note from the Bank
+Paper_Maiden_II_1	Note from the Bank
+Paper_Maiden_I_1	Harbor Manager's Note
 Paper_Omar	Omar's Note
+Paper_Omar_1	Omar's Note
 Paper_Omar_I	Varnia Entrance Note
+Paper_Omar_I_1	Varnia Entrance Note
 Paper_RacingStage	Researcher's Note
+Paper_RacingStage_1	Researcher's Note
 Paper_RacingStage_I	Racecourse Owner's Note
+Paper_RacingStage_I_1	Racecourse Owner's Note
 Paper_Randel	Randelle's Note
+Paper_Randel_1	Randelle's Note
 Paper_Randel_I	Engineer's Research Log
+Paper_Randel_I_1	Engineer's Research Log
 Paper_ReventineMonastery_Document	Reventine Monastery Exclusive Document
 Paper_SecretSip	Trainee's Note
-Paper_SecretSip_I	Note at Point of Contact
+Paper_SecretSip_1	Trainee's Note
+Paper_SecretSip_I	Note from Point of Contact
+Paper_SecretSip_I_1	Note from Point of Contact
 Paper_Sniks	Nix's Note
+Paper_Sniks_1	Nix's Note
 Paper_Sniks_I	Note from the Freesword Barracks
+Paper_Sniks_I_1	Note from the Freesword Barracks
 Paper_StonemireRuins_Report_2	Stonemire Ruins Record No. 2
 Paper_StonemireRuins_Report_3	Stonemire Ruins Record No. 3
 Paper_Ugmum	Ugmon's Note
+Paper_Ugmum_1	Ugmon's Note
 Paper_VegetableBox	Produce Order Form
+Paper_VegetableBox_1	Produce Order Form
 Paphneil_PlateArmor_Armor	Scorchflame Plate Armor
 Paphneil_PlateArmor_Armor_Upgrade	Kuku Flame-Resistant Armor
 Paphneil_PlateArmor_Cloak	Scorchflame Plate Cloak
@@ -3838,7 +4045,6 @@ Peach	Peach
 Peach_Seed	Peach Seed
 Pear	Pear
 PearTree_Seed	Pear Tree Seed
-peas	Peas
 Peony	Peony
 Peori_Leather_Gloves	Fiori Leather Gloves
 Perelli_Leather_Boots	Perelli Leather Boots
@@ -3854,13 +4060,13 @@ Permit_Del_Furniture	Furniture Supply Contract - Timberton
 Permit_Del_General	Provisions Supply Contract - Delesyia
 Permit_Del_Seed	Seed Supply Contract - Delesyia
 Permit_Del_Tavern	Food Supply Contract - Delesyia
+Permit_DemZoo_Costume	Outfit Supply Contract - Demeniss Wildlife Park
 Permit_Dem_Costume	Outfit Supply Contract - Demeniss
 Permit_Dem_Equipment	Equipment Supply Contract - Demeniss
 Permit_Dem_Furniture	Furniture Supply Contract - Hidden Grove
 Permit_Dem_General	Provisions Supply Contract - Demeniss
 Permit_Dem_Seed	Seed Supply Contract - Demeniss
 Permit_Dem_Tavern	Food Supply Contract - Demeniss
-Permit_DemZoo_Costume	Outfit Supply Contract - Demeniss Wildlife Park
 Permit_Her_Costume	Outfit Supply Contract - Hernand
 Permit_Her_Equipment	Equipment Supply Contract - Hernand
 Permit_Her_Furniture	Furniture Supply Contract - Timberham
@@ -3897,10 +4103,10 @@ Persein_Leather_Gloves	Persein Leather Gloves
 Persein_Leather_Gloves_I	Persein Leather Gloves
 Perseus_Leather_Gloves	Perseus Leather Gloves
 Pervin_Bomb	Perwin Explosive
-PetArmor_backpack_Armor_Cat	Peddler Cat Outfit
-PetArmor_backpack_Helm_Cat	Peddler Cat Hat
 PetArmor_Fabric_Armor_Dog	Puppy Cloth Outfit
 PetArmor_Fabric_Helm_Dog	Puppy Cloth Hat
+PetArmor_Marni_Armor	Visionette Neckerchief
+PetArmor_Marni_Helm	Visionette
 PetArmor_Musket_Armor_Cat	Uniform Cat Outfit
 PetArmor_Musket_Helm_Cat	Uniform Cat Hat
 PetArmor_Plate_Armor_Cat	Cat Plate Armor
@@ -3908,6 +4114,11 @@ PetArmor_Plate_Armor_Dog	Puppy Plate Armor
 PetArmor_Plate_Helm_Cat	Cat Plate Helm
 PetArmor_Plate_Helm_Dog	Puppy Plate Helm
 PetArmor_Rescue_Armor_Dog	Rescue Puppy Outfit
+PetArmor_backpack_Armor_Cat	Peddler Cat Outfit
+PetArmor_backpack_Helm_Cat	Peddler Cat Hat
+Pet_Bond_Amulet	Sigil of Bonding
+Pet_Phoenix_Amulet	Sigil of Solidarity (Phoenix)
+Pet_Phoenix_Feather	Phoenix Feather
 Petra_Leather_Gloves	Petra Leather Gloves
 Phavan_Leather_Armor	Favan Leather Armor
 Philaphy_OneHandMace	Thalwynd Hammer
@@ -3944,13 +4155,13 @@ Pomegranate_Seed	Pomegranate Seed
 Porcell_Fabric_Gloves_I	Porcell Cloth Gloves
 Porcell_Fabric_Gloves_II	Porcell Cloth Gloves
 Pormeranian_Leather_Armor	Pomerin Leather Armor
-Pororin_Sacred	Pororin Relic
 PororinChildrenForest_Book	A Traveler's Log
+Pororin_Sacred	Pororin Relic
 Porugate_Leather_Gloves	Brogant Leather Gloves
 Possesion_Insam	Ginseng
 Possesion_Myurdin_Leather_Armor	Umbra's Hierophany Leather Armor
 Possesion_Myurdin_Leather_Gloves	Umbra's Hierophany Leather Gloves
-Pot_Head	Jar Lid
+Pot_Head	Jar
 Potato	Potato
 Potion_StatBuff_Tier1_0001	Freya's Lesser Elixir
 Potion_StatBuff_Tier1_0002	Apollonia's Lesser Elixir
@@ -3986,16 +4197,16 @@ Prisoner_Fabric_Armor_VI	Captive's Cloth Armor
 Prisoner_Fabric_Armor_VII	Captive's Cloth Armor
 Prisoner_Fabric_Armor_VIII	Captive's Cloth Armor
 Prisoner_Fabric_Boots	Captive's Cloth Boots
-Prisoner_Fabric_Helm	Captive's Cloth Headband
+Prisoner_Fabric_Helm	Captive's Cloth Cap
 Prisoner_Fabric_Helm_I	Captive's Cloth Helm
-Prisoner_Fabric_Helm_II	Captive's Cloth Helm
-Prisoner_Fabric_Helm_III	Captive's Cloth Helm
-Prisoner_Fabric_Helm_IV	Captive's Cloth Helm
+Prisoner_Fabric_Helm_II	Captive's Cloth Cap
+Prisoner_Fabric_Helm_III	Captive's Cloth Headband
+Prisoner_Fabric_Helm_IV	Captive's Cloth Cap
 Prisoner_Leather_Gloves	Leather Half-Gloves
 Prisoner_Leather_Gloves_I	Darren Leather Gloves
 Prisoner_Leather_Gloves_II	Darren Leather Gloves
-Prisoner_Leather_Helm	Captive's Leather Helm
-Prisoner_Leather_Helm_I	Captive's Folded Leather Helm
+Prisoner_Leather_Helm	Captive's Leather Hat
+Prisoner_Leather_Helm_I	Captive's Folded Leather Hat
 Protect_Electric_Leather_Gloves	Insulated Gloves
 Protective_Leather_Armor	Antumbra Bismuth Protection Suit
 Pumpkin	Pumpkin
@@ -4056,6 +4267,20 @@ Quest_MarchellBastier_Letter	Marshell's Letter
 Quest_MarchellByron_Letter	B's Secret Letter
 Quest_Order_Delkin_Pot	Stone Jar
 Quest_Paper_AbyssTeleport	White Crow's Letter
+Quest_Paper_Airship_Journal	Sky Galleon Vargon Journal
+Quest_Paper_Antumbra_Contract	Pact of Antumbra
+Quest_Paper_Askelund_Judgment	Fort Askelund Written Judgment
+Quest_Paper_Askelund_SlaveJournal	Fort Askelund Slave's Journal
+Quest_Paper_Balthazar_Memo	Balthazar's Note
+Quest_Paper_Bankruptcy_Document	List of Bankruptcy
+Quest_Paper_Bastier_Journal	Bastier Journal
+Quest_Paper_Bastion_Secret	Bastier's Secret Letter
+Quest_Paper_Beighen_Notice	Beighen Poster
+Quest_Paper_BioExperiment_Blueprint	Biopod Blueprint found at Marni Laboratorium
+Quest_Paper_BiologicalResearch_Journal	Research Log on Living Subjects
+Quest_Paper_Biological_Journal	Test Subject Log
+Quest_Paper_Chaser_Journal	Tracker's Torn Journal
+Quest_Paper_Child_Notice	Missing Child Poster
 Quest_Paper_Chocolate_Factory_BackPack	Mobile Chocolate Workshop Research Journal
 Quest_Paper_Circus3	Circus Invitation
 Quest_Paper_ContributionShop_Hernand	Hernand Contribution Shop Flyer
@@ -4076,7 +4301,10 @@ Quest_Paper_Crim_Sniks	Nix's Poster
 Quest_Paper_Crim_Thibault	Tibo's Poster
 Quest_Paper_Crim_Thomas	Thomas's Poster
 Quest_Paper_Crim_Zara	Zara's Poster
+Quest_Paper_Crowman_Adoptation	Adoption Form
+Quest_Paper_Cult_Order	Order Directive
 Quest_Paper_Damian_AirJump	Letter for Damiane
+Quest_Paper_DeadHunter_Journal	Dead Hunter's Journal
 Quest_Paper_Del_Doni	Donny's Poster
 Quest_Paper_Del_Forex	Forrex's Poster
 Quest_Paper_Del_Grundak	Grond's Poster
@@ -4107,6 +4335,8 @@ Quest_Paper_Dem_Orlonel	Olanelle's Poster
 Quest_Paper_Dem_Palga	Palgar's Poster
 Quest_Paper_Dem_Trollmag	Trolmagg's Poster
 Quest_Paper_Dem_Zarkon	Zargon's Poster
+Quest_Paper_DemenissPolice	Demeniss Tribunal
+Quest_Paper_Dismissal_Document	Discharge Order
 Quest_Paper_DrugFactory_I	Ingredient Dispenser Instructions
 Quest_Paper_DrugFactory_II	Washer Instructions
 Quest_Paper_DrugFactory_III	Grinder Instructions
@@ -4114,10 +4344,13 @@ Quest_Paper_DrugFactory_IV	Dosing Pump Instructions
 Quest_Paper_DrugFactory_V	Heater Instructions
 Quest_Paper_DrugFactory_VI	Bottling Machine Instructions
 Quest_Paper_DrugFactory_VII	Lift Instructions
-Quest_Paper_Empty_I	Simple Poster
-Quest_Paper_Empty_II	Simple Poster
 Quest_Paper_EmptyIII	Simple Poster
 Quest_Paper_EmptyIV	Simple Poster
+Quest_Paper_Empty_I	Simple Poster
+Quest_Paper_Empty_II	Simple Poster
+Quest_Paper_Foodstorage	Kuku Cooler Blueprint
+Quest_Paper_Gregor_Letter	Tributes to Gregor
+Quest_Paper_HeavyFoodstorage	Enhanced Kuku Cooler Blueprint
 Quest_Paper_Her_Adelina	Adrina's Poster
 Quest_Paper_Her_Aldun	Alden's Poster
 Quest_Paper_Her_Alfred	Alfred's Poster
@@ -4159,12 +4392,31 @@ Quest_Paper_Kwe_Ratko	Rocco's Poster
 Quest_Paper_Kwe_Richart	Richart's Poster
 Quest_Paper_Kwe_RonHardt	Ronnard's Poster
 Quest_Paper_Kwe_Terinand	Terianne's Poster
+Quest_Paper_LaserTank_Blueprint	Thunder Crusher Blueprint
+Quest_Paper_Letter	Jian's Letter
+Quest_Paper_LongleafForest_PatrolRecord	Longleaf Forest Patrol Report
+Quest_Paper_MarniAirship_Journal	Marni Airship Journal
+Quest_Paper_Marni_CtrafingJournal	Marni's Invention Journal
+Quest_Paper_Marnihouse_Blueprint	Biopod Blueprint found at Marni Mansion
+Quest_Paper_MasterDoo_Ideology	Master Doo's Beliefs
+Quest_Paper_Merchant_Warning	Warning from the Merchant Guild
+Quest_Paper_Military_Notice	Soldier Recruitment Post
+Quest_Paper_MineFortress_Blueprint	Storm Crusher Blueprint
 Quest_Paper_Nature	Lost Letter
 Quest_Paper_Progression	Alustin's Letter
-Quest_Paper_Propagation	Wisdom between Donation and Fruition
+Quest_Paper_Propagation	Wisdom Between Donation and Fruition
 Quest_Paper_Recipe_KuKu_Pot_RoketBag	Letter from Grimnir
+Quest_Paper_Sparring_Journal	Duel Journal
 Quest_Paper_Stamina	Lost Letter
+Quest_Paper_Tariv_Storybook	Tarivian Fairytale
 Quest_Paper_TaxStatement	Tax Notice
+Quest_Paper_Technician_Journal	Kidnapped Engineer's Journal
+Quest_Paper_Torn_Order	Torn Subjugation Order
+Quest_Paper_Tristan_Journal	Tristan's Journal
+Quest_Paper_Verdict_Treason	Treason Verdict
+Quest_Paper_Walter_Document	Walter's Research Journal
+Quest_Paper_Wyvern_Species_Memo	Wyvern Traits
+Quest_Paper_Zoo_Flyer	Wildlife Park Flyer
 Quest_PendantInSnow_Letter	Letter to Younger Brother
 Quest_Poison_Pyogo	Poison-Soaked Oakwood Mushroom
 Quest_TrollCube_I	Engraved Stone
@@ -4230,6 +4482,7 @@ Quest_WantedPaper_0107	Bounty Notice - Patrick
 Quest_WantedPaper_0108	Bounty Notice - Jonathan
 Quest_WantedPaper_0109	Bounty Notice - Frank
 Quest_WantedPaper_0110	Bounty Notice - Broll
+Quest_WantedPaper_Arsonist_TheFaceless	Bounty Notice - The Masked Liberator
 Quest_Witch_Token_I	Witch's Token
 Quest_Witch_Token_II	Witch's Token
 Quest_Witch_Token_III	Witch's Token
@@ -4245,9 +4498,9 @@ Radiano_Leather_Armor	Radiano Leather Armor
 Radley_Fabric_Armor	Radley Cloth Armor
 Rafflia_Leather_Boots	Raphelia Leather Boots
 Raging_Tempests_Leader_Leather_Gloves	Raging Tempest's Leather Gloves
-Raging_Tempests_Leader_Plate_Boots	Raging Tempest's Plate Boots
 Raging_Tempests_Leader_PlateArmor_Armor	Raging Tempest's Plate Armor
 Raging_Tempests_Leader_PlateArmor_Helm	Raging Tempest's Plate Helm
+Raging_Tempests_Leader_Plate_Boots	Raging Tempest's Plate Boots
 Rahelm_Fabric_Helm	Rahelm Cloth Headband
 Rakhir_Fabric_Gloves	Rakhir Cloth Gloves
 Rakkli_PlateArmor_Armor	Rakkli Plate Armor
@@ -4322,6 +4575,7 @@ Recipe_Book_PlateArmor_II	Plate Armors of the World, Vol. II
 Recipe_Book_PlateArmor_III	Plate Armors of the World, Vol. III
 Recipe_Book_PlateArmor_IV	Plate Armors of the World, Vol. IV
 Recipe_Book_Posion_Aroww	Poison Arrow Blueprint
+Recipe_Book_Pumpkin_Helm	Pumpkin Head Crafting Manual
 Recipe_Book_RangeWeapon_Metal_I	Ranged Weapons of the World - Guns, Vol. I
 Recipe_Book_RangeWeapon_Metal_II	Ranged Weapons of the World - Guns, Vol. II
 Recipe_Book_RangeWeapon_Metal_III	Ranged Weapons of the World - Guns, Vol. III
@@ -4357,9 +4611,9 @@ Recipe_Fish_Sanjeok	Recipe: Fish Skewers
 Recipe_Fish_Soup	Recipe: Mixed Stew
 Recipe_Fish_Stew	Recipe: Fish Stew
 Recipe_Fish_Vegetable_Porridge	Recipe: Vegetable and Seafood Porridge
+Recipe_FruitTea	Recipe: Fruit Tea
 Recipe_Fruit_Porridge	Recipe: Fruit Punch
 Recipe_Fruit_Wine	Recipe: Wine
-Recipe_FruitTea	Recipe: Fruit Tea
 Recipe_Full_Course_of_Braised_Fish	Recipe: Assorted Braised Fish
 Recipe_GoldBar	Alchemy Formula: Gold Bar
 Recipe_Grilled_Meat_Fish	Recipe: Grilled Meat and Fish
@@ -4374,9 +4628,9 @@ Recipe_Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_FabricArmor_LV1	Gear Bl
 Recipe_Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_LeatherArmor_LV1	Gear Blueprint: Rend
 Recipe_Item_Skill_AbyssGear_AddCriticalRateByMaterialKey_PlateArmor_LV1	Gear Blueprint: Shatter
 Recipe_Item_Skill_AbyssGear_AddFrendly_LV1	Gear Blueprint: Solidarity
-Recipe_Item_Skill_AbyssGear_AdditionalThief_LV1	Gear Blueprint: Ledgermain
 Recipe_Item_Skill_AbyssGear_AddKillSkillLevel_LV1	Gear Blueprint: Energy Drain
 Recipe_Item_Skill_AbyssGear_AddMoneyDropRate_LV1	Gear Blueprint: Fortune
+Recipe_Item_Skill_AbyssGear_AdditionalThief_LV1	Gear Blueprint: Ledgermain
 Recipe_Item_Skill_AbyssGear_Antumbra_Spear	Gear Blueprint: Warden of Darkness
 Recipe_Item_Skill_AbyssGear_Antumbra_TwoHandRod	Gear Blueprint: Dark Crescent
 Recipe_Item_Skill_AbyssGear_ArrowRain_LV1	Gear Blueprint: Arrow Rain
@@ -4410,9 +4664,9 @@ Recipe_Item_Skill_AbyssGear_DarkenRobe_LV1	Gear Blueprint: Wound of Darkness
 Recipe_Item_Skill_AbyssGear_DogClaw_LV1	Gear Blueprint: Hound's Claws
 Recipe_Item_Skill_AbyssGear_EnergyBurst_LV1	Gear Blueprint: Kinetic Burst
 Recipe_Item_Skill_AbyssGear_EnlightenmentWave_LV1	Gear Blueprint: Karmic Pulse
+Recipe_Item_Skill_AbyssGear_EquipDropRate_LV1	Gear Blueprint: Disarm
 Recipe_Item_Skill_AbyssGear_Equip_AddHorseExp_LV1	Gear Blueprint: Equestrian
 Recipe_Item_Skill_AbyssGear_Equip_AddPetFriendly_LV1	Gear Blueprint: Companionship
-Recipe_Item_Skill_AbyssGear_EquipDropRate_LV1	Gear Blueprint: Disarm
 Recipe_Item_Skill_AbyssGear_FireBreath_LV1	Gear Blueprint: Volcanic Eruption
 Recipe_Item_Skill_AbyssGear_FlashCombo_LV1	Gear Blueprint: Slashing Reeds
 Recipe_Item_Skill_AbyssGear_FoodSkillLevelUp_LV1	Gear Blueprint: Gourmet
@@ -4424,8 +4678,8 @@ Recipe_Item_Skill_AbyssGear_Hyena_PoisonImmune	Gear Blueprint: Heart of the Serp
 Recipe_Item_Skill_AbyssGear_Immune_Bismuth	Gear Blueprint: Heart of Stone
 Recipe_Item_Skill_AbyssGear_ImpBoss	Gear Blueprint: Howling of Chaos
 Recipe_Item_Skill_AbyssGear_Karanda	Gear Blueprint: Pillar of Wind
-Recipe_Item_Skill_AbyssGear_LandMash_LV1	Gear Blueprint: Groundsurge
 Recipe_Item_Skill_AbyssGear_LanFord	Gear Blueprint: Parting Gift
+Recipe_Item_Skill_AbyssGear_LandMash_LV1	Gear Blueprint: Groundsurge
 Recipe_Item_Skill_AbyssGear_Leebur	Gear Blueprint: Shadow Claw
 Recipe_Item_Skill_AbyssGear_LightningBreath_LV1	Gear Blueprint: Orbs of Lightning
 Recipe_Item_Skill_AbyssGear_LightningStab_LV1	Gear Blueprint: Storm Fang
@@ -4483,7 +4737,7 @@ Recipe_Pan_fried_Fruit_Pancake	Recipe: Pickled Fruit
 Recipe_Pan_fried_Grain_Pancake	Recipe: Battered Grains
 Recipe_Pan_fried_Meat_Fish_Pancake	Recipe: Battered Meat and Fish
 Recipe_Pan_fried_Meat_Fruit_Pancake	Recipe: Marinated Meat
-Recipe_Pan_fried_Meat_Grain_Pancake	Recipe: Meat Stew
+Recipe_Pan_fried_Meat_Grain_Pancake	Recipe: Meat Soup
 Recipe_Pan_fried_Meat_Pancake	Recipe: Battered Meat
 Recipe_Pan_fried_Meat_Vegetable_Pancake	Recipe: Steamed Eggs
 Recipe_Pan_fried_Vegetable_Fruit_Pancake	Recipe: Vegetable Rice Cake
@@ -4527,12 +4781,13 @@ Recipe_Vegetable_Juice	Recipe: Vegetable Juice
 Recipe_Vegetable_Porridge	Recipe: Vegetable Porridge
 Reckleeman_TwoHandSword	Balton Longsword
 Recle_OneHandTowerShield	Rekel Large Shield
-Red_Ring	Rough Bluestone Ring
-Redbeet	Beet
 RedDeerHorn_Mushroom	Poison Fire Coral Mushroom
 RedHare_Horse_Report	Sighting of Camora
+RedNose_Lantern	Dark Fog Lantern
+RedStone	Bloodstone
+Red_Ring	Rough Bluestone Ring
+Redbeet	Beet
 Redin_ChainMail_Armor	Reddin Chain Mail
-Redknight_Plate_Boots	Plate Boots of Cursed Soul
 Redknight_PlateArmor_Armor	Plate Armor of Cursed Soul
 Redknight_PlateArmor_Cloak	Plate Cloak of Cursed Soul
 Redknight_PlateArmor_Gloves	Plate Gloves of Cursed Soul
@@ -4540,19 +4795,19 @@ Redknight_PlateArmor_Helm	Plate Helm of Cursed Soul
 Redknight_PlateArmor_Helm_II	Turncoat Plate Helm
 Redknight_PlateArmor_Helm_III	Plumed Wells Rebel's Plate Helm
 Redknight_PlateArmor_Helm_IV	Wells Rebel's Silver Plate Helm
+Redknight_Plate_Boots	Plate Boots of Cursed Soul
 Redleader_Leather_Gloves	Red Rider's Leather Gloves
 Redleader_PlateArmor_Armor	Red Rider's Plate Armor
 Redleader_PlateArmor_Helm	Red Rider's Plate Helm
 Redman_PlateArmor_Armor	Redman Plate Armor
-RedNose_Lantern	Dark Fog Lantern
 Redrin_Fabric_Helm	Redrin Cloth Cap
 Redsentinel_ChainMail_Armor	Crimson Chaser Mail
 Redsentinel_ChainMail_Cloak	Crimson Chaser Chain Cloak
 Redsentinel_Necklace	Crimson Warden's Necklace
 Redsentinel_PlateArmor_Gloves	Crimson Chaser Chain Gloves
 Redsentinel_PlateArmor_Helm	Crimson Chaser Plate Helm
-RedStone	Bloodstone
 ReedDevil_Doll	Devil of the Reed Field's Doll
+ReedDevil_Mask	Mask of the Devil of the Reed Field
 Reeddevil_Fabric_Boots	Sunset Reed Cloth Boots
 Reeddevil_Fabric_Boots_T5_QA	Reeddevil Fabric Boots T5 QA
 Reeddevil_Fabric_Gloves	Sunset Reed Cloth Gloves
@@ -4565,7 +4820,6 @@ Reeddevil_Leather_Armor_I	Reed Devil Underling's Red Armor
 Reeddevil_Leather_Armor_II	Reed Devil Underling's Yellow Armor
 Reeddevil_Leather_Armor_III	Reed Devil Underling's Armor
 Reeddevil_Leather_Cloak	Sunset Reed Leather Cloak
-ReedDevil_Mask	Mask of the Devil of the Reed Field
 Reeddevil_Troll_Fabric_Helm	Reed Devil Minion Troll's Cloth Helm
 Reeddevil_Troll_Leather_Armor	Reed Devil Troll Armor
 Regglin_Boss_Fabric_Boots	Fundamentalist Officer Cloth Boots
@@ -4643,16 +4897,13 @@ Riclia_Leather_Armor	Riclia Leather Armor
 Riding_AlpineIbex_Amulet	Sigil of Solidarity (Icicle Edge Alpine Ibex)
 Riding_AlpineIbex_Horn	Icicle Edge Alpine Ibex Horn
 Riding_Bear_Amulet	Sigil of Solidarity (White Bear)
-Riding_Bear_Claw	White Bear Claws
+Riding_Bear_Claw	White Bear's Claws
 Riding_Deer_Amulet	Sigil of Solidarity (Snowwhite Deer)
-Riding_Deer_Horn	Snowwhite Deer Antlers
+Riding_Deer_Horn	Snowwhite Deer's Antlers
 Riding_Fabric_Armor	Riding Attire
 Riding_Fabric_Cloak	Riding Cloak
-riding_Leather_Boots	Riding Boots
-riding_Leather_Gloves	Master Trainer's Touch
-riding_Leather_Helm	Leather Riding Hat
 Riding_Warthog_Amulet	Sigil of Solidarity (Rock Tusk Warthog)
-Riding_Warthog_Tooth	Rock Tusk Warthog Molar
+Riding_Warthog_Tooth	Rock Tusk Warthog's Tusk
 Riding_Wolf_Amulet	Sigil of Solidarity (Silver Fang)
 Riding_Wolf_Tooth	Fang of Silver Fang
 Riesi_Boots	Shoddy Rishi's Boots
@@ -4698,8 +4949,8 @@ Rosemary_yellow	Yellow Rosemary
 Roshine_Fabric_Armor	Roshayne Cloth Armor
 Rossbara_Leather_Gloves	Rossbara Leather Gloves
 Rosvar_HorseArmor_Helm	Rosbar Champron
-Royal_Hunting_Ground_Flag_III	Small Royal Hunting Ground Banner Pike
 RoyalGuard_OneHandShield	Royal Guard Shield
+Royal_Hunting_Ground_Flag_III	Small Royal Hunting Ground Banner Pike
 Rubaunon_Fabric_Armor	Lubonon Cloth Armor
 Rubber_seed	Rubber Tree Seed
 Rubbiden_Leather_Armor	Rubidan Leather Armor
@@ -4731,10 +4982,10 @@ SamGyeTang	Bird Soup
 SamGyeTang_Large	Satisfying Bird Soup
 SamGyeTang_Medium	Filling Bird Soup
 SamGyeTang_XLarge	Hearty Bird Soup
-Samuel_Plate_Boots	Dark Marksman's Plate Boots
 Samuel_PlateArmor_Armor	Dark Marksman's Plate Armor
 Samuel_PlateArmor_Cloak	Dark Marksman's Plate Cloak
 Samuel_PlateArmor_Gloves	Dark Marksman's Plate Gloves
+Samuel_Plate_Boots	Dark Marksman's Plate Boots
 Saolo_Leather_Armor	Saolo Leather Armor
 Sarantos_Leather_Boots	Sarantos Leather Boots
 Sarantos_Leather_Boots_I	Dirty Sarantos Leather Boots
@@ -4766,7 +5017,6 @@ Schmidt_PlateArmor_Armor	Schmidt Plate Armor
 Schtump_Fabric_Armor	Schtump Cloth Armor
 Schtump_Fabric_Cloak	Schtump Cloth Cloak
 Scopa_Leather_Boots	Scoppa Leather Boots
-scorpion	Scorpion
 Scouter_HP_PlateArmor_Helm	Health Detection Device
 Scovi_Fabric_Helm	Scobby Cloth Headband
 ScrapMetal_BackPack_I	Scrap Metal Pack
@@ -4957,10 +5207,11 @@ Sian_Fabric_Helm	Sian Cloth Cap
 Sicillion_Leather_Armor	Sicillion Leather Armor
 Sidmon_Leather_Boots	Sydmon Leather Boots
 Sidmon_OneHandSword	Sydmon Sword
-silence_Flag_I	Small Heavy Silence Banner Pike
-silence_Flag_II	Medium Heavy Silence Banner Pike
 Silien_Leather_Boots	Cyllian Leather Boots
 Silien_OneHandSword	Wells Sword
+SilverArmor_PlateArmor_Gloves	Silver Plate Gloves
+SilverArmor_PlateArmor_Helm	Inquisitor's Plate Helm
+SilverOre	Silver Ore
 Silver_Armor_OneHandMace	Mace of Betrayal
 Silver_Armor_OneHandTowerShield	Shield of Betrayal
 Silver_Bullet	Silver Bullet
@@ -4968,25 +5219,22 @@ Silver_Pack	Full Silver Pouch
 Silver_PlateArmor_Armor	Sliver Plate Armor
 Silver_PlateArmor_Cloak	Silver Plate Cloak
 Silver_Vizione_Stand_TwoHandSpear	Silver Visione Stand
-SilverArmor_PlateArmor_Gloves	Silver Plate Gloves
-SilverArmor_PlateArmor_Helm	Inquisitor's Plate Helm
-SilverOre	Silver Ore
 Sinseollo	Harvest Soup
 Sinseollo_Large	Satisfying Harvest Soup
 Sinseollo_Medium	Filling Harvest Soup
 Sinseollo_XLarge	Hearty Harvest Soup
-Sir_Catfish_Plate_Boots	Sir Catfish's Plate Boots
 Sir_Catfish_PlateArmor_Armor	Sir Catfish's Armor
 Sir_Catfish_PlateArmor_Gloves	Sir Catfish's Plate Gloves
+Sir_Catfish_Plate_Boots	Sir Catfish's Plate Boots
 Sirion_Fabric_Armor	Sirion Cloth Armor
 Sirius_Barley_Fabric_Helm	Wyvernflame Cloth Helm
 Sitanca_PlateArmor_Armor	Sitanca Plate Armor
 Skardoo_Leather_Armor	Scarteau Leather Armor
 Skian_Fabric_Helm	Skian Cloth Cap
-Skull_Knight_Plate_Boots	Frostcursed Plate Boots
-Skull_Knight_PlateArmor_Gloves	Frostcursed Plate Gloves
 SkullKnight_Follower_Plate_Boots_I	Skull Knight Follower's Plate Boots
 SkullKnight_PlateArmor_Helm	Frostcursed Plate Helm
+Skull_Knight_PlateArmor_Gloves	Frostcursed Plate Gloves
+Skull_Knight_Plate_Boots	Frostcursed Plate Boots
 Sladen_Leather_Gloves	Sladen Leather Gloves
 Slarke_OneHandMace	Dekarr Hammer
 Slaughterer_Leahter_Armor	Slaughterer's Leather Armor
@@ -4994,11 +5242,11 @@ Slave_Fabric_Boots	Slave's Cloth Boots
 Sleep_Arrow	Sleep Arrow
 Sleeshorn_Leather_Gloves	Sleishorn Leather Gloves
 Slowin_Leather_Armor	Slouwen Leather Armor
+SmallAnimal_Poop	Manure
 Small_Copper_Pack	Light Copper Pouch
 Small_Mechanical_Powerplant	Small Battery
 Small_Mechanical_Powerplant_Pack	Small Battery
 Small_Silver_Pack	Modest Silver Pouch
-SmallAnimal_Poop	Manure
 Smilodon_Leather_Armor	Smilodon Leather Armor
 Smoke_Bomb	Smoke Bomb
 SnapDragon	Snapdragon
@@ -5011,18 +5259,18 @@ Solas_PlateArmor_Gloves_I	Eclipsed Solas Plate Gloves
 Solas_PlateArmor_Helm	Solas Plate Helm
 Soldier_BackPack	Soldier's Pack
 Soldier_General_Fabric_Cloak	Hernandian Guard Captain's Cloth Cloak
-Soldier_General_Plate_Boots	Guard Captain's Plate Boots
 Soldier_General_PlateArmor_Armor	Guard Captain's Plate Armor
 Soldier_General_PlateArmor_Gloves	Hernandian Guard Captain's Plate Gloves
 Soldier_General_PlateArmor_Helm	Guard Captain's Plate Helm
+Soldier_General_Plate_Boots	Guard Captain's Plate Boots
 Soldworth_Leather_Armor	Solworth Leather Armor
 Somieh_Leather_Armor	Somier Leather Armor
 Songyi_Mushroom	Pine Mushroom
 Songyi_Mushroom_BackPacK	Pine Mushroom Pack
 Songyi_Mushroom_Tea	Pine Mushroom Tea
 Soron_Leather_Armor	Soron Leather Armor
-Soul_TwoHandSpear	Soul Spear
 SoulKnight_OneHandSword	Shackle of Might
+Soul_TwoHandSpear	Soul Spear
 Soulknight_Sprit_OneHandSword	Specter Sword
 Soulknight_Sprit_OneHandTowerShield	Shield of the Phantom
 Sound_OneHandShield	Shield of Ringing
@@ -5048,6 +5296,7 @@ Ssari_Mushroom	Coral Mushroom
 Ssari_Mushroom_BackPack	Coral Mushroom Pack
 Ssari_Mushroom_Tea	Coral Mushroom Tea
 Stammers_Leather_Gloves	Steinmers Leather Gloves
+Star_OneHandRapier	Sword of Starlight
 Stardust_Necklace	Stardust Necklace
 Steel_OneHandCannon	Steel Blaster
 StellenManor_ClosetKey	Stellen Manor Closet Key
@@ -5073,11 +5322,11 @@ Stugrup_Leather_Armor	Stugrub Leather Armor
 Sugar	Sugar
 SungroveManor_HomeKey	Sungrove Manor Key
 Surasang_00	Grand Meal
-Surasang_00_jijeongta	Aromatic Grand Meal
 Surasang_00_Taro	Refreshing Grand Meal
+Surasang_00_jijeongta	Aromatic Grand Meal
 Surasang_01	Extravagant Meal
-Surasang_01_chlorella	Energizing Extravagant Meal
 Surasang_01_Chocolate	Satisfying Extravagant Meal
+Surasang_01_chlorella	Energizing Extravagant Meal
 Surasang_02	Lavish Meal
 Surasang_02_Dulse	Hearty Lavish Meal
 Surasang_02_Ensete	Piquant Lavish Meal
@@ -5160,9 +5409,6 @@ Tesslit_Leather_Gloves_II	Russet Pavis Leather Gloves
 Tesslit_Leather_Gloves_III	Large Pavis Leather Gloves
 Tesslit_Leather_Helm	Helm of Loyal Friendship
 Tesslit_Leather_Helm_T2_QA	Tesslit Leather Helm T2 QA
-Test_OneHandAxe	Test OneHandAxe
-Test_OneHandMace	Test OneHandMace
-Testarmor	Testarmor
 TestNeck_1_1	TestNeck 1 1
 TestNeck_1_2	TestNeck 1 2
 TestNeck_2_1	TestNeck 2 1
@@ -5177,6 +5423,10 @@ TestNeck_5_3	TestNeck 5 3
 TestShield	TestShield
 TestSword	TestSword
 TestTwoHandAxe	TestTwoHandAxe
+Test_OneHandAxe	Test OneHandAxe
+Test_OneHandMace	Test OneHandMace
+Testarmor	Testarmor
+TheFaceless_Mask	The Mask of Liberation
 ThiefGloves	Great Thief's Gloves
 ThiefWand_Flower	Shrubby Sophora
 Tibbletanus_Fabric_Cloak	Black Bears' Cloth Cloak
@@ -5206,14 +5456,13 @@ Tironet_OneHandRapier	Grace Rapier
 Tirtit_Leather_Boots	Ator's Will Leather Boots
 Tiruna_Leather_Boots	Tiruna Leather Boots
 Titan_Necklace	Necklace of Lightning
-Titan_Plate_Boots	Lightning Bolt Plate Boots
 Titan_PlateArmor_Armor	Lightning Bolt Plate Armor
 Titan_PlateArmor_Armor_Upgrade	Kuku Lightning-Resistant Armor
 Titan_PlateArmor_Gloves	Lightning Bolt Plate Gloves
 Titan_PlateArmor_Helm	Lightning Bolt Plate Helm
+Titan_Plate_Boots	Lightning Bolt Plate Boots
 Titan_Spear	Titan's Spear
 Titunan_Fabric_Armor	Tytuan Cloth Armor
-toad	Toad
 Tobias_Leather_Boots	Tobias Leather Boots
 Toddbern_OneHandShotgun	Delesyian Shotgun
 Tohkar_Fabric_Armor	Tohkar Cloth Armor
@@ -5225,8 +5474,6 @@ Tolkane_Fabric_Armor	Tolkane Cloth Armor
 Tomaso_Soldiers_TwoHandSpear	Tommaso Guard's Dagger-Tipped Spear
 Tomato	Tomato
 Tomato_Seed	Tomato Seed
-tommaso_Flag_I	Small Tommaso Banner Pike
-tommaso_Flag_II	Medium Tommaso Banner Pike
 Torben_Fabric_Helm	Torben Cloth Cap
 Torch	Torch
 Tormand_ChainMail_Armor	Tormand Chain Mail
@@ -5267,7 +5514,7 @@ Trade_Glass_02	Glass
 Trade_Glass_PackedInVehicle	Packaged Glass
 Trade_Golden_Sword_Unpack	Golden Sword
 Trade_Gun_02	Gun
-Trade_Gun_PackedInVehicle	Packaged Packaged Gun
+Trade_Gun_PackedInVehicle	Packaged Gun
 Trade_Gunpowder_02	High-Purity Gunpowder
 Trade_Gunpowder_PackedInVehicle	Packaged Gunpowder
 Trade_Honey_02	Honey
@@ -5410,6 +5657,7 @@ Ultar_Fabric_Armor	Ultar Cloth Armor
 Ultarine_Leather_Helm	Uphren Leather Helm
 Umbra_Necklace	Eternal Darkness
 Umbrella_Mushroom	Grisette Mushroom
+UnSeal_Epistle	Unsealed Letter
 University_BackPack	Student's Pack
 UnknownDiary_Aldun	Unknown Adventurer's Log
 UnknownDiary_Bernor	Unknown Adventurer's Log
@@ -5424,7 +5672,6 @@ UnknownDiary_Retonic	Unknown Adventurer's Log
 UnknownDiary_Richart	Unknown Adventurer's Log
 UnknownDiary_RonHardt	Unknown Adventurer's Log
 UnknownDiary_Shay_Research	Unknown Adventurer's Log
-UnSeal_Epistle	Unsealed Letter
 UnyieldingShields_Flag	Small Calphadean Banner Pike
 Uronthai_Leather_Armor	Ulontai Leather Armor
 Vain_Leather_Gloves	Byren's Leather Gloves
@@ -5436,6 +5683,8 @@ Valkyder_PlateArmor_Armor_I	Valkyder Plate Armor
 ValleyRockWatchTower_Book	Gorgerock Watchman's Journal
 Valliron_ChainMail_Armor	Valton Chain Mail
 Valoric_PlateArmor_Helm	Sungrove Standard Plate Helm
+Valteon_PlateArmor_Armor	Baltheon Plate Armor
+Valteon_PlateArmor_Gloves	Baltheon Plate Gloves
 Vanti_Fabric_Armor	Bantree Cloth Armor
 Varanguard_Leather_Armor	Varanguard Leather Armor
 Varantine_Fabric_Armor	Delesyian Cloth Attire
@@ -5472,7 +5721,7 @@ Vergill_Fabric_Helm	Berghill Cloth Cap
 Verheim_TwoHandSword	Sielos Longsword
 Veronde_Fabric_Armor	Veronde Cloth Armor
 Veronde_Fabric_Helm	Veronde Cloth Cap
-Veroon_Leather_Gloves	Behrun Hide Bracers
+Veroon_Leather_Gloves	Behrun Leather Bracers
 Vertical_PlateArmor_Armor	Serroa Plate Armor
 Very_Small_Copper_Pack	Paltry Copper Pouch
 Vex_Fabric_Armor	Vex Cloth Armor
@@ -5498,8 +5747,8 @@ Visione_Chip_Bariklair	Barrick's Hideout
 Visione_Chip_BaronBarrel	Keglord Garnier Mk. XXIII
 Visione_Chip_BigTreeRoots	Hollow Tree
 Visione_Chip_BlockedSupply	Blocked Supply Route
-Visione_Chip_Bloodcoronation	The Blood Coronation
 Visione_Chip_BloodTombstone	Blood-Soaked Gravestone
+Visione_Chip_Bloodcoronation	The Blood Coronation
 Visione_Chip_BloodyFarmhouse	Bloody Farmhouse
 Visione_Chip_BluemontManorAlley	Bluemont Manor Alley
 Visione_Chip_Bolmen	Dolmen
@@ -5515,7 +5764,6 @@ Visione_Chip_BrookFieldManor	Brookfield Manor
 Visione_Chip_BumperCrop	Bountiful Harvest
 Visione_Chip_BursadaIslandRuins	Remote Ruins
 Visione_Chip_CarnageStreet	Bloodstained Street
-Visione_Chip_castleruincamp	Castle Ruins Encampment
 Visione_Chip_CaveEntrance	Mysterious Cave Entrance
 Visione_Chip_CliffUnderHome	Settlement Beneath the Cliff
 Visione_Chip_CrowdedBranch	Branch of Birds
@@ -5527,10 +5775,10 @@ Visione_Chip_DeadTreeRoad	Withered Path
 Visione_Chip_DeathSandpit	Pit of Death
 Visione_Chip_DelesiaAcademy	Inside of the Delesyian Institute
 Visione_Chip_DelesyiaBell	Bell of Delesyia
+Visione_Chip_DemJohnDoe	Unidentifiable Corpse
 Visione_Chip_DemenissCabin	Demeniss Cabin
 Visione_Chip_DemenissFuture	Future of Demeniss
 Visione_Chip_DemenissOrphanage	Demeniss Orphanage
-Visione_Chip_DemJohnDoe	Unidentifiable Corpse
 Visione_Chip_DesertCrocodile	Ruler of the Oasis
 Visione_Chip_DesertShipwreck	Desert Shipwreck
 Visione_Chip_DesertSwamp	Desert Swamp
@@ -5540,7 +5788,6 @@ Visione_Chip_DinosaurBones	Giant Bone Pile
 Visione_Chip_DumpBell	Abandoned Bell
 Visione_Chip_Dungeon	Dungeon
 Visione_Chip_EdgeAltar	Cliff Edge Altar
-Visione_Chip_emptycoffin	Empty Coffin
 Visione_Chip_EmptyRanch	Abandoned Ranch
 Visione_Chip_EndlessDanger	Lonely Troll
 Visione_Chip_EntHunterLair	Mistwood Hunters' Hideout
@@ -5556,22 +5803,20 @@ Visione_Chip_GiantBallista	Giant Ballista
 Visione_Chip_GiantBone	Remains of the Giants
 Visione_Chip_GiantBoots	Giant's Boot
 Visione_Chip_GiantRoots	Wide Roots Hideout
-Visione_Chip_GodsGarden	Garden of the Gods
 Visione_Chip_GodTreeCamp	Eldertree Research Camp
+Visione_Chip_GodsGarden	Garden of the Gods
 Visione_Chip_GraceMansion	Glenbright Manor
 Visione_Chip_GraceMansionStorage	Glenbright Manor Storage
 Visione_Chip_GreyRift	Ashen Rift
-Visione_Chip_guardiandeity	Guardian Deity Altar
 Visione_Chip_Hall	H.A.L.L.
 Visione_Chip_Halsius	St. Halssius's House of Healing
 Visione_Chip_HatRock	Hat Shaped Boulder
 Visione_Chip_HayroofFarmWindmill	Hayroof Farm Windmill
 Visione_Chip_HellWoodFortGoblin	Goblins of Fort Hellwood
 Visione_Chip_HelmaraVillageScrapGrave	Helmara Scrap Graveyard
-Visione_Chip_hernandcampsite	Hernand Encampment
+Visione_Chip_HernandGibbet	Hernand Gallows
 Visione_Chip_HernandcastleBallroom	Hernand Banquet Hall
 Visione_Chip_HernandcastleChamber	Hernand Office
-Visione_Chip_HernandGibbet	Hernand Gallows
 Visione_Chip_HiddenSpace_0001	Hidden Space - 0001
 Visione_Chip_HiddenSpace_0002	Hidden Space - 0002
 Visione_Chip_HiddenSpace_0003	Hidden Space - 0003
@@ -5749,7 +5994,7 @@ Visione_Chip_LongleafTree_DailyLife	Day of the Longleaf Tribe
 Visione_Chip_LongleafTree_HuntBegin	Beginning of the Hunt
 Visione_Chip_LongleafTree_OmenMisfortune	Signs of Misfortune
 Visione_Chip_MaidsTales	Stories of the Maids
-Visione_Chip_Mansion_Byron_Memory	Memory of Byron Manor
+Visione_Chip_Mansion_Byron_Memory	Memory of Byron's Manor
 Visione_Chip_Mansion_Marseille_Memory_I	Azerian's Whereabouts
 Visione_Chip_Mansion_Marseille_Memory_II	Bastier's Co-conspirators
 Visione_Chip_MarniFirstMeet	Secret of the Helm
@@ -5768,8 +6013,8 @@ Visione_Chip_MushroomRock	Mushroom Rock
 Visione_Chip_MysteryTower	Mysterious Giant Tower
 Visione_Chip_NamelessHeorGrave	A Hero's Tomb
 Visione_Chip_NoEenterZone	Restricted Area
-Visione_Chip_Oakenshieldmanor	Serkis's Study
 Visione_Chip_OakenshieldManorhall	Oakenshield Manor Reception Room
+Visione_Chip_Oakenshieldmanor	Serkis's Study
 Visione_Chip_OasisMonument	Oasis Headstone
 Visione_Chip_OasisShelter	Oasis Hearth
 Visione_Chip_OdeckHunterCamp	Hunters of Odeck
@@ -5787,19 +6032,16 @@ Visione_Chip_PailuneSecretBase	Pailune Secret Vault
 Visione_Chip_PaintedCave	Painted Cavern
 Visione_Chip_PainterRegret	A Painter's Regret
 Visione_Chip_PetrifiedHumans	Petrified Humans
-Visione_Chip_pharmacy	Halssius Apothecary
 Visione_Chip_PororinCave	Pororin Cave
 Visione_Chip_PrecariousRock	Unstable Rock
-Visione_Chip_precipicecoffin	Clifftop Coffin
 Visione_Chip_RectangularStone	Square Rock
 Visione_Chip_ReventineWinery	Reventine Winery
 Visione_Chip_RidgehunterLeatherMaker	Ridgehunter Tannery
 Visione_Chip_RightHandStone	Right Hand Boulder
-Visione_Chip_riverdam	Upper Nas River Dam
 Visione_Chip_RiverwardOutpost	Riverward Outpost Dispatch
 Visione_Chip_RockCreviceRuinse	Rockshard Valley Ruins
-Visione_Chip_RockingStone	Rocking Boulder
 Visione_Chip_RockShelter	A House Between Rocks
+Visione_Chip_RockingStone	Rocking Boulder
 Visione_Chip_RockshroudRuins	Rockveil Ruins
 Visione_Chip_Roofless	Roofless House
 Visione_Chip_RootFortress	Report on Roothold
@@ -5813,8 +6055,8 @@ Visione_Chip_SandHole	Sand Dunes
 Visione_Chip_SavageFangStele	Savage Fangs Monument
 Visione_Chip_ScaryHole	Eerie Pit
 Visione_Chip_Sculptor	A Suspicious Sculptor
-Visione_Chip_Shipwreck	Sky Galleon
 Visione_Chip_ShipWreckOakBarrel	Shipwreck Oak Barrel
+Visione_Chip_Shipwreck	Sky Galleon
 Visione_Chip_SilenceShipwreck	Shipwreck in Silence
 Visione_Chip_SilverbrookRuins	Silverbrook Ruins
 Visione_Chip_Sinkhole	Sinkhole
@@ -5839,7 +6081,6 @@ Visione_Chip_ValleyRockWatchTower	Gorgerock Watchtower
 Visione_Chip_VatnhollCamp	Vat'nholl Camp
 Visione_Chip_VerheimRuins	Verheim Ruins
 Visione_Chip_VikingTomb	Grave of Warriors' Axes
-Visione_Chip_vinevillage	Ivynook
 Visione_Chip_WagonOnATree	Treetop Wagon
 Visione_Chip_WarNews	News of War
 Visione_Chip_WaterFallsCabin	Cabin by the Waterfall
@@ -5847,11 +6088,19 @@ Visione_Chip_WeirdSkull	A Strange Skull
 Visione_Chip_WindmillCoastShipWreck	Coast Windmill Shipwreck
 Visione_Chip_WisdomWell	Well of Enlightenment
 Visione_Chip_Witch_Kidnapped_Memory	Memory of the Kidnapped Witch
-Visione_Chip_WoodenGazebo	Wooden Pavilion
 Visione_Chip_WoodKnot	Shipyard Wood Knot
+Visione_Chip_WoodenGazebo	Wooden Pavilion
 Visione_Chip_WreckedTradingShip	Wrecked Trading Ship
 Visione_Chip_ZianeTomb	Burial Mound
 Visione_Chip_ZooHole	Wildlife Park Passageway
+Visione_Chip_castleruincamp	Castle Ruins Encampment
+Visione_Chip_emptycoffin	Empty Coffin
+Visione_Chip_guardiandeity	Guardian Deity Altar
+Visione_Chip_hernandcampsite	Hernand Encampment
+Visione_Chip_pharmacy	Halssius Apothecary
+Visione_Chip_precipicecoffin	Clifftop Coffin
+Visione_Chip_riverdam	Upper Nas River Dam
+Visione_Chip_vinevillage	Ivynook
 Vixer_Leather_Boots	Vixer Leather Shoes
 Volcanic_OneHandCannon	Volcanic Blaster
 Volcker_Fabric_Helm	St. Halssius Priest's Hat
@@ -5887,8 +6136,6 @@ Wandering_Mercenary_Leather_Armor	Wandering Freesword's Leather Armor
 Wanted_Criminal_BackPack_I	Outlaw's Gold Ore Pack
 Wanted_Criminal_BackPack_II	Outlaw's Graverobber Pack
 Wants_Leather_Gloves	Wentz Leather Gloves
-Warblick_Fabric_Armor	Warblick Cloth Armor
-Warren_Beynon_Leather_Boots	Warren Beynon's Leather Boots
 WarRobot_Backpack_01	A.T.A.G. Thrusterpack Mk I
 WarRobot_Backpack_02	A.T.A.G. Thrusterpack Mk II
 WarRobot_Backpack_03	A.T.A.G. Thrusterpack Mk III
@@ -5905,12 +6152,14 @@ WarRobot_Gatling_01	A.T.A.G. Machine Gun
 WarRobot_Laser_01	A.T.A.G. Laser
 WarRobot_RepairTool_01_L	A.T.A.G. Pincers
 WarRobot_RepairTool_01_R	A.T.A.G. Welder
+Warblick_Fabric_Armor	Warblick Cloth Armor
+Warren_Beynon_Leather_Boots	Warren Beynon's Leather Boots
 Warstein_Fabric_Armor	Warstein Cloth Armor
 Watcher_BackPack	Watcher Pack
 Water	Water
-Water_Bomb	Water Bomb
 WaterPower_BackPack	Hydro Generator Bag
 WaterSliding_Plate_Boots	Vaporwalker
+Water_Bomb	Water Bomb
 Watous_Leather_Gloves	Wertesh Leather Gloves
 Weapon_BackPack_I	Weaponsmith's Pack
 Weapon_BackPack_II	Weaponsmith's Pack
@@ -5930,6 +6179,12 @@ WeatherWeaver_Necklace	Rainstorm Necklace
 WeatherWeaver_Sunny_Necklace	Radiant Necklace
 Weeren_PlateArmor_Gloves	Weirren Plate Gloves
 Wegalawn_Leather_Gloves	Vicaron Leather Gloves
+WellsDungeon_Key	Thornbriar Dungeon Key
+WellsKnight_PlateArmor_Armor	Grotevant Plate Armor
+WellsKnight_PlateArmor_Cloak	Grotevant Cloak
+WellsKnight_PlateArmor_Gloves	Grotevant Plate Gloves
+WellsKnight_PlateArmor_Helm	Grotevant Plate Helm
+WellsKnight_Plate_Boots	Grotevant Plate Boots
 Wells_Brigade_Flag	Small Wells Brigade Banner Pike
 Wells_Brigade_Rebel_ChainMail_Armor_I	Turncoat Chain Mail
 Wells_Brigade_Rebel_ChainMail_Armor_II	Turncoat Chain Mail
@@ -5948,40 +6203,34 @@ Wells_Flag_II	Medium Wells Banner Pike
 Wells_HorseArmor_Armor	Wells Military Barding
 Wells_PlateArmor_Armor	Wells Rider Plate Armor
 Wells_TwoHandGiantSpear	Elite Vanguard
-WellsDungeon_Key	Thornbriar Dungeon Key
-WellsKnight_Plate_Boots	Grotevant Plate Boots
-WellsKnight_PlateArmor_Armor	Grotevant Plate Armor
-WellsKnight_PlateArmor_Cloak	Grotevant Cloak
-WellsKnight_PlateArmor_Gloves	Grotevant Plate Gloves
-WellsKnight_PlateArmor_Helm	Grotevant Plate Helm
 WestDemenissChurch_Key	Church Crypt Key
 Wheat	Wheat
 Wheel_BackPack	Wheelwright's Pack
-White_Bear_Leather_Helm	White Bear Helm
-White_Crocodile_Leather_Gloves	Pale Predator's Leather Gloves
-White_Douglas_Leather_Gloves	Crowcaller's White Leather Gloves
-White_Horse_Report	Sighting of Royler
-White_Lion_Necklace	White Lion Necklace
 WhiteBear_TwoHandAxe	Split Tooth
 WhiteCrow_Witch_TwoHandedWarHammer	Crow Whisperer
 WhiteHair_Root	Satintail Root
 WhiteHorn_Earring	White Horn's Earring
 WhiteHorn_Leather_Helm	White Horn Leather Helm
 WhiteStone	Scolecite Ore
+White_Bear_Leather_Helm	White Bear Helm
+White_Crocodile_Leather_Gloves	Pale Predator's Leather Gloves
+White_Douglas_Leather_Gloves	Crowcaller's White Leather Gloves
+White_Horse_Report	Sighting of Royler
+White_Lion_Necklace	White Lion Necklace
 Wild_Honey	Wild Honey
 Wild_Insam	Wild Ginseng
 Wind_Power_OneHandShield	Gale Shield
 Wind_TwoHandSpear	Propeller Spear
 WindmillCoastShipWreck_Book	Navigator's Log
 Wintharden_Fabric_Armor	Ator's Will Cloth Armor
-Witch_WingFan	Eastern Witch's Fan
 WitchWarehouse_Key	Witch's Storehouse Key
+Witch_WingFan	Eastern Witch's Fan
 Witley_Fabric_Boots	Whitley Cloth Boots
 Witley_Fabric_Gloves	Whitley Cloth Gloves
 Witley_Leather_Armor	Whitley Leather Armor
-Witters_Plate_Boots	Witters Plate Boots
 Witters_PlateArmor_Gloves	Witters Plate Gloves
 Witters_PlateArmor_Helm	Witters Plate Helm
+Witters_Plate_Boots	Witters Plate Boots
 Wolf_Chief_Leather_Helm	Alpha Wolf Helm
 Wolf_Leather	Long Hair Hide
 Wolf_OneHandSword	Sword of the Wolf
@@ -5993,6 +6242,8 @@ Wolf_Pursuer_Leather_Boots	Wolf Tracker Leather Boots
 Wolf_Pursuer_Leather_Gloves	Wolf Tracker Leather Gloves
 Wolf_Test_OneHandSword	Wolf Test OneHandSword
 Wood	Timber
+Wood_Branch_01	Tree Branch
+Wood_Branch_02	Sturdy Tree Branch
 Wood_Lantern	Wooden Lantern
 Wood_OneHandShield	Grey Wolf Wooden Shield
 Woodbrock_Leather_Boots	Woodbrock Leather Boots
@@ -6020,3 +6271,64 @@ Ziggurat_Leather_Gloves_II	Ziggurat Leather Gloves
 Ziggurat_Leather_Helm_II	Chemists' Mask Leather Helm
 Ziggurat_Leather_Helm_III	Chemists' Iron Mask Leather Helm
 Zinianne_Fabric_Armor	Zynian Cloth Armor
+Zoo_Entry_Ticket	Wildlife Park Ticket
+barnia_Flag_I	Small Varnian Banner Pike
+barnia_Flag_II	Medium Varnian Banner Pike
+burrowingtoad	Burrowing Toad
+cacao_Seed	Cacao Seed
+centipede	Centipede
+cotton_BackPack	Cotton Pack
+dain_Leather_Gloves	Dane Leather Bands
+deerking_Flag_I	Small Staglord Banner Pike
+deerking_Flag_II	Medium Staglord Banner Pike
+demenissnobility_Flag_I	Small Demenissian Noble's Banner
+demenissnobility_Flag_II	Small Demenissian Noble's Banner
+demenissnobility_Flag_III	Small Demenissian Noble's Banner
+demenissnobility_Flag_IV	Medium Demenissian Noble's Banner Pike
+demenissnobility_Flag_V	Medium Demenissian Noble's Banner Pike
+demenissnobility_Flag_VI	Medium Demenissian Noble's Banner Pike
+diereuben_Leather_Gloves	Dirrebin Leather Gloves
+dragonkiller_Flag_I	Small Flame Knights Banner Pike
+dragonkiller_Flag_II	Medium Flame Knights Banner Pike
+fort_Flag_I	Small Dusksongs Banner Pike
+fort_Flag_II	Small Faceless Banner Pike
+fort_Flag_III	Small Twilight Messengers Banner Pike
+fort_Flag_IV	Medium Dusksongs Banner Pike
+fort_Flag_V	Medium Faceless Banner Pike
+fort_Flag_VI	Medium Twilight Messengers Banner Pike
+frog	Poison Frog
+gimmick_tool_kinetic_barbell_0001	Kinetic Counterweight
+gimmick_tool_kinetic_barbell_0002	Kinetic Knight
+gimmick_tool_kinetic_boat_0001	Kinetic Boat
+gimmick_tool_kinetic_circle_0001	Kinetic Circle
+gimmick_tool_kinetic_dolphin_0001	Kinetic Dolphin Family
+gimmick_tool_kinetic_dolphin_0002	Kinetic Dolphin
+grape_BackPack	Grape Pack
+grape_Seed	Grape Seed
+graymane_Flag_I	Tiny Greymane Banner Pike
+graymane_Flag_II	Small Greymane Banner Pike
+graymane_Flag_III	Medium Greymane Banner Pike
+greenfrog	Tree Frog
+king_LostPeople_PlateArmor_Armor	Frostcursed Plate Armor
+king_LostPeople_PlateArmor_Armor_Upgrade	Kuku Ice-Resistant Armor
+king_LostPeople_PlateArmor_Cloak	Frostcursed Plate Cloak
+lilian_Leather_Boots	Lilian Leather Boots
+marni_Flag_I	Small Marni Banner Pike
+marni_Flag_II	Medium Marni Banner Pike
+musket_Flag_I	Small Musket of Demeniss Banner Pike
+musket_Flag_II	Medium Musket of Demeniss Banner Pike
+orange_BackPack	Orange Pack
+orange_Seed	Orange Seed
+orchids_BackPack	Dendrobium Orchid Pack
+pailloon_Flag_I	Small Pailunese Banner Pike
+pailloon_Flag_II	Medium Pailunese Banner Pike
+peas	Peas
+riding_Leather_Boots	Riding Boots
+riding_Leather_Gloves	Master Trainer's Touch
+riding_Leather_Helm	Leather Riding Hat
+scorpion	Scorpion
+silence_Flag_I	Small Heavy Silence Banner Pike
+silence_Flag_II	Medium Heavy Silence Banner Pike
+toad	Toad
+tommaso_Flag_I	Small Tommaso Banner Pike
+tommaso_Flag_II	Medium Tommaso Banner Pike

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,11 +1,10 @@
 ## Crimson Desert 1.04.00 Support
 
-- Updated internal offsets so apply, picker filtering, and real-armor teardown all work on game version 1.04.00. Transmog no longer crashes or silently no-ops after the patch
-- Display name table refreshed against the latest save-editor dataset so the picker shows proper names for every 1.04.00 item (full 6334/6334 coverage, previously 6019)
-- Cloak items now appear in the Cloak category again. The game renumbered the cloak type code on 1.04.00, which dropped them into "Other" in previous builds
-- PlayerSafe filter re-tuned for 1.04.00 so cross-body items stay correctly marked for Kliff / Damiane / Oongka
-- Hot-reloading the mod no longer strips your character or crashes on the next apply. Auto-apply now waits until the item catalog finishes loading before re-applying your active preset
-- "Append" button and hotkey now create a blank preset with every slot ticked + none (a clean hide-all template) and apply it immediately, instead of copying your current outfit
-- New "Copy" button duplicates the currently-visible picker rows into a new preset, so you can fork an existing preset without overwriting it
-- Unsaved picker edits now show an orange `[UNSAVED -- click Save]` banner at the top of the overlay and tint the Save button orange with a `*` marker, so pending edits are hard to miss
-- Developer-build hot-reload is more resilient: the DLL now runs its hook teardown from both the loader shutdown path and `DLL_PROCESS_DETACH`, so re-injecting a rebuilt logic DLL no longer leaves stale hooks behind
+- Restored full functionality on game version 1.04.00. Transmog apply, real-armor teardown, the picker filter, and the PlayerSafe check all work again after the patch
+- Cloak items show up in the Cloak category again (the game renumbered cloaks on 1.04.00 and the picker was dropping them into Other)
+- Display name coverage is now complete: the picker shows a friendly name for every 1.04.00 item (was missing ~300 names after the patch)
+- Hot-reloading the mod mid-game no longer strips your character or crashes the next apply. Auto-apply waits for the item catalog to finish loading before re-applying your preset
+- Append now creates a blank preset with every slot set to hide (ticked + none) and applies it immediately, instead of copying your current outfit
+- New Copy button duplicates the currently-visible picker rows into a new preset so you can fork without overwriting
+- Unsaved picker edits now show an orange `[UNSAVED -- click Save]` banner at the top of the overlay and tint the Save button orange with a `*` marker
+- Developer hot-reload is more resilient: reloading a rebuilt logic DLL no longer leaves stale hooks behind

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,9 +1,7 @@
 ## Crimson Desert 1.04.00 Support
 
 - Restored full functionality on game version 1.04.00. Transmog apply, real-armor teardown, the picker filter, and the PlayerSafe check all work again after the patch
-- Cloak items show up in the Cloak category again (the game renumbered cloaks on 1.04.00 and the picker was dropping them into Other)
 - Display name coverage is now complete: the picker shows a friendly name for every 1.04.00 item (was missing ~300 names after the patch)
-- Hot-reloading the mod mid-game no longer strips your character or crashes the next apply. Auto-apply waits for the item catalog to finish loading before re-applying your preset
 - Append now creates a blank preset with every slot set to hide (ticked + none) and applies it immediately, instead of copying your current outfit
 - New Copy button duplicates the currently-visible picker rows into a new preset so you can fork without overwriting
 - Unsaved picker edits now show an orange `[UNSAVED -- click Save]` banner at the top of the overlay and tint the Save button orange with a `*` marker

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,11 @@
-## [Title for next release]
+## Crimson Desert 1.04.00 Support
 
-- New feature
-- Bug fix
-- Improvement
+- Updated internal offsets so apply, picker filtering, and real-armor teardown all work on game version 1.04.00. Transmog no longer crashes or silently no-ops after the patch
+- Display name table refreshed against the latest save-editor dataset so the picker shows proper names for every 1.04.00 item (full 6334/6334 coverage, previously 6019)
+- Cloak items now appear in the Cloak category again. The game renumbered the cloak type code on 1.04.00, which dropped them into "Other" in previous builds
+- PlayerSafe filter re-tuned for 1.04.00 so cross-body items stay correctly marked for Kliff / Damiane / Oongka
+- Hot-reloading the mod no longer strips your character or crashes on the next apply. Auto-apply now waits until the item catalog finishes loading before re-applying your active preset
+- "Append" button and hotkey now create a blank preset with every slot ticked + none (a clean hide-all template) and apply it immediately, instead of copying your current outfit
+- New "Copy" button duplicates the currently-visible picker rows into a new preset, so you can fork an existing preset without overwriting it
+- Unsaved picker edits now show an orange `[UNSAVED -- click Save]` banner at the top of the overlay and tint the Save button orange with a `*` marker, so pending edits are hard to miss
+- Developer-build hot-reload is more resilient: the DLL now runs its hook teardown from both the loader shutdown path and `DLL_PROCESS_DETACH`, so re-injecting a rebuilt logic DLL no longer leaves stale hooks behind

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -134,7 +134,9 @@ If you run into issues, check the OptiScaler documentation for DLL naming and co
 [*]Use the search box to filter by name -items are auto-categorized to the correct slot
 [*]Select an item -changes stay [b]pending[/b] until you click [b]Apply All[/b]
 [*]Click [b]Apply All[/b] to commit all slot changes at once
-[*]Use [b]Append[/b] in the Presets section to save your current look
+[*]Use [b]Append[/b] in the Presets section to create a fresh preset with every slot ticked and set to (none) -- a hide-all starting point you can fill in from the pickers
+[*]Use [b]Copy[/b] to duplicate the current preset (including any unsaved picker edits) into a new slot you can tweak without touching the source
+[*][b]Save[/b] commits unsaved picker edits back into the active preset. The button turns orange with a [b]*[/b] marker and a [b][UNSAVED -- click Save][/b] banner appears in the header whenever your edits differ from the stored preset
 [*]Use [b]Prev[/b] / [b]Next[/b] to cycle through saved presets
 [*]Press [b]Home[/b] again to close the overlay
 [/list]

--- a/CrimsonDesertLiveTransmog/src/dev/logic_exports.cpp
+++ b/CrimsonDesertLiveTransmog/src/dev/logic_exports.cpp
@@ -24,7 +24,7 @@ static HANDLE g_instanceMutex = nullptr;
 
 extern "C" __declspec(dllexport) bool Init()
 {
-    // Process gate — UAL loads ASIs into ALL processes in the game
+    // Process gate -- UAL loads ASIs into ALL processes in the game
     // directory, including crashpad_handler.exe. Bail immediately if
     // we're not in the real game.
     if (!CDCore::Dev::is_target_process(Transmog::GAME_PROCESS_NAME))
@@ -40,7 +40,7 @@ extern "C" __declspec(dllexport) bool Init()
     logger.info("[DEV] Logic DLL Init() called");
     Transmog::Version::logVersionInfo();
 
-    // Per-PID mutex — prevents duplicate ASI loading within the same
+    // Per-PID mutex -- prevents duplicate ASI loading within the same
     // process (e.g. old production ASI alongside the dev build).
     if (!CDCore::Dev::acquire_instance_mutex(
             Transmog::INSTANCE_MUTEX_PREFIX, g_instanceMutex))
@@ -80,6 +80,21 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID /*lpRese
     {
         DisableThreadLibraryCalls(hModule);
         g_hModule = hModule;
+    }
+    else if (ul_reason_for_call == DLL_PROCESS_DETACH)
+    {
+        // Safety net: if the loader failed to call our exported
+        // `Shutdown()` before FreeLibrary (or Shutdown() hung and the
+        // loader's post-shutdown sleep elapsed), the hooks we installed
+        // would remain patched-in-place while our trampoline memory
+        // unmaps. A fresh reload of this logic DLL would then scan the
+        // still-patched prologues, install new hooks on top, and every
+        // future call through BatchEquip/VEC would chain into freed
+        // memory and crash. DMK_Shutdown is idempotent and detects the
+        // Windows loader-lock path internally (detaches worker threads
+        // instead of joining), so calling it here is safe even when the
+        // exported Shutdown() already ran.
+        DMK_Shutdown();
     }
 
     return TRUE;

--- a/CrimsonDesertLiveTransmog/src/input_handler.cpp
+++ b/CrimsonDesertLiveTransmog/src/input_handler.cpp
@@ -133,7 +133,7 @@ namespace Transmog
                 []()
                 {
                     // Clear also flips flag_enabled to false so a subsequent
-                    // Toggle sees cleared == disabled — avoids 2-press bug.
+                    // Toggle sees cleared == disabled -- avoids 2-press bug.
                     DMK::Logger::get_instance().info(
                         "Clear hotkey pressed -- disabling transmog");
                     flag_enabled().store(false, std::memory_order_relaxed);
@@ -162,10 +162,7 @@ namespace Transmog
                 s_presetAppendCombos,
                 []()
                 {
-                    // Capture real gear first so append snapshots the actual
-                    // loadout, not the previously-active preset's mappings.
                     DMK::Logger::get_instance().info("Preset append hotkey pressed");
-                    Transmog::capture_outfit();
                     PresetManager::instance().append_from_state();
                     Transmog::manual_apply();
                 });

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -24,20 +24,29 @@ namespace Transmog
     static constexpr std::size_t k_maxNameLen = 96;
 
     // Variant-metadata detection (see item_name_table.hpp::has_variant_meta).
-    // Clean base items have `*(desc+0x3A0) == <sentinel>` where <sentinel>
-    // is a shared empty-object pointer (IDA: off_1459D0B38 on v1.02.00 -- an
-    // IRefCounted vtable in the exe's .data section). Non-sentinel values
-    // point to a per-item metadata struct threaded through a catalog-wide
-    // linked list. Members of this list failed to render via runtime
-    // transmog on all tested samples.
+    // Clean base items have `*(desc+<offset>) == <sentinel>` where
+    // <sentinel> is a shared empty-object pointer (IDA: off_1459D0B38 on
+    // v1.02.00 -- an IRefCounted vtable in the exe's .data section).
+    // Non-sentinel values point to a per-item metadata struct threaded
+    // through a catalog-wide linked list; members of this list failed to
+    // render via runtime transmog on all tested samples.
     //
-    // The sentinel's RVA is NOT stable across patches -- any .data reshuffle
-    // moves it. Instead of hardcoding the RVA, we resolve the sentinel
-    // statistically at catalog-build time: scan every valid descriptor's
-    // +0x3A0 qword, the value that appears in the clear majority of items
-    // (historically ~60% on v1.02.00, ~3625/6024) IS the sentinel. This
-    // needs no symbol anchor and self-heals across future game updates.
-    static constexpr std::ptrdiff_t k_descVariantMetaOffset = 0x3A0;
+    // The field offset shifts across major game revisions as the
+    // descriptor struct grows:
+    //
+    //   v1.02.00 -- +0x3A0 (original)
+    //   v1.04.00 -- +0x3C8 (descriptor gained 0x28 bytes of new fields
+    //               between +0x3A0 and +0x3C8; +0x3A0 now carries an
+    //               unrelated `0x1FFFFFFFF` bit-pattern value)
+    //
+    // The sentinel value itself is also unstable (any .data reshuffle
+    // moves it). Rather than hardcoding either the offset or the
+    // sentinel RVA, the builder resolves the sentinel statistically at
+    // catalog-build time: scan every valid descriptor's +0x3C8 qword,
+    // the value that appears in the clear majority of items (~3-5k of
+    // ~6k) IS the sentinel. Self-heals across future game updates as
+    // long as the catalog stays statistically dominated by base items.
+    static constexpr std::ptrdiff_t k_descVariantMetaOffset = 0x3C8;
 
     // --- iteminfo (qword_145CEF370) container layout, v1.02.00 ---
     // Source: IDA sub_1402D75D0 + static analysis. These are runtime data
@@ -178,11 +187,23 @@ namespace Transmog
     // only {0x012F}) are classified as Generic -- the engine accepts
     // them on any humanoid body, so the picker shows them for every
     // character.
+    // Body-type classifier tokens on v1.04.00 (renumbered from v1.03.01
+    // when the engine's class-enum was re-keyed; each token shifted by
+    // +1 or +2). Verified live against the rule-classifier arrays of
+    // WellsKnight_PlateArmor_{Helm, Armor} (known male carriers) and
+    // Demian_Leather_Armor (known female carrier). Structure unchanged
+    // at +0x248/+0x250 (rule list), +0x20/+0x28 (classifier list per
+    // rule), 0x38 rule stride; only the enum values moved.
+    //
+    //   v1.03.01:  male   {0x0018, 0x0058, 0x02E3}
+    //              female {0x0072, 0x0382, 0x0300}
+    //   v1.04.00:  male   {0x0019, 0x0059, 0x02E5}
+    //              female {0x0073, 0x0384, 0x0302}
     static constexpr std::uint16_t k_maleBodyTokens[] = {
-        0x0018, 0x0058, 0x02E3,
+        0x0019, 0x0059, 0x02E5,
     };
     static constexpr std::uint16_t k_femaleBodyTokens[] = {
-        0x0072, 0x0382, 0x0300,
+        0x0073, 0x0384, 0x0302,
     };
     // Body bits are accumulated during the classifier scan:
     //   Male / Female  -- saw a token from the respective body set
@@ -385,11 +406,17 @@ namespace Transmog
     // unmapped as non-equipment.
 
     // Slot mapping for the canonical item-type code at desc+0x44.
-    // Values verified via CE on v1.03.01, 2026-04-21:
-    //   0x04=Helm  0x05=Chest  0x06=Gloves  0x07=Boots  0x45=Cloak
+    // Helm/Chest/Gloves/Boots verified on v1.03.01 (2026-04-21) and
+    // confirmed unchanged on v1.04.00 (2026-04-23). Cloak shifted from
+    // 0x45 -> 0x46 on v1.04.00 (one-code insertion in the engine enum
+    // between Boots and Cloak). Both legacy and current values accepted
+    // so the mapping stays valid across patches that haven't shifted
+    // the earlier slots.
+    //   0x04=Helm  0x05=Chest  0x06=Gloves  0x07=Boots
+    //   0x45/0x46=Cloak
     // Other observed codes (explicitly rejected -- these are not
     // transmog-compatible armor slots):
-    //   0x20=Shield, 0x53=Horse/mount armor, 0xFFFF=Quest/non-equipment,
+    //   0x20=Shield, 0x53/0x54=Horse/mount armor, 0xFFFF=Quest/non-equipment,
     //   plus any other unmapped code.
     static TransmogSlot slot_from_type_code(std::uint16_t code) noexcept
     {
@@ -399,7 +426,8 @@ namespace Transmog
         case 0x05: return TransmogSlot::Chest;
         case 0x06: return TransmogSlot::Gloves;
         case 0x07: return TransmogSlot::Boots;
-        case 0x45: return TransmogSlot::Cloak;
+        case 0x45:
+        case 0x46: return TransmogSlot::Cloak;
         default:   return TransmogSlot::Count;
         }
     }
@@ -707,9 +735,12 @@ namespace Transmog
             const uint16_t equipType =
                 read_u16_safe(descPtr + 0x42, etOk);
 
-            // Item-type code at desc+0x44 (u16). CE-verified 2026-04-21:
-            //   0x04=Helm, 0x05=Chest, 0x06=Gloves, 0x07=Boots, 0x45=Cloak,
-            //   0x20=Shield, 0x53=Horse/mount armor, 0xFFFF=Quest/Non-equipment.
+            // Item-type code at desc+0x44 (u16). CE-verified on
+            // v1.03.01 (2026-04-21) and v1.04.00 (2026-04-23):
+            //   0x04=Helm, 0x05=Chest, 0x06=Gloves, 0x07=Boots,
+            //   0x45/0x46=Cloak (shifted +1 on v1.04.00),
+            //   0x20=Shield, 0x53/0x54=Horse/mount armor,
+            //   0xFFFF=Quest/Non-equipment.
             // This is the canonical game-side classifier for item category;
             // slot derivation no longer depends on parsing the item name.
             bool tcOk = false;
@@ -729,10 +760,11 @@ namespace Transmog
         }
 
         // Pass 2 -- statistically derive the variant-meta sentinel.
-        // The sentinel is the value that appears at desc+0x3A0 in the
-        // clear majority of items (historically ~60% on v1.02.00). Any
-        // other pointer at that slot = per-item variant metadata and
-        // gates out of runtime transmog.
+        // The sentinel is the value that appears at
+        // desc+k_descVariantMetaOffset in the clear majority of items
+        // (historically ~60% on v1.02.00). Any other pointer at that
+        // slot = per-item variant metadata and gates out of runtime
+        // transmog.
         //
         // Tally non-zero metaPtr values; the mode is the sentinel.
         uintptr_t resolvedSentinel = 0;
@@ -781,8 +813,8 @@ namespace Transmog
         for (auto &e : scratch)
         {
             // Item "has variant" (picker shows carrier-color) if either:
-            //   - desc+0x3A0 is non-sentinel (traditional catalog-level
-            //     variant-meta record), OR
+            //   - desc+k_descVariantMetaOffset is non-sentinel
+            //     (traditional catalog-level variant-meta record), OR
             //   - the item has >= 2 body-bearing classifier rules,
             //     i.e. separate male + female identity-gated rules.
             //     Empirically these are dual-body NPC items that need

--- a/CrimsonDesertLiveTransmog/src/item_name_table.hpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.hpp
@@ -95,23 +95,28 @@ namespace Transmog
 
         /**
          * @brief True if the item's descriptor has a non-sentinel
-         *        pointer at `+0x3A0` (i.e. a variant metadata struct).
+         *        pointer at the variant-metadata slot (see
+         *        `k_descVariantMetaOffset` in item_name_table.cpp for
+         *        the per-version offset: +0x3A0 on v1.02.00, +0x3C8 on
+         *        v1.04.00).
          *
          * Items with this flag set are members of an engine-internal
-         * linked list threaded via `desc+0x3A0`. Across the 14 labeled
+         * linked list threaded via that slot. Across the 14 labeled
          * armor samples we tested live, flagged items all failed to
          * render via runtime transmog on the player. The exact semantic
          * meaning of the meta struct is not fully mapped -- users see
          * these as "damaged" in-game but the catalog-wide population
-         * (~2399/6024 items) includes non-armor readables too, so the
-         * label is intentionally mechanism-neutral. The overlay treats
-         * this as "may not render" and warns in the picker.
+         * (~2399/6024 items on v1.02.00) includes non-armor readables
+         * too, so the label is intentionally mechanism-neutral. The
+         * overlay treats this as "may not render" and warns in the
+         * picker.
          *
          * Detector: the sentinel pointer is resolved STATISTICALLY at
-         * build() time as the mode of `*(desc+0x3A0)` across all valid
-         * descriptors (~60% share it on v1.02.00). No hardcoded RVA --
-         * the detector self-heals across future .data shuffles. Returns
-         * false for unknown ids or when the catalog isn't yet built.
+         * build() time as the mode of `*(desc+k_descVariantMetaOffset)`
+         * across all valid descriptors (~60% share it on v1.02.00). No
+         * hardcoded RVA, so the detector self-heals across future
+         * .data shuffles. Returns false for unknown ids or when the
+         * catalog isn't yet built.
          */
         bool has_variant_meta(uint16_t itemId) const;
 

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -186,10 +186,12 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
     //
     // Exact: only show items whose auto-detected category matches
     //        this slot (helm-suffixed items for the helm slot, etc.)
-    // Hide variants: hide items with variant metadata at desc+0x3A0;
-    //        all tested samples in that bucket failed to render via
-    //        runtime transmog, so hiding them by default keeps the
-    //        picker free of non-functional items.
+    // Hide variants: hide items flagged by has_variant_meta() (see
+    //        item_name_table.cpp::k_descVariantMetaOffset for the
+    //        per-version descriptor offset); all tested samples in
+    //        that bucket failed to render via runtime transmog, so
+    //        hiding them by default keeps the picker free of
+    //        non-functional items.
     ImGui::Checkbox("Exact", &ui.exactFilter);
     ImGui::SameLine();
     ImGui::Checkbox("Safe only", &ui.hideIncompatible);
@@ -609,6 +611,27 @@ static int s_renameIndex = -1;
     return false;
 }
 
+// Returns true when slot_mappings differs from the active preset's
+// persisted slots -- i.e. the user edited rows in the overlay but has
+// not committed the change back into the JSON preset via Save. Used to
+// tint the Save button so unsaved work is visible.
+[[nodiscard]] static bool has_pending_save() noexcept
+{
+    const auto *p = Transmog::PresetManager::instance().active_preset();
+    if (!p)
+        return false;
+
+    const auto &mappings = Transmog::slot_mappings();
+    for (std::size_t i = 0; i < Transmog::k_slotCount; ++i)
+    {
+        if (mappings[i].active != p->slots[i].active)
+            return true;
+        if (mappings[i].targetItemId != p->slots[i].itemId)
+            return true;
+    }
+    return false;
+}
+
 // --- draw_overlay_content ---
 // All ImGui widget calls for the transmog UI.  Called by both the
 // ReShade tab callback and the standalone window wrapper.
@@ -623,6 +646,7 @@ static void draw_overlay_content()
     // badge and yellow button tint to reduce visual noise.
     const bool pending =
         !s_autoApply && has_pending_changes();
+    const bool pendingSave = has_pending_save();
 
     // --- Header ---
 
@@ -635,6 +659,13 @@ static void draw_overlay_content()
         ImGui::SameLine();
         ui_text_colored(ImVec4(1.0f, 0.85f, 0.2f, 1.0f),
                         "  [PENDING -- click Apply All]");
+    }
+
+    if (pendingSave)
+    {
+        ImGui::SameLine();
+        ui_text_colored(ImVec4(1.0f, 0.55f, 0.25f, 1.0f),
+                        "  [UNSAVED -- click Save]");
     }
 
     ImGui::Separator();
@@ -862,31 +893,27 @@ static void draw_overlay_content()
 
         if (ImGui::Button("Append"))
         {
-            capture_outfit();
             pm.append_from_state();
             manual_apply();
         }
         if (ImGui::IsItemHovered())
-            ui_tooltip("Capture your currently-worn real armor as a "
-                       "new preset, then apply it.");
+            ui_tooltip("Append a new preset with every slot ticked + "
+                       "none (hides all armor), then apply it.");
 
         ImGui::SameLine();
 
-        // Copy: like Append but skips capture_outfit -- forks the
-        // current slot-mapping state (loaded from the active preset +
-        // any edits you made in the rows) into a brand-new preset.
-        // Useful for duplicating an existing preset and tweaking the
-        // fork without overwriting the source.
+        // Copy forks the current slot rows (from the active preset + any
+        // edits) into a brand-new preset so the user can tweak without
+        // overwriting the source.
         if (ImGui::Button("Copy"))
         {
-            pm.append_from_state();
+            pm.duplicate_current();
             manual_apply();
         }
         if (ImGui::IsItemHovered())
             ui_tooltip("Duplicate the current slot rows into a new "
-                       "preset (without re-capturing real armor), "
-                       "then apply it. Use after selecting a preset "
-                       "and tweaking the rows to fork it.");
+                       "preset, then apply it. Use after selecting a "
+                       "preset and tweaking the rows to fork it.");
 
         ImGui::SameLine();
 
@@ -1142,11 +1169,28 @@ static void draw_overlay_content()
 
     ImGui::SameLine();
 
-    if (ImGui::Button("Save"))
+    if (pendingSave)
+    {
+        ImGui::PushStyleColor(ImGuiCol_Button,
+                              ImVec4(0.80f, 0.40f, 0.15f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                              ImVec4(0.95f, 0.52f, 0.20f, 1.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive,
+                              ImVec4(1.00f, 0.60f, 0.25f, 1.0f));
+    }
+    if (ImGui::Button(pendingSave ? "Save *" : "Save"))
     {
         pm.replace_current_from_state();
         pm.save();
     }
+    if (pendingSave)
+        ImGui::PopStyleColor(3);
+    if (ImGui::IsItemHovered())
+        ui_tooltip(pendingSave
+                       ? "Commit current slot rows into the active "
+                         "preset (unsaved edits pending)."
+                       : "Commit current slot rows into the active "
+                         "preset.");
 
     ImGui::EndDisabled();
 

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -323,10 +323,37 @@ namespace Transmog
         auto &cp = ensure_character(m_activeCharacter);
         int idx = static_cast<int>(cp.presets.size());
         std::string name = "Preset " + std::to_string(idx);
+        Preset blank;
+        blank.name = name;
+        for (auto &s : blank.slots)
+        {
+            s.active = true;
+            s.itemId = 0;
+            s.itemName.clear();
+        }
+        cp.presets.push_back(std::move(blank));
+        cp.activePreset = idx;
+
+        apply_to_state();
+
+        DMK::Logger::get_instance().info(
+            "Preset appended: '{}' (index {}, all slots ticked + none)",
+            name, idx);
+        save();
+    }
+
+    void PresetManager::duplicate_current()
+    {
+        auto &cp = ensure_character(m_activeCharacter);
+        int idx = static_cast<int>(cp.presets.size());
+        std::string name = "Preset " + std::to_string(idx);
         cp.presets.push_back(capture_from_state(name));
         cp.activePreset = idx;
 
-        DMK::Logger::get_instance().info("Preset appended: '{}' (index {})", name, idx);
+        apply_to_state();
+
+        DMK::Logger::get_instance().info(
+            "Preset duplicated: '{}' (index {})", name, idx);
         save();
     }
 
@@ -335,7 +362,14 @@ namespace Transmog
         auto *p = active_preset_mut();
         if (!p)
         {
-            append_from_state();
+            auto &cp = ensure_character(m_activeCharacter);
+            int idx = static_cast<int>(cp.presets.size());
+            std::string name = "Preset " + std::to_string(idx);
+            cp.presets.push_back(capture_from_state(name));
+            cp.activePreset = idx;
+
+            DMK::Logger::get_instance().info("Preset replaced: '{}' (index {})", name, idx);
+            save();
             return;
         }
 

--- a/CrimsonDesertLiveTransmog/src/preset_manager.hpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.hpp
@@ -76,8 +76,16 @@ namespace Transmog
         Preset *active_preset_mut();
         const std::vector<Preset> &presets() const;
 
-        /// Append a new preset from current slot_mappings state.
+        /// Append a fresh preset with every slot ticked + none (hide all).
+        /// Pushes the new state into slot_mappings before returning so the
+        /// caller can manual_apply() immediately.
         void append_from_state();
+
+        /// Append a new preset that snapshots the current slot_mappings
+        /// (active character's picker rows). Unlike append_from_state, this
+        /// preserves the currently-loaded item selections so the user can
+        /// fork-edit an existing preset without overwriting the source.
+        void duplicate_current();
 
         /// Overwrite the active preset with current slot_mappings state.
         void replace_current_from_state();

--- a/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
+++ b/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
@@ -54,20 +54,33 @@ namespace Transmog::RealPartTearDown
         // we touch anything dangerous.
         //
         // a1 (SlotPopulator descriptor context) layout:
-        //   +0x78 QWORD pointer to the PartDef/auth-table container.
+        //   +0x78 QWORD pointer to the PartDef/auth-table container on
+        //               v1.03.01; shifted to +0x88 on v1.04.00 as the
+        //               component struct gained 0x10 bytes of new
+        //               fields in front of this slot.
         //
-        // container layout:
+        // container layout (unchanged across v1.03.01 / v1.04.00):
         //   +0x00 QWORD header (unused by this module)
         //   +0x08 QWORD base address of stride-0xC8 entry array
         //   +0x10 DWORD live entry count
         //   +0x14 DWORD capacity
         //
-        // entry layout (stride 0xC8 / 200 bytes):
+        // entry layout (stride 0xC8 / 200 bytes, unchanged):
         //   +0x08 WORD  primary item word (0xFFFF == empty slot)
         //   +0x10 QWORD gate (must be non-zero for live entries)
-        //   +0x88 WORD  alt item word (0xFFFF → fall back to +0x08)
+        //   +0x88 WORD  alt item word (0xFFFF -> fall back to +0x08)
         //   +0xC0 WORD  slot tag (search key; helm=0x0003 .. boot=0x0010)
-        constexpr std::uintptr_t k_containerPtrOffset      = 0x78;
+        //
+        // v1.04.00 entry-layout confirmation: the ADD path in the game's
+        // auth-table helper (sub_14EF6B830) executes
+        //     add rbx, [r12+08]        ; rbx = array + offset
+        //     mov [rbx+0xC0], ax        ; slot tag write
+        //     inc [r12+0x10]            ; count++
+        // captured live under a data-write breakpoint on the count
+        // field during a helm unequip. Confirms stride 0xC8 (rbx pre-add
+        // was 0xAF0 = 14 * 0xC8 for the 14 live entries observed) and
+        // slot-tag offset 0xC0.
+        constexpr std::uintptr_t k_containerPtrOffset      = 0x88;
         constexpr std::uintptr_t k_containerArrayBaseOffset = 0x08;
         constexpr std::uintptr_t k_containerCountOffset    = 0x10;
         constexpr std::uintptr_t k_entryStride             = 0xC8;

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -16,6 +16,22 @@
 
 namespace Transmog
 {
+    // SlotPopulator (sub_14076C960) maintains a dispatch cache on the
+    // component at (basePtr, count, cap). The triple shifted 0x20
+    // bytes higher between v1.03.01 and v1.04.00 as the component
+    // gained new fields lower in the struct:
+    //
+    //   v1.03.01 -- basePtr @ +0x1B8, count @ +0x1C0, cap @ +0x1C4
+    //   v1.04.00 -- basePtr @ +0x1D8, count @ +0x1E0, cap @ +0x1E4
+    //
+    // Reading the old offsets on v1.04.00 returns zero for count (the
+    // u32 that lives there is always 0), which makes apply look like
+    // a no-op; writing the old offsets scribbles into adjacent fields
+    // and corrupts the component a slot at a time.
+    constexpr std::ptrdiff_t k_compSlotCacheBasePtrOffset = 0x1D8;
+    constexpr std::ptrdiff_t k_compSlotCacheCountOffset   = 0x1E0;
+    constexpr std::ptrdiff_t k_compSlotCacheCapOffset     = 0x1E4;
+
     void apply_transmog(__int64 a1, uint16_t targetId)
     {
         auto slotPop = slot_populator_fn();
@@ -194,9 +210,20 @@ namespace Transmog
     }
 
     // Descriptor size. Stride between consecutive descriptors observed
-    // in CE: 0x400 (1024). Over-read is fine -- we copy into a private
-    // buffer and only the game's actual reads matter.
-    static constexpr std::size_t k_descBufSize = 0x400;
+    // in CE on the live build:
+    //
+    //   v1.03.01 -- 0x400 (1024)
+    //   v1.04.00 -- 0xA00 (2560)
+    //
+    // The hybrid buffer is memcpy'd from the target descriptor up to
+    // this size; any byte beyond ends up as VirtualAlloc-zero. If
+    // SlotPopulator or its callees read past the copied range they see
+    // zeros instead of the real descriptor data, which faults when the
+    // zero is treated as an embedded pointer, vtable, or index. Keep
+    // this at or above the live stride; over-copy is safe because the
+    // source descriptor is always at least a full stride wide in the
+    // pool allocator.
+    static constexpr std::size_t k_descBufSize = 0xA00;
 
     // Descriptor offsets read by SlotPopulator for character-context
     // matching BEFORE visual/mesh data. Must come from the CARRIER so
@@ -466,9 +493,9 @@ namespace Transmog
         __try
         {
             const auto count =
-                *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
+                *reinterpret_cast<volatile uint32_t *>(a1 + k_compSlotCacheCountOffset);
             const auto base =
-                *reinterpret_cast<volatile uintptr_t *>(a1 + 0x1B8);
+                *reinterpret_cast<volatile uintptr_t *>(a1 + k_compSlotCacheBasePtrOffset);
             if (base > 0x10000)
             {
                 for (uint32_t e = 0; e < count; ++e)
@@ -827,8 +854,10 @@ namespace Transmog
                 lastIds[i] = 0;
         }
 
-        // SlotPopulator (sub_14076C960) maintains a dispatch cache at
-        // a1+0x1B8 (base ptr), a1+0x1C0 (count), a1+0x1C4 (cap). Each
+        // SlotPopulator (sub_14076C960) maintains a dispatch cache on
+        // the component at (basePtr, count, cap). The triple offsets
+        // are defined by the k_compSlotCache* constants at the top of
+        // this file (they shifted between v1.03.01 and v1.04.00). Each
         // entry is 24 bytes:
         //   +0x00 uint16  slotNativeId
         //   +0x08 __int128* subArray (queued ItemInfoBlobs)
@@ -866,9 +895,9 @@ namespace Transmog
         __try
         {
             const auto count =
-                *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
+                *reinterpret_cast<volatile uint32_t *>(a1 + k_compSlotCacheCountOffset);
             const auto base =
-                *reinterpret_cast<volatile uintptr_t *>(a1 + 0x1B8);
+                *reinterpret_cast<volatile uintptr_t *>(a1 + k_compSlotCacheBasePtrOffset);
             if (base > 0x10000)
             {
                 for (uint32_t e = 0; e < count; ++e)
@@ -1097,7 +1126,7 @@ namespace Transmog
             __try
             {
                 postCount =
-                    *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
+                    *reinterpret_cast<volatile uint32_t *>(a1 + k_compSlotCacheCountOffset);
             }
             __except (EXCEPTION_EXECUTE_HANDLER)
             {
@@ -1204,7 +1233,7 @@ namespace Transmog
         __try
         {
             uint32_t liveCount =
-                *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
+                *reinterpret_cast<volatile uint32_t *>(a1 + k_compSlotCacheCountOffset);
             logger.trace("[dispatch] post-apply liveCount={} "
                          "ourWrittenCount={}",
                          liveCount, ourWrittenCount);
@@ -1370,8 +1399,8 @@ namespace Transmog
                 auto entryArray = *reinterpret_cast<uintptr_t *>(entryDesc + 8);
                 auto entryCount = *reinterpret_cast<uint32_t *>(entryDesc + 16);
 
-                auto savedCount = *reinterpret_cast<uint32_t *>(a1 + 0x1C0);
-                *reinterpret_cast<uint32_t *>(a1 + 0x1C0) = 0;
+                auto savedCount = *reinterpret_cast<uint32_t *>(a1 + k_compSlotCacheCountOffset);
+                *reinterpret_cast<uint32_t *>(a1 + k_compSlotCacheCountOffset) = 0;
 
                 for (uint32_t e = 0; e < entryCount && entryArray > 0x10000; ++e)
                 {
@@ -1393,10 +1422,10 @@ namespace Transmog
 
                 // Restore count to the larger of saved and live.
                 uint32_t liveCount =
-                    *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0);
+                    *reinterpret_cast<volatile uint32_t *>(a1 + k_compSlotCacheCountOffset);
                 uint32_t finalCount =
                     (liveCount > savedCount) ? liveCount : savedCount;
-                *reinterpret_cast<volatile uint32_t *>(a1 + 0x1C0) = finalCount;
+                *reinterpret_cast<volatile uint32_t *>(a1 + k_compSlotCacheCountOffset) = finalCount;
             }
         }
         __except (EXCEPTION_EXECUTE_HANDLER)

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -714,6 +714,7 @@ namespace Transmog
                 s_lastApplyOk.store(false, std::memory_order_release);
 
                 int notReadyStreak = 0;
+                int catalogWaitStreak = 0;
                 bool wrapperChanged = false;
 
                 for (int attempt = 0; attempt < k_maxAutoApplyAttempts;
@@ -751,6 +752,38 @@ namespace Transmog
                             wrapperChanged = true;
                             break;
                         }
+                    }
+
+                    // Gate on item-catalog readiness. On hot reload the
+                    // game is already mid-session with real equipment
+                    // populated, so the "real armor changed" branch in
+                    // apply_all_transmog would fire tear_down before the
+                    // preset has any resolved item IDs (names still
+                    // pending background-thread catalog build). That
+                    // strips the character and leaves slots in a state
+                    // where the deferred post-resolve re-apply crashes.
+                    // Hold the retry budget here until the catalog
+                    // publishes; the attempt counter does not advance
+                    // during the wait so a slow catalog build does not
+                    // exhaust attempts. The outer wrapper-change check
+                    // above still runs each tick.
+                    if (!ItemNameTable::instance().ready())
+                    {
+                        if (catalogWaitStreak == 0)
+                            logger.debug(
+                                "Load detect: catalog not ready -- "
+                                "holding auto-apply (attempt {})",
+                                attempt + 1);
+                        ++catalogWaitStreak;
+                        --attempt; // do not consume an attempt slot
+                        continue;
+                    }
+                    if (catalogWaitStreak > 0)
+                    {
+                        logger.debug(
+                            "Load detect: catalog became ready after "
+                            "{} deferred ticks", catalogWaitStreak);
+                        catalogWaitStreak = 0;
                     }
 
                     if (attempt > 0 &&


### PR DESCRIPTION
## Summary

### LT game 1.04.00 fixes
- Descriptor stride bumped to `0xA00` (was `0x400`); component slot-cache offsets bumped to `0x1D8/0x1E0/0x1E4` (was `0x1B8/0x1C0/0x1C4`).
- Variant-meta sentinel offset bumped to `0x3C8` (was `0x3A0`).
- Tear-down container offset bumped to `0x88` (was `0x78`).
- Cloak slot type code now accepts both `0x45` and `0x46` (renumbered on 1.04.00).
- PlayerSafe body-token lists re-numbered for 1.04.00.

### LT hot-reload hardening
- Auto-apply holds until `ItemNameTable::ready()` so a hot-reload no longer fires teardown on an unresolved preset.
- Dev logic DLL calls `DMK_Shutdown()` from `DLL_PROCESS_DETACH` as a safety net so re-injection leaves no stale trampolines.
- `CDCore::resolve_address` has a JMP-prefix fallback so EH and LT can install hooks on shared targets (VEC, BatchEquip) in any load order.

### LT overlay / preset UX
- **Append** now creates a blank preset with every slot ticked + none (hide-all template) and applies immediately.
- **Copy** duplicates the current picker rows into a new preset via new `PresetManager::duplicate_current()`.
- Header shows an orange `[UNSAVED -- click Save]` banner when `slot_mappings` differs from the active preset's stored slots; Save button tints orange with a `*` suffix.

### Data
- `CrimsonDesertLiveTransmog_display_names.tsv` refreshed against the save-editor repo's `item_names.json`. Full 6334/6334 coverage (was 6019/6334).
