### PR TITLE
fix(equip-hide): multi-protagonist support and reliability

### DIFF
--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -147,6 +147,39 @@ namespace CDCore
     [[nodiscard]] std::uint32_t current_controlled_character_idx() noexcept;
 
     /**
+     * @brief One-based protagonist index for an arbitrary body pointer.
+     * @details Walks the live WorldSystem chain to recover the
+     *          primary-actor (always Kliff on a Kliff-led save) slot byte
+     *          at +0x50, then computes
+     *          `bodySlot - primarySlot` from the matching byte read off
+     *          the supplied body. The diff maps to:
+     *
+     *              0 = Kliff   (returns 1)
+     *              1 = Damiane (returns 2)
+     *              2 = Oongka  (returns 3)
+     *
+     *          Any other diff, an out-of-range body pointer, an
+     *          un-published WorldSystem holder, or a faulted chain walk
+     *          all return 0 (unknown). The returned 1-based index aligns
+     *          with current_controlled_character_idx() so consumers that
+     *          subtract 1 to get a 0-based array index can use this
+     *          helper interchangeably.
+     *
+     *          Cheap and SEH-protected: safe to call from any thread,
+     *          including the rendering thread, and tolerates the body
+     *          pointer being recycled, freed, or torn between the read
+     *          of the primary chain and the +0x50 byte read on `body`.
+     * @param body Pointer to a ClientChildOnlyInGameActor instance
+     *             (the same kind of pointer EquipHide enumerates from
+     *             user+0xD0..+0x108). Pass 0 to disable the lookup
+     *             (returns 0).
+     * @return 1 for Kliff, 2 for Damiane, 3 for Oongka, or 0 when the
+     *         identity cannot be resolved.
+     */
+    [[nodiscard]] std::uint32_t resolve_character_idx_for_body(
+        std::uintptr_t body) noexcept;
+
+    /**
      * @brief Clear the last-known-good identity cache.
      * @details Call on world-reload transitions (save load, return to
      *          title) so the resolver does not keep returning the

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -347,6 +347,142 @@ namespace CDCore
         return 0;
     }
 
+    namespace
+    {
+        // Read just the primary actor's slot-index byte. Mirrors
+        // walk_chain_seh's pointer-validity discipline (every intermediate
+        // pointer below the 64 KiB guard region is rejected) so a torn
+        // chain can never reach the final byte read with garbage state.
+        // Output is the slot byte in `outPrimarySlot` plus a `valid` flag;
+        // a faulted walk leaves the byte at zero and `valid` at false.
+        struct PrimarySlotProbe
+        {
+            std::uint8_t slot;
+            bool         valid;
+        };
+
+        PrimarySlotProbe read_primary_slot_seh(std::uintptr_t holder) noexcept
+        {
+            PrimarySlotProbe out{};
+            if (holder < k_minValidPtr)
+            {
+                return out;
+            }
+            __try
+            {
+                const auto ws =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(holder);
+                if (ws < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto am =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(
+                        ws + k_wsToActorMgrOffset);
+                if (am < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto user =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(
+                        am + k_actorMgrToUserOffset);
+                if (user < k_minValidPtr)
+                {
+                    return out;
+                }
+                const auto primary =
+                    *reinterpret_cast<const volatile std::uintptr_t *>(
+                        user + k_userToPrimaryActorOffset);
+                if (primary < k_minValidPtr)
+                {
+                    return out;
+                }
+                out.slot =
+                    *reinterpret_cast<const volatile std::uint8_t *>(
+                        primary + k_actorSlotIndexByteOffset);
+                out.valid = true;
+                return out;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return out;
+            }
+        }
+
+        // SEH-isolated single-byte read on an arbitrary body pointer.
+        // Returns the slot byte plus a validity flag; a fault during the
+        // read (recycled or freed body, partially-torn structure right
+        // after a swap) leaves the byte at zero and the flag at false.
+        struct BodySlotProbe
+        {
+            std::uint8_t slot;
+            bool         valid;
+        };
+
+        BodySlotProbe read_body_slot_seh(std::uintptr_t body) noexcept
+        {
+            BodySlotProbe out{};
+            if (body < k_minValidPtr)
+            {
+                return out;
+            }
+            __try
+            {
+                out.slot =
+                    *reinterpret_cast<const volatile std::uint8_t *>(
+                        body + k_actorSlotIndexByteOffset);
+                out.valid = true;
+                return out;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return out;
+            }
+        }
+
+    } // anonymous namespace
+
+    std::uint32_t resolve_character_idx_for_body(std::uintptr_t body) noexcept
+    {
+        if (body < k_minValidPtr)
+        {
+            return 0;
+        }
+        const auto holder = s_wsHolder.load(std::memory_order_acquire);
+        if (holder == 0)
+        {
+            return 0;
+        }
+        // Two independent SEH probes: the primary-actor walk faulting
+        // does not invalidate the body byte read and vice versa. Both
+        // must succeed for the diff to mean anything.
+        const auto primary = read_primary_slot_seh(holder);
+        if (!primary.valid)
+        {
+            return 0;
+        }
+        const auto bodyProbe = read_body_slot_seh(body);
+        if (!bodyProbe.valid)
+        {
+            return 0;
+        }
+        const int diff = static_cast<int>(bodyProbe.slot) -
+                         static_cast<int>(primary.slot);
+        if (diff == 0)
+        {
+            return 1; // Kliff
+        }
+        if (diff == k_damianeSlotDiff)
+        {
+            return 2; // Damiane
+        }
+        if (diff == k_oongkaSlotDiff)
+        {
+            return 3; // Oongka
+        }
+        return 0;
+    }
+
     void invalidate_controlled_character() noexcept
     {
         // Release ordering pairs with the acquire load in

--- a/CrimsonDesertCore/src/indexed_string_table.cpp
+++ b/CrimsonDesertCore/src/indexed_string_table.cpp
@@ -153,7 +153,11 @@ namespace CDCore
         }
         else
         {
-            logger.info(
+            // Per-scan summary stays at TRACE so the deferred-scan poll
+            // path (called every 2s until table stability) does not flood
+            // the INFO stream. Call sites that want a one-shot INFO line
+            // emit their own at init-time decision points.
+            logger.trace(
                 "{}: {} entries for prefix '{}' in range 0x{:X}..0x{:X} "
                 "in {}ms",
                 cfg.logLabel, entries, cfg.prefix ? cfg.prefix : "",

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -240,7 +240,7 @@ In this example, pressing `V` would still toggle Shields and Masks, but Helm wou
 
 ## Per-Character Parts Overrides
 
-Each category's `Parts` list can be overridden per protagonist by adding a section named `[CategoryName:CharacterName]`. Supported names: `Kliff`, `Damiane`, `Oongka`. Only the `Parts` key is per-character; `Enabled`, `DefaultHidden`, and hotkeys remain global.
+Each category's `Parts` list can be overridden per protagonist by adding a section named `[CategoryName:CharacterName]`. Supported names: `Kliff`, `Damiane`, `Oongka`. Only the `Parts` key is per-character; `Enabled`, `DefaultHidden`, and hotkeys remain global. The shipped INI template lists the exact `CD_*` part name beside each per-character override comment so you can pick names out without guessing.
 
 Three ways to set a per-character `Parts` value:
 
@@ -277,7 +277,7 @@ Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ...
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L
 ```
 
-The active character is detected by walking the live WorldSystem pointer chain to the currently-controlled actor and decoding its built-in identity fields. Switching between protagonists automatically swaps the effective Parts list on the next tick.
+The active character is detected by walking the live WorldSystem pointer chain to the currently-controlled actor and decoding its built-in identity fields. Each party member visible on screen tracks its own per-character Parts list independently, so hiding armor on Damiane and then swapping back to Kliff keeps Damiane's armor hidden while Kliff renders under his own configuration. The previously-controlled character's hide state is preserved across swaps until you toggle it off explicitly.
 
 ## Compatibility with Replacer Mods
 

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -128,18 +128,35 @@ DefaultHidden = false
 ; that character's override to avoid floating-mesh clipping when toggled visible.
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux
 
-; Kliff can additionally hide: left-hand daggers, left gauntlet, bola.
-; (Vanilla-hidden for him: R-daggers, 1H axes/maces, right gauntlet, L-fist, handcannon.)
+; Kliff can additionally hide: left-hand daggers (CD_MainWeapon_Dagger_L,
+;   CD_MainWeapon_Dagger_IN_L), left gauntlet (CD_MainWeapon_Gauntlet_L),
+;   bola (CD_MainWeapon_Bola).
+; Vanilla-hidden for him (omitted from his override): right-hand daggers
+;   (CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R), 1H axes
+;   (CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L), 1H maces
+;   (CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L), right gauntlet
+;   (CD_MainWeapon_Gauntlet), left fist (CD_MainWeapon_Fist_L), handcannon
+;   (CD_MainWeapon_HandCannon).
 [OneHandWeapons:Kliff]
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Gauntlet_L, CD_MainWeapon_Bola
 
-; Damiane can additionally hide: left-hand daggers, 1H axes, 1H maces, both gauntlets.
-; (Vanilla-hidden for her: R-dagger, fan, L-fist, handcannon, bola.)
+; Damiane can additionally hide: left-hand daggers (CD_MainWeapon_Dagger_L,
+;   CD_MainWeapon_Dagger_IN_L), 1H axes (CD_MainWeapon_Axe_R,
+;   CD_MainWeapon_Axe_L), 1H maces (CD_MainWeapon_Mace_R,
+;   CD_MainWeapon_Mace_L), both gauntlets (CD_MainWeapon_Gauntlet,
+;   CD_MainWeapon_Gauntlet_L).
+; Vanilla-hidden for her (omitted from her override): right-hand dagger
+;   (CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R), fan
+;   (CD_MainWeapon_Fan, lives in [SpecialWeapons]), left fist
+;   (CD_MainWeapon_Fist_L), handcannon (CD_MainWeapon_HandCannon),
+;   bola (CD_MainWeapon_Bola).
 [OneHandWeapons:Damiane]
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L
 
-; Oongka's vanilla-hidden set has not been verified. Leave empty to inherit
-; the conservative base; fill in once you confirm his sheath meshes.
+; Oongka's vanilla-hidden set has not been verified. Leaving Parts empty
+; (or omitting the section entirely) inherits the conservative base list
+; defined in [OneHandWeapons] above; fill in once you confirm his sheath
+; meshes.
 [OneHandWeapons:Oongka]
 Parts =
 
@@ -191,18 +208,24 @@ DefaultHidden = false
 ; without a stowed mesh on a given character are omitted from their override.
 Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book
 
-; Kliff can additionally hide: fire can.
-; (Vanilla-hidden for him: torch, flute, pan, pipe, saw, shooter, sprayer.)
+; Kliff can additionally hide: fire can (CD_Tool_FireCan).
+; Vanilla-hidden for him (omitted from his override): torch (CD_Tool_Torch),
+;   flute (CD_Tool_Flute), pan (CD_Tool_Pan), pipe (CD_Tool_Pipe),
+;   saw (CD_Tool_Saw), shooter (CD_Tool_Shooter), sprayer (CD_Tool_Sprayer).
 [Tools:Kliff]
 Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book, CD_Tool_FireCan
 
-; Damiane can additionally hide: saw, pan, shooter.
-; (Vanilla-hidden for her: torch, flute, pipe, sprayer, firecan.)
+; Damiane can additionally hide: saw (CD_Tool_Saw), pan (CD_Tool_Pan),
+;   shooter (CD_Tool_Shooter).
+; Vanilla-hidden for her (omitted from her override): torch (CD_Tool_Torch),
+;   flute (CD_Tool_Flute), pipe (CD_Tool_Pipe), sprayer (CD_Tool_Sprayer),
+;   fire can (CD_Tool_FireCan).
 [Tools:Damiane]
 Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book, CD_Tool_Saw, CD_Tool_Pan, CD_Tool_Shooter
 
-; Oongka's vanilla-hidden tool set has not been verified. Leave empty to
-; inherit the conservative base.
+; Oongka's vanilla-hidden tool set has not been verified. Leaving Parts
+; empty (or omitting the section entirely) inherits the conservative base
+; list defined in [Tools] above.
 [Tools:Oongka]
 Parts =
 

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,65 +1,14 @@
-## [Title for next release]
+## Multi-Protagonist Support and 1.04.00 Reliability
 
-- Migrated to DetourModKit 3.2.3 lifecycle helpers. `Bootstrap` collapses
-  the dllmain process gate, instance mutex, and async-logger setup into
-  a single call; the three background workers run on `StoppableWorker`
-  with cooperative `std::stop_token` shutdown.
-- Hotkey bindings go through `DMK::Config::register_press_combo`, which
-  fuses the INI key registration with `InputManager::register_press()`.
-  Existing user INI hotkey values continue to work without changes. An
-  empty INI value or the literal `NONE` (case-insensitive, whole-string
-  only) is recognised as a silent opt-out sentinel by DMK at parse time,
-  so unbound bindings produce no log noise on any `Config::reload()`
-  cycle. A live INI edit that assigns a real combo still goes live on
-  the next reload, and a non-empty value whose every comma-separated
-  token fails to parse still trips DMK's INI-typo WARNING with the
-  offending raw string.
-- Behaviour change: when multiple categories share a Toggle hotkey,
-  each category now flips its own state independently. The previous
-  `IndependentToggle=false` "flip all together" semantics depended on a
-  manual de-dupe pass that DetourModKit's per-binding cancellation
-  guards have superseded. Bind the same combo to `[General] HideAll` /
-  `[General] ShowAll` for a synchronised toggle.
-- New optional INI key `[General] AutoReloadConfig=true` (default true)
-  enables filesystem-watcher hot-reload of the INI. Setters re-fire on
-  every save so most tweaks no longer require relaunching the game.
-  Set to `false` to opt out. The reload callback re-derives the cached
-  hidden-state masks and hands the actual vis-byte commit to the game
-  thread via the same needs-direct-write primitive that drives
-  character-swap re-application, so edits to `[Helm]/[Chest]/...`
-  `Enabled` / `DefaultHidden` flags, and to `Parts=` lists (including
-  per-character overrides such as `[Chest:Damiane] Parts=NONE`), take
-  effect within one mid-hook tick of the save. The `Parts=` setter
-  writes into the inactive lookup buffer; the reload tail calls
-  `rebuild_part_lookup()` to atomically publish the rebuilt buffer so
-  the mid-hook classifier and the direct-write pass see the new part
-  list on the next tick.
-- Atomic-bool config items use upstream `Config::register_atomic<bool>`,
-  and the log-level lambda has been replaced with
-  `Config::register_log_level`. User-visible behaviour is unchanged.
-- AOB resolution now uses `DetourModKit::Scanner::resolve_cascade`
-  directly. Mod behaviour is unchanged; the wrapper layer is shorter.
-  The `EquipVisCheck` mid-hook target is routed through
-  `Scanner::resolve_cascade_with_prologue_fallback`, matching every
-  other AOB call site, so when SafetyHook's prior detour-jump still
-  occupies the mid-body bytes the resolver retries each candidate
-  with the first five byte-tokens replaced by the near-JMP signature
-  and lands on the same cmp instruction. Production first-load is
-  unchanged: the original-bytes patterns still win the cascade.
-- `EquipHide::shutdown()` calls `DMK_Shutdown()` for full DetourModKit
-  teardown: every managed hook (`EquipVisCheck`, `PartAddShow`,
-  `PostfixEval`, `VisualEquipChange`, `VisualEquipSwap`) is removed
-  so SafetyHook restores the original bytes at each patched site,
-  the InputManager poller is stopped and its bindings cleared, the
-  `ConfigWatcher` is stopped, and the `Config` registered-items list
-  is wiped. Background workers are joined before the teardown so no
-  thread is mid-call into a SafetyHook trampoline when the trampoline
-  pages are reclaimed; visibility-byte cleanup also runs before
-  `DMK_Shutdown()` so the cleanup walk completes while its host code
-  is still mapped. Each detour body snapshots its trampoline pointer
-  at entry and bails to a safe default if the snapshot is null,
-  defending the brief drain window between hook removal and DLL
-  unmap. The next Logic-DLL `Init()` re-runs `Logger::configure`,
-  `Config::register_*`, `HookManager::create_*_hook`, and
-  `InputManager::start()` from a fresh DMK state, so dev hot reload
-  starts each cycle from clean singletons.
+- Per-character armor-hide settings now stick when you swap protagonists; hiding gear on one party member no longer flips back when you switch to another.
+- Per-character Parts overrides are now honoured by the live mid-hook (not just the resync pass), so a hash excluded from one protagonist's `[Section:CharName]` list will no longer be momentarily hidden on that protagonist's frames.
+- INI template now lists the exact `CD_*` part names alongside each per-character override comment, so users can copy-paste names without guessing what "R-daggers" or "fire can" map to.
+- Detect all three party members on game version 1.04.00 (the third character was previously missing the per-character hide mask).
+- Toggle hotkeys reliably apply right after a character swap; presses are no longer silently dropped on internal lock contention.
+- Equipment hash table now retries until your world finishes loading, so worlds with extremely sparse table state at startup still converge to the full hide list.
+- Hot-reload during development no longer hangs the game on shutdown.
+- Quieter logs: per-binding registration and per-part trace lines moved off the default INFO/DEBUG output.
+- Migrated to DetourModKit 3.2.3 lifecycle helpers; existing INI files keep working unchanged.
+- INI auto-reload (default on) -- most edits to category Enabled/DefaultHidden/Parts/per-character overrides take effect within a single frame, no relaunch required. Disable via `[General] AutoReloadConfig=false`.
+- Categories sharing the same `ToggleHotkey` now flip independently (each on its own state). Bind the same combo to `[General] HideAll`/`ShowAll` for a synchronised toggle.
+- Cleaner shutdown: full DetourModKit teardown removes every hook and restores patched bytes, so dev hot-reload starts each cycle from a clean state.

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -239,7 +239,7 @@ Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ...
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L
 [/code]
 
-The active character is detected by walking the live WorldSystem pointer chain to the currently-controlled actor and decoding its built-in identity fields. Switching between protagonists automatically swaps the effective Parts list on the next tick.
+The active character is detected by walking the live WorldSystem pointer chain to the currently-controlled actor and decoding its built-in identity fields. Each party member visible on screen tracks its own per-character Parts list independently, so hiding armor on Damiane and then swapping back to Kliff keeps Damiane's armor hidden while Kliff renders under his own configuration. The previously-controlled character's hide state is preserved across swaps until you toggle it off explicitly.
 
 [line]
 

--- a/CrimsonDesertEquipHide/src/armor_injection.cpp
+++ b/CrimsonDesertEquipHide/src/armor_injection.cpp
@@ -59,7 +59,7 @@ namespace EquipHide
         }
     }
 
-    static int inject_armor_entries_for_map(uintptr_t mapBase) noexcept
+    static int inject_armor_entries_for_map(uintptr_t mapBase, int charIdx) noexcept
     {
         auto &mtx = vis_write_mutex();
         if (!mtx.try_lock())
@@ -94,9 +94,20 @@ namespace EquipHide
                 category_bit(Category::Gloves) |
                 category_bit(Category::Boots);
 
-            for (const auto &[hash, mask] : get_part_map())
+            // Per-character map drives both the part list AND the
+            // hide-mask classification: charIdx=-1 (unknown body or
+            // fallback path) collapses to the active-character map
+            // through get_part_map_for / is_any_category_hidden_for so
+            // single-character behaviour is preserved for unidentified
+            // slots.
+            const auto &partMap =
+                (charIdx >= 0 && charIdx < static_cast<int>(kCharIdxCount))
+                    ? get_part_map_for(charIdx)
+                    : get_part_map();
+
+            for (const auto &[hash, mask] : partMap)
             {
-                const bool hidden = is_any_category_hidden(mask);
+                const bool hidden = is_any_category_hidden_for(mask, charIdx);
 
                 if (!hidden)
                 {
@@ -170,6 +181,13 @@ namespace EquipHide
         if (!addrs.mapInsert || !addrs.mapLookup || !addrs.indexedStringGlobal)
             return;
 
+        // Hidden-state masks (used by is_any_category_hidden_for) are
+        // global, so the global anyHidden short-circuit is still
+        // correct: if no category is hidden anywhere, every per-
+        // character query also returns false. The cascade-fix injection
+        // path also writes vis=0 when no category is hidden, which we
+        // intentionally still skip here -- it would re-fire on every
+        // tick in the no-hidden case.
         bool anyHidden = false;
         for (std::size_t i = 0; i < CATEGORY_COUNT; ++i)
         {
@@ -206,6 +224,12 @@ namespace EquipHide
             if (!vc)
                 continue;
 
+            // Per-slot character idx. -1 (unknown / fallback path)
+            // routes injection through the active-character map so
+            // unidentified slots preserve single-character behaviour.
+            const int charIdx =
+                ps.visCharIdx[i].load(std::memory_order_relaxed);
+
             /* Per-player SEH so one bad pointer does not skip the rest. */
             __try
             {
@@ -225,10 +249,10 @@ namespace EquipHide
                 }
                 auto mapBase = descNode + 0x20;
                 logger.trace("ArmorInject [{}]: vc=0x{:X} comp=0x{:X} "
-                             "descNode=0x{:X} mapBase=0x{:X}",
-                             i, vc, comp, descNode, mapBase);
+                             "descNode=0x{:X} mapBase=0x{:X} char_idx={}",
+                             i, vc, comp, descNode, mapBase, charIdx);
 
