### PR TITLE
fix(live-transmog): restore Capture Outfit

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Title for next release]
+## Game Patch 1.04.00 Capture Outfit Fix
 
-- New feature
-- Bug fix
-- Improvement
+- Capture Outfit and the equipment restore after Clear work again on game version 1.04.00.

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -98,6 +98,28 @@ namespace Transmog
         }
     }
 
+    // --- Player-component layout ---
+    //
+    // Pointer to the PartDef/auth-table container on the SlotPopulator
+    // descriptor (a1). The container is the entry table used by the
+    // capture path:
+    //
+    //   container +0x08  QWORD   stride-0xC8 entry array base
+    //   container +0x10  DWORD   live entry count
+    //   container +0x14  DWORD   capacity
+    //
+    // The pointer slot itself shifted between game versions as the
+    // component grew new fields below it:
+    //
+    //   v1.03.01 -- pointer @ a1 + 0x78
+    //   v1.04.00 -- pointer @ a1 + 0x88   (+0x10 of new fields inserted)
+    //
+    // Reading the old offset on v1.04.00 returns garbage (the qword
+    // that lives at +0x78 is no longer the container pointer), which
+    // is what produced the "Capture: no entry table" warning. Mirrors
+    // k_containerPtrOffset in real_part_tear_down.cpp.
+    constexpr std::ptrdiff_t k_compEntryTablePtrOffset = 0x88;
+
     // --- Public interface ---
 
     static __int64 get_player_a1()
@@ -186,7 +208,7 @@ namespace Transmog
 
         __try
         {
-            auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + 120);
+            auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + k_compEntryTablePtrOffset);
             if (entryDesc < 0x10000) { logger.warning("Capture: no entry table"); return; }
             auto entryArray = *reinterpret_cast<uintptr_t *>(entryDesc + 8);
             auto entryCount = *reinterpret_cast<uint32_t *>(entryDesc + 16);
@@ -246,7 +268,7 @@ namespace Transmog
 
         __try
         {
-            auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + 120);
+            auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + k_compEntryTablePtrOffset);
             if (entryDesc < 0x10000) return;
             auto entryArray = *reinterpret_cast<uintptr_t *>(entryDesc + 8);
             auto entryCount = *reinterpret_cast<uint32_t *>(entryDesc + 16);

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -32,6 +32,17 @@ namespace Transmog
     constexpr std::ptrdiff_t k_compSlotCacheCountOffset   = 0x1E0;
     constexpr std::ptrdiff_t k_compSlotCacheCapOffset     = 0x1E4;
 
+    // Pointer to the PartDef/auth-table container on a1.
+    //
+    //   v1.03.01 -- container @ a1 + 0x78
+    //   v1.04.00 -- container @ a1 + 0x88   (+0x10 of new fields below)
+    //
+    // Mirrors k_containerPtrOffset in real_part_tear_down.cpp. Reading
+    // the old offset on v1.04.00 yields a non-container qword that
+    // either dereferences to junk or fails the >0x10000 sanity gate,
+    // skipping the real-item restore loop entirely.
+    constexpr std::ptrdiff_t k_compEntryTablePtrOffset    = 0x88;
+
     void apply_transmog(__int64 a1, uint16_t targetId)
     {
         auto slotPop = slot_populator_fn();
@@ -1393,7 +1404,7 @@ namespace Transmog
 
         __try
         {
-            auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + 120);
+            auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + k_compEntryTablePtrOffset);
             if (entryDesc > 0x10000)
             {
                 auto entryArray = *reinterpret_cast<uintptr_t *>(entryDesc + 8);


### PR DESCRIPTION
## Summary
- Game 1.04.00 grew the SlotPopulator descriptor by 0x10 bytes, shifting the PartDef/auth-table container pointer from `a1+0x78` to `a1+0x88`.
- Capture Outfit bailed with `Capture: no entry table`, and the post-Clear real-equipment restore silently skipped.
- Replaced the three hardcoded `+ 120` literals with a documented `k_compEntryTablePtrOffset = 0x88` constant in `transmog.cpp` (capture_outfit, capture_real_equipment) and `transmog_apply.cpp` (clear-pass real-item restore).
- `real_part_tear_down.cpp` was already on `0x88` via its own `k_containerPtrOffset` (CE-verified during a helm unequip data-write BP), confirming the new offset.

## Test plan
- [x] Build `transmog_logic` (dev-msvc): no warnings on touched TUs.
- [x] In-game: Capture Outfit on a fully-equipped character writes a complete preset (no "no entry table" warning).
- [x] In-game: Clear preset, then verify real equipment restores correctly.
- [x] Sanity: vanilla equip/unequip and existing transmog apply still work.
