### PR TITLE
fix(equip-hide): stop equipment bleed onto NPCs; remove PlayerOnly

### DIFF
--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -102,8 +102,6 @@ The mod is configured via the `CrimsonDesertEquipHide.ini` file:
 [General]
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
-; Apply only to player characters
-PlayerOnly = true
 ; Set to true if you use mods that alter the default visibility of equipment
 ; via PAZ patching (e.g. character replacers like 'Playing Kliff as Damiane',
 ; armor replacers, transmog mods). ForceShow overrides their changes so

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -76,8 +76,6 @@ LogLevel = Info
 ; Re-load this INI automatically on save without restarting the game
 ; (filesystem-watcher driven). Set false to opt out.
 AutoReloadConfig = true
-; Apply only to player characters
-PlayerOnly = true
 ; Set to true if you use mods that alter the default visibility of
 ; equipment via PAZ patching (e.g. character replacers like
 ; "Playing Kliff as Damiane", armor replacers, transmog mods).

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Fix: equipment hiding no longer occasionally bleeds onto NPCs after a
+  save load or character swap.
+- Removed the `PlayerOnly` setting; hiding is now always limited to the
+  playable cast. Existing INIs with the entry can leave it in place; it
+  is simply ignored.

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -109,8 +109,6 @@ The mod can be configured by editing the [b]CrimsonDesertEquipHide.ini[/b] file:
 [General]
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
-; Apply only to player characters
-PlayerOnly = true
 ; Set to true if you use mods that alter the default visibility of equipment
 ; via PAZ patching (e.g. character replacers like 'Playing Kliff as Damiane',
 ; armor replacers, transmog mods). ForceShow overrides their changes so

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -47,8 +47,6 @@ namespace EquipHide
             "General", "LogLevel", "INFO");
 
         DMK::Config::register_atomic<bool>(
-            "General", "PlayerOnly", "Player Only", flag_player_only(), true);
-        DMK::Config::register_atomic<bool>(
             "General", "ForceShow", "Force Show", flag_force_show(), false);
         DMK::Config::register_atomic<bool>(
             "General", "BaldFix", "Bald Fix", flag_bald_fix(), true);

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -453,9 +453,6 @@ namespace EquipHide
 
     bool check_player_filter(uintptr_t a1) noexcept
     {
-        if (!flag_player_only().load(std::memory_order_relaxed))
-            return true;
-
         if (a1 < 0x10000)
             return false;
 
@@ -530,7 +527,14 @@ namespace EquipHide
                 }
             }
 
-            return ps.count.load(std::memory_order_relaxed) <= 0 ||
+            /* Fail-closed: until the fallback path has cached at
+               least one protagonist, do NOT admit the candidate. The
+               historic permissive `<= 0` admitted every actor during
+               the resolve gap, leaking hides onto NPCs that then
+               could not be restored at runtime (their vis ctrls were
+               never in the active set, so the orphan sweep skipped
+               them). */
+            return ps.count.load(std::memory_order_relaxed) > 0 &&
                    is_player_vis_ctrl(a1);
         }
 
@@ -540,7 +544,8 @@ namespace EquipHide
             (cnt & (k_resolveInterval - 1)) == 0)
             resolve_player_vis_ctrls();
 
-        return ps.count.load(std::memory_order_relaxed) <= 0 ||
+        /* Fail-closed (see fallback branch above for rationale). */
+        return ps.count.load(std::memory_order_relaxed) > 0 &&
                is_player_vis_ctrl(a1);
     }
 

--- a/CrimsonDesertEquipHide/src/player_detection.hpp
+++ b/CrimsonDesertEquipHide/src/player_detection.hpp
@@ -12,7 +12,9 @@ namespace EquipHide
 
     /**
      * @brief Check player-only filter. Returns false (reject) if the actor
-     *        is not a known protagonist when PlayerOnly mode is active.
+     *        is not a known protagonist; admission is unconditional --
+     *        equipment hiding only applies to the playable cast (Kliff,
+     *        Damiane, Oongka), never to NPCs.
      *
      * Side effects: triggers resolve cycle (global chain) or caches new
      * vis ctrls (fallback mode).

--- a/CrimsonDesertEquipHide/src/shared_state.cpp
+++ b/CrimsonDesertEquipHide/src/shared_state.cpp
@@ -26,7 +26,6 @@ namespace EquipHide
     static std::unordered_map<VisKey, uint8_t, VisKeyHash> s_originalVis;
     static std::atomic<bool> s_needsDirectWrite{false};
 
-    static std::atomic<bool> s_playerOnly{true};
     static std::atomic<bool> s_forceShow{false};
     static std::atomic<bool> s_baldFix{true};
     static std::atomic<bool> s_glidingFix{true};
@@ -45,7 +44,6 @@ namespace EquipHide
     std::unordered_map<VisKey, uint8_t, VisKeyHash> &original_vis_map() { return s_originalVis; }
     std::atomic<bool> &needs_direct_write() { return s_needsDirectWrite; }
 
-    std::atomic<bool> &flag_player_only() { return s_playerOnly; }
     std::atomic<bool> &flag_force_show() { return s_forceShow; }
     std::atomic<bool> &flag_bald_fix() { return s_baldFix; }
     std::atomic<bool> &flag_gliding_fix() { return s_glidingFix; }

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -112,7 +112,6 @@ namespace EquipHide
     std::atomic<bool> &needs_direct_write();
 
     // --- Feature flags ---
-    std::atomic<bool> &flag_player_only();
     std::atomic<bool> &flag_force_show();
     std::atomic<bool> &flag_bald_fix();
     std::atomic<bool> &flag_gliding_fix();


### PR DESCRIPTION
## Summary
- Fixes the bug where toggling a category off would occasionally strip the same gear from every NPC after a save load or character swap, with no way to restore it short of restarting the game.
- Removes the `PlayerOnly` INI setting; hiding is now unconditionally limited to the playable cast (Kliff, Damiane, Oongka). Existing INIs carrying the entry are ignored.

## Root cause
The protagonist filter was fail-open on an empty resolver set: during the brief window after a save load or character swap when no protagonist had been identified, the in-engine vis-check hook treated *every* actor as the player and wrote `vis=2` on whichever NPC happened to be restreaming. Once the per-NPC vis byte was cached, the orphan sweep skipped it (its vis-ctrl was never in the active set), so the leak survived toggling, INI edits, and a full session, only the shutdown sweep cleared it.

The filter is now fail-closed: until a protagonist is identified, nothing hides.

## Test plan
- [x] Fresh game launch → toggle each category → only the controlled protagonist's gear hides.
- [x] Save-load → toggle → no NPC bleed.
- [x] In-session character swap (Kliff ↔ Damiane ↔ Oongka) → toggle → per-character overrides still apply, no NPC bleed.
- [x] Pre-existing INI with `PlayerOnly = true|false` still loads cleanly (entry ignored).