-                int result = inject_armor_entries_for_map(mapBase);
+                int result = inject_armor_entries_for_map(mapBase, charIdx);
                 if (result >= 0)
                 {
                     ps.armorInjected[i].store(true, std::memory_order_relaxed);

--- a/CrimsonDesertEquipHide/src/background_threads.cpp
+++ b/CrimsonDesertEquipHide/src/background_threads.cpp
@@ -1,4 +1,5 @@
 #include "background_threads.hpp"
+#include "constants.hpp"
 #include "indexed_string_table.hpp"
 #include "player_detection.hpp"
 #include "shared_state.hpp"
@@ -32,10 +33,17 @@ namespace EquipHide
         std::unique_ptr<DetourModKit::StoppableWorker> s_resolvePollWorker;
 
         // --- Deferred IndexedStringA scan tuning ---
-        constexpr int k_maxScanAttempts = 10;
+        // Stability-based convergence mirrors LT's "wait until ready, then
+        // commit once" pattern. LT signals readiness via build()==Ok; the
+        // IndexedStringA table has no equivalent ready signal because it
+        // populates incrementally as scenes load, so the analog is
+        // structural settling: commit once the scan count stops changing
+        // for k_stabilityRequired consecutive polls (~6s of no growth at
+        // the 2s retry cadence).
         constexpr int k_scanRetryMs = 2000;
-        constexpr int k_scanIdleRetryMs = 10000;
         constexpr int k_scanInitialDelayMs = 8000;
+        constexpr int k_scanWarnEvery = 30;
+        constexpr int k_stabilityRequired = 3;
 
         // Sleeps in short slices and observes both the StoppableWorker
         // stop_token and the legacy shutdown_requested() flag so the
@@ -62,75 +70,122 @@ namespace EquipHide
         {
             auto &logger = DMK::Logger::get_instance();
             const auto mapLookupAddr = resolved_addrs().mapLookup;
+            if (!mapLookupAddr)
+                return;
 
-            int realAttempts = 0;
-            bool tableReady = false;
+            // Initial grace mirrors LT's k_nametableInitialDelayMs so the
+            // game has a chance to seed the table before we start polling.
+            if (!sleep_responsive_ms(st, k_scanInitialDelayMs))
+                return;
+
+            std::size_t prevCount = 0;
+            int stableStreak = 0;
+            int attempt = 0;
+
             for (;;)
             {
-                int sleepMs;
-                if (realAttempts == 0 && !tableReady)
-                    sleepMs = k_scanInitialDelayMs;
-                else if (!tableReady)
-                    sleepMs = k_scanIdleRetryMs;
-                else
-                    sleepMs = k_scanRetryMs;
-
-                if (!sleep_responsive_ms(st, sleepMs))
+                if (!sleep_responsive_ms(st, k_scanRetryMs))
                     return;
 
+                ++attempt;
                 auto runtimeHashes = scan_indexed_string_table(mapLookupAddr);
-                if (runtimeHashes.empty())
+                const auto curCount = runtimeHashes.size();
+
+                if (curCount == 0)
+                {
+                    // Table still entirely empty: reset streak so we never
+                    // commit the empty state on stability.
+                    if (attempt % k_scanWarnEvery == 0)
+                        logger.warning(
+                            "IndexedStringA deferred scan: still waiting "
+                            "after {} attempts (table empty)",
+                            attempt);
+                    stableStreak = 0;
+                    prevCount = 0;
                     continue;
+                }
+
+                if (curCount != prevCount)
+                {
+                    // Growing or shrinking: not stable yet, reset streak
+                    // and update the baseline.
+                    stableStreak = 0;
+                    prevCount = curCount;
+                    logger.trace(
+                        "IndexedStringA deferred scan: attempt {}, {} "
+                        "entries (changed, stability streak reset)",
+                        attempt, curCount);
+
+                    if (attempt % k_scanWarnEvery == 0)
+                        logger.warning(
+                            "IndexedStringA deferred scan: still waiting "
+                            "after {} attempts ({} entries currently, "
+                            "table still settling)",
+                            attempt, curCount);
+                    continue;
+                }
+
+                ++stableStreak;
+                if (stableStreak < k_stabilityRequired)
+                {
+                    logger.trace(
+                        "IndexedStringA deferred scan: attempt {}, {} "
+                        "entries (stable {}/{}, awaiting commit)",
+                        attempt, curCount, stableStreak,
+                        k_stabilityRequired);
+
+                    if (attempt % k_scanWarnEvery == 0)
+                        logger.warning(
+                            "IndexedStringA deferred scan: {} entries "
+                            "after {} attempts (stable streak {}/{}, "
+                            "need {} consecutive identical scans)",
+                            curCount, attempt, stableStreak,
+                            k_stabilityRequired, k_stabilityRequired);
+                    continue;
+                }
+
+                // Re-check stop right before the blocking commit
+                // sequence. cleanup_vis_bytes() blocking-locks
+                // vis_write_mutex; if shutdown raced past join here,
+                // skipping the commit lets the worker exit cleanly.
+                if (st.stop_requested() ||
+                    shutdown_requested().load(std::memory_order_relaxed))
+                    return;
 
                 const auto totalParts = total_part_count();
+                // Capture unresolved parts BEFORE moving runtimeHashes into
+                // the published map, since get_unresolved_parts borrows it.
                 auto unresolved = get_unresolved_parts(runtimeHashes);
                 const auto resolvedCount = totalParts - unresolved.size();
 
-                // Table not meaningfully populated yet -- keep waiting
-                // without burning attempt budget.
-                if (resolvedCount < 10)
-                    continue;
+                logger.info(
+                    "IndexedStringA deferred scan: stable at {} entries "
+                    "across {} consecutive scans, committing "
+                    "({}/{} resolved, {} attempts)",
+                    curCount, k_stabilityRequired,
+                    resolvedCount, totalParts, attempt);
 
-                tableReady = true;
-                ++realAttempts;
+                set_runtime_hashes(std::move(runtimeHashes));
+                rebuild_part_lookup();
+                deferred_scan_pending().store(
+                    false, std::memory_order_relaxed);
 
-                // Accept results when >=90% resolved or attempt budget spent.
-                constexpr auto k_minResolvePct = 90;
-                const bool enough =
-                    (resolvedCount * 100 / totalParts) >= k_minResolvePct;
+                // Restore any vis bytes set during a prior scan phase
+                // so the rebuilt part map can re-apply with correct
+                // hashes.
+                cleanup_vis_bytes();
 
-                if (enough || realAttempts >= k_maxScanAttempts)
-                {
-                    set_runtime_hashes(std::move(runtimeHashes));
-                    rebuild_part_lookup();
-                    deferred_scan_pending().store(
+                auto &ps = player_state();
+                for (int j = 0; j < k_maxProtagonists; ++j)
+                    ps.armorInjected[j].store(
                         false, std::memory_order_relaxed);
+                needs_direct_write().store(
+                    true, std::memory_order_relaxed);
 
-                    // Restore any vis bytes set during a prior scan phase
-                    // so the rebuilt part map can re-apply with correct
-                    // hashes.
-                    cleanup_vis_bytes();
-
-                    auto &ps = player_state();
-                    for (int j = 0; j < k_maxProtagonists; ++j)
-                        ps.armorInjected[j].store(
-                            false, std::memory_order_relaxed);
-                    needs_direct_write().store(
+                if (!unresolved.empty())
+                    lazy_probe_pending().store(
                         true, std::memory_order_relaxed);
-
-                    logger.info(
-                        "Deferred scan complete: {}/{} resolved ({} attempts)",
-                        resolvedCount, totalParts, realAttempts);
-
-                    if (!unresolved.empty())
-                        lazy_probe_pending().store(
-                            true, std::memory_order_relaxed);
-                    return;
-                }
-
-                logger.trace(
-                    "Deferred scan attempt {}: {}/{} resolved, retrying",
-                    realAttempts, resolvedCount, totalParts);
+                return;
             }
         }
 
@@ -166,6 +221,14 @@ namespace EquipHide
                 auto unresolved = get_unresolved_parts(runtimeHashes);
                 if (unresolved.empty())
                 {
+                    // Same stop-check rationale as deferred_scan_body:
+                    // cleanup_vis_bytes() takes vis_write_mutex blocking,
+                    // which can stall behind the resolve-poll worker's
+                    // try-locked critical section during shutdown.
+                    if (st.stop_requested() ||
+                        shutdown_requested().load(std::memory_order_relaxed))
+                        return;
+
                     set_runtime_hashes(std::move(runtimeHashes));
                     rebuild_part_lookup();
                     cleanup_vis_bytes();
@@ -323,18 +386,56 @@ namespace EquipHide
         // shutdown() flips the legacy shutdown_requested() flag before
         // calling here; explicit shutdown() on each worker also
         // request_stop()s the stop_token so bodies exit promptly.
-        std::lock_guard<std::mutex> lk(s_workersMtx);
+        //
+        // Lock-ordering: extract each unique_ptr into a local under
+        // s_workersMtx, then RELEASE the mutex before joining. Joining
+        // while holding s_workersMtx deadlocks against the mid-hook
+        // path on the game thread: an EquipVisCheck tick calls
+        // launch_lazy_probe() which blocks on s_workersMtx.lock();
+        // meanwhile the lazy-probe worker body itself calls
+        // cleanup_vis_bytes() (blocking lock on vis_write_mutex) which
+        // can stall behind the resolve-poll worker's try_lock-held
+        // critical section in resolve_player_vis_ctrls. With the lock
+        // held, shutdown waits on the lazy-probe join while the game
+        // thread waits on s_workersMtx -- forever.
+        //
+        // Request stop on all three first so the bodies start unwinding
+        // concurrently while we sequentially join, shaving wall-clock
+        // shutdown latency without changing the join order.
+        auto &logger = DMK::Logger::get_instance();
 
-        if (s_deferredScanWorker)
-            s_deferredScanWorker->shutdown();
-        if (s_lazyProbeWorker)
-            s_lazyProbeWorker->shutdown();
-        if (s_resolvePollWorker)
-            s_resolvePollWorker->shutdown();
+        std::unique_ptr<DetourModKit::StoppableWorker> deferredLocal;
+        std::unique_ptr<DetourModKit::StoppableWorker> lazyLocal;
+        std::unique_ptr<DetourModKit::StoppableWorker> resolveLocal;
+        {
+            std::lock_guard<std::mutex> lk(s_workersMtx);
+            deferredLocal = std::move(s_deferredScanWorker);
+            lazyLocal = std::move(s_lazyProbeWorker);
+            resolveLocal = std::move(s_resolvePollWorker);
+        }
 
-        s_deferredScanWorker.reset();
-        s_lazyProbeWorker.reset();
-        s_resolvePollWorker.reset();
+        if (deferredLocal)
+            deferredLocal->request_stop();
+        if (lazyLocal)
+            lazyLocal->request_stop();
+        if (resolveLocal)
+            resolveLocal->request_stop();
+
+        if (resolveLocal)
+        {
+            logger.info("{} shutdown: joining resolve-poll worker", MOD_NAME);
+            resolveLocal->shutdown();
+        }
+        if (lazyLocal)
+        {
+            logger.info("{} shutdown: joining lazy-probe worker", MOD_NAME);
+            lazyLocal->shutdown();
+        }
+        if (deferredLocal)
+        {
+            logger.info("{} shutdown: joining deferred-scan worker", MOD_NAME);
+            deferredLocal->shutdown();
+        }
     }
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/categories.cpp
+++ b/CrimsonDesertEquipHide/src/categories.cpp
@@ -385,6 +385,109 @@ namespace EquipHide
     static constexpr std::size_t k_bitsetWords = 1024;
     static std::array<uint64_t, k_bitsetWords> s_classifyBitsets[2]{};
 
+    /**
+     * @brief Parse a Parts= string and write classification entries into
+     *        the supplied target map.
+     * @details Mirrors the body of register_parts() but operates on an
+     *          arbitrary map argument so the same token-parse logic can
+     *          populate either the legacy active-map double-buffer or a
+     *          per-character map without code duplication. Logging is
+     *          suppressed to avoid the per-character build loop spamming
+     *          the same warnings the active-map build already emits.
+     */
+    static void register_parts_into(
+        Category cat,
+        const std::string &partsStr,
+        std::unordered_map<uint32_t, CategoryMask> &target)
+    {
+        const auto bit = category_bit(cat);
+
+        // Clear prior entries for this category from the target map so
+        // a per-character rebuild that drops a part still reflects the
+        // removal in the per-character classification.
+        for (auto it = target.begin(); it != target.end();)
+        {
+            it->second &= ~bit;
+            if (it->second == 0)
+                it = target.erase(it);
+            else
+                ++it;
+        }
+
+        if (partsStr.find_first_not_of(" ,") == std::string::npos)
+            return;
+
+        // NONE sentinel: explicitly disables the category for this scope
+        // (per-character override path). Silent return.
+        {
+            auto first = partsStr.find_first_not_of(" \t,");
+            auto last  = partsStr.find_last_not_of(" \t,");
+            if (first != std::string::npos && last != std::string::npos &&
+                (last - first + 1) == 4)
+            {
+                auto ch = [&](std::size_t i) {
+                    char c = partsStr[first + i];
+                    return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + 32) : c;
+                };
+                if (ch(0) == 'n' && ch(1) == 'o' && ch(2) == 'n' && ch(3) == 'e')
+                    return;
+            }
+        }
+
+        const auto &nameMap = name_to_hash_map();
+        if (nameMap.empty())
+            return;
+
+        std::size_t pos = 0;
+        while (pos < partsStr.size())
+        {
+            while (pos < partsStr.size() && (partsStr[pos] == ' ' || partsStr[pos] == ','))
+                ++pos;
+            if (pos >= partsStr.size())
+                break;
+
+            auto end = partsStr.find(',', pos);
+            if (end == std::string::npos)
+                end = partsStr.size();
+
+            std::string token = partsStr.substr(pos, end - pos);
+            pos = end;
+
+            while (!token.empty() && token.back() == ' ')
+                token.pop_back();
+            while (!token.empty() && token.front() == ' ')
+                token.erase(token.begin());
+
+            if (token.empty())
+                continue;
+
+            auto it = nameMap.find(token);
+            if (it != nameMap.end())
+            {
+                if (it->second == 0)
+                    continue;
+                target[it->second] |= bit;
+                continue;
+            }
+
+            if (token.size() > 2 && token[0] == '0' && (token[1] == 'x' || token[1] == 'X'))
+            {
+                try
+                {
+                    auto id = static_cast<uint32_t>(
+                        std::stoul(token.substr(2), nullptr, 16));
+                    target[id] |= bit;
+                }
+                catch (...)
+                {
+                    // Malformed hex IDs are reported by the active-map
+                    // build (register_parts) so suppressing the warning
+                    // here just avoids duplication.
+                }
+            }
+        }
+    }
+
     void register_parts(Category cat, const std::string& partsStr, bool storeBase)
     {
         if (storeBase)
@@ -469,11 +572,13 @@ namespace EquipHide
             {
                 if (it->second == 0)
                 {
-                    logger.trace("  {} skipped {} (no stable hash)", category_section(cat), token);
+                    if (storeBase)
+                        logger.trace("  {} skipped {} (no stable hash)", category_section(cat), token);
                     continue;
                 }
                 writeMap[it->second] |= category_bit(cat);
-                logger.trace("  {} += {} (0x{:04X})", category_section(cat), token, it->second);
+                if (storeBase)
+                    logger.trace("  {} += {} (0x{:04X})", category_section(cat), token, it->second);
                 continue;
             }
 
@@ -483,7 +588,8 @@ namespace EquipHide
                 {
                     auto id = static_cast<uint32_t>(std::stoul(token.substr(2), nullptr, 16));
                     writeMap[id] |= category_bit(cat);
-                    logger.trace("  {} += 0x{:04X} (raw)", category_section(cat), id);
+                    if (storeBase)
+                        logger.trace("  {} += 0x{:04X} (raw)", category_section(cat), id);
                     continue;
                 }
                 catch (...)
@@ -496,6 +602,36 @@ namespace EquipHide
                          category_section(cat), token);
         }
     }
+
+    // ---------------------------------------------------------------------
+    // Per-character part maps (Phase 3 option (a) -- per-character
+    // unordered_map). Rationale: hot path is classify_part_for() called
+    // from apply_direct_vis_write per (vis_ctrl, hash) pair on every
+    // schedule. Option (b) would tag every entry of the merged map with
+    // an array<CategoryMask, kCharIdxCount> (12 bytes per value vs 4),
+    // tripling the cache footprint of the inner walk that already
+    // dominates direct-write latency. Option (a) pays a small rebuild
+    // cost on character swap / INI reload (rare, off the hot path) in
+    // exchange for one map lookup keyed on charIdx during direct write.
+    //
+    // The per-character maps are built alongside the active-map double-
+    // buffer flip in build_part_lookup() so all consumers see the same
+    // generation. Each is keyed (hash -> CategoryMask) exactly like the
+    // legacy maps.
+    // ---------------------------------------------------------------------
+    static std::unordered_map<uint32_t, CategoryMask>
+        s_partMapsPerChar[kCharIdxCount];
+
+    // Per-character flat tables and bitsets, mirroring the active-map
+    // fast paths (flat-table for the contiguous range, bitset for the
+    // needs_classification_for fast filter). Outliers are searched off
+    // the per-character unordered_map directly because the per-char
+    // outlier count is small enough that maintaining a sorted vector
+    // alongside is not worth the rebuild cost.
+    static std::array<CategoryMask, k_flatSize>
+        s_flatTablesPerChar[kCharIdxCount]{};
+    static std::array<uint64_t, k_bitsetWords>
+        s_classifyBitsetsPerChar[kCharIdxCount]{};
 
     // --- Outlier hash set ---
     static constexpr std::size_t k_maxOutliers = 8;
@@ -608,6 +744,61 @@ namespace EquipHide
         s_activeMap.fetch_xor(1, std::memory_order_release);
     }
 
+    /**
+     * @brief Rebuild the per-character classification maps + flat tables
+     *        + bitsets for every supported protagonist.
+     * @details Independent of the active-map double-buffer flip so the
+     *          per-character maps are a stable side store: a swap to a
+     *          different active character does not have to relink the
+     *          per-character data, only the read pointer for the legacy
+     *          active-map fast paths. Called from rebuild_part_lookup
+     *          while s_rebuildMutex is held, so concurrent reads of the
+     *          per-character data through the lookup helpers are
+     *          serialised by the rebuild path.
+     */
+    static void build_per_char_part_maps()
+    {
+        for (std::size_t c = 0; c < kCharIdxCount; ++c)
+        {
+            auto &map = s_partMapsPerChar[c];
+            map.clear();
+
+            for (std::size_t catIdx = 0; catIdx < CATEGORY_COUNT; ++catIdx)
+            {
+                // Effective Parts for character c = the per-character
+                // override if non-empty, else the base [Section] Parts.
+                // Mirrors effective_parts_for_category() but parameterised
+                // on c instead of the active character.
+                const auto &override_parts = s_categoryPartsPerChar[catIdx][c];
+                const auto &effective =
+                    !override_parts.empty()
+                        ? override_parts
+                        : s_categoryParts[catIdx];
+                if (effective.empty())
+                    continue;
+                register_parts_into(static_cast<Category>(catIdx),
+                                    effective, map);
+            }
+
+            // Rebuild the per-character flat table + bitset from the
+            // freshly-populated map. Same flat-base / flat-end window as
+            // the active-map path so the contiguous-range fast path is
+            // structurally identical.
+            auto &flat = s_flatTablesPerChar[c];
+            auto &bits = s_classifyBitsetsPerChar[c];
+            flat.fill(0);
+            bits.fill(0);
+
+            for (const auto &[hash, mask] : map)
+            {
+                if (hash >= k_flatBase && hash <= k_flatEnd)
+                    flat[hash - k_flatBase] = mask;
+                if (hash < 0x10000)
+                    bits[hash / 64] |= (1ULL << (hash % 64));
+            }
+        }
+    }
+
     void rebuild_part_lookup()
     {
         std::lock_guard<std::mutex> lock(s_rebuildMutex);
@@ -622,6 +813,14 @@ namespace EquipHide
         }
 
         build_part_lookup();
+        // Per-character maps are an additive structure: the active-map
+        // double-buffer above keeps the legacy (active-character)
+        // semantics alive for callers that have not been migrated, while
+        // the per-character maps make swap-time identity preserved at
+        // each vis ctrl. Building them here ensures both views stay in
+        // sync across every rebuild trigger (init, INI auto-reload,
+        // set_active_character, deferred IndexedString scan completion).
+        build_per_char_part_maps();
     }
 
     void set_active_character(int newIdx)
@@ -731,6 +930,63 @@ namespace EquipHide
     const std::unordered_map<uint32_t, CategoryMask>& get_part_map()
     {
         return s_partMaps[s_activeMap.load(std::memory_order_acquire)];
+    }
+
+    bool needs_classification_for(uint32_t hash, int charIdx) noexcept
+    {
+        if (charIdx < 0 || charIdx >= static_cast<int>(kCharIdxCount))
+            return needs_classification(hash);
+        if (hash >= 0x10000)
+            return false;
+        const auto &bits = s_classifyBitsetsPerChar[
+            static_cast<std::size_t>(charIdx)];
+        return (bits[hash / 64] & (1ULL << (hash % 64))) != 0;
+    }
+
+    CategoryMask classify_part_for(uint32_t hash, int charIdx) noexcept
+    {
+        if (charIdx < 0 || charIdx >= static_cast<int>(kCharIdxCount))
+            return classify_part(hash);
+
+        const auto c = static_cast<std::size_t>(charIdx);
+
+        // Flat-table fast path for the contiguous range, mirroring the
+        // active-map classify_part hot path.
+        if (hash >= k_flatBase && hash <= k_flatEnd)
+            return s_flatTablesPerChar[c][hash - k_flatBase];
+
+        // Outliers: search the per-character unordered_map directly.
+        // Keeping a sorted outlier vector per character would shave a
+        // few cycles off the rare miss but doubles the per-rebuild cost
+        // for a path that fires only on outlier hashes.
+        const auto &map = s_partMapsPerChar[c];
+        const auto it = map.find(hash);
+        return (it != map.end()) ? it->second : CategoryMask{0};
+    }
+
+    const std::unordered_map<uint32_t, CategoryMask> &
+    get_part_map_for(int charIdx) noexcept
+    {
+        // Out-of-range fallback returns the active-character map so any
+        // accidental misuse stays observably correct (legacy behaviour)
+        // rather than crashing.
+        if (charIdx < 0 || charIdx >= static_cast<int>(kCharIdxCount))
+            return get_part_map();
+        return s_partMapsPerChar[static_cast<std::size_t>(charIdx)];
+    }
+
+    bool is_any_category_hidden_for(CategoryMask mask, int charIdx) noexcept
+    {
+        // The hidden-state masks (s_activePresetMask, s_presetHiddenMask,
+        // s_hiddenMask) are global -- they reflect the user's per-
+        // category Hidden / Enabled toggles, NOT the per-character Parts
+        // overrides. The per-character split happens in classify_part_for
+        // (different hashes -> different category bits). Hidden-state
+        // computation can therefore reuse the active-character helper
+        // verbatim once the caller has classified through the per-
+        // character map.
+        (void)charIdx;
+        return is_any_category_hidden(mask);
     }
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/categories.hpp
+++ b/CrimsonDesertEquipHide/src/categories.hpp
@@ -232,6 +232,51 @@ namespace EquipHide
     /** @brief Returns true if ANY category in the given bitmask is currently hidden. */
     bool is_any_category_hidden(CategoryMask mask);
 
+    /**
+     * @brief Returns true if ANY category in the bitmask is hidden FOR a
+     *        specific protagonist idx.
+     * @details Looks up a per-character classification map keyed on charIdx
+     *          (0=Kliff, 1=Damiane, 2=Oongka). Each per-character map
+     *          merges the base [Section] Parts with that character's
+     *          [Section:CharName] Parts overrides exactly as the active-
+     *          character map does, but every map is kept resident
+     *          simultaneously so per-vis-ctrl writes can resolve the
+     *          right hide mask without re-running set_active_character.
+     *
+     *          charIdx == -1 (unknown body / NPC follower / pre-resolve
+     *          tick) falls back to the active-character map so a slot
+     *          with unresolved identity mirrors the active character's
+     *          hide state (single-character semantics).
+     * @param mask Category bitmask -- the part-classification value
+     *             returned by classify_part.
+     * @param charIdx 0..kCharIdxCount-1 for a known protagonist, or -1
+     *                for the active-character fallback.
+     */
+    [[nodiscard]] bool is_any_category_hidden_for(CategoryMask mask,
+                                                  int charIdx) noexcept;
+
+    /**
+     * @brief Classify a part hash USING a specific character's part map.
+     * @details Mirror of classify_part keyed on charIdx. charIdx == -1
+     *          falls back to the active-character map so an unidentified
+     *          slot still classifies correctly under single-character
+     *          semantics.
+     * @return 0 if the hash is not tracked in the requested character's
+     *         (or the active character's, on -1) part map.
+     */
+    [[nodiscard]] CategoryMask classify_part_for(uint32_t partHash,
+                                                 int charIdx) noexcept;
+
+    /**
+     * @brief Per-character variant of needs_classification.
+     * @details Exists for parity with the active-character classification
+     *          fast path. Returns true if hash N has an entry in the
+     *          character-specific part map. Caller is expected to follow
+     *          up with classify_part_for and is_any_category_hidden_for.
+     */
+    [[nodiscard]] bool needs_classification_for(uint32_t hash,
+                                                int charIdx) noexcept;
+
     /** @brief Recompute cached hidden-state masks from category_states(). Call after any mutation. */
     void update_hidden_mask();
 
@@ -242,5 +287,19 @@ namespace EquipHide
      *          not overlap a second rebuild.
      */
     const std::unordered_map<uint32_t, CategoryMask> &get_part_map();
+
+    /**
+     * @brief Returns the per-character part map for a specific protagonist idx.
+     * @details Built alongside the active-map double-buffer in
+     *          rebuild_part_lookup(); each character's map is a snapshot of
+     *          (base [Section] Parts merged with that character's
+     *          [Section:CharName] override) at the last rebuild point.
+     *          Caller MUST pass a valid charIdx (0..kCharIdxCount-1);
+     *          the active-character fallback is the consumer's
+     *          responsibility (see is_any_category_hidden_for and the
+     *          direct-write loop for the canonical pattern).
+     */
+    [[nodiscard]] const std::unordered_map<uint32_t, CategoryMask> &
+    get_part_map_for(int charIdx) noexcept;
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -318,7 +318,47 @@ namespace EquipHide
         if (!check_player_filter(a1))
             return;
 
-        if (is_any_category_hidden(mask))
+        // Per-character override resolution. The cascade and chest-lock
+        // paths above gate engine-wide state and intentionally use the
+        // GLOBAL classify_part / is_any_category_hidden masks; this block
+        // keeps the actual vis=2 write per-character so an INI override
+        // that excludes a hash for one protagonist does not get hidden
+        // by the mid-hook on that protagonist's frames.
+        //
+        // The vis-ctrl scan is O(n) where n is at most k_maxProtagonists
+        // (3 after the phantom-filter ship), so the added cost is a
+        // handful of relaxed atomic loads + one extra flat-table lookup
+        // per call. Relaxed ordering is sufficient: the resolve poll
+        // thread publishes consistent (visCtrls[i], visCharIdx[i])
+        // pairs on each pass, and a torn read produces at worst one
+        // stale per-char idx for a single frame, well within the
+        // existing swap-detect timing tolerance.
+        int charIdx = -1;
+        {
+            auto &ps = player_state();
+            const auto vcCount = ps.count.load(std::memory_order_relaxed);
+            for (int i = 0; i < vcCount; ++i)
+            {
+                if (ps.visCtrls[i].load(std::memory_order_relaxed) == a1)
+                {
+                    charIdx = ps.visCharIdx[i].load(std::memory_order_relaxed);
+                    break;
+                }
+            }
+        }
+
+        // Refine the hide decision against the per-character part map.
+        // charIdx == -1 (untracked actor) preserves legacy behaviour by
+        // falling back to the global mask computed earlier.
+        CategoryMask charMask = mask;
+        if (charIdx >= 0 && charIdx < static_cast<int>(kCharIdxCount))
+        {
+            charMask = classify_part_for(partHash, charIdx);
+            if (charMask == 0)
+                return; // hash excluded from this character's effective Parts
+        }
+
+        if (is_any_category_hidden_for(charMask, charIdx))
         {
             auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x1C);
             *visPtr = 2;
@@ -422,30 +462,54 @@ namespace EquipHide
             logger.info("Player identification: global pointer chain");
         }
 
-        if (addrs.mapLookup)
-        {
-            auto runtimeHashes = scan_indexed_string_table(addrs.mapLookup);
-            if (!runtimeHashes.empty())
-            {
-                logger.info("IndexedStringA scan: {} entries resolved at init",
-                            runtimeHashes.size());
-                set_runtime_hashes(std::move(runtimeHashes));
-            }
-            else
-            {
-                logger.info("IndexedStringA table not ready at init, "
-                            "starting deferred scan thread");
-                deferred_scan_pending().store(true, std::memory_order_relaxed);
-                launch_deferred_scan();
-            }
-        }
-        else
+        if (!addrs.mapLookup)
         {
             logger.warning("MapLookup not resolved, cannot scan IndexedStringA table");
         }
 
         load_config();
         original_vis_map().reserve(get_part_map().size());
+
+        // Initial IndexedStringA scan + deferred-launch decision.
+        // Mirrors LiveTransmog's transmog_worker pattern: commit the sync
+        // attempt so the mod is immediately functional, then launch the
+        // deferred worker unless the table is already fully resolved on
+        // the first try. Convergence in the worker is stability-based
+        // (LT's structural-ready analog), not a coverage percentage.
+        if (addrs.mapLookup)
+        {
+            auto runtimeHashes = scan_indexed_string_table(addrs.mapLookup);
+            const auto initialResolved = runtimeHashes.size();
+            const auto totalExpected = total_part_count();
+
+            if (initialResolved > 0)
+                set_runtime_hashes(std::move(runtimeHashes));
+
+            const bool fullyResolved = totalExpected > 0 &&
+                                       initialResolved == totalExpected;
+            if (!fullyResolved)
+            {
+                logger.info(
+                    "IndexedStringA scan: {}/{} entries at init, "
+                    "starting deferred scan thread (stability-check mode)",
+                    initialResolved, totalExpected);
+                deferred_scan_pending().store(true, std::memory_order_relaxed);
+                launch_deferred_scan();
+            }
+            else
+            {
+                logger.info(
+                    "IndexedStringA scan: {}/{} entries at init "
+                    "(fully resolved, no deferred retry)",
+                    initialResolved, totalExpected);
+            }
+
+            // Rebuild the part lookup against whatever subset got committed
+            // so the active map reflects the partial-or-full hash set.
+            // The deferred worker will rebuild again when it converges.
+            if (initialResolved > 0)
+                rebuild_part_lookup();
+        }
 
         // Mid-body scan with the shared cascade resolver. The
         // prologue-fallback variant survives dev hot-reload: when a
@@ -649,22 +713,38 @@ namespace EquipHide
 
     void shutdown()
     {
-        DMK::Logger::get_instance().info("{} shutting down...", MOD_NAME);
+        auto &logger = DMK::Logger::get_instance();
+        logger.info("{} shutting down...", MOD_NAME);
 
+        // Per-step bracket logs around each blocking call let any
+        // future shutdown stall be pinpointed to the exact step
+        // (worker join, vis-byte cleanup, DMK teardown, etc.). The
+        // teardown path crosses several mutexes and the SafetyHook
+        // trampoline drain window, so a silent hang would otherwise
+        // be undiagnosable from the user's log alone. Logger::flush()
+        // between steps drains the async queue so a hang inside a
+        // step still surfaces every line the prior step emitted.
+        logger.info("{} shutdown: step 1 disable_auto_reload", MOD_NAME);
         // Disable the INI watcher up front so an in-flight save event
         // cannot fire setters while we are tearing state down.
         DMK::Config::disable_auto_reload();
+        logger.flush();
 
+        logger.info("{} shutdown: step 2 signal stop", MOD_NAME);
         shutdown_requested().store(true, std::memory_order_relaxed);
         lazy_probe_pending().store(false, std::memory_order_relaxed);
+        logger.flush();
 
+        logger.info("{} shutdown: step 3 join workers", MOD_NAME);
         // Drain workers before the DMK teardown removes the hooks they
         // call into. shutdown_requested is the cooperative stop signal
         // each StoppableWorker body polls; joining them first guarantees
         // no worker is mid-call into a SafetyHook trampoline when the
         // trampoline pages are unmapped.
         join_background_threads();
+        logger.flush();
 
+        logger.info("{} shutdown: step 4 cleanup vis bytes", MOD_NAME);
         // Restore visibility bytes while the hooks are still installed
         // and the game's part registry is reachable. The vis-byte
         // cleanup walks per-actor arrays and writes back the original
@@ -672,7 +752,9 @@ namespace EquipHide
         // would race the loader unmapping the Logic-DLL pages backing
         // the cleanup function itself.
         cleanup_vis_bytes();
+        logger.flush();
 
+        logger.info("{} shutdown: step 5 DMK_Shutdown", MOD_NAME);
         // Full DMK teardown: removes every managed hook (EquipVisCheck,
         // PartAddShow, PostfixEval, VisualEquipChange, VisualEquipSwap),
         // stops and clears the InputManager poller along with its
@@ -683,8 +765,12 @@ namespace EquipHide
         // if the snapshot is null, defending the brief drain window
         // between hook removal and DLL unmap.
         DMK_Shutdown();
+        logger.flush();
 
+        logger.info("{} shutdown: step 6 clear hotkey guards", MOD_NAME);
         clear_hotkey_guards();
+        logger.info("{} shutdown complete", MOD_NAME);
+        logger.flush();
     }
 
 } // namespace EquipHide

--- a/CrimsonDesertEquipHide/src/input_handler.cpp
+++ b/CrimsonDesertEquipHide/src/input_handler.cpp
@@ -44,6 +44,14 @@ namespace EquipHide
             ps.armorInjected[i].store(false, std::memory_order_relaxed);
 
         inject_armor_entries();
+        /* Publish the request before attempting the write inline. If
+           apply_direct_vis_write loses the lock race against the
+           mid-hook or resolve poll, the next mid-hook tick clears the
+           flag and re-runs the write -- the toggle is no longer
+           silently dropped on contention. The inline call below still
+           executes on the common (uncontended) path so single-shot
+           hotkey latency is unchanged. */
+        needs_direct_write().store(true, std::memory_order_release);
         apply_direct_vis_write();
     }
 

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -185,37 +185,189 @@ namespace EquipHide
                 set_active_character(idx);
             }
 
-            static constexpr ptrdiff_t k_bodyOffsets[] = {
-                0xD0, 0xD8, 0xE0, 0xE8, 0xF0, 0xF8, 0x100, 0x108};
+            /* Protagonist enumeration -- two complementary walks.
+               The UA+0xD0..+0x108 stride-8 array is the PRIMARY
+               source: it always carries the controlled body and on
+               multi-protagonist saves typically also the anchor and
+               at least one party-member slot. Per-slot SEH and a
+               vtable filter give deterministic identity decoding via
+               the same +0x68 / +0x40 / +0xE8 chain the body-to-vc
+               resolver uses. The ActorManager body pool at AM+0xF0
+               AUGMENTS the UA walk to pick up summoned party members
+               that the UA stride does not expose on every build
+               (observed: third party member surfacing only through
+               the AM pool on certain world states). The dedupe pass
+               below skips an AM entry whose vis_ctrl already matches
+               a UA-walk slot.
+
+               AM-pool field layout:
+                 AM+0xF0 = body pointer array (densely populated)
+                 AM+0xF8 = packed u64 -- LOW u32 = count, HIGH u32 = cap.
+                           Iterate against `cap` (HIGH u32) because the
+                           count field has been observed reading 0 on
+                           populated worlds while the allocation cap
+                           still reflects the entries that exist; using
+                           count would skip every live body. The hard
+                           cap k_amBodyArrayHardCap below absorbs a
+                           torn HIGH u32 that overflows reasonable
+                           pool sizes.
+                 body+0x50 = slot byte. NOT a reliable discriminator
+                             in this pool (live entries seen carrying
+                             values like 0x23). Acceptance is on vtable
+                             equality + CDCore positive identity decode
+                             below; the slot byte is read only inside
+                             CDCore's own pointer-validity discipline.
+               read_qword_unsafe is required because the standard
+               read_ptr_unsafe filters values below 0x10000 to zero,
+               which would discard the entire packed field whenever
+               either half lives in that range. */
+            constexpr ptrdiff_t k_amBodyArrayDataOff   = 0xF0;
+            constexpr ptrdiff_t k_amBodyArrayPackedOff = 0xF8;
+            constexpr uint32_t  k_amBodyArrayHardCap   = 4096;
 
             int count = 0;
-            for (auto off : k_bodyOffsets)
+            int uaWalkCount = 0;
+            int amWalkCount = 0;
+
+            /* PRIMARY: UA stride walk over user+{0xD0, 0xD8, 0xE0,
+               0xE8, 0xF0, 0xF8, 0x100, 0x108}. Per-slot SEH absorbs a
+               single stale pointer without aborting the rest. */
+            constexpr ptrdiff_t k_uaStrideOffsets[] = {
+                0xD0, 0xD8, 0xE0, 0xE8, 0xF0, 0xF8, 0x100, 0x108
+            };
+            for (auto off : k_uaStrideOffsets)
             {
                 if (count >= k_maxProtagonists)
                     break;
-
-                /* Per-slot SEH so one bad body pointer does not abort the loop. */
                 __try
                 {
-                    auto candidate = read_ptr_unsafe(user, off);
+                    const auto candidate = read_ptr_unsafe(user, off);
                     if (!candidate)
                         continue;
 
-                    auto vt = read_ptr_unsafe(candidate, 0);
+                    const auto vt = read_ptr_unsafe(candidate, 0);
                     if (vt != addrs.childActorVtbl)
                         continue;
 
-                    auto vc = body_to_vis_ctrl(candidate);
-                    if (vc)
-                        ps.visCtrls[count++] = vc;
+                    const auto vc = body_to_vis_ctrl(candidate);
+                    if (!vc)
+                        continue;
+
+                    bool dup = false;
+                    for (int k = 0; k < count; ++k)
+                    {
+                        if (ps.visCtrls[k].load(std::memory_order_relaxed) == vc)
+                        {
+                            dup = true;
+                            break;
+                        }
+                    }
+                    if (dup)
+                        continue;
+
+                    const auto idxU32 =
+                        CDCore::resolve_character_idx_for_body(candidate);
+                    const int charIdx = (idxU32 >= 1 && idxU32 <= 3)
+                                            ? static_cast<int>(idxU32) - 1
+                                            : -1;
+
+                    ps.visCtrls[count].store(vc, std::memory_order_relaxed);
+                    ps.visCharIdx[count].store(charIdx, std::memory_order_relaxed);
+                    ++count;
+                    ++uaWalkCount;
                 }
                 __except (EXCEPTION_EXECUTE_HANDLER)
                 {
                 }
             }
 
+            /* AUGMENT: AM body-pool walk. Iterates against the HIGH u32
+               of AM+0xF8 (cap) because the LOW u32 (count) has been
+               observed reading 0 on populated worlds. Vtable-only
+               filter at this point (slot-byte at +0x50 is unreliable
+               in this pool); positive identity decode via CDCore is
+               required below before admitting any candidate, so a
+               vtable-equal NPC sharing the protagonist child-actor
+               class cannot leak in. Dedupe against the UA-walk
+               results so a body appearing in both sources occupies
+               a single visCtrls slot. */
+            const auto bodyArr = read_ptr_unsafe(am, k_amBodyArrayDataOff);
+            if (bodyArr)
+            {
+                const uint64_t packed =
+                    read_qword_unsafe(am, k_amBodyArrayPackedOff);
+                const uint32_t cap = static_cast<uint32_t>(packed >> 32);
+                uint32_t iterCount = cap;
+                if (iterCount > k_amBodyArrayHardCap)
+                {
+                    static std::atomic<bool> s_clampLogged{false};
+                    if (!s_clampLogged.exchange(true, std::memory_order_relaxed))
+                        DMK::Logger::get_instance().warning(
+                            "Resolve: AM body-pool cap {} exceeds hard cap {}; clamping",
+                            cap, k_amBodyArrayHardCap);
+                    iterCount = k_amBodyArrayHardCap;
+                }
+
+                for (uint32_t i = 0; i < iterCount && count < k_maxProtagonists; ++i)
+                {
+                    /* Per-entry SEH so a single stale / NULL slot does
+                       not abort enumeration of the rest of the pool. */
+                    __try
+                    {
+                        const auto candidate = read_ptr_unsafe(
+                            bodyArr, static_cast<ptrdiff_t>(i) * 8);
+                        if (!candidate)
+                            continue;
+
+                        const auto vt = read_ptr_unsafe(candidate, 0);
+                        if (vt != addrs.childActorVtbl)
+                            continue;
+
+                        const auto vc = body_to_vis_ctrl(candidate);
+                        if (!vc)
+                            continue;
+
+                        bool dup = false;
+                        for (int k = 0; k < count; ++k)
+                        {
+                            if (ps.visCtrls[k].load(std::memory_order_relaxed) == vc)
+                            {
+                                dup = true;
+                                break;
+                            }
+                        }
+                        if (dup)
+                            continue;
+
+                        /* Vtable equality alone admits companions and
+                           horses sharing the protagonist child-actor
+                           class, which would flood visCtrls with
+                           phantom slots that consume the cap and
+                           receive the active character's mask. Require
+                           a positive CDCore identity decode (1..3)
+                           before admitting an AM candidate. */
+                        const auto idxU32 =
+                            CDCore::resolve_character_idx_for_body(candidate);
+                        if (idxU32 < 1 || idxU32 > 3)
+                            continue;
+                        const int charIdx = static_cast<int>(idxU32) - 1;
+
+                        ps.visCtrls[count].store(vc, std::memory_order_relaxed);
+                        ps.visCharIdx[count].store(charIdx, std::memory_order_relaxed);
+                        ++count;
+                        ++amWalkCount;
+                    }
+                    __except (EXCEPTION_EXECUTE_HANDLER)
+                    {
+                    }
+                }
+            }
+
             for (int i = count; i < k_maxProtagonists; ++i)
+            {
                 ps.visCtrls[i].store(0, std::memory_order_relaxed);
+                ps.visCharIdx[i].store(-1, std::memory_order_relaxed);
+            }
 
             ps.primaryVisCtrl.store(
                 count > 0 ? ps.visCtrls[0].load(std::memory_order_relaxed) : 0,
@@ -232,6 +384,15 @@ namespace EquipHide
                     DMK::Logger::get_instance().debug(
                         "Resolve: ws=0x{:X} am=0x{:X} user=0x{:X} count={}",
                         ws, am, user, count);
+            }
+            if (count > 0)
+            {
+                static std::atomic<bool> s_resolvedLogged{false};
+                if (!s_resolvedLogged.exchange(true, std::memory_order_relaxed))
+                    DMK::Logger::get_instance().info(
+                        "Player set resolved: {} protagonist(s) tracked "
+                        "(UA-walk={}, AM-walk={})",
+                        count, uaWalkCount, amWalkCount);
             }
             if (count > 0)
             {
@@ -344,6 +505,16 @@ namespace EquipHide
                                         expected, n + 1, std::memory_order_relaxed))
                                 {
                                     ps.visCtrls[n].store(a1, std::memory_order_relaxed);
+                                    /* Fallback path runs when the global
+                                       chain-walk AOB failed at init, so
+                                       the body pointer underlying `a1`
+                                       is not directly reachable -- mark
+                                       the slot's identity as unknown.
+                                       Consumers fall back to the active
+                                       character's hide mask, mirroring
+                                       single-character semantics for
+                                       unidentified slots. */
+                                    ps.visCharIdx[n].store(-1, std::memory_order_relaxed);
                                     ps.primaryVisCtrl.store(
                                         ps.visCtrls[0].load(std::memory_order_relaxed),
                                         std::memory_order_relaxed);

--- a/CrimsonDesertEquipHide/src/shared_state.cpp
+++ b/CrimsonDesertEquipHide/src/shared_state.cpp
@@ -3,9 +3,27 @@
 namespace EquipHide
 {
     static ResolvedAddresses s_resolvedAddrs{};
-    static PlayerState s_playerState{};
+    // Initialise visCharIdx to -1 (unknown) so any pre-resolve consumer
+    // (e.g. apply_direct_vis_write firing before resolve_player_vis_ctrls
+    // has populated the slots) treats the entry as "no per-character
+    // override -- fall back to the active character's hide mask".
+    // PlayerState's default ctor zero-inits the array; bring up an
+    // initialiser helper invoked at first access via construct-on-first-use.
+    static PlayerState &make_player_state() noexcept
+    {
+        static PlayerState state{};
+        static const bool s_seeded = []() noexcept
+        {
+            for (int i = 0; i < k_maxProtagonists; ++i)
+                state.visCharIdx[i].store(-1, std::memory_order_relaxed);
+            return true;
+        }();
+        (void)s_seeded;
+        return state;
+    }
+
     static std::mutex s_visWriteMtx;
-    static std::unordered_map<uintptr_t, uint8_t> s_originalVis;
+    static std::unordered_map<VisKey, uint8_t, VisKeyHash> s_originalVis;
     static std::atomic<bool> s_needsDirectWrite{false};
 
     static std::atomic<bool> s_playerOnly{true};
@@ -22,9 +40,9 @@ namespace EquipHide
     static std::atomic<int64_t> s_lazyProbeSignal{0};
 
     ResolvedAddresses &resolved_addrs() { return s_resolvedAddrs; }
-    PlayerState &player_state() { return s_playerState; }
+    PlayerState &player_state() { return make_player_state(); }
     std::mutex &vis_write_mutex() { return s_visWriteMtx; }
-    std::unordered_map<uintptr_t, uint8_t> &original_vis_map() { return s_originalVis; }
+    std::unordered_map<VisKey, uint8_t, VisKeyHash> &original_vis_map() { return s_originalVis; }
     std::atomic<bool> &needs_direct_write() { return s_needsDirectWrite; }
 
     std::atomic<bool> &flag_player_only() { return s_playerOnly; }

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -40,10 +40,21 @@ namespace EquipHide
 
     ResolvedAddresses &resolved_addrs();
 
-    /** @brief Per-protagonist vis_ctrl pointers and injection state. */
+    /** @brief Per-protagonist vis_ctrl pointers and injection state.
+     *  @details visCharIdx is parallel to visCtrls: visCharIdx[i] holds
+     *           the 0-based protagonist index (0=Kliff, 1=Damiane,
+     *           2=Oongka) that visCtrls[i] belongs to, or -1 when the
+     *           identity could not be resolved (NPC follower, unknown
+     *           protagonist, or transient torn read just after a swap).
+     *           Entries with idx == -1 fall back to the active-character
+     *           hide-mask in the per-character hide write so old single-
+     *           character behaviour is preserved for unidentified slots.
+     *           Stored as int32 atomics because std::atomic<signed char>
+     *           is not guaranteed lock-free on x64. */
     struct PlayerState
     {
         std::atomic<uintptr_t> visCtrls[k_maxProtagonists]{};
+        std::atomic<int> visCharIdx[k_maxProtagonists]{};
         std::atomic<int> count{0};
         std::atomic<uintptr_t> primaryVisCtrl{0};
         std::atomic<bool> armorInjected[k_maxProtagonists]{};
@@ -54,8 +65,48 @@ namespace EquipHide
     /** @brief Mutex guarding direct vis-byte writes and original-value map. */
     std::mutex &vis_write_mutex();
 
-    /** @brief Map of vis-byte addresses to their original values before modification. */
-    std::unordered_map<uintptr_t, uint8_t> &original_vis_map();
+    /**
+     * @brief Composite key for the per-(visCtrl, address) original-value map.
+     * @details Keying purely on the vis-byte address makes character-swap
+     *          invalidation lossy: two protagonists sharing the same part
+     *          name resolve to two distinct vis-byte addresses, but
+     *          orphan-restoring "every entry whose hash is not in the
+     *          active map" would also revert the previously-active
+     *          character's vis bytes back to visible because that
+     *          character's vis ctrl no longer ticks through
+     *          apply_direct_vis_write. Including visCtrl in the key
+     *          scopes restore decisions to the matching vis ctrl and
+     *          leaves the inactive character's hide state in place.
+     */
+    struct VisKey
+    {
+        uintptr_t visCtrl;
+        uintptr_t addr;
+
+        bool operator==(const VisKey &other) const noexcept
+        {
+            return visCtrl == other.visCtrl && addr == other.addr;
+        }
+    };
+
+    /** @brief Hash for VisKey -- xor mix of the two pointer fields. */
+    struct VisKeyHash
+    {
+        std::size_t operator()(const VisKey &k) const noexcept
+        {
+            // The two fields are unrelated heap addresses on x64; xor
+            // mix is sufficient because the std lib hashes each field
+            // through a strong integer hash before composition is even
+            // observable. Rotate one half so two pointers that happen
+            // to alias do not collapse to zero.
+            const auto a = std::hash<uintptr_t>{}(k.visCtrl);
+            const auto b = std::hash<uintptr_t>{}(k.addr);
+            return a ^ (b + 0x9e3779b97f4a7c15ULL + (a << 6) + (a >> 2));
+        }
+    };
+
+    /** @brief Map of (vis_ctrl, vis-byte address) pairs to their original values. */
+    std::unordered_map<VisKey, uint8_t, VisKeyHash> &original_vis_map();
 
     /** @brief Flag set when vis-byte writes need to be flushed. */
     std::atomic<bool> &needs_direct_write();
@@ -89,6 +140,19 @@ namespace EquipHide
     {
         auto addr = *reinterpret_cast<const uintptr_t *>(base + off);
         return (addr > 0x10000) ? addr : 0;
+    }
+
+    /** @brief Unsafe raw u64 read -- use ONLY inside SEH-protected hot paths.
+     *  @details Companion to `read_ptr_unsafe` for fields that hold packed
+     *           non-pointer data such as the AM body-pool count/cap pair at
+     *           AM+0xF8 (low u32 = count, high u32 = cap). The
+     *           pointer-validity rejection in `read_ptr_unsafe` would zero
+     *           the entire qword for any value below 0x10000, which is
+     *           wrong for a packed integer field whose low half routinely
+     *           lives in that range. Returns the raw value verbatim. */
+    inline uint64_t read_qword_unsafe(uintptr_t base, ptrdiff_t off) noexcept
+    {
+        return *reinterpret_cast<const uint64_t *>(base + off);
     }
 
     /** @brief Returns true if the part at the given hash pointer is hidden by any category. */

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -1,4 +1,5 @@
 #include "visibility_write.hpp"
+#include "categories.hpp"
 #include "shared_state.hpp"
 
 #include <DetourModKit.hpp>
@@ -6,6 +7,7 @@
 #include <Windows.h>
 
 #include <algorithm>
+#include <array>
 #include <vector>
 
 namespace EquipHide
@@ -13,145 +15,255 @@ namespace EquipHide
     /* File-scope scratch buffer reused across apply_direct_vis_write calls.
        Populated under vis_write_mutex (held for the full duration of the
        function) so concurrent callers never race. File scope rather than a
-       local inside the __try block both avoids MSVC C2712 (no
-       non-trivially-destructible object sharing scope with __try) and
-       keeps the stack small for game threads with tight stack reserves. */
-    static std::vector<std::uintptr_t> s_touchedVisAddrs;
+       local inside the __try block keeps the stack small for game threads
+       with tight stack reserves and side-steps MSVC C2712.
+
+       Stores composite (vis_ctrl, addr) keys so the orphan sweep can
+       distinguish "this address is no longer in any character's part
+       map" (true orphan -- restore) from "this address belongs to a
+       different vis_ctrl that has already been processed in this pass"
+       (not an orphan -- leave alone). Address-only keying would
+       restore the previously-active character's vis bytes back to
+       visible on a swap, because the new character's vis ctrl does
+       not iterate the outgoing character's vis-byte addresses. */
+    static std::vector<VisKey> s_touchedVisKeys;
+
+    /* File-scope active vis-ctrl scratch for the orphan sweep. */
+    static std::array<std::uintptr_t, k_maxProtagonists> s_activeVisCtrls{};
+
+    /* Stateless less-than comparator on (vis_ctrl, addr) lexicographic
+       order. Free function (not a lambda) so it can sit alongside __try
+       without tripping C2712 on captured lambdas. */
+    static bool vis_key_less(const VisKey &a, const VisKey &b) noexcept
+    {
+        if (a.visCtrl != b.visCtrl)
+            return a.visCtrl < b.visCtrl;
+        return a.addr < b.addr;
+    }
+
+    /* Implementation body extracted out of the SEH-wrapped public entry
+       point so MSVC's C2712 ("Cannot use __try in functions that require
+       object unwinding") does not fire. The new per-(vis_ctrl, addr)
+       keyed map and the per-character map selection both introduce
+       hidden temporaries (VisKey rvalues, conditional reference
+       materialisation, structured-binding pair access on a map keyed by
+       a class type) that MSVC reports as object unwinding requirements
+       and refuses to combine with __try. Pattern mirrors
+       equip_hide.cpp::on_vis_check_impl. */
+    static void apply_direct_vis_write_impl() noexcept
+    {
+        auto &addrs = resolved_addrs();
+        auto &logger = DMK::Logger::get_instance();
+        auto lookup = reinterpret_cast<MapLookupFn>(addrs.mapLookup);
+        auto &ps = player_state();
+        auto &origVis = original_vis_map();
+        const auto n = ps.count.load(std::memory_order_relaxed);
+        int hiddenCount = 0;
+        int restoredCount = 0;
+
+        for (int i = 0; i < n; ++i)
+        {
+            auto vc = ps.visCtrls[i].load(std::memory_order_relaxed);
+            if (!vc)
+                continue;
+
+            /* Per-slot character idx. -1 (unknown body, fallback path,
+               pre-resolve) collapses to the active character's map via
+               classify_part_for / is_any_category_hidden_for so
+               unidentified slots preserve single-character semantics. */
+            const int charIdx =
+                ps.visCharIdx[i].load(std::memory_order_relaxed);
+
+            auto comp = read_ptr_unsafe(vc, 0x58);
+            if (!comp)
+            {
+                logger.trace("DirectWrite [{}]: vc=0x{:X} comp=NULL (+0x58)",
+                             i, vc);
+                continue;
+            }
+            auto descNode = read_ptr_unsafe(comp, 0x218);
+            if (!descNode)
+            {
+                logger.trace("DirectWrite [{}]: vc=0x{:X} comp=0x{:X} "
+                             "descNode=NULL (+0x218)", i, vc, comp);
+                continue;
+            }
+            auto mapBase = descNode + 0x20;
+
+            /* Choose the character-specific map for the iteration.
+               charIdx == -1 routes to the active-character map so a
+               slot we could not identify still cycles through the
+               full active-character part list. */
+            const auto *partMapPtr =
+                (charIdx >= 0 && charIdx < static_cast<int>(kCharIdxCount))
+                    ? &get_part_map_for(charIdx)
+                    : &get_part_map();
+
+            for (auto pmIt = partMapPtr->begin();
+                 pmIt != partMapPtr->end(); ++pmIt)
+            {
+                const auto hash = pmIt->first;
+                const auto mask = pmIt->second;
+
+                auto entry = lookup(mapBase, &hash);
+                if (!entry)
+                    continue;
+
+                const auto visAddr = entry + 0x1C;
+                const VisKey key{vc, visAddr};
+                s_touchedVisKeys.push_back(key);
+                auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
+
+                /* Per-character hidden-state lookup: classify_part_for
+                   has already produced `mask` from the per-character
+                   map. is_any_category_hidden_for currently mirrors
+                   the active-character helper because the Hidden /
+                   Enabled toggles are global -- only the parts list
+                   is per-character. Plumbed regardless so a future
+                   per-character Hidden / Enabled overlay slots in
+                   without re-touching this hot path. */
+                if (is_any_category_hidden_for(mask, charIdx))
+                {
+                    if (origVis.find(key) == origVis.end())
+                        origVis[key] = *visPtr;
+                    *visPtr = 2;
+                    ++hiddenCount;
+                    logger.trace("  [{}] 0x{:04X} hidden (vis=2, char_idx={})",
+                                 i, hash, charIdx);
+                }
+                else
+                {
+                    auto it = origVis.find(key);
+                    if (it != origVis.end())
+                    {
+                        const auto restored = (it->second == 2) ? 0 : it->second;
+                        *visPtr = static_cast<uint8_t>(restored);
+                        logger.trace("  [{}] 0x{:04X} restored (vis={}, char_idx={})",
+                                     i, hash, restored, charIdx);
+                        origVis.erase(it);
+                        ++restoredCount;
+                    }
+                    else if (flag_force_show().load(std::memory_order_relaxed))
+                    {
+                        *visPtr = 0;
+                        ++restoredCount;
+                        logger.trace("  [{}] 0x{:04X} force-shown (vis=0, char_idx={})",
+                                     i, hash, charIdx);
+                    }
+                }
+            }
+        }
+
+        /* Orphan sweep, per-vis-ctrl edition.
+           An entry in origVis is considered orphaned ONLY when its
+           vis_ctrl matches a vis_ctrl that was processed this pass
+           (i.e. that vis_ctrl is currently in ps.visCtrls) AND no
+           (vis_ctrl, addr) pair we just touched matches the entry's
+           key. Entries belonging to a vis_ctrl that is no longer in
+           the active player set are untouched -- they will be cleaned
+           up by cleanup_vis_bytes() at shutdown -- so a character swap
+           does not strip the inactive character's hide state from the
+           now-unwatched vis_ctrl. An unconditional sweep that ignored
+           vis_ctrl identity would walk only the active character's
+           part map, find every previously-active character's vis-byte
+           address absent from the touched set, and restore them to
+           visible -- silently undoing the prior character's hide
+           state on every swap.
+
+           Sort + binary_search on composite keys: lexicographic
+           (vis_ctrl, addr) ordering keeps the active-vis-ctrl set
+           clustered and matches the equality semantics of VisKey. */
+        std::sort(s_touchedVisKeys.begin(), s_touchedVisKeys.end(),
+                  vis_key_less);
+
+        s_activeVisCtrls.fill(0);
+        int activeCount = 0;
+        for (int i = 0; i < n && activeCount < k_maxProtagonists; ++i)
+        {
+            auto vc = ps.visCtrls[i].load(std::memory_order_relaxed);
+            if (vc)
+                s_activeVisCtrls[activeCount++] = vc;
+        }
+
+        int orphanRestored = 0;
+        for (auto it = origVis.begin(); it != origVis.end();)
+        {
+            const auto entryKey = it->first;
+
+            bool vcIsActive = false;
+            for (int j = 0; j < activeCount; ++j)
+            {
+                if (s_activeVisCtrls[j] == entryKey.visCtrl)
+                {
+                    vcIsActive = true;
+                    break;
+                }
+            }
+            if (!vcIsActive)
+            {
+                /* vis_ctrl is no longer tracked -- this entry's
+                   character has been swapped out or the player set
+                   changed shape entirely. Leave the vis byte alone so
+                   the inactive character's hide state survives the
+                   swap; cleanup_vis_bytes() at shutdown handles the
+                   final restore. */
+                ++it;
+                continue;
+            }
+            if (std::binary_search(s_touchedVisKeys.begin(),
+                                   s_touchedVisKeys.end(), entryKey,
+                                   vis_key_less))
+            {
+                ++it;
+                continue;
+            }
+
+            auto *visPtr = reinterpret_cast<uint8_t *>(entryKey.addr);
+            const auto origVal = it->second;
+            const auto restored = (origVal == 2) ? 0 : origVal;
+            *visPtr = static_cast<uint8_t>(restored);
+            it = origVis.erase(it);
+            ++orphanRestored;
+        }
+        if (orphanRestored > 0)
+            logger.debug(
+                "DirectWrite: {} orphan vis bytes restored "
+                "(category change for active vis ctrls)",
+                orphanRestored);
+        restoredCount += orphanRestored;
+
+        logger.trace("DirectWrite: {} protagonists, {} hidden, {} restored",
+                     n, hiddenCount, restoredCount);
+    }
 
     void apply_direct_vis_write() noexcept
     {
         auto &addrs = resolved_addrs();
         if (!addrs.mapLookup)
             return;
-        /* Manual lock/unlock: MSVC SEH does not run C++ destructors on unwind
-           under /EHsc, so an RAII lock would stay held after a caught fault. */
+        /* Manual lock/unlock: MSVC SEH does not run C++ destructors on
+           unwind under /EHsc, so an RAII lock would stay held after a
+           caught fault. */
         auto &mtx = vis_write_mutex();
         if (!mtx.try_lock())
+        {
+            /* Lost the lock race against another writer (mid-hook,
+               resolve poll, or a second input-thread tick). Republish
+               the work-pending signal so the mid-hook re-runs us on
+               the next game frame; without this the toggle that
+               triggered this call would be silently dropped and the
+               user-visible vis byte would not flip. */
+            needs_direct_write().store(true, std::memory_order_release);
+            DMK::Logger::get_instance().trace(
+                "DirectWrite: try_lock failed, deferred to mid-hook");
             return;
+        }
 
-        s_touchedVisAddrs.clear();
+        s_touchedVisKeys.clear();
 
         __try
         {
-            auto &logger = DMK::Logger::get_instance();
-            auto lookup = reinterpret_cast<MapLookupFn>(addrs.mapLookup);
-            auto &ps = player_state();
-            auto &origVis = original_vis_map();
-            const auto n = ps.count.load(std::memory_order_relaxed);
-            int hiddenCount = 0;
-            int restoredCount = 0;
-
-            for (int i = 0; i < n; ++i)
-            {
-                auto vc = ps.visCtrls[i].load(std::memory_order_relaxed);
-                if (!vc)
-                    continue;
-
-                auto comp = read_ptr_unsafe(vc, 0x58);
-                if (!comp)
-                {
-                    logger.trace("DirectWrite [{}]: vc=0x{:X} comp=NULL (+0x58)",
-                                 i, vc);
-                    continue;
-                }
-                auto descNode = read_ptr_unsafe(comp, 0x218);
-                if (!descNode)
-                {
-                    logger.trace("DirectWrite [{}]: vc=0x{:X} comp=0x{:X} "
-                                 "descNode=NULL (+0x218)", i, vc, comp);
-                    continue;
-                }
-                auto mapBase = descNode + 0x20;
-
-                for (const auto &[hash, mask] : get_part_map())
-                {
-                    auto entry = lookup(mapBase, &hash);
-                    if (!entry)
-                        continue;
-
-                    const auto visAddr = entry + 0x1C;
-                    s_touchedVisAddrs.push_back(visAddr);
-                    auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
-
-                    if (is_any_category_hidden(mask))
-                    {
-                        if (origVis.find(visAddr) == origVis.end())
-                            origVis[visAddr] = *visPtr;
-                        *visPtr = 2;
-                        ++hiddenCount;
-                        logger.trace("  [{}] 0x{:04X} hidden (vis=2)",
-                                     i, hash);
-                    }
-                    else
-                    {
-                        auto it = origVis.find(visAddr);
-                        if (it != origVis.end())
-                        {
-                            const auto restored = (it->second == 2) ? 0 : it->second;
-                            *visPtr = static_cast<uint8_t>(restored);
-                            logger.trace("  [{}] 0x{:04X} restored (vis={})",
-                                         i, hash, restored);
-                            origVis.erase(it);
-                            ++restoredCount;
-                        }
-                        else if (flag_force_show().load(std::memory_order_relaxed))
-                        {
-                            *visPtr = 0;
-                            ++restoredCount;
-                            logger.trace("  [{}] 0x{:04X} force-shown (vis=0)",
-                                         i, hash);
-                        }
-                    }
-                }
-            }
-
-            /* Orphan sweep. An entry lands here when its hash was in the
-               active character's hidden category at a previous apply pass
-               (so we wrote vis=2 and cached the original in origVis) but
-               is no longer in the part map for the current character (or
-               its category stopped being registered). The main loop above
-               iterates only the active character's map, so those orphan
-               entries would otherwise retain vis=2 indefinitely. Since
-               part-mesh names are shared across protagonists (e.g.
-               CD_Upperbody / CD_Vest exist on every humanoid), the
-               leaked vis=2 write from the previous character causes the
-               matching mesh on the new character to render hidden until
-               shutdown triggers cleanup_vis_bytes().
-
-               The touched-address vector is sorted once (cheap: at most a
-               few hundred entries) and orphan membership is resolved via
-               binary_search, giving O((|orig| + |touched|) * log(|touched|))
-               for the sweep. Restored bytes use the same (origVal == 2 ?
-               0 : origVal) mapping the in-map restore branch uses, so the
-               resulting state is indistinguishable from the path a
-               same-character hide-then-show would have taken. */
-            std::sort(s_touchedVisAddrs.begin(), s_touchedVisAddrs.end());
-            int orphanRestored = 0;
-            for (auto it = origVis.begin(); it != origVis.end();)
-            {
-                const auto visAddr = it->first;
-                if (std::binary_search(s_touchedVisAddrs.begin(),
-                                       s_touchedVisAddrs.end(), visAddr))
-                {
-                    ++it;
-                    continue;
-                }
-                auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
-                const auto origVal = it->second;
-                const auto restored = (origVal == 2) ? 0 : origVal;
-                *visPtr = static_cast<uint8_t>(restored);
-                it = origVis.erase(it);
-                ++orphanRestored;
-            }
-            if (orphanRestored > 0)
-                logger.debug(
-                    "DirectWrite: {} orphan vis bytes restored "
-                    "(category or character-swap sweep)",
-                    orphanRestored);
-            restoredCount += orphanRestored;
-
-            logger.trace("DirectWrite: {} protagonists, {} hidden, {} restored",
-                         n, hiddenCount, restoredCount);
+            apply_direct_vis_write_impl();
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -162,6 +274,26 @@ namespace EquipHide
         mtx.unlock();
     }
 
+    /* Implementation body for cleanup_vis_bytes(): structured binding on
+       map<VisKey, ...> creates the same hidden-temporary issue
+       apply_direct_vis_write_impl works around. Same _impl pattern
+       keeps the SEH wrapper free of unwind state. */
+    static void cleanup_vis_bytes_impl() noexcept
+    {
+        auto &origVis = original_vis_map();
+        int restoredCount = 0;
+        for (auto it = origVis.begin(); it != origVis.end(); ++it)
+        {
+            auto *visPtr = reinterpret_cast<uint8_t *>(it->first.addr);
+            *visPtr = it->second;
+            ++restoredCount;
+        }
+        origVis.clear();
+
+        DMK::Logger::get_instance().debug(
+            "Cleanup: {} vis bytes restored", restoredCount);
+    }
+
     void cleanup_vis_bytes() noexcept
     {
         auto &mtx = vis_write_mutex();
@@ -169,18 +301,7 @@ namespace EquipHide
 
         __try
         {
-            auto &origVis = original_vis_map();
-            int restoredCount = 0;
-            for (const auto &[visAddr, origVal] : origVis)
-            {
-                auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
-                *visPtr = origVal;
-                ++restoredCount;
-            }
-            origVis.clear();
-
-            DMK::Logger::get_instance().debug(
-                "Cleanup: {} vis bytes restored", restoredCount);
+            cleanup_vis_bytes_impl();
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {


### PR DESCRIPTION
## Summary

Restores EquipHide functionality on game version 1.04.00 with full multi-protagonist support, plus several reliability fixes uncovered while testing.

## Changes

- **Per-character hide state** -- settings now survive character swaps. Both the resync pass and the live mid-hook honour per-character Parts overrides, so hashes excluded from one protagonist's `[Section:CharName]` list will not flicker hidden on that protagonist.
- **3-protagonist detection on 1.04.00** -- the third party member's body moved to the ActorManager actor pool. EH now walks `AM+0xF0` (cap-gated, vtable + slot filtered) on top of the legacy `UA+{0xD0..0x108}` stride to recover all 3 controllable characters.
- **Toggle reliability** -- hotkey presses no longer drop on lock contention against the resolve-poll thread or the mid-hook; missed inline writes are retried on the next mid-hook tick.
- **Indefinite scan retry** -- the IndexedStringA deferred scan now waits for the table to stabilise (3 consecutive identical scan counts) instead of giving up after a fixed budget. Mirrors LiveTransmog's wait-for-ready pattern. Users with sparse tables at init now converge once their world finishes loading.
- **Shutdown deadlock** -- dev hot-reload no longer hangs the game on shutdown. `s_workersMtx` is released before joining workers; per-step bracket logs surface any future stall.
- **INI template** -- per-character override comments now list the exact `CD_*` part names alongside each abbreviation (e.g. "right-hand daggers (CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R)") so users can configure overrides without guessing names.
- **Quieter logs** -- per-binding registration moved off DEBUG; per-part rebuild trace gated to initial config load only; CDCore per-scan summary moved off INFO.
- **CDCore** -- added `resolve_character_idx_for_body(body)` helper for callers that need per-body protagonist identification.

## Test plan

- [x] Load with all 3 protagonists summoned; log shows `count=3` in the `Resolve:` line and `ArmorInject [0..2]` only (no phantom slots).
- [x] Hide armor on Damiane, swap to Kliff -- her armor stays hidden.
- [x] Configure a per-character Parts override in INI excluding a hash from Damiane's list; verify the part stays visible on her body but hides on Kliff.
- [x] Trigger a hot-reload; log shows all `shutting down... step N` lines complete.
- [x] Load a save where the IndexedStringA table is sparse at init (e.g. main menu transition); verify the deferred scan eventually commits with `stable at N entries across 3 consecutive scans`.
