### PR TITLE
fix: per-protagonist detection with EH+LT coexistence

### DIFF
--- a/CrimsonDesertCore/include/cdcore/anchors.hpp
+++ b/CrimsonDesertCore/include/cdcore/anchors.hpp
@@ -295,6 +295,246 @@ namespace CDCore::Anchors
          ResolveMode::Direct, -0x25, 0},
     };
 
+    // -----------------------------------------------------------------------
+    // Player -- static pointer for the server-side party-state root global.
+    //
+    // Resolves to qword_145F0D580 in the v1.04.00 .text. The dereference of
+    // that qword is a heap-allocated root object (no specific RTTI) whose
+    // chain is:
+    //
+    //   *(player_static)        -> root container
+    //   *(root  + 0x18)         -> pa::NwVirtualAsyncSession
+    //   *(nwSes + 0xA0)         -> pa::ServerUserActor
+    //   *(srvUA + 0xD0)         -> pa::ServerChildOnlyInGameActor
+    //                              (the party container)
+    //
+    // Inside the party container the three protagonist slots are inline
+    // structs at fixed offsets with stride 0x100:
+    //
+    //   party + 0x68            = Kliff slot
+    //   party + 0x168           = Damiane slot
+    //   party + 0x268           = Oongka slot
+    //
+    // Per slot the active-flag byte is at slot+0x2C (1 = currently
+    // controlled, 0 = passive). The character is identified by which slot
+    // offset, NEVER by a stored character ID. The +0x40 dword is an
+    // observability handle and is volatile; it is logged for diagnostics
+    // but not used for identity.
+    //
+    // The CE-validated state-transition table (5 transitions across radial
+    // swaps and a save-load) confirmed the invariant that exactly one slot
+    // has +0x2C == 1 while the player is in-world; zero slots are active
+    // during cutscenes / loading screens. The top three pointers in the
+    // chain (root, NwVirtualAsyncSession, ServerUserActor) stay identical
+    // across save-load; only the final party container reallocates.
+    //
+    // Why this static and not the older WorldSystem holder at +0x5F0D210:
+    // the WorldSystem chain reaches a CLIENT-side ChildOnlyInGameActor pool
+    // whose per-actor +0x50 byte was the prior identity discriminator. On
+    // v1.04.00 that byte ceased to discriminate (every protagonist reads
+    // 0x08), and actor-pool reuse made the field unstable across radial
+    // swaps. The Player static reaches the SERVER-side party state, which
+    // identifies the controlled character by slot offset (a structural
+    // invariant) instead of by a value the engine can repurpose.
+    //
+    // 3-tier cascade. Stable read sites verified unique on v1.04.00 via
+    // mcp__cheatengine__aob_scan (each returns exactly 1 hit).
+    // -----------------------------------------------------------------------
+    inline constexpr AddrCandidate k_playerStaticCandidates[] = {
+        // P1 -- the unique writer site at sub_1420D0470.
+        //   4C 89 3D <disp32>          mov [rip+disp32], r15
+        //   48 8B 8F F8 00 00 00       mov rcx, [rdi+0xF8]
+        //   41 BC 04 02 00 00          mov r12d, 0x204
+        //   48 85 C9 ??                test rcx, rcx ; jcc rel8
+        //
+        // Writer encodings on globals are typically rare (one or two per
+        // module) and the immediately-following load from [rdi+0xF8] +
+        // mov-r12d-0x204 sequence is semantically distinctive. The 0x204
+        // is a SEMANTIC constant (an initialisation tag) and is kept
+        // literal per the §2 exception; the rel8 of the trailing jcc is
+        // wildcarded because branch distance can shift.
+        {"PlayerStatic_P1_WriterSite",
+         "4C 89 3D ?? ?? ?? ?? 48 8B 8F F8 00 00 00 "
+         "41 BC 04 02 00 00 48 85 C9 ??",
+         ResolveMode::RipRelative, 3, 7},
+
+        // P2 -- read-into-r12 at sub_1420D3700+0x39.
+        //   4C 8B 25 <disp32>          mov r12, [rip+disp32]
+        //   8B D5                      mov edx, ebp
+        //   4C 8B F0                   mov r14, rax
+        //   E8 <disp32>                call <subroutine>
+        //   48 8B D8                   mov rbx, rax
+        //   48 85 C0 ??                test rax, rax ; jcc rel8
+        //
+        // The 4C 8B 25 prefix (load into r12) is uncommon; combined with
+        // the immediate mov-edx-ebp / mov-r14-rax / call / mov-rbx-rax /
+        // test-rax-rax tail it pins this single read site. Both rel32
+        // displacements are wildcarded (linker-owned).
+        {"PlayerStatic_P2_ReadIntoR12",
+         "4C 8B 25 ?? ?? ?? ?? 8B D5 4C 8B F0 "
+         "E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 ??",
+         ResolveMode::RipRelative, 3, 7},
+
+        // P3 -- read-into-rcx + stack-slot test at sub_140819600+0x14F.
+        //   48 8B 0D <disp32>          mov rcx, [rip+disp32]
+        //   E8 <disp32>                call <subroutine>
+        //   83 7C 24 ?? 00             cmp dword [rsp+disp8], 0
+        //   74 ??                      jz rel8
+        //   48 8B 8E E0 00 00 00       mov rcx, [rsi+0xE0]
+        //
+        // The 48 8B 0D / E8 mov-then-call shape is common, but the tail
+        // (cmp dword [rsp+disp8], 0; jz rel8; mov rcx, [rsi+0xE0]) pins
+        // this site. 0xE0 is a game-struct ABI offset, kept literal. The
+        // stack disp8 in the cmp and the rel8 jz target are wildcarded.
+        {"PlayerStatic_P3_ReadStackTest",
+         "48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? "
+         "83 7C 24 ?? 00 74 ?? 48 8B 8E E0 00 00 00",
+         ResolveMode::RipRelative, 3, 7},
+    };
+
+    // -----------------------------------------------------------------------
+    // RadialSwapKey -- mid-body anchor inside the radial-UI character-swap
+    // handler (sub_1422019A0). At this site EAX has just been loaded with
+    // the requested characterinfo key from the radial input pointer in RSI:
+    //
+    //   ; sub_1422019A0 fragment, loads the destination key and forwards to
+    //   ; sub_141B0C2B0 which commits the new actor to User+0xD8.
+    //   8B 06              mov eax, [rsi]            ; ANCHOR
+    //   89 45 78           mov [rbp+0x78], eax       ; HOOK +2 lands here
+    //   48 8B 0D ?? ?? ?? ?? mov rcx, [rip+disp32]   ; lookup table base
+    //   48 83 C1 60        add rcx, 60h
+    //   48 8D 55 78        lea rdx, [rbp+0x78]
+    //   E8 ?? ?? ?? ??     call sub_1402FB1C0        ; hash table lookup
+    //   B9 FF FF 00 00     mov ecx, 0FFFFh           ; sentinel
+    //   48 85 C0           test rax, rax
+    //   74 05              jz <skip>
+    //   0F B7 18           movzx ebx, word ptr [rax]
+    //   EB 02              jmp +2
+    //
+    // CE-verified live (v1.04.00, 2026-05-02) across four protagonist
+    // transitions: EAX = 0x01 (Kliff), 0x04 (Damiane), 0x06 (Oongka).
+    //
+    // The hook offset is +2 (the byte length of `mov eax, [rsi]`) so the
+    // mid-hook lands on the immediately-following `mov [rbp+0x78], eax`,
+    // i.e. the instruction at which the captured key is fully realised in
+    // the EAX register and not yet shadowed by the lookup-table call. EAX
+    // is the source of the captured value; reading it from the SafetyHook
+    // Context64 as `ctx.rax & 0xFFFF'FFFFu` gives the raw key.
+    //
+    // Coverage caveat: scripted cutscene auto-switches that drive the
+    // player back to Kliff do NOT pass through this handler (verified
+    // live: zero hits on a forced Kliff return). The +0x2C slot decode
+    // and the resolver's last-known-good cache cover those paths.
+    //
+    // 5-tier cascade ordered for cross-mod coordination.
+    //
+    // Cross-mod model: CrimsonDesertCore is a STATIC library, so each Logic
+    // DLL (LiveTransmog, EquipHide) carries its own copy of CDCore state and
+    // installs its own SafetyHook MidHook against this site. SafetyHook's
+    // internal chaining at the JMP-target site lets two MidHooks coexist --
+    // each consumer's trampoline runs independently on every radial swap.
+    // The price is that whichever consumer initialises FIRST overwrites the
+    // hook target's prelude bytes with the SafetyHook stub (a 5-byte JMP at
+    // match+2 plus zero or more NOP-padded partial-instruction bytes); the
+    // sibling consumer that scans SECOND no longer sees the original
+    // `89 45 78 48 8B 0D ...` shape at offset +2 through +11 of the match.
+    //
+    // Patch survival:
+    //   - SafetyHook's MidHook overwrites COMPLETE instructions starting at
+    //     the hook target. Bytes 0..1 of the match (`8B 06`, the leading
+    //     mov-eax-from-rsi) are LEFT INTACT because the hook target is at
+    //     match+2.
+    //   - Bytes match+2 through match+11 (the `89 45 78 48 8B 0D ?? ?? ?? ??`
+    //     window -- 3 bytes of `mov [rbp+0x78], eax` plus 7 bytes of
+    //     `mov rcx, [rip+disp32]`) are FULLY OVERWRITTEN by the JMP+pad.
+    //   - Bytes match+12 onward (`48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? B9
+    //     FF FF 00 00 48 85 C0 74 05 0F B7 18 EB 02`) are UNCHANGED -- they
+    //     sit past the displaced range and are reached only via the
+    //     SafetyHook trampoline's epilogue.
+    //
+    // P1 / P2 anchor exclusively in the post-patch-invariant tail
+    // (match+12 onward) so they match the live binary regardless of whether
+    // a sibling has already patched the prelude. dispOffset = -10 walks back
+    // from the new anchor's start (which is at original-match+12) to the
+    // hook target (at original-match+2): -10 = +2 - 12. P3 / P4 / P5 are
+    // the original prelude-anchored candidates retained for the
+    // pre-any-patch first-load case where every byte still matches; on a
+    // post-patched site they fail gracefully and the cascade falls through
+    // to P1 / P2.
+    //
+    // resolve_cascade iterates declaration order and returns first match
+    // (see scanner.cpp scan_candidates), so the post-patch-tolerant
+    // candidates MUST come first to guarantee the second consumer resolves
+    // the same hook target the first consumer already patched.
+    //
+    // The `0F B7 18 EB 02` (movzx ebx, word ptr [rax]; jmp +2) tail is the
+    // unique disambiguator: a structurally identical shape at sub_1421D5990
+    // in a different handler is followed by an index-write
+    // (`48 89 B5 28 03 00 00`) instead, so any candidate that includes
+    // bytes past the call locks onto this site exclusively.
+    // -----------------------------------------------------------------------
+    inline constexpr AddrCandidate k_radialSwapKeyCandidates[] = {
+        // P1 -- post-patch-invariant tail with literal rel8 jz. Anchors
+        // entirely in the bytes past the SafetyHook displaced window
+        // (match+12 onward of the original prelude shape):
+        //   add rcx, 0x60; lea rdx,[rbp+0x78]; call <disp32>;
+        //   mov ecx, 0xFFFF; test rax,rax; jz +5; movzx ebx,[rax];
+        //   jmp +2.
+        // The unique movzx-ebx + jmp-+2 tail pins this site (see comment
+        // block above for the sibling-handler disambiguator). dispOffset
+        // -10 walks back to the original hook target at match+2 of the
+        // prelude shape (= start-of-this-anchor + 2 - 12).
+        {"RadialSwapKey_P1_PostPatchFull",
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "B9 FF FF 00 00 48 85 C0 74 05 0F B7 18 EB 02",
+         ResolveMode::Direct, -10, 0},
+
+        // P2 -- same post-patch-invariant tail with the rel8 jz target
+        // wildcarded. Survives a recompile that shifts the branch
+        // distance while the surrounding instruction stream is preserved.
+        // Falls back to P1 only when an exact-byte match wins first; same
+        // dispOffset semantics.
+        {"RadialSwapKey_P2_PostPatchWildcardRel8",
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "B9 FF FF 00 00 48 85 C0 74 ?? 0F B7 18 EB 02",
+         ResolveMode::Direct, -10, 0},
+
+        // P3 -- pre-patch full-prelude anchor (was P1). Matches only on a
+        // first-load scan against an unpatched site. Anchors on the full
+        // prelude (mov eax,[rsi]; mov [rbp+0x78],eax; mov rcx,[rip+disp32];
+        // add rcx,0x60; lea rdx,[rbp+0x78]; call <disp32>) followed by the
+        // unique tail (mov ecx,0xFFFF; test rax,rax; jz +5; movzx ebx,[rax];
+        // jmp +2). dispOffset +2 walks forward to the hook target. After
+        // a sibling has patched, bytes match+2..+11 differ, so this
+        // candidate fails gracefully and the cascade falls through to P1.
+        {"RadialSwapKey_P3_FullSequence",
+         "8B 06 89 45 78 48 8B 0D ?? ?? ?? ?? "
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "B9 FF FF 00 00 48 85 C0 74 05 0F B7 18 EB 02",
+         ResolveMode::Direct, 2, 0},
+
+        // P4 -- pre-patch prelude with wildcarded rel8 jz target (was P2).
+        // Same first-load-only matching characteristic as P3; tolerates a
+        // future build that shifts the jz branch distance.
+        {"RadialSwapKey_P4_WildcardRel8",
+         "8B 06 89 45 78 48 8B 0D ?? ?? ?? ?? "
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "B9 FF FF 00 00 48 85 C0 74 ?? 0F B7 18 EB 02",
+         ResolveMode::Direct, 2, 0},
+
+        // P5 -- minimal-tail prelude anchor (was P3). Drops the post-call
+        // test/movzx tail and ends at the `mov ecx, 0xFFFF` sentinel-load.
+        // Verified unique on v1.04.00. Last-resort first-load fallback if
+        // both P3 and P4 fail to a future tail rewrite. Also fails on a
+        // post-patched site (the prelude bytes are gone), at which point
+        // P1 / P2 carry the resolution.
+        {"RadialSwapKey_P5_MinimalTail",
+         "8B 06 89 45 78 48 8B 0D ?? ?? ?? ?? "
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "B9 FF FF 00 00",
+         ResolveMode::Direct, 2, 0},
+    };
+
 } // namespace CDCore::Anchors
 
 #endif // CDCORE_ANCHORS_HPP

--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -1,67 +1,62 @@
 #ifndef CDCORE_CONTROLLED_CHAR_HPP
 #define CDCORE_CONTROLLED_CHAR_HPP
 
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 
 // ---------------------------------------------------------------------------
 // Controlled-character resolver.
 //
-// Walks the live WorldSystem chain on every query and identifies the
-// currently-controlled protagonist via a two-part decode: a structural
-// invariant for Kliff plus a slot-index diff for the two companions.
+// Walks the live server-side party-state chain on every query and identifies
+// the currently-controlled protagonist by which fixed-offset slot inside the
+// party container has its active-flag byte set.
 //
-//   *(WS holder)           -> WorldSystem instance (session heap)
-//   *(ws   + 0x30)         -> ActorManager singleton
-//   *(am   + 0x28)         -> UserActor singleton (ClientUserActor)
-//   *(user + 0xD0)         -> primary actor slot (always Kliff in the
-//                             current story progression)
-//   *(user + 0xD8)         -> controlled client actor (rotates on swap)
+//   *(player_static)        -> root container
+//   *(root  + 0x18)         -> pa::NwVirtualAsyncSession
+//   *(nwSes + 0xA0)         -> pa::ServerUserActor
+//   *(srvUA + 0xD0)         -> pa::ServerChildOnlyInGameActor
+//                              (the party container)
 //
-// Decode rules:
-//   1. If *(user + 0xD0) == *(user + 0xD8), the primary slot coincides with
-//      the controlled slot, which only happens when Kliff is the active
-//      character. This is a pure structural check, independent of any
-//      numeric field that could shift across saves.
+// Inside the party container the three protagonist slots are inline structs
+// at fixed offsets with stride 0x100:
 //
-//   2. Otherwise, a companion is controlled. The byte at actor+0x60 is a
-//      per-actor slot index assigned at allocation time in a fixed order
-//      (Kliff, Damiane, Oongka). The absolute value varies per save (the
-//      slot-index pool is shared with other actors), but WITHIN any given
-//      save:
-//          Damiane.slot == Kliff.slot + 1
-//          Oongka.slot  == Kliff.slot + 2
-//      Using Kliff's slot (always at user+0xD0) as the anchor, the diff
-//      against the controlled actor's slot uniquely identifies the
-//      companion.
+//   party + 0x68            = Kliff slot
+//   party + 0x168           = Damiane slot
+//   party + 0x268           = Oongka slot
 //
-// Previous decode attempts -- (party_class, char_kind) at +0xDC/+0xEC -- are
-// NOT used. Both values shift with party composition (e.g. Damiane in a
-// 3-party save and Oongka in the same save both read (party_class=3,
-// char_kind=2), making the key structurally ambiguous).
+// Per slot the active-flag byte at slot+0x2C is the discriminator: exactly
+// one slot reads 1 while the player is in-world (cutscenes / loading screens
+// produce zero hot slots, which the resolver reports as Unknown). The +0x40
+// dword is an observability handle that is volatile across sessions and
+// asset rebuilds; it is logged for diagnostic correlation only and never
+// participates in identity decoding.
 //
-// To absorb transient torn reads (the controlled-actor pointer can be
-// briefly stale during a swap event) the resolver keeps a last-known-good
-// cache: any decode that does not match one of the three known identities
-// returns the cached value instead, and the cache refreshes whenever a
-// fresh known-identity decode succeeds.
+// Why identity is decoded by SLOT OFFSET and not by a stored character ID:
+// inside the party container the slot for a given protagonist is at a fixed
+// compile-time-known offset, which is a structural invariant of the engine
+// layout and cannot drift across actor-pool reuse, save-load reallocation,
+// or radial-menu swaps. Earlier resolver iterations decoded a per-actor
+// byte field that the engine repurposed across versions; the slot-offset
+// approach is immune to that class of regression because there is no engine
+// field whose meaning the resolver depends on.
 //
-// The resolver requires the consumer to publish the WorldSystem holder
-// static address once (typically right after that mod's own AOB scan
-// resolves it). Until set_world_system_holder() has been called, every
-// query returns Unknown. This avoids duplicating the WorldSystem AOB scan
-// across every consumer.
+// To absorb transient torn reads (the active-flag byte can momentarily
+// disagree across the three slots during a swap event when the engine is
+// still flipping bytes) the resolver keeps a last-known-good cache: any
+// query that returns no single-1-bit-hot slot reuses the cached value
+// instead, and the cache refreshes whenever a fresh single-bit-hot decode
+// succeeds.
 //
-// Known assumption: character allocation order is always Kliff, Damiane,
-// Oongka. A save containing only Kliff + Oongka (no Damiane) would allocate
-// Oongka at Kliff+1 and would be decoded as Damiane. No such save has been
-// observed in the current game content; if one arises, the consumer mod's
-// overlay allows manual override and the misdetection is a UX hiccup, not a
-// correctness failure.
+// The resolver requires the consumer to publish the player static address
+// once (typically right after that mod's own AOB scan resolves it). Until
+// set_player_static_holder() has been called, every query returns Unknown.
+// This avoids duplicating the AOB scan across every consumer.
 //
 // Thread safety:
-//   - set_world_system_holder() is safe from any thread; later writers win,
-//     which is the intended behaviour if a consumer re-resolves on reload.
+//   - set_player_static_holder() and set_world_system_holder() are safe from
+//     any thread; later writers win, which is the intended behaviour if a
+//     consumer re-resolves on reload.
 //   - current_controlled_character() is non-blocking and SEH-guarded; safe
 //     to call from any thread including the rendering thread.
 // ---------------------------------------------------------------------------
@@ -71,11 +66,12 @@ namespace CDCore
     /**
      * @brief Identifies one of the three controlled playable characters.
      * @details The Unknown sentinel is returned before
-     *          set_world_system_holder() has been called, before the chain
+     *          set_player_static_holder() has been called, before the chain
      *          walk yields a known identity (very early in the loading
-     *          screen), and after invalidate_controlled_character() until
-     *          the next chain walk observes one of the three known keys
-     *          and refreshes the cache.
+     *          screen, or while a cutscene zeroes every slot's active flag),
+     *          and after invalidate_controlled_character() until the next
+     *          chain walk observes one of the three known keys and refreshes
+     *          the cache.
      */
     enum class ControlledCharacter : std::uint8_t
     {
@@ -86,40 +82,49 @@ namespace CDCore
     };
 
     /**
-     * @brief Publish the WorldSystem holder static address to the
-     *        controlled-character resolver.
-     * @details Both consumer mods (CrimsonDesertEquipHide and
-     *          CrimsonDesertLiveTransmog) AOB-scan for the WorldSystem
-     *          holder during their own init. Whichever resolves first
-     *          should hand the address to Core via this call so the
-     *          resolver does not need its own AOB scan. Subsequent calls
-     *          overwrite the previous value, which is the intended
-     *          behaviour when a consumer re-scans.
+     * @brief Publish the WorldSystem holder static address to Core.
+     * @details Retained for callers that need the WorldSystem reach
+     *          (UserActor, body-pool walks, mesh-bound state). The
+     *          controlled-character resolver no longer consumes this
+     *          pointer; identification is handled via
+     *          set_player_static_holder() instead.
      * @param holderAddr Absolute address of the WorldSystem holder slot
      *                   (the static qword whose dereference yields the
      *                   live WorldSystem instance pointer). Pass 0 to
-     *                   disable the resolver.
+     *                   clear.
      */
     void set_world_system_holder(std::uintptr_t holderAddr) noexcept;
 
     /**
+     * @brief Publish the server-side player static address to the
+     *        controlled-character resolver.
+     * @details Both consumer mods (CrimsonDesertEquipHide and
+     *          CrimsonDesertLiveTransmog) AOB-scan for the player static
+     *          during their own init. Whichever resolves first should hand
+     *          the address to Core via this call so the resolver does not
+     *          need its own AOB scan. Subsequent calls overwrite the
+     *          previous value.
+     * @param holderAddr Absolute address of the player static slot (the
+     *                   static qword whose dereference yields the root
+     *                   container described in the file-level comment).
+     *                   Pass 0 to disable the resolver.
+     */
+    void set_player_static_holder(std::uintptr_t holderAddr) noexcept;
+
+    /**
      * @brief Resolve the currently-controlled character.
-     * @details Walks WorldSystem -> ActorManager -> UserActor, reads both
-     *          the primary actor at user+0xD0 and the controlled actor at
-     *          user+0xD8 plus the slot-index byte at +0x60 on each. Decodes
-     *          Kliff by the structural invariant
-     *          `*(user+0xD0) == *(user+0xD8)` and the two companions by
-     *          the diff between the controlled slot and the primary slot
-     *          (Damiane = primary + 1, Oongka = primary + 2). When the
-     *          decode does not match a known identity (faulted chain walk,
-     *          torn read across a swap transition, unrecognised future
-     *          slot offset) the resolver returns the previously-cached
-     *          identity instead, so transient drift does not flap the
-     *          controlled character.
+     * @details Walks the server-side party-state chain and reads the
+     *          active-flag byte at slot+0x2C for each of the three fixed
+     *          protagonist offsets (Kliff=0x68, Damiane=0x168,
+     *          Oongka=0x268). Returns the slot whose flag reads 1. When no
+     *          slot is hot (cutscene, loading screen) or more than one is
+     *          hot (transient torn read mid-swap), the resolver returns the
+     *          previously-cached identity instead, so transient drift does
+     *          not flap the controlled character.
      * @return The identified character, or ControlledCharacter::Unknown
-     *         when the WorldSystem holder has not been published yet,
-     *         when the chain walk faults, or when neither the live decode
-     *         nor the last-known-good cache yields a known value.
+     *         when the player static has not been published yet, when the
+     *         chain walk faults, or when neither the live decode nor the
+     *         last-known-good cache yields a known value.
      */
     [[nodiscard]] ControlledCharacter current_controlled_character() noexcept;
 
@@ -147,49 +152,204 @@ namespace CDCore
     [[nodiscard]] std::uint32_t current_controlled_character_idx() noexcept;
 
     /**
-     * @brief One-based protagonist index for an arbitrary body pointer.
-     * @details Walks the live WorldSystem chain to recover the
-     *          primary-actor (always Kliff on a Kliff-led save) slot byte
-     *          at +0x50, then computes
-     *          `bodySlot - primarySlot` from the matching byte read off
-     *          the supplied body. The diff maps to:
+     * @brief One-based protagonist index for an arbitrary client body
+     *        pointer.
+     * @details Looks up @p body in the learning cache populated by
+     *          current_controlled_character() each time the resolver
+     *          observes a known controlled identity. Returns 0 when
+     *          the body has not yet been seen as controlled (the user
+     *          has never been that character in this session) --
+     *          callers should treat 0 as "unknown" and fall back to
+     *          the active character's mask, which is the safe
+     *          degradation.
      *
-     *              0 = Kliff   (returns 1)
-     *              1 = Damiane (returns 2)
-     *              2 = Oongka  (returns 3)
+     *          Why a learning cache instead of a structural decode:
+     *          the v1.04.00 client body has no reachable back-reference
+     *          to its protagonist slot in the party container, and the
+     *          per-actor +0x50 byte that earlier builds used as a slot
+     *          index ceased to discriminate on this build. Observing
+     *          the controlled-body / known-character pairing each
+     *          resolver tick is the only stable mapping available from
+     *          the public game-state surface.
      *
-     *          Any other diff, an out-of-range body pointer, an
-     *          un-published WorldSystem holder, or a faulted chain walk
-     *          all return 0 (unknown). The returned 1-based index aligns
-     *          with current_controlled_character_idx() so consumers that
-     *          subtract 1 to get a 0-based array index can use this
-     *          helper interchangeably.
+     *          Cache scope: per-DLL (CDCore is statically linked into
+     *          each consumer Logic DLL). Each consumer learns
+     *          independently. Cleared by
+     *          invalidate_controlled_character() on save-load so dead
+     *          body pointers cannot mis-attribute a future protagonist.
+     *          Preserved across in-session radial swaps (callers should
+     *          use invalidate_swap_caches() on those transitions) since
+     *          the engine rotates user+0xD8 between existing body
+     *          pointers in the pool without reallocating bodies.
      *
-     *          Cheap and SEH-protected: safe to call from any thread,
-     *          including the rendering thread, and tolerates the body
-     *          pointer being recycled, freed, or torn between the read
-     *          of the primary chain and the +0x50 byte read on `body`.
-     * @param body Pointer to a ClientChildOnlyInGameActor instance
-     *             (the same kind of pointer EquipHide enumerates from
-     *             user+0xD0..+0x108). Pass 0 to disable the lookup
-     *             (returns 0).
-     * @return 1 for Kliff, 2 for Damiane, 3 for Oongka, or 0 when the
-     *         identity cannot be resolved.
+     * @param body Pointer to a ClientChildOnlyInGameActor instance.
+     * @return 1 for Kliff, 2 for Damiane, 3 for Oongka, or 0 for
+     *         unknown (not yet learned, or invalid pointer).
      */
     [[nodiscard]] std::uint32_t resolve_character_idx_for_body(
         std::uintptr_t body) noexcept;
 
     /**
-     * @brief Clear the last-known-good identity cache.
+     * @brief One entry in the body learning cache snapshot.
+     * @details charIdx uses the same 1-based encoding as
+     *          current_controlled_character_idx(): 1 for Kliff, 2 for
+     *          Damiane, 3 for Oongka. body is the user+0xD8 pointer
+     *          observed at the time the entry was stamped.
+     */
+    struct BodyCacheEntry
+    {
+        std::uintptr_t body;
+        std::uint32_t  charIdx;
+    };
+
+    /**
+     * @brief Copy up to @p cap entries from the body learning cache into
+     *        the caller-provided buffer.
+     * @details Fills entries in unspecified iteration order. Returns the
+     *          number of entries copied (capped at the smaller of @p cap
+     *          and the live cache size). Acquires a shared lock on the
+     *          cache mutex for the duration of the copy; the call is
+     *          non-blocking from a contention standpoint because the
+     *          cache writers are infrequent (one stamp per
+     *          controlled-character resolution).
+     *
+     *          Entries with character == Unknown are skipped (they
+     *          cannot occur in practice because current_controlled
+     *          _character() only stamps known identities, but the guard
+     *          is cheap).
+     *
+     * @param out Pointer to a buffer of at least @p cap entries.
+     * @param cap Capacity of the buffer in entries.
+     * @return Number of entries written.
+     */
+    [[nodiscard]] std::size_t snapshot_body_cache(
+        BodyCacheEntry *out,
+        std::size_t cap) noexcept;
+
+    /**
+     * @brief Install the radial-swap-key capture mid-hook at the
+     *        resolved address.
+     * @details The hook target must be the instruction immediately
+     *          following the EAX-load from the radial-UI input pointer
+     *          (the `mov [rbp+0x78], eax` at sub_1422019A0+e9 in
+     *          v1.04.00). At hook entry the low 32 bits of RAX hold the
+     *          requested characterinfo key (1 = Kliff, 4 = Damiane,
+     *          6 = Oongka). The hook stamps a short-lived process-wide
+     *          pending-key record so the next chain-walk that observes
+     *          a non-Kliff identity can attribute the user-actor pointer
+     *          to the captured key, building an actor->character cache
+     *          that the resolver consults before falling back to the
+     *          slot-offset decode.
+     *
+     *          Single-owner semantics within a DLL:
+     *          - First call with a non-zero @p hookAddr: builds the
+     *            SafetyHook MidHook against that address.
+     *          - Subsequent calls with the SAME @p hookAddr: idempotent
+     *            no-op (the hook is already live at the requested site).
+     *          - Subsequent calls with a DIFFERENT non-zero @p hookAddr:
+     *            destroy the existing MidHook and rebuild against the
+     *            new address (used if an AOB re-resolution shifts the
+     *            target mid-session).
+     *          - Call with @p hookAddr == 0: tear down the MidHook so
+     *            the patched bytes return to the original instruction
+     *            sequence. Safe to call when no hook is installed.
+     *
+     *          Cross-DLL coordination: CrimsonDesertCore is linked as a
+     *          STATIC library, so each consumer Logic DLL (LiveTransmog,
+     *          EquipHide) carries its own copy of CDCore state and its
+     *          own SafetyHook MidHook against the shared process address.
+     *          When both consumers call this function against the same
+     *          target site, SafetyHook's internal chaining lets the two
+     *          MidHooks coexist transparently -- each consumer's
+     *          trampoline runs independently on every radial swap. The
+     *          AOB cascade in cdcore/anchors.hpp k_radialSwapKeyCandidates
+     *          is ordered so the post-patch-tolerant patterns resolve
+     *          first, ensuring the second consumer to scan still finds
+     *          the same hook target the first consumer already patched.
+     *
+     *          Failure modes (returns false): SafetyHook allocation
+     *          failure (ENOMEM-shaped, rare), trampoline placement
+     *          failure (target page already heavily hooked), or address
+     *          below the 64 KiB guard region. On any failure the
+     *          resolver continues to function via the slot-offset decode
+     *          and the LKG cache; only the deterministic
+     *          radial-attribution layer is missing for this consumer.
+     *
+     * @param hookAddr Absolute address of the `mov [rbp+0x78], eax`
+     *                 instruction inside sub_1422019A0. The AOB cascade
+     *                 in cdcore/anchors.hpp k_radialSwapKeyCandidates
+     *                 resolves to this address. Pass 0 to tear down.
+     * @return true on successful install / idempotent no-op / teardown,
+     *         false on SafetyHook error.
+     */
+    bool install_radial_swap_hook(std::uintptr_t hookAddr) noexcept;
+
+    /**
+     * @brief Tear down the radial-swap-key mid-hook owned by this DLL.
+     * @details Equivalent to install_radial_swap_hook(0). Safe to call
+     *          when no hook is installed; safe to call from shutdown
+     *          paths. Idempotent. Each consumer DLL owns its own
+     *          MidHook; calling this in one DLL does not affect any
+     *          other DLL's MidHook against the same process address.
+     */
+    void uninstall_radial_swap_hook() noexcept;
+
+    /**
+     * @brief Full world-reload invalidation. Clears the last-known-good
+     *        identity cache, the actor->character cache, the pending
+     *        radial-swap-key record, AND the body->character learning
+     *        cache.
      * @details Call on world-reload transitions (save load, return to
      *          title) so the resolver does not keep returning the
      *          previous save's character while the new save is still
      *          populating the engine state. After invalidation the
      *          resolver returns Unknown until the next chain walk observes
-     *          one of the three known keys and refreshes the cache. Safe
-     *          to call from any thread; non-blocking.
+     *          one of the three known keys and refreshes the cache.
+     *
+     *          Why the body cache is flushed here: save-load reallocates
+     *          the body pool, so any cached body pointer becomes a
+     *          dangling key the engine may reuse for a different
+     *          protagonist. Mis-attribution after reload is prevented by
+     *          dropping the entire body map.
+     *
+     *          For in-session protagonist swaps (radial menu rotation,
+     *          scripted Kliff returns) use invalidate_swap_caches()
+     *          instead -- it preserves the body cache because radial
+     *          swaps only rotate user+0xD8 between EXISTING body
+     *          pointers in the pool, leaving previously-learned
+     *          bodies still valid.
+     *
+     *          Safe to call from any thread; non-blocking.
      */
     void invalidate_controlled_character() noexcept;
+
+    /**
+     * @brief Clear the LKG identity cache, the actor->character cache,
+     *        and the pending radial-swap-key record, but preserve the
+     *        body->character learning cache.
+     * @details Use this on in-session protagonist swaps (radial menu
+     *          rotation, scripted Kliff returns). The controlled actor
+     *          pointer at user+0xD8 rotates between existing body
+     *          pointers in the pool; the body pointers themselves stay
+     *          valid for the lifetime of the session, so previously-
+     *          learned body identities remain correct after the swap.
+     *
+     *          What this clears:
+     *            - last-known-good cached identity (s_lastGoodChar)
+     *            - actor (userActor parent) -> character cache
+     *            - pending radial-swap-key record
+     *
+     *          What this preserves:
+     *            - body (user+0xD8 pointer) -> character cache
+     *
+     *          For full world-reload semantics use
+     *          invalidate_controlled_character() instead, which also
+     *          flushes the body cache because save-load may reuse old
+     *          body pointers for different characters.
+     *
+     *          Safe to call from any thread; non-blocking.
+     */
+    void invalidate_swap_caches() noexcept;
 
 } // namespace CDCore
 

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -2,85 +2,72 @@
 
 #include <DetourModKit.hpp>
 
+#include <safetyhook/context.hpp>
+#include <safetyhook/mid_hook.hpp>
+
 #include <Windows.h>
 
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
 
 namespace CDCore
 {
     namespace
     {
-        // s_wsHolder holds the absolute address of the WorldSystem holder
-        // static, published by a consumer's init code. While zero every
+        // Server-side player-state holder static. Published by a consumer's
+        // init code via set_player_static_holder(). While zero every
         // resolver query short-circuits to Unknown so the mod degrades
         // gracefully when the consumer has not yet completed its own AOB
         // scan (or that scan fails on a future patch).
+        std::atomic<std::uintptr_t> s_playerStaticHolder{0};
+
+        // WorldSystem holder retained for callers that walk the client-side
+        // chain (UserActor body pool, mesh state). Identity decoding does
+        // not consume this pointer; it is stored only because the public
+        // set_world_system_holder() API still exists for source-level
+        // compatibility with consumers that publish both addresses.
         std::atomic<std::uintptr_t> s_wsHolder{0};
 
-        // s_lastGoodChar caches the most recent known identity. The chain
-        // walk can land mid-swap when the engine is rewriting user+0xD8 and
-        // produce garbage; the cache absorbs those torn reads so the
-        // resolver does not flap between Unknown and a known character
-        // within a single swap. Stored as the underlying enum value to keep
-        // the atomic lock-free on x64.
+        // Cache of the most recent known identity. The chain walk can land
+        // mid-swap when the engine is rewriting active-flag bytes on the
+        // three slots and produce a transient state with zero or two hot
+        // slots; the cache absorbs those torn reads so the resolver does
+        // not flap between Unknown and a known character within a single
+        // swap. Stored as the underlying enum value to keep the atomic
+        // lock-free on x64.
         std::atomic<std::uint8_t> s_lastGoodChar{
             static_cast<std::uint8_t>(ControlledCharacter::Unknown)};
 
-        // Walk offsets starting at the WorldSystem holder static:
+        // Walk offsets from the player static down to the party container.
+        // See controlled_char.hpp for the full chain narrative.
         //
-        //   *(holder)            -> WorldSystem instance (session heap)
-        //   *(ws   + 0x30)       -> ActorManager singleton
-        //   *(am   + 0x28)       -> UserActor singleton (ClientUserActor)
-        //   *(user + 0xD0)       -> primary actor slot (always Kliff in the
-        //                           current story progression; this value
-        //                           is the structural Kliff anchor)
-        //   *(user + 0xD8)       -> controlled client actor (rotates on swap)
-        //
-        // The UserActor pointer is stable for the lifetime of a save: only
-        // user+0xD8 rotates when the player switches which body they
-        // control. When Kliff is the controlled character, user+0xD0 and
-        // user+0xD8 reference the same actor; this coincidence is the
-        // structural Kliff detector used below.
-        constexpr std::ptrdiff_t k_wsToActorMgrOffset          = 0x30;
-        constexpr std::ptrdiff_t k_actorMgrToUserOffset        = 0x28;
-        constexpr std::ptrdiff_t k_userToPrimaryActorOffset    = 0xD0;
-        constexpr std::ptrdiff_t k_userToControlledActorOffset = 0xD8;
+        //   *(holder)            -> root container (no specific RTTI)
+        //   *(root  + 0x18)      -> pa::NwVirtualAsyncSession
+        //   *(nwSes + 0xA0)      -> pa::ServerUserActor
+        //   *(srvUA + 0xD0)      -> pa::ServerChildOnlyInGameActor
+        //                           (the party container)
+        constexpr std::ptrdiff_t k_rootToNwSessionOffset    = 0x18;
+        constexpr std::ptrdiff_t k_nwSessionToUserOffset    = 0xA0;
+        constexpr std::ptrdiff_t k_userToPartyOffset        = 0xD0;
 
-        // Per-actor slot-index byte on ClientChildOnlyInGameActor.
-        //
-        // v1.04.00: byte at +0x50 holds the raw engine slot-index
-        //
-        //   Kliff   +0x50 = 1
-        //   Damiane +0x50 = 2
-        //   Oongka  +0x50 = 3
-        //
-        // Each body's +0x50 is stable across frames and distinct per
-        // protagonist; +0x64 carries the same byte redundantly but
-        // +0x50 is qword-aligned.
-        //
-        // v1.03.01 used +0x60 for this role. On v1.04.00 the +0x60 byte
-        // reads 1 for every body and is no longer a discriminator.
-        //
-        // The primaryActor (UA+0xD0) is always Kliff on a Kliff-led
-        // save, so `controlledSlot - primarySlot` yields the companion
-        // diff:
-        //
-        //   Damiane - Kliff = 1
-        //   Oongka  - Kliff = 2
-        //
-        // When Kliff is the controlled character UA+0xD0 == UA+0xD8
-        // and decode_probe short-circuits via the pointer equality
-        // check before the slot diff is evaluated.
-        //
-        // The 1.03.01 fallback caveat (`save with only Kliff + Oongka
-        // decodes Oongka as Damiane`) has not been re-verified on a
-        // 2-protagonist v1.04.00 save; keep the {1, 2} diff table
-        // strict until that re-test lands.
-        constexpr std::ptrdiff_t k_actorSlotIndexByteOffset = 0x50;
-        constexpr int k_damianeSlotDiff = 1;
-        constexpr int k_oongkaSlotDiff  = 2;
+        // Per-protagonist slot offsets inside the party container. Stride
+        // is 0x100 between consecutive slots; the absolute offsets are
+        // baked into the engine layout and serve as the identity
+        // discriminator. Adding a fourth protagonist would extend this
+        // table at +0x368.
+        constexpr std::ptrdiff_t k_kliffSlotOffset   = 0x68;
+        constexpr std::ptrdiff_t k_damianeSlotOffset = 0x168;
+        constexpr std::ptrdiff_t k_oongkaSlotOffset  = 0x268;
+
+        // Per-slot fields:
+        //   slot + 0x2C   u8   active flag (1 = controlled, 0 = passive)
+        //   slot + 0x40   u32  observability handle (volatile; log-only)
+        constexpr std::ptrdiff_t k_slotActiveFlagOffset       = 0x2C;
+        constexpr std::ptrdiff_t k_slotObservabilityOffset    = 0x40;
 
         // Lower bound for "looks like a heap pointer". Any value below the
         // 64 KiB Windows guard region is treated as null/invalid; this
@@ -88,15 +75,19 @@ namespace CDCore
         // an uninitialised slot may carry before the singleton is wired up.
         constexpr std::uintptr_t k_minValidPtr = 0x10000;
 
-        // One chain walk yields enough structural data to decode identity.
-        // Populated fully only when the walk completes without faulting; on
-        // any fault `valid` stays false and the numeric fields carry zero.
+        // One chain walk yields the three slot bytes plus their
+        // observability handles. Populated fully only when the walk
+        // completes without faulting; on any fault `valid` stays false and
+        // the numeric fields carry zero.
         struct ChainProbe
         {
-            std::uintptr_t primaryActor;
-            std::uintptr_t controlledActor;
-            std::uint8_t   primarySlot;
-            std::uint8_t   controlledSlot;
+            std::uintptr_t partyContainer;
+            std::uint8_t   kliffActive;
+            std::uint8_t   damianeActive;
+            std::uint8_t   oongkaActive;
+            std::uint32_t  kliffObservability;
+            std::uint32_t  damianeObservability;
+            std::uint32_t  oongkaObservability;
             bool           valid;
         };
 
@@ -104,14 +95,8 @@ namespace CDCore
         // rejects the combination of __try and any C++ object with a
         // non-trivial destructor in the same scope (C2712). Each
         // intermediate pointer is rejected if it falls below the guard
-        // region so a half-torn chain cannot reach the final byte reads
-        // with garbage state.
-        //
-        // Reads BOTH user+0xD0 (primary actor, Kliff anchor) and
-        // user+0xD8 (controlled actor) plus the slot-index byte on each
-        // actor (see k_actorSlotIndexByteOffset). The two byte reads
-        // cost negligible cache traffic because the actor was just
-        // dereferenced and is already in cache.
+        // region so a half-torn chain cannot reach the slot reads with
+        // garbage state.
         ChainProbe walk_chain_seh(std::uintptr_t holder) noexcept
         {
             ChainProbe out{};
@@ -121,51 +106,67 @@ namespace CDCore
             }
             __try
             {
-                const auto ws =
+                const auto root =
                     *reinterpret_cast<const volatile std::uintptr_t *>(holder);
-                if (ws < k_minValidPtr)
+                if (root < k_minValidPtr)
                 {
                     return out;
                 }
-                const auto am =
+                const auto nwSession =
                     *reinterpret_cast<const volatile std::uintptr_t *>(
-                        ws + k_wsToActorMgrOffset);
-                if (am < k_minValidPtr)
+                        root + k_rootToNwSessionOffset);
+                if (nwSession < k_minValidPtr)
                 {
                     return out;
                 }
-                const auto user =
+                const auto userActor =
                     *reinterpret_cast<const volatile std::uintptr_t *>(
-                        am + k_actorMgrToUserOffset);
-                if (user < k_minValidPtr)
+                        nwSession + k_nwSessionToUserOffset);
+                if (userActor < k_minValidPtr)
                 {
                     return out;
                 }
-                const auto primary =
+                const auto party =
                     *reinterpret_cast<const volatile std::uintptr_t *>(
-                        user + k_userToPrimaryActorOffset);
-                if (primary < k_minValidPtr)
+                        userActor + k_userToPartyOffset);
+                if (party < k_minValidPtr)
                 {
                     return out;
                 }
-                const auto controlled =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(
-                        user + k_userToControlledActorOffset);
-                if (controlled < k_minValidPtr)
-                {
-                    return out;
-                }
-                const auto primarySlot =
+                // Three slot reads, each one byte for the active flag and
+                // one dword for the observability handle. The slot bytes
+                // are nominally pinned at compile-time-stable offsets so
+                // a fault here would indicate a torn party container that
+                // the SEH guard correctly rejects.
+                const auto kliffSlot   = party + k_kliffSlotOffset;
+                const auto damianeSlot = party + k_damianeSlotOffset;
+                const auto oongkaSlot  = party + k_oongkaSlotOffset;
+                const auto kliffActive =
                     *reinterpret_cast<const volatile std::uint8_t *>(
-                        primary + k_actorSlotIndexByteOffset);
-                const auto controlledSlot =
+                        kliffSlot + k_slotActiveFlagOffset);
+                const auto damianeActive =
                     *reinterpret_cast<const volatile std::uint8_t *>(
-                        controlled + k_actorSlotIndexByteOffset);
-                out.primaryActor    = primary;
-                out.controlledActor = controlled;
-                out.primarySlot     = primarySlot;
-                out.controlledSlot  = controlledSlot;
-                out.valid           = true;
+                        damianeSlot + k_slotActiveFlagOffset);
+                const auto oongkaActive =
+                    *reinterpret_cast<const volatile std::uint8_t *>(
+                        oongkaSlot + k_slotActiveFlagOffset);
+                const auto kliffObs =
+                    *reinterpret_cast<const volatile std::uint32_t *>(
+                        kliffSlot + k_slotObservabilityOffset);
+                const auto damianeObs =
+                    *reinterpret_cast<const volatile std::uint32_t *>(
+                        damianeSlot + k_slotObservabilityOffset);
+                const auto oongkaObs =
+                    *reinterpret_cast<const volatile std::uint32_t *>(
+                        oongkaSlot + k_slotObservabilityOffset);
+                out.partyContainer       = party;
+                out.kliffActive          = kliffActive;
+                out.damianeActive        = damianeActive;
+                out.oongkaActive         = oongkaActive;
+                out.kliffObservability   = kliffObs;
+                out.damianeObservability = damianeObs;
+                out.oongkaObservability  = oongkaObs;
+                out.valid                = true;
                 return out;
             }
             __except (EXCEPTION_EXECUTE_HANDLER)
@@ -174,49 +175,55 @@ namespace CDCore
             }
         }
 
-        // Decode identity from a completed chain probe using the
-        // structural D0==D8 invariant for Kliff and the slot-index diff
-        // for companions. Returns Unknown when the probe is not valid or
-        // the slot diff falls outside the expected {1, 2} range.
+        // Decode identity from a completed chain probe. Returns Unknown
+        // when the probe is invalid, when no slot is hot (cutscene /
+        // loading screen), or when more than one slot is hot (a transient
+        // engine state mid-swap that the cache layer is responsible for
+        // smoothing over).
         ControlledCharacter decode_probe(const ChainProbe &probe) noexcept
         {
             if (!probe.valid)
             {
                 return ControlledCharacter::Unknown;
             }
-            if (probe.controlledActor == probe.primaryActor)
+            const int hotCount = (probe.kliffActive   == 1 ? 1 : 0) +
+                                 (probe.damianeActive == 1 ? 1 : 0) +
+                                 (probe.oongkaActive  == 1 ? 1 : 0);
+            if (hotCount != 1)
+            {
+                return ControlledCharacter::Unknown;
+            }
+            if (probe.kliffActive == 1)
             {
                 return ControlledCharacter::Kliff;
             }
-            const int diff = static_cast<int>(probe.controlledSlot) -
-                             static_cast<int>(probe.primarySlot);
-            if (diff == k_damianeSlotDiff)
+            if (probe.damianeActive == 1)
             {
                 return ControlledCharacter::Damiane;
             }
-            if (diff == k_oongkaSlotDiff)
-            {
-                return ControlledCharacter::Oongka;
-            }
-            return ControlledCharacter::Unknown;
+            return ControlledCharacter::Oongka;
         }
 
-        // Diagnostic: log each unique (controlledSlot - primarySlot) diff
-        // observed from a valid probe, at most once per process. Four slots
-        // covers the three expected values plus one transient anomaly.
-        // Logs both the raw slot bytes and the computed diff so a future
-        // patch that alters the offset layout is immediately visible.
-        std::array<std::atomic<std::uint32_t>, 4> s_seenProbes{};
+        // Diagnostic: log each unique active-flag triplet observed from a
+        // valid probe, at most once per process. Eight slots covers the
+        // four expected states (none-hot, Kliff-hot, Damiane-hot,
+        // Oongka-hot) with headroom for transient torn-read patterns. The
+        // observability dwords are logged alongside the active flags so
+        // session-to-session correlation is possible without re-running
+        // the resolver in a debugger.
+        std::array<std::atomic<std::uint32_t>, 8> s_seenProbes{};
 
         constexpr std::uint32_t k_probeSentinel = 0xFFFFFFFFu;
 
+        // Pack the three active-flag bytes (each clamped to {0, 1}) into a
+        // 24-bit signature. Guaranteed distinct from k_probeSentinel
+        // because the high byte is always zero.
         std::uint32_t pack_probe_signature(const ChainProbe &probe) noexcept
         {
-            // primary in low byte, controlled in next byte, leaves the
-            // high half zero. Guaranteed distinct from k_probeSentinel
-            // because bit 31 is never set.
-            return static_cast<std::uint32_t>(probe.primarySlot) |
-                   (static_cast<std::uint32_t>(probe.controlledSlot) << 8);
+            const std::uint32_t k = (probe.kliffActive == 1) ? 1u : 0u;
+            const std::uint32_t d = (probe.damianeActive == 1) ? 1u : 0u;
+            const std::uint32_t o = (probe.oongkaActive == 1) ? 1u : 0u;
+            return k | (d << 8) | (o << 16);
         }
 
         void log_first_seen_probe(const ChainProbe &probe,
@@ -238,9 +245,6 @@ namespace CDCore
                             std::memory_order_relaxed,
                             std::memory_order_relaxed))
                     {
-                        const int diff =
-                            static_cast<int>(probe.controlledSlot) -
-                            static_cast<int>(probe.primarySlot);
                         // Prefer the short character name when the decode
                         // matched one of the three known identities.
                         // Unknown falls back to a literal "Unknown" label
@@ -249,11 +253,16 @@ namespace CDCore
                         // self-describing log line even for anomalies.
                         const auto name = controlled_character_name(decoded);
                         DMK::Logger::get_instance().info(
-                            "ControlledChar: probe primary_slot={} "
-                            "controlled_slot={} diff={} -> {}",
-                            static_cast<unsigned>(probe.primarySlot),
-                            static_cast<unsigned>(probe.controlledSlot),
-                            diff,
+                            "ControlledChar: probe kliff_active={} "
+                            "damiane_active={} oongka_active={} "
+                            "kliff_obs=0x{:X} damiane_obs=0x{:X} "
+                            "oongka_obs=0x{:X} -> {}",
+                            static_cast<unsigned>(probe.kliffActive),
+                            static_cast<unsigned>(probe.damianeActive),
+                            static_cast<unsigned>(probe.oongkaActive),
+                            probe.kliffObservability,
+                            probe.damianeObservability,
+                            probe.oongkaObservability,
                             name.empty() ? std::string_view{"Unknown"}
                                          : name);
                         return;
@@ -267,6 +276,369 @@ namespace CDCore
             // Seen-set exhausted. The resolver stays functional; only the
             // diagnostic log is silently dropped for additional unknown
             // probe signatures.
+        }
+
+        // -------------------------------------------------------------------
+        // Radial-swap-key capture: actor pointer -> character cache.
+        //
+        // The mid-hook installed by install_radial_swap_hook() fires inside
+        // the radial UI's swap handler at the moment EAX has just been
+        // loaded with the requested characterinfo key (1 = Kliff,
+        // 4 = Damiane, 6 = Oongka). At that point User+0xD8 still holds
+        // the OLD actor pointer; the new actor commit happens later in
+        // the same handler when sub_141B0C2B0 writes the resolved actor.
+        //
+        // Correlation strategy (chosen for cleaner concurrency vs. a
+        // second hook on the call return):
+        //
+        //   1. Hook stamps a short-lived process-wide pending record
+        //      with (key, deadline_tick). Single record because a radial
+        //      swap is a synchronous user event with no nested handlers.
+        //
+        //   2. The next chain-walk in current_controlled_character() that
+        //      observes a valid userActor and a non-Kliff slot+0x2C
+        //      decode commits (actor_ptr -> key) into the actor cache,
+        //      then clears the pending record. The deadline (currently
+        //      2000 ms) bounds the window so a stale record from a
+        //      cancelled radial cannot pollute future commits.
+        //
+        //   3. The resolver consults the cache before falling back to
+        //      the slot-offset decode when the +0x2C decode itself
+        //      yielded Unknown but the chain walk reached a valid
+        //      userActor. Cache hits are deterministic per-actor;
+        //      cache misses fall through to the slot decode.
+        //
+        // Concurrency model: shared_mutex on the cache because the hook
+        // (game thread) and resolver (worker threads + main render) hit
+        // the cache asymmetrically -- many readers, occasional writer.
+        // The pending record itself is two atomics (key + deadline);
+        // races on the pending-record path collapse to a benign no-op
+        // because either the hook overwrites a stale pending value or
+        // the resolver clears one we are about to commit. In both cases
+        // the next radial swap rebuilds the record correctly.
+        //
+        // Why a per-actor cache instead of a single "latest key" atomic:
+        // the LiveTransmog preset routing must distinguish between
+        // saved-out and reloaded actor pointers (actor pool reuses old
+        // addresses across save loads). A per-actor map naturally goes
+        // stale at save-load -- pre-existing entries reference dead
+        // pointers the engine will not reuse for the same character --
+        // and invalidate_controlled_character() clears the cache to
+        // bound stale-entry growth.
+        // -------------------------------------------------------------------
+
+        // 2-second window: typical radial swap commits within tens of
+        // milliseconds, but post-swap the resolver only refreshes when
+        // a consumer queries it; 2 s tolerates one full
+        // load_detect_thread tick before declaring the pending record
+        // stale. Bounded above by the next radial swap clobbering it.
+        constexpr std::uint64_t k_pendingKeyWindowMs = 2000u;
+
+        // Engine characterinfo keys, verified live (CE 2026-05-02 across
+        // four protagonist transitions including a save B follow-up):
+        //   key 1 -> Kliff
+        //   key 4 -> Damiane
+        //   key 6 -> Oongka
+        // Other key values land outside the protagonist set and are
+        // stored as Unknown so the cache never falsely attributes an
+        // NPC body to one of the three.
+        constexpr std::uint32_t k_keyKliff   = 1u;
+        constexpr std::uint32_t k_keyDamiane = 4u;
+        constexpr std::uint32_t k_keyOongka  = 6u;
+
+        ControlledCharacter character_from_key(std::uint32_t key) noexcept
+        {
+            switch (key)
+            {
+                case k_keyKliff:   return ControlledCharacter::Kliff;
+                case k_keyDamiane: return ControlledCharacter::Damiane;
+                case k_keyOongka:  return ControlledCharacter::Oongka;
+                default:           return ControlledCharacter::Unknown;
+            }
+        }
+
+        // Pending-record fields. s_pendingKey is read in the resolver
+        // hot path so it is a plain atomic instead of a struct under a
+        // lock; the deadline atomic provides freshness gating without
+        // taking a mutex on every query. A non-zero pendingKey with
+        // deadline >= now is "live"; everything else is "expired".
+        std::atomic<std::uint32_t> s_pendingKey{0};
+        std::atomic<std::uint64_t> s_pendingDeadlineMs{0};
+
+        // Per-actor identity cache populated by the resolver when a
+        // pending record commits, and consulted by the resolver as a
+        // Stage 3 layer when the chain walk reaches a valid userActor
+        // but the slot decode returns Unknown (or for cross-validation
+        // when both Damiane and Oongka are radial-controllable but
+        // neither holds a hot +0x2C flag in the formal party). Ranged
+        // small (the engine has at most three live protagonist actor
+        // pointers per session); the unordered_map is sized for that.
+        std::shared_mutex s_actorCacheMutex;
+        std::unordered_map<std::uintptr_t, ControlledCharacter>
+            s_actorKeyCache;
+
+        // Learning cache: body pointer (user+0xD8 at the moment of an
+        // identified-controlled snapshot) -> character. Populated as a
+        // side effect of every successful current_controlled_character()
+        // call that sees a non-Unknown identity AND can reach user+0xD8
+        // via the WS chain. Each protagonist's body is added to the
+        // cache the first time the user controls that character; from
+        // then on resolve_character_idx_for_body() can attribute roster
+        // bodies to their identities even while a different protagonist
+        // is currently controlled.
+        //
+        // Lifetime: cleared together with s_actorKeyCache in
+        // invalidate_controlled_character() because save-load
+        // reallocates the body pool; pre-existing entries reference
+        // dead pointers the engine may reuse for a different character.
+        //
+        // Why a learning cache instead of a structural decode: the
+        // v1.04.00 client body has no reachable back-reference to its
+        // protagonist slot in the party container, and the per-actor
+        // +0x50 byte that earlier builds used as a slot index ceased
+        // to discriminate on this build. Observing the controlled-body
+        // / known-character pairing each resolver tick is the only
+        // stable mapping available from the public game-state surface.
+        std::shared_mutex s_bodyCacheMutex;
+        std::unordered_map<std::uintptr_t, ControlledCharacter>
+            s_bodyKeyCache;
+
+        // SafetyHook owner. Held in a dedicated mutex because the
+        // install/uninstall paths must serialise against each other,
+        // and a second mutex separate from s_actorCacheMutex prevents
+        // any caller of the public install/uninstall API from blocking
+        // a resolver query already inside the cache critical section.
+        //
+        // Single-owner-per-DLL semantics: CrimsonDesertCore is linked
+        // as a STATIC library, so this state is private to whichever
+        // Logic DLL (LiveTransmog or EquipHide) owns this translation
+        // unit's instance. When both consumers AOB-resolve the same
+        // radial-swap site and call install_radial_swap_hook(addr),
+        // each DLL builds its own MidHook independently. SafetyHook's
+        // internal chaining at the JMP-target site lets the two
+        // MidHooks coexist -- each consumer's callback fires on every
+        // radial swap. The AOB cascade in cdcore/anchors.hpp is
+        // ordered so the post-patch-tolerant patterns match first,
+        // letting the second consumer resolve the same target after
+        // the first has already patched the prelude bytes.
+        std::mutex s_hookMutex;
+        safetyhook::MidHook s_radialSwapHook;
+        std::atomic<std::uintptr_t> s_radialSwapHookAddr{0};
+
+        // SafetyHook MidHook destination. Lives at file scope (function
+        // pointer cannot be a lambda capture target). Reads the low 32
+        // bits of RAX -- the captured characterinfo key -- and stamps
+        // the pending record with a deadline 2 s in the future. Must
+        // not block, allocate, or call into anything that can re-enter
+        // SafetyHook; the body is a single atomic store pair.
+        void radial_swap_midhook(safetyhook::Context &ctx) noexcept
+        {
+            // EAX = ctx.rax low 32 bits. The mid-hook lands on
+            // `mov [rbp+0x78], eax` so RAX holds the just-loaded key
+            // and is not yet shadowed by the lookup-table call.
+            const auto key =
+                static_cast<std::uint32_t>(ctx.rax & 0xFFFFFFFFu);
+            const auto now = GetTickCount64();
+            // Order: stamp the deadline first so the resolver does not
+            // observe a fresh key with a stale deadline. The acquire
+            // load on the resolver side pairs with these releases.
+            s_pendingDeadlineMs.store(now + k_pendingKeyWindowMs,
+                                      std::memory_order_release);
+            s_pendingKey.store(key, std::memory_order_release);
+        }
+
+        // Try to commit the pending key against the supplied actor
+        // pointer. Called from the resolver hot path on every query
+        // that sees a valid userActor. Cheap on the no-pending fast
+        // path (one relaxed atomic load + branch). On commit, takes
+        // the cache mutex exclusive briefly; commit failures (expired
+        // record, unknown key) silently drop the pending record so a
+        // late retry does not double-commit.
+        void try_commit_pending(std::uintptr_t userActor) noexcept
+        {
+            if (userActor < k_minValidPtr)
+            {
+                return;
+            }
+            const auto key = s_pendingKey.load(std::memory_order_acquire);
+            if (key == 0)
+            {
+                return;
+            }
+            const auto deadline =
+                s_pendingDeadlineMs.load(std::memory_order_acquire);
+            const auto now = GetTickCount64();
+            if (now > deadline)
+            {
+                // Stale; clear so we do not consume it on a later
+                // unrelated query.
+                s_pendingKey.store(0, std::memory_order_release);
+                s_pendingDeadlineMs.store(0, std::memory_order_release);
+                return;
+            }
+            const auto ch = character_from_key(key);
+            if (ch == ControlledCharacter::Unknown)
+            {
+                // Out-of-range key (engine repurposed the slot for an
+                // NPC body or a future protagonist not in our table);
+                // clear and do not pollute the cache.
+                s_pendingKey.store(0, std::memory_order_release);
+                s_pendingDeadlineMs.store(0, std::memory_order_release);
+                return;
+            }
+            {
+                std::unique_lock<std::shared_mutex> lk(s_actorCacheMutex);
+                s_actorKeyCache[userActor] = ch;
+            }
+            s_pendingKey.store(0, std::memory_order_release);
+            s_pendingDeadlineMs.store(0, std::memory_order_release);
+
+            DMK::Logger::get_instance().info(
+                "ControlledChar: radial-swap cache bind userActor=0x{:X} "
+                "-> {} (key={})",
+                static_cast<std::uint64_t>(userActor),
+                controlled_character_name(ch),
+                key);
+        }
+
+        ControlledCharacter lookup_actor_cache(
+            std::uintptr_t userActor) noexcept
+        {
+            if (userActor < k_minValidPtr)
+            {
+                return ControlledCharacter::Unknown;
+            }
+            std::shared_lock<std::shared_mutex> lk(s_actorCacheMutex);
+            const auto it = s_actorKeyCache.find(userActor);
+            if (it == s_actorKeyCache.end())
+            {
+                return ControlledCharacter::Unknown;
+            }
+            return it->second;
+        }
+
+        // SEH-isolated reach to the userActor pointer alone. The full
+        // walk_chain_seh() above stops at the party container; the
+        // cache layer keys on the userActor (party container's parent
+        // in the chain) because the actor pointer is what the engine
+        // commits per radial swap and what the radial-swap-key hook's
+        // pending record is meant to attribute to.
+        std::uintptr_t walk_to_user_actor_seh(std::uintptr_t holder) noexcept
+        {
+            if (holder < k_minValidPtr)
+            {
+                return 0;
+            }
+            __try
+            {
+                const auto root = *reinterpret_cast<
+                    const volatile std::uintptr_t *>(holder);
+                if (root < k_minValidPtr)
+                {
+                    return 0;
+                }
+                const auto nwSession = *reinterpret_cast<
+                    const volatile std::uintptr_t *>(
+                    root + k_rootToNwSessionOffset);
+                if (nwSession < k_minValidPtr)
+                {
+                    return 0;
+                }
+                const auto userActor = *reinterpret_cast<
+                    const volatile std::uintptr_t *>(
+                    nwSession + k_nwSessionToUserOffset);
+                if (userActor < k_minValidPtr)
+                {
+                    return 0;
+                }
+                return userActor;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return 0;
+            }
+        }
+
+        // SEH-isolated walk that resolves user+0xD8 -- the rotating
+        // CLIENT body pointer used as the body-cache key. Walks the WS
+        // chain (s_wsHolder -> ws -> ws+0x30 (ActorManager) -> am+0x28
+        // (ClientUserActor) -> +0xD8). The PLAYER-STATIC chain reaches
+        // a distinct server-side ServerUserActor whose +0xD8 is not
+        // the client body and would mis-key the cache (EquipHide's
+        // body_to_vis_ctrl walker and char-swap detector both consume
+        // the client body, so the cache must be keyed on it).
+        //
+        // Returns 0 when the WS holder has not been published yet,
+        // when any intermediate pointer is below the guard region, or
+        // when the load faults. Callers treat 0 as "no stamp this
+        // tick" and leave the cache unchanged.
+        std::uintptr_t walk_to_controlled_body_seh() noexcept
+        {
+            const auto wsHolder =
+                s_wsHolder.load(std::memory_order_acquire);
+            if (wsHolder < k_minValidPtr)
+            {
+                return 0;
+            }
+            __try
+            {
+                const auto ws = *reinterpret_cast<
+                    const volatile std::uintptr_t *>(wsHolder);
+                if (ws < k_minValidPtr)
+                {
+                    return 0;
+                }
+                // ws + 0x30 -> ActorManager. Same offset as walks
+                // elsewhere in the codebase (EH player_detection, LT
+                // transmog_worker).
+                const auto am = *reinterpret_cast<
+                    const volatile std::uintptr_t *>(ws + 0x30);
+                if (am < k_minValidPtr)
+                {
+                    return 0;
+                }
+                // am + 0x28 -> ClientUserActor.
+                const auto userActor = *reinterpret_cast<
+                    const volatile std::uintptr_t *>(am + 0x28);
+                if (userActor < k_minValidPtr)
+                {
+                    return 0;
+                }
+                // user + 0xD8 -> controlled CLIENT body. The userActor
+                // singleton stays constant across radial swaps; only
+                // this field rotates per swap, so it is the correct
+                // key for body-identity attribution.
+                const auto controlledBody = *reinterpret_cast<
+                    const volatile std::uintptr_t *>(userActor + 0xD8);
+                if (controlledBody < k_minValidPtr)
+                {
+                    return 0;
+                }
+                return controlledBody;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return 0;
+            }
+        }
+
+        // Stamp (body -> character) into the learning cache. Called from
+        // current_controlled_character() at every success exit. The
+        // shared_mutex pattern matches s_actorKeyCache: many readers
+        // (resolve_character_idx_for_body) and an occasional writer
+        // (this stamp). Skips when @p body is below the guard region or
+        // when @p ch is Unknown -- callers should only stamp on a
+        // confirmed identity.
+        void stamp_body_cache(std::uintptr_t body,
+                              ControlledCharacter ch) noexcept
+        {
+            if (body < k_minValidPtr ||
+                ch == ControlledCharacter::Unknown)
+            {
+                return;
+            }
+            std::unique_lock<std::shared_mutex> lk(s_bodyCacheMutex);
+            s_bodyKeyCache[body] = ch;
         }
 
     } // anonymous namespace
@@ -283,9 +655,22 @@ namespace CDCore
         }
     }
 
+    void set_player_static_holder(std::uintptr_t holderAddr) noexcept
+    {
+        s_playerStaticHolder.store(holderAddr, std::memory_order_release);
+
+        if (holderAddr != 0)
+        {
+            DMK::Logger::get_instance().info(
+                "ControlledChar: Player static holder published at 0x{:X}",
+                static_cast<std::uint64_t>(holderAddr));
+        }
+    }
+
     ControlledCharacter current_controlled_character() noexcept
     {
-        const auto holder = s_wsHolder.load(std::memory_order_acquire);
+        const auto holder =
+            s_playerStaticHolder.load(std::memory_order_acquire);
         if (holder == 0)
         {
             return ControlledCharacter::Unknown;
@@ -299,22 +684,160 @@ namespace CDCore
             log_first_seen_probe(probe, decoded);
         }
 
-        // A known-identity decode refreshes the last-known-good cache.
-        // Anything else (invalid probe from a faulted chain walk, torn
-        // read mid-swap that lands on an unexpected slot diff, or an
-        // unrecognised future slot offset) is rejected and the
-        // previously-cached identity is reused instead. When the cache
-        // itself is empty (pre-world, post-invalidation) the final return
-        // falls through to Unknown.
+        // Resolver layering, top-to-bottom:
+        //
+        //   1. Slot-offset decode (above): returns the character whose
+        //      +0x2C flag is uniquely hot. Wins outright for all in-
+        //      world states where the engine maintains the formal
+        //      party invariant.
+        //
+        //   2. Pending-key commit + actor cache lookup (this block):
+        //      walks the chain to the userActor and consults the
+        //      radial-swap cache built by the mid-hook. Resolves the
+        //      ghost-roster case where the formal party shows zero or
+        //      multiple hot slots but the radial UI deterministically
+        //      picked a specific character moments earlier.
+        //
+        //   3. Last-known-good cache (below): preserves the previously
+        //      decoded identity when both prior layers return Unknown.
+        //      Bridges transient torn reads mid-swap and any decode
+        //      path that has never seen a known identity yet.
+        const auto userActor = walk_to_user_actor_seh(holder);
+        try_commit_pending(userActor);
+
+        // A known slot-offset decode wins. Refresh the LKG cache so a
+        // subsequent torn-read query can fall back to it.
         if (decoded != ControlledCharacter::Unknown)
         {
             s_lastGoodChar.store(static_cast<std::uint8_t>(decoded),
                                  std::memory_order_release);
+            // Body-cache stamp: the chain walk just confirmed `decoded`
+            // is the controlled identity, so user+0xD8 right now points
+            // to that character's body. Reading it here lets
+            // resolve_character_idx_for_body() attribute the body for
+            // EquipHide's UA stride walk on later ticks even when a
+            // different protagonist is being controlled.
+            const auto controlledBody = walk_to_controlled_body_seh();
+            stamp_body_cache(controlledBody, decoded);
             return decoded;
         }
 
+        // Slot decode unknown -- consult the actor cache. A hit here is
+        // the deterministic answer for ghost-roster scenes where the
+        // formal +0x2C invariant does not apply but the radial UI's
+        // captured key is still authoritative for the live actor. Also
+        // refreshes the LKG cache on hit so a later query that the
+        // userActor walk happens to fault on still resolves correctly.
+        const auto cached = lookup_actor_cache(userActor);
+        if (cached != ControlledCharacter::Unknown)
+        {
+            s_lastGoodChar.store(static_cast<std::uint8_t>(cached),
+                                 std::memory_order_release);
+            // Body-cache stamp: the actor cache resolved an identity
+            // for the live userActor, so user+0xD8 currently holds the
+            // body for `cached`. Same rationale as the slot-decode
+            // branch above -- learn the body here so later body-keyed
+            // queries resolve without re-running this chain walk.
+            const auto controlledBody = walk_to_controlled_body_seh();
+            stamp_body_cache(controlledBody, cached);
+            return cached;
+        }
+
+        // Neither the slot decode nor the actor cache yielded a known
+        // identity; fall back to the last-known-good. Empty pre-world
+        // and post-invalidation, in which case the final return is
+        // Unknown.
         return static_cast<ControlledCharacter>(
             s_lastGoodChar.load(std::memory_order_acquire));
+    }
+
+    bool install_radial_swap_hook(std::uintptr_t hookAddr) noexcept
+    {
+        std::lock_guard<std::mutex> lk(s_hookMutex);
+
+        const auto current =
+            s_radialSwapHookAddr.load(std::memory_order_acquire);
+
+        if (hookAddr == 0)
+        {
+            // Teardown path. Idempotent: when nothing is installed the
+            // moved-from MidHook destructor below is a no-op.
+            if (current == 0)
+            {
+                return true;
+            }
+            // Destroy the MidHook so the patched bytes return to their
+            // original instruction sequence. safetyhook::MidHook's
+            // destructor handles unhook plus trampoline-page free under
+            // SafetyHook's own internal synchronization. When two
+            // consumer DLLs both have a MidHook here, each tears down
+            // its own copy independently -- SafetyHook's chaining
+            // unwinds the JMP target back through the remaining hooks.
+            s_radialSwapHook = safetyhook::MidHook{};
+            s_radialSwapHookAddr.store(0, std::memory_order_release);
+
+            DMK::Logger::get_instance().info(
+                "ControlledChar: radial-swap hook uninstalled");
+            return true;
+        }
+
+        if (hookAddr < k_minValidPtr)
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: radial-swap hook rejected -- address "
+                "0x{:X} below guard region",
+                static_cast<std::uint64_t>(hookAddr));
+            return false;
+        }
+
+        if (current == hookAddr)
+        {
+            // Already installed at this exact address. Idempotent.
+            return true;
+        }
+
+        if (current != 0)
+        {
+            // Address shifted (AOB re-resolution mid-session). Tear
+            // down the existing MidHook before rebuilding so we never
+            // hold two MidHooks owned by the same DLL slot.
+            DMK::Logger::get_instance().info(
+                "ControlledChar: radial-swap hook target shifted "
+                "0x{:X} -> 0x{:X}, rebuilding",
+                static_cast<std::uint64_t>(current),
+                static_cast<std::uint64_t>(hookAddr));
+            s_radialSwapHook = safetyhook::MidHook{};
+            s_radialSwapHookAddr.store(0, std::memory_order_release);
+        }
+
+        // Build the SafetyHook MidHook. SafetyHook's internal chaining
+        // tolerates a sibling DLL having already patched this site
+        // with its own MidHook; the JMP at the hook target is rewritten
+        // to chain through both callbacks transparently.
+        auto built = safetyhook::MidHook::create(
+            reinterpret_cast<void *>(hookAddr),
+            radial_swap_midhook);
+        if (!built)
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: radial-swap hook creation failed at "
+                "0x{:X}",
+                static_cast<std::uint64_t>(hookAddr));
+            return false;
+        }
+
+        s_radialSwapHook = std::move(*built);
+        s_radialSwapHookAddr.store(hookAddr, std::memory_order_release);
+
+        DMK::Logger::get_instance().info(
+            "ControlledChar: radial-swap hook installed at 0x{:X}",
+            static_cast<std::uint64_t>(hookAddr));
+        return true;
+    }
+
+    void uninstall_radial_swap_hook() noexcept
+    {
+        (void)install_radial_swap_hook(0);
     }
 
     std::string_view controlled_character_name(
@@ -347,152 +870,114 @@ namespace CDCore
         return 0;
     }
 
-    namespace
+    std::uint32_t resolve_character_idx_for_body(
+        std::uintptr_t body) noexcept
     {
-        // Read just the primary actor's slot-index byte. Mirrors
-        // walk_chain_seh's pointer-validity discipline (every intermediate
-        // pointer below the 64 KiB guard region is rejected) so a torn
-        // chain can never reach the final byte read with garbage state.
-        // Output is the slot byte in `outPrimarySlot` plus a `valid` flag;
-        // a faulted walk leaves the byte at zero and `valid` at false.
-        struct PrimarySlotProbe
-        {
-            std::uint8_t slot;
-            bool         valid;
-        };
-
-        PrimarySlotProbe read_primary_slot_seh(std::uintptr_t holder) noexcept
-        {
-            PrimarySlotProbe out{};
-            if (holder < k_minValidPtr)
-            {
-                return out;
-            }
-            __try
-            {
-                const auto ws =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(holder);
-                if (ws < k_minValidPtr)
-                {
-                    return out;
-                }
-                const auto am =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(
-                        ws + k_wsToActorMgrOffset);
-                if (am < k_minValidPtr)
-                {
-                    return out;
-                }
-                const auto user =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(
-                        am + k_actorMgrToUserOffset);
-                if (user < k_minValidPtr)
-                {
-                    return out;
-                }
-                const auto primary =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(
-                        user + k_userToPrimaryActorOffset);
-                if (primary < k_minValidPtr)
-                {
-                    return out;
-                }
-                out.slot =
-                    *reinterpret_cast<const volatile std::uint8_t *>(
-                        primary + k_actorSlotIndexByteOffset);
-                out.valid = true;
-                return out;
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return out;
-            }
-        }
-
-        // SEH-isolated single-byte read on an arbitrary body pointer.
-        // Returns the slot byte plus a validity flag; a fault during the
-        // read (recycled or freed body, partially-torn structure right
-        // after a swap) leaves the byte at zero and the flag at false.
-        struct BodySlotProbe
-        {
-            std::uint8_t slot;
-            bool         valid;
-        };
-
-        BodySlotProbe read_body_slot_seh(std::uintptr_t body) noexcept
-        {
-            BodySlotProbe out{};
-            if (body < k_minValidPtr)
-            {
-                return out;
-            }
-            __try
-            {
-                out.slot =
-                    *reinterpret_cast<const volatile std::uint8_t *>(
-                        body + k_actorSlotIndexByteOffset);
-                out.valid = true;
-                return out;
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return out;
-            }
-        }
-
-    } // anonymous namespace
-
-    std::uint32_t resolve_character_idx_for_body(std::uintptr_t body) noexcept
-    {
+        // Learning-cache lookup. The cache is populated as a side
+        // effect of every successful current_controlled_character()
+        // call -- the resolver stamps (user+0xD8 -> identity) once it
+        // confirms the controlled character, and after the user has
+        // cycled through each protagonist at least once every
+        // protagonist's body pointer is cache-resident. Roster bodies
+        // (party members visible in the world but not currently
+        // controlled) resolve here without requiring a structural
+        // decode the v1.04.00 layout does not expose.
+        //
+        // Zero return on miss is the safe degradation: callers in
+        // EquipHide treat zero as "unknown body" and fall back to the
+        // active character's hide mask, which matches single-character
+        // semantics until the cache warms.
         if (body < k_minValidPtr)
         {
             return 0;
         }
-        const auto holder = s_wsHolder.load(std::memory_order_acquire);
-        if (holder == 0)
+        std::shared_lock<std::shared_mutex> lk(s_bodyCacheMutex);
+        const auto it = s_bodyKeyCache.find(body);
+        if (it == s_bodyKeyCache.end())
         {
             return 0;
         }
-        // Two independent SEH probes: the primary-actor walk faulting
-        // does not invalidate the body byte read and vice versa. Both
-        // must succeed for the diff to mean anything.
-        const auto primary = read_primary_slot_seh(holder);
-        if (!primary.valid)
+        switch (it->second)
         {
-            return 0;
-        }
-        const auto bodyProbe = read_body_slot_seh(body);
-        if (!bodyProbe.valid)
-        {
-            return 0;
-        }
-        const int diff = static_cast<int>(bodyProbe.slot) -
-                         static_cast<int>(primary.slot);
-        if (diff == 0)
-        {
-            return 1; // Kliff
-        }
-        if (diff == k_damianeSlotDiff)
-        {
-            return 2; // Damiane
-        }
-        if (diff == k_oongkaSlotDiff)
-        {
-            return 3; // Oongka
+            case ControlledCharacter::Kliff:   return 1;
+            case ControlledCharacter::Damiane: return 2;
+            case ControlledCharacter::Oongka:  return 3;
+            case ControlledCharacter::Unknown: return 0;
         }
         return 0;
     }
 
-    void invalidate_controlled_character() noexcept
+    std::size_t snapshot_body_cache(BodyCacheEntry *out, std::size_t cap) noexcept
+    {
+        if (out == nullptr || cap == 0)
+        {
+            return 0;
+        }
+        std::shared_lock<std::shared_mutex> lk(s_bodyCacheMutex);
+        std::size_t written = 0;
+        for (const auto &kv : s_bodyKeyCache)
+        {
+            if (written >= cap)
+            {
+                break;
+            }
+            std::uint32_t idx = 0;
+            switch (kv.second)
+            {
+                case ControlledCharacter::Kliff:   idx = 1; break;
+                case ControlledCharacter::Damiane: idx = 2; break;
+                case ControlledCharacter::Oongka:  idx = 3; break;
+                case ControlledCharacter::Unknown: continue;
+            }
+            out[written++] = BodyCacheEntry{kv.first, idx};
+        }
+        return written;
+    }
+
+    void invalidate_swap_caches() noexcept
     {
         // Release ordering pairs with the acquire load in
         // current_controlled_character() so any reader that subsequently
         // observes the Unknown sentinel also observes side effects the
         // caller performed before invalidating (e.g. clearing per-character
-        // preset caches in preparation for a save-load transition).
+        // preset caches in preparation for the swap settling).
         s_lastGoodChar.store(
             static_cast<std::uint8_t>(ControlledCharacter::Unknown),
             std::memory_order_release);
+
+        // In-session radial swaps rotate user+0xD8 between existing body
+        // pointers in the pool but reallocate the userActor parent only
+        // on save-load. The actor->character cache keys on the userActor
+        // pointer; clearing it on every swap is the safe choice because
+        // the cache is bounded by the number of distinct userActor
+        // singletons the engine produces (typically one per session) and
+        // a stale entry would otherwise short-circuit the resolver to a
+        // pre-swap identity. The pending radial-swap-key record is also
+        // cleared because any in-flight commit it referenced is moot
+        // once the swap completes.
+        {
+            std::unique_lock<std::shared_mutex> lk(s_actorCacheMutex);
+            s_actorKeyCache.clear();
+        }
+
+        s_pendingKey.store(0, std::memory_order_release);
+        s_pendingDeadlineMs.store(0, std::memory_order_release);
+    }
+
+    void invalidate_controlled_character() noexcept
+    {
+        // Full world-reload clear. Save-load transitions reallocate
+        // every chain pointer including the body pool; flushing the
+        // body cache here prevents post-load mis-attribution where
+        // the engine reuses a previously-cached body address for a
+        // different protagonist. The swap-scope state (LKG, actor
+        // cache, pending record) is cleared by the helper below.
+        invalidate_swap_caches();
+
+        {
+            std::unique_lock<std::shared_mutex> lk(s_bodyCacheMutex);
+            s_bodyKeyCache.clear();
+        }
     }
 
 } // namespace CDCore

--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -171,7 +171,7 @@ execute_process(
     RESULT_VARIABLE rc
 )
 if(rc EQUAL 0)
-    message(STATUS "Direct deploy OK — cleaning staging")
+    message(STATUS "Direct deploy OK -- cleaning staging")
     file(REMOVE "${STAGING_DLL}")
     # PDB: best-effort copy alongside the DLL
     if(EXISTS "${SRC_PDB}")

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- NPCs are no longer accidentally stripped by the protagonist hide settings.
+- Per-character hide masks now apply correctly to each visible protagonist (after one radial-cycle through all three).
+- Fixed coexistence with Live Transmog: both mods can now be loaded together without breaking radial-menu tracking.

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -36,6 +36,8 @@ namespace EquipHide
 
     inline constexpr auto &k_worldSystemCandidates =
         CDCore::Anchors::k_worldSystemCandidates;
+    inline constexpr auto &k_playerStaticCandidates =
+        CDCore::Anchors::k_playerStaticCandidates;
     inline constexpr auto &k_mapLookupCandidates =
         CDCore::Anchors::k_mapLookupCandidates;
     inline constexpr auto &k_partAddShowCandidates =
@@ -44,6 +46,8 @@ namespace EquipHide
         CDCore::Anchors::k_visualEquipChangeCandidates;
     inline constexpr auto &k_batchEquipCandidates =
         CDCore::Anchors::k_batchEquipCandidates;
+    inline constexpr auto &k_radialSwapKeyCandidates =
+        CDCore::Anchors::k_radialSwapKeyCandidates;
     // Historical EH name. BatchEquip is the unified label.
     inline constexpr auto &k_visualEquipSwapCandidates =
         CDCore::Anchors::k_batchEquipCandidates;

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -411,13 +411,66 @@ namespace EquipHide
             k_worldSystemCandidates, std::size(k_worldSystemCandidates),
             "WorldSystem");
 
-        // Publish the WorldSystem holder to the Core controlled-character
-        // resolver. Core walks WorldSystem -> ActorManager -> UserActor ->
-        // controlled_actor(+0xD8) -> identity u32s at +0xDC and +0xEC.
-        // Idempotent across consumers: when CrimsonDesertLiveTransmog is
-        // loaded alongside, both publish the same address and the later
-        // writer wins (the intended behaviour after a re-resolve).
+        // Publish the WorldSystem holder to Core. The WorldSystem chain
+        // is the client-side reach used by the per-frame body-pool walk
+        // and by other client-side state. Identity decoding no longer
+        // consumes this pointer on v1.04.00 (the discriminator byte
+        // ceased to be unique in this build); the player static
+        // resolved below feeds the controlled-character resolver
+        // instead. Idempotent across consumers: when LiveTransmog is
+        // loaded alongside, both publish the same address and the
+        // later writer wins.
         CDCore::set_world_system_holder(addrs.worldSystem);
+
+        addrs.playerStatic = resolve_address(
+            k_playerStaticCandidates, std::size(k_playerStaticCandidates),
+            "PlayerStatic");
+
+        // Publish the player static to the Core controlled-character
+        // resolver. The chain (root -> NwVirtualAsyncSession ->
+        // ServerUserActor -> ServerChildOnlyInGameActor) reaches the
+        // server-side party container, where each protagonist occupies
+        // a fixed-offset slot (Kliff=0x68, Damiane=0x168, Oongka=0x268)
+        // and the active-flag byte at slot+0x2C identifies the
+        // currently-controlled character. Idempotent with the matching
+        // publish in LiveTransmog.
+        CDCore::set_player_static_holder(addrs.playerStatic);
+
+        // Install the radial-swap-key capture mid-hook via Core. Core
+        // owns this DLL's SafetyHook instance and the per-DLL
+        // actor->character cache; EquipHide's role is to publish the
+        // resolved hook address so the controlled-character resolver
+        // gains its deterministic ghost-roster layer even when
+        // LiveTransmog is not loaded.
+        //
+        // Two-consumer (EH + LT) coordination: CrimsonDesertCore is a
+        // STATIC library, so this DLL owns its own MidHook independent
+        // of any sibling DLL's MidHook against the same process address.
+        // The AOB cascade is ordered to match either an unpatched site
+        // or a site whose prelude bytes have already been displaced by
+        // a sibling's earlier MidHook install (see anchors.hpp), so the
+        // scan succeeds regardless of load order. SafetyHook's internal
+        // chaining at the JMP target lets both DLLs' callbacks fire on
+        // every radial swap.
+        {
+            const auto radialAddr = resolve_address(
+                k_radialSwapKeyCandidates,
+                std::size(k_radialSwapKeyCandidates),
+                "RadialSwapKey");
+            if (radialAddr)
+            {
+                if (!CDCore::install_radial_swap_hook(radialAddr))
+                    logger.warning(
+                        "Radial-swap key hook install failed -- "
+                        "ghost-roster character resolution disabled");
+            }
+            else
+            {
+                logger.warning(
+                    "RadialSwapKey AOB failed -- ghost-roster "
+                    "character resolution disabled");
+            }
+        }
 
         addrs.childActorVtbl = resolve_address(
             k_childActorVtblCandidates, std::size(k_childActorVtblCandidates),
@@ -750,6 +803,12 @@ namespace EquipHide
         // would race the loader unmapping the Logic-DLL pages backing
         // the cleanup function itself.
         cleanup_vis_bytes();
+        logger.flush();
+
+        // Tear down the Core-owned radial-swap mid-hook before the
+        // SafetyHook trampoline pages can be touched by a late-firing
+        // game thread. Idempotent.
+        CDCore::uninstall_radial_swap_hook();
         logger.flush();
 
         logger.info("{} shutdown: step 5 DMK_Shutdown", MOD_NAME);

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -8,6 +8,9 @@
 
 #include <Windows.h>
 
+#include <array>
+#include <cstddef>
+
 namespace EquipHide
 {
     static std::atomic<uint32_t> s_resolveCounter{0};
@@ -132,16 +135,23 @@ namespace EquipHide
                actor stays valid from Core's perspective and the
                resolver's torn-read absorption returns the previous
                character's name on any chain walk that lands on the
-               new wrapper before its +0x60 slot-index byte is
-               populated. Result downstream: set_active_character()
-               gets called with the wrong idx for one or more ticks
-               after the swap and the per-character Parts list
-               switches to the outgoing character's overrides until
-               the next tick re-classifies. Invalidating here costs at
-               most one polling tick of additional latency (the
-               resolver returns Unknown until the chain walk on the
-               new wrapper lands a known identity key) which the
-               caller tolerates by idx=-1 falling back to base Parts.
+               new wrapper before the slot decode catches up.
+
+               We use invalidate_swap_caches() (not the full
+               invalidate_controlled_character()) because in-session
+               swaps rotate user+0xD8 between EXISTING body pointers in
+               the pool without reallocating bodies. The body learning
+               cache (body -> character) populated by CDCore stays
+               valid across the swap; flushing it would force every
+               party member visible in the world to fall back to the
+               active character's hide mask until the user manually
+               cycled through each protagonist again, which is exactly
+               the bug this split is fixing. We only need to evict the
+               swap-scope state here: the LKG identity (so the resolver
+               does not return the OLD character on the first post-swap
+               query before the radial hook / slot decode catches up)
+               and the actor->character cache (which is bounded small
+               enough that flushing on every swap costs nothing).
 
                The prevControlledActor != 0 guard mirrors the
                first-boot suppression above: on the very first tick
@@ -156,10 +166,10 @@ namespace EquipHide
                 {
                     DMK::Logger::get_instance().info(
                         "Char swap detected: controlled actor "
-                        "(0x{:X} -> 0x{:X}); invalidating controlled-"
-                        "char cache for in-session swap",
+                        "(0x{:X} -> 0x{:X}); invalidating swap-scope "
+                        "caches (body cache preserved)",
                         s_prevControlledActor, controlledActor);
-                    CDCore::invalidate_controlled_character();
+                    CDCore::invalidate_swap_caches();
                 }
                 s_prevControlledActor = controlledActor;
             }
@@ -185,182 +195,64 @@ namespace EquipHide
                 set_active_character(idx);
             }
 
-            /* Protagonist enumeration -- two complementary walks.
-               The UA+0xD0..+0x108 stride-8 array is the PRIMARY
-               source: it always carries the controlled body and on
-               multi-protagonist saves typically also the anchor and
-               at least one party-member slot. Per-slot SEH and a
-               vtable filter give deterministic identity decoding via
-               the same +0x68 / +0x40 / +0xE8 chain the body-to-vc
-               resolver uses. The ActorManager body pool at AM+0xF0
-               AUGMENTS the UA walk to pick up summoned party members
-               that the UA stride does not expose on every build
-               (observed: third party member surfacing only through
-               the AM pool on certain world states). The dedupe pass
-               below skips an AM entry whose vis_ctrl already matches
-               a UA-walk slot.
-
-               AM-pool field layout:
-                 AM+0xF0 = body pointer array (densely populated)
-                 AM+0xF8 = packed u64 -- LOW u32 = count, HIGH u32 = cap.
-                           Iterate against `cap` (HIGH u32) because the
-                           count field has been observed reading 0 on
-                           populated worlds while the allocation cap
-                           still reflects the entries that exist; using
-                           count would skip every live body. The hard
-                           cap k_amBodyArrayHardCap below absorbs a
-                           torn HIGH u32 that overflows reasonable
-                           pool sizes.
-                 body+0x50 = slot byte. NOT a reliable discriminator
-                             in this pool (live entries seen carrying
-                             values like 0x23). Acceptance is on vtable
-                             equality + CDCore positive identity decode
-                             below; the slot byte is read only inside
-                             CDCore's own pointer-validity discipline.
-               read_qword_unsafe is required because the standard
-               read_ptr_unsafe filters values below 0x10000 to zero,
-               which would discard the entire packed field whenever
-               either half lives in that range. */
-            constexpr ptrdiff_t k_amBodyArrayDataOff   = 0xF0;
-            constexpr ptrdiff_t k_amBodyArrayPackedOff = 0xF8;
-            constexpr uint32_t  k_amBodyArrayHardCap   = 4096;
+            /* Build the protagonist vis-ctrl list strictly from the body
+               learning cache. Each entry there was stamped while the
+               resolver observed a known controlled identity, so it is
+               guaranteed to be a protagonist body and never an NPC
+               sharing the child-actor vtable. Bodies the user has not
+               yet been in this session are absent from the cache;
+               consumers downstream of visCtrls fall back to vanilla
+               visibility for those bodies, which is the user-accepted
+               trade (one radial cycle through all three protagonists
+               at session start populates every entry). */
+            std::array<CDCore::BodyCacheEntry, k_maxProtagonists> bodyEntries;
+            const auto entryCount = CDCore::snapshot_body_cache(
+                bodyEntries.data(), bodyEntries.size());
 
             int count = 0;
-            int uaWalkCount = 0;
-            int amWalkCount = 0;
-
-            /* PRIMARY: UA stride walk over user+{0xD0, 0xD8, 0xE0,
-               0xE8, 0xF0, 0xF8, 0x100, 0x108}. Per-slot SEH absorbs a
-               single stale pointer without aborting the rest. */
-            constexpr ptrdiff_t k_uaStrideOffsets[] = {
-                0xD0, 0xD8, 0xE0, 0xE8, 0xF0, 0xF8, 0x100, 0x108
-            };
-            for (auto off : k_uaStrideOffsets)
+            for (std::size_t i = 0; i < entryCount; ++i)
             {
                 if (count >= k_maxProtagonists)
+                {
                     break;
-                __try
-                {
-                    const auto candidate = read_ptr_unsafe(user, off);
-                    if (!candidate)
-                        continue;
-
-                    const auto vt = read_ptr_unsafe(candidate, 0);
-                    if (vt != addrs.childActorVtbl)
-                        continue;
-
-                    const auto vc = body_to_vis_ctrl(candidate);
-                    if (!vc)
-                        continue;
-
-                    bool dup = false;
-                    for (int k = 0; k < count; ++k)
-                    {
-                        if (ps.visCtrls[k].load(std::memory_order_relaxed) == vc)
-                        {
-                            dup = true;
-                            break;
-                        }
-                    }
-                    if (dup)
-                        continue;
-
-                    const auto idxU32 =
-                        CDCore::resolve_character_idx_for_body(candidate);
-                    const int charIdx = (idxU32 >= 1 && idxU32 <= 3)
-                                            ? static_cast<int>(idxU32) - 1
-                                            : -1;
-
-                    ps.visCtrls[count].store(vc, std::memory_order_relaxed);
-                    ps.visCharIdx[count].store(charIdx, std::memory_order_relaxed);
-                    ++count;
-                    ++uaWalkCount;
                 }
-                __except (EXCEPTION_EXECUTE_HANDLER)
+                if (bodyEntries[i].charIdx < 1 ||
+                    bodyEntries[i].charIdx > 3)
                 {
+                    continue;
                 }
-            }
-
-            /* AUGMENT: AM body-pool walk. Iterates against the HIGH u32
-               of AM+0xF8 (cap) because the LOW u32 (count) has been
-               observed reading 0 on populated worlds. Vtable-only
-               filter at this point (slot-byte at +0x50 is unreliable
-               in this pool); positive identity decode via CDCore is
-               required below before admitting any candidate, so a
-               vtable-equal NPC sharing the protagonist child-actor
-               class cannot leak in. Dedupe against the UA-walk
-               results so a body appearing in both sources occupies
-               a single visCtrls slot. */
-            const auto bodyArr = read_ptr_unsafe(am, k_amBodyArrayDataOff);
-            if (bodyArr)
-            {
-                const uint64_t packed =
-                    read_qword_unsafe(am, k_amBodyArrayPackedOff);
-                const uint32_t cap = static_cast<uint32_t>(packed >> 32);
-                uint32_t iterCount = cap;
-                if (iterCount > k_amBodyArrayHardCap)
+                /* body_to_vis_ctrl is SEH-protected on its inner reads
+                   but the outer __try wrapping the whole resolve
+                   already covers the chase here. */
+                const auto vc = body_to_vis_ctrl(bodyEntries[i].body);
+                if (!vc)
                 {
-                    static std::atomic<bool> s_clampLogged{false};
-                    if (!s_clampLogged.exchange(true, std::memory_order_relaxed))
-                        DMK::Logger::get_instance().warning(
-                            "Resolve: AM body-pool cap {} exceeds hard cap {}; clamping",
-                            cap, k_amBodyArrayHardCap);
-                    iterCount = k_amBodyArrayHardCap;
+                    continue;
                 }
 
-                for (uint32_t i = 0; i < iterCount && count < k_maxProtagonists; ++i)
+                /* Dedupe against earlier entries -- a single body
+                   cannot map to more than one vis-ctrl in practice,
+                   but the dedup guards against a torn-write window
+                   between the body stamp and the body_to_vis_ctrl
+                   walk inside this same resolve cycle. */
+                bool dup = false;
+                for (int k = 0; k < count; ++k)
                 {
-                    /* Per-entry SEH so a single stale / NULL slot does
-                       not abort enumeration of the rest of the pool. */
-                    __try
+                    if (ps.visCtrls[k].load(std::memory_order_relaxed) == vc)
                     {
-                        const auto candidate = read_ptr_unsafe(
-                            bodyArr, static_cast<ptrdiff_t>(i) * 8);
-                        if (!candidate)
-                            continue;
-
-                        const auto vt = read_ptr_unsafe(candidate, 0);
-                        if (vt != addrs.childActorVtbl)
-                            continue;
-
-                        const auto vc = body_to_vis_ctrl(candidate);
-                        if (!vc)
-                            continue;
-
-                        bool dup = false;
-                        for (int k = 0; k < count; ++k)
-                        {
-                            if (ps.visCtrls[k].load(std::memory_order_relaxed) == vc)
-                            {
-                                dup = true;
-                                break;
-                            }
-                        }
-                        if (dup)
-                            continue;
-
-                        /* Vtable equality alone admits companions and
-                           horses sharing the protagonist child-actor
-                           class, which would flood visCtrls with
-                           phantom slots that consume the cap and
-                           receive the active character's mask. Require
-                           a positive CDCore identity decode (1..3)
-                           before admitting an AM candidate. */
-                        const auto idxU32 =
-                            CDCore::resolve_character_idx_for_body(candidate);
-                        if (idxU32 < 1 || idxU32 > 3)
-                            continue;
-                        const int charIdx = static_cast<int>(idxU32) - 1;
-
-                        ps.visCtrls[count].store(vc, std::memory_order_relaxed);
-                        ps.visCharIdx[count].store(charIdx, std::memory_order_relaxed);
-                        ++count;
-                        ++amWalkCount;
-                    }
-                    __except (EXCEPTION_EXECUTE_HANDLER)
-                    {
+                        dup = true;
+                        break;
                     }
                 }
+                if (dup)
+                {
+                    continue;
+                }
+
+                const int charIdx = static_cast<int>(bodyEntries[i].charIdx) - 1;
+                ps.visCtrls[count].store(vc, std::memory_order_relaxed);
+                ps.visCharIdx[count].store(charIdx, std::memory_order_relaxed);
+                ++count;
             }
 
             for (int i = count; i < k_maxProtagonists; ++i)
@@ -390,9 +282,8 @@ namespace EquipHide
                 static std::atomic<bool> s_resolvedLogged{false};
                 if (!s_resolvedLogged.exchange(true, std::memory_order_relaxed))
                     DMK::Logger::get_instance().info(
-                        "Player set resolved: {} protagonist(s) tracked "
-                        "(UA-walk={}, AM-walk={})",
-                        count, uaWalkCount, amWalkCount);
+                        "Player set resolved: {} protagonist(s) tracked",
+                        count);
             }
             if (count > 0)
             {

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -16,6 +16,7 @@ namespace EquipHide
     struct ResolvedAddresses
     {
         uintptr_t worldSystem = 0;
+        uintptr_t playerStatic = 0;
         uintptr_t childActorVtbl = 0;
         uintptr_t mapLookup = 0;
         uintptr_t mapInsert = 0;

--- a/CrimsonDesertLiveTransmog/CMakeLists.txt
+++ b/CrimsonDesertLiveTransmog/CMakeLists.txt
@@ -219,7 +219,7 @@ execute_process(
     RESULT_VARIABLE rc
 )
 if(rc EQUAL 0)
-    message(STATUS "Direct deploy OK — cleaning staging")
+    message(STATUS "Direct deploy OK -- cleaning staging")
     file(REMOVE "${STAGING_DLL}")
     if(EXISTS "${SRC_PDB}")
         execute_process(

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Radial-menu character switching is now reliably tracked, so each protagonist's preset applies after a swap.
+- Fixed the wrong outfit briefly appearing on a teammate after a save-load.
+- Fixed coexistence with Equip Hide: both mods can now be loaded together without breaking radial-menu tracking.

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -29,6 +29,8 @@ namespace Transmog
     // single source of truth lives in cdcore/anchors.hpp).
     inline constexpr auto &k_worldSystemCandidates =
         CDCore::Anchors::k_worldSystemCandidates;
+    inline constexpr auto &k_playerStaticCandidates =
+        CDCore::Anchors::k_playerStaticCandidates;
     inline constexpr auto &k_mapLookupCandidates =
         CDCore::Anchors::k_mapLookupCandidates;
     inline constexpr auto &k_partAddShowCandidates =
@@ -39,6 +41,8 @@ namespace Transmog
         CDCore::Anchors::k_visualEquipChangeCandidates;
     inline constexpr auto &k_batchEquipCandidates =
         CDCore::Anchors::k_batchEquipCandidates;
+    inline constexpr auto &k_radialSwapKeyCandidates =
+        CDCore::Anchors::k_radialSwapKeyCandidates;
 
     namespace detail
     {

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -47,6 +47,7 @@ namespace Transmog
     static std::atomic<bool> s_clearPending{false};
     static std::atomic<std::size_t> s_pendingSlotIndex{k_slotCount};
     static std::array<std::uint16_t, k_slotCount> s_lastAppliedCarrierIds{};
+    static std::atomic<std::uintptr_t> s_swapStaleComp{0};
 
     ResolvedAddresses &resolved_addrs() { return s_resolvedAddrs; }
     std::array<SlotMapping, k_slotCount> &slot_mappings() { return s_slotMappings; }
@@ -79,5 +80,6 @@ namespace Transmog
     std::array<std::uint16_t, k_slotCount> &last_applied_carrier_ids() { return s_lastAppliedCarrierIds; }
     std::atomic<bool> &clear_pending() { return s_clearPending; }
     std::atomic<std::size_t> &pending_slot_index() { return s_pendingSlotIndex; }
+    std::atomic<std::uintptr_t> &swap_stale_comp() { return s_swapStaleComp; }
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -118,6 +118,27 @@ namespace Transmog
     /// effect. This is acceptable -- the user's most recent action wins.
     std::atomic<std::size_t> &pending_slot_index();
 
+    /// Stale-body guard for the load-time char-swap window.
+    ///
+    /// On a save-load with a non-Kliff protagonist the engine first
+    /// spawns Kliff's body, then transitions `user+0xD8` to the saved
+    /// character's body several seconds later. Between those two events
+    /// the in-session swap detector observes the identity change and
+    /// schedules an apply, but the WS-chain walk inside
+    /// `resolve_player_component()` still resolves the soon-to-be-
+    /// obsolete (Kliff) body. That apply would write the new
+    /// character's preset onto the wrong actor, leaving the previous
+    /// body wearing the wrong outfit once the engine finishes rotating.
+    ///
+    /// The detector stamps the about-to-be-stale `comp` here; the
+    /// apply entry returns early when `a1` matches. Once `user+0xD8`
+    /// rotates and the next apply runs against a different `a1`, the
+    /// guard clears itself. Save-load invalidation also clears it
+    /// because all queued state is wiped at that boundary anyway.
+    /// Zero means "no stale body in flight"; a successful skip is
+    /// silent except for a debug log line.
+    std::atomic<std::uintptr_t> &swap_stale_comp();
+
     // --- Hot-path utilities ---
 
     inline int64_t steady_ms() noexcept

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -675,10 +675,13 @@ namespace Transmog
         // --- Input ---
 
         // Resolve WorldSystem pointer for player detection on load and
-        // publish the same address to the Core controlled-character
-        // resolver. Core walks WorldSystem -> ActorManager -> UserActor ->
-        // controlled_actor(+0xD8) -> identity u32s at +0xDC and +0xEC;
-        // unresolved holder degrades to Unknown without crashing.
+        // publish the same address to Core. The WorldSystem chain is the
+        // client-side reach used by load-time transmog and the per-frame
+        // body-pool walk; on v1.04.00 it no longer participates in
+        // controlled-character identification (the +0x50 byte that used
+        // to discriminate between protagonists ceased to be unique in
+        // this build). Identity decoding now consumes the player static
+        // resolved below.
         {
             auto wsAddr = resolve_address(
                 k_worldSystemCandidates,
@@ -695,6 +698,75 @@ namespace Transmog
                 logger.warning(
                     "WorldSystem AOB failed -- load-time transmog and "
                     "per-character presets disabled");
+            }
+        }
+
+        // Resolve the server-side player static and publish it to Core.
+        // The cascade exposes a RIP-relative load-or-store of the static
+        // qword (writer in P1, two readers in P2/P3); the resolver walks
+        // root -> NwVirtualAsyncSession (+0x18) -> ServerUserActor (+0xA0)
+        // -> ServerChildOnlyInGameActor (+0xD0) and identifies the
+        // controlled character by which fixed-offset slot inside the
+        // party container has slot+0x2C set to 1. An unresolved holder
+        // degrades the resolver to Unknown without crashing; consumer
+        // code already treats Unknown as "preserve previous identity".
+        {
+            auto playerAddr = resolve_address(
+                k_playerStaticCandidates,
+                std::size(k_playerStaticCandidates),
+                "PlayerStatic");
+            if (playerAddr)
+            {
+                logger.info("Player static at 0x{:X}", playerAddr);
+                CDCore::set_player_static_holder(playerAddr);
+            }
+            else
+            {
+                logger.warning(
+                    "PlayerStatic AOB failed -- controlled-character "
+                    "detection disabled, presets cannot route by character");
+            }
+        }
+
+        // Resolve the radial-UI swap-key capture site and install the
+        // mid-hook in Core. The hook stamps a pending characterinfo key
+        // (1 = Kliff, 4 = Damiane, 6 = Oongka) every time the radial UI
+        // commits a swap; the resolver consumes that key on the next
+        // chain walk to bind the live userActor pointer to a known
+        // character, providing deterministic identity for ghost-roster
+        // states the slot-offset decode cannot resolve. Optional
+        // feature -- failure leaves the slot-offset decode and the LKG
+        // cache as the resolver's only layers, which is the pre-fix
+        // behaviour.
+        //
+        // Two-consumer (LT + EH) coordination: CrimsonDesertCore is a
+        // STATIC library, so this DLL owns its own MidHook independent
+        // of any sibling DLL's MidHook against the same process address.
+        // The AOB cascade is ordered to match either an unpatched site
+        // or a site whose prelude bytes have already been displaced by
+        // a sibling's earlier MidHook install (see anchors.hpp), so the
+        // scan succeeds regardless of load order. SafetyHook's internal
+        // chaining at the JMP target lets both DLLs' callbacks fire on
+        // every radial swap.
+        {
+            const auto radialAddr = resolve_address(
+                k_radialSwapKeyCandidates,
+                std::size(k_radialSwapKeyCandidates),
+                "RadialSwapKey");
+            if (radialAddr)
+            {
+                if (!CDCore::install_radial_swap_hook(radialAddr))
+                {
+                    logger.warning(
+                        "Radial-swap key hook install failed -- "
+                        "ghost-roster character resolution disabled");
+                }
+            }
+            else
+            {
+                logger.warning(
+                    "RadialSwapKey AOB failed -- ghost-roster "
+                    "character resolution disabled");
             }
         }
 
@@ -732,6 +804,13 @@ namespace Transmog
         stop_load_detect_thread();
         stop_apply_worker();
         join_deferred_nametable_scan();
+
+        // Tear down the Core-owned radial-swap mid-hook before the
+        // SafetyHook trampoline pages can be touched by a late-firing
+        // game thread. Idempotent: safe to call when no hook is
+        // installed and when the matching uninstall has already run
+        // from a sibling consumer.
+        CDCore::uninstall_radial_swap_hook();
 
         // Full DMK teardown: removes every managed hook (BatchEquip,
         // VEC, PartAddShow), stops and clears the InputManager poller

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -693,11 +693,58 @@ namespace Transmog
             return;
         }
 
+        // Stale-body guard. The load-detect thread stamps the
+        // about-to-be-obsolete body pointer into swap_stale_comp()
+        // when an in-session character swap fires before the engine
+        // has rotated `user+0xD8` to the new body. If our resolver
+        // still walks to that pre-rotation body, applying here would
+        // paint the new character's preset onto the previous body
+        // (e.g. on a Damiane save: Kliff's body ends up wearing
+        // Damiane's outfit until the engine finally rotates and the
+        // load-detect retry fires a fresh apply on the correct body).
+        // Skipping returns control to the load-detect retry budget,
+        // which will see the new component address on its next tick.
+        // Apply paths that run on a body other than the stale one
+        // clear the guard; save-load invalidation also clears it.
+        {
+            const auto staleComp =
+                swap_stale_comp().load(std::memory_order_acquire);
+            if (staleComp != 0 &&
+                staleComp == static_cast<std::uintptr_t>(a1))
+            {
+                logger.debug(
+                    "[dispatch] apply_all_transmog skipped: body still "
+                    "pre-swap, a1={:#018x}, stale={:#018x}",
+                    static_cast<uint64_t>(a1),
+                    static_cast<uint64_t>(staleComp));
+                return;
+            }
+        }
+
         // Suppress VEC hook for the entire operation.
         suppress_vec().store(true, std::memory_order_release);
 
         logger.trace("[dispatch] apply_all_transmog entry a1={:#018x}",
                      static_cast<uint64_t>(a1));
+
+        // Body has rotated past the stale one (or no swap was in
+        // flight) -- this apply will run against the live body, so
+        // any captured stale value is now obsolete. CAS-clear under
+        // the original captured value to avoid stomping a fresh
+        // capture from a later swap that raced into the worker
+        // between the early-out above and here.
+        {
+            auto staleComp =
+                swap_stale_comp().load(std::memory_order_acquire);
+            if (staleComp != 0 &&
+                staleComp != static_cast<std::uintptr_t>(a1))
+            {
+                swap_stale_comp().compare_exchange_strong(
+                    staleComp, 0,
+                    std::memory_order_release,
+                    std::memory_order_relaxed);
+            }
+        }
 
         // Snapshot lastIds for diagnostic logging.
         const std::array<uint16_t, k_slotCount> prevIds = lastIds;

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -534,6 +534,15 @@ namespace Transmog
                         CDCore::invalidate_controlled_character();
                         prevCharName.clear();
                         pendingCharName.clear();
+                        // Save-load wipes every pending state -- any
+                        // body the swap guard had captured against the
+                        // outgoing world is by definition gone now, so
+                        // clear it. Leaving a stale value here would
+                        // suppress the first post-load apply if the new
+                        // world happened to recycle the same component
+                        // address.
+                        swap_stale_comp().store(
+                            0, std::memory_order_release);
                     }
                     prevUser = curUser;
                 }
@@ -602,6 +611,30 @@ namespace Transmog
                         }
                         logger.info("Char swap detected: {} -> {}",
                                     oldName, liveName);
+                        // Stale-body guard. On a save-load that
+                        // reaches the swap branch (e.g. loading a
+                        // Damiane save), the engine spawns Kliff's
+                        // body first and routes the saved-character
+                        // transition through this same handler ~10s
+                        // later, but `user+0xD8` does not rotate to
+                        // the new body until several seconds AFTER
+                        // we schedule the apply. Without a guard the
+                        // apply runs while resolve_player_component()
+                        // still walks to the soon-to-be-obsolete body
+                        // (Kliff) and writes the new character's
+                        // preset onto the wrong actor. Stamp the
+                        // body we last observed so the apply entry
+                        // can short-circuit until the engine
+                        // finishes rotating; the load-detect block
+                        // below fires its own apply on the new body
+                        // once the rotation completes. Skip the
+                        // store on first-tick (prevComp == 0): no
+                        // observation has been made, so there is
+                        // nothing to mark stale.
+                        if (prevComp > 0x10000)
+                            swap_stale_comp().store(
+                                static_cast<std::uintptr_t>(prevComp),
+                                std::memory_order_release);
                         if (flag_enabled().load(std::memory_order_relaxed))
                             schedule_transmog_ms(200);
                         pm.save();
@@ -614,45 +647,47 @@ namespace Transmog
             // Detect change: new component appeared or address changed.
             if (comp > 0x10000 && comp != prevComp)
             {
-                // Advance prevComp BEFORE the controlled-char gate so
-                // the worker does not re-observe the same change every
-                // tick while the world is still loading. The next
-                // genuine component change is still detected because
-                // prevComp tracks the most recent observed value, not
-                // the most recent successfully-applied one.
-                logger.info("Load detect: player component changed ({:#x} -> {:#x})",
-                            static_cast<uint64_t>(prevComp),
-                            static_cast<uint64_t>(comp));
-                prevComp = comp;
-
-                // Wipe the controlled-character LKG cache so the gate
-                // below decides on a fresh chain walk instead of stale
-                // identity from a previous controlled actor. A
-                // player_component change always means user+0xD8 now
-                // points at a different ClientChildOnlyInGameActor; the
-                // LKG identity from the prior actor is no longer
-                // applicable, but the resolver's torn-read absorption
-                // would otherwise return that stale name on any chain
-                // walk that lands on the new wrapper before its slot
-                // fields (actor+0x60 slot-index byte used by the
-                // companion diff) have been populated. That stale name
-                // would route the auto-apply pipeline through
-                // PresetManager::set_active_character() with the wrong
-                // character, committing the previous character's
-                // preset onto the new actor. Invalidating here costs
-                // at most one outer-loop tick of latency (the gate
-                // defers until the chain walk lands a known key) and
-                // is the only correctness-preserving choice on a swap.
-                CDCore::invalidate_controlled_character();
-
-                // Safety gate: do not auto-apply until the resolver
-                // returns a known character. With LKG invalidated
-                // immediately above, liveChar comes back empty until
-                // the chain walk on the new wrapper lands a known
-                // identity; the retry loop below tolerates that by
-                // design (next outer-loop tick re-evaluates).
+                // Resolve identity WITHOUT invalidating the LKG cache.
+                //
+                // The new resolver in CDCore walks a fresh chain every
+                // call (Player static -> party container -> per-slot
+                // active-flag bytes) and never caches a per-actor
+                // pointer that could go stale, so the historical reason
+                // for invalidating on every player_component change no
+                // longer applies.
+                //
+                // Trade-off resolved against keeping LKG: the engine
+                // rotates player_component before it commits the new
+                // active-flag byte to the server-side party container.
+                // During that window the chain reads all-zero flags and
+                // the resolver returns Unknown. Invalidating LKG here
+                // would force the auto-apply gate to defer until the
+                // engine settled, which on certain saves (Prologue,
+                // post-cutscene resume) it never does until the player
+                // takes a control action. Letting LKG persist makes the
+                // resolver fall back to the previously-controlled
+                // character through that window. The fallback is
+                // correct for save-load resuming the same identity
+                // (the dominant case) and self-corrects within one
+                // tick after the engine writes the new flag for an
+                // in-session swap.
                 const std::string liveChar =
                     current_controlled_character_name();
+
+                // Advance prevComp BEFORE the controlled-char gate so
+                // the worker does not re-observe the same change every
+                // tick while the world is still loading. prevComp
+                // tracks the most recent observed value, not the most
+                // recent successfully-applied one.
+                logger.info(
+                    "Load detect: player component changed "
+                    "({:#x} -> {:#x}); controlled = {}",
+                    static_cast<uint64_t>(prevComp),
+                    static_cast<uint64_t>(comp),
+                    liveChar.empty() ? std::string_view{"<unresolved>"}
+                                     : std::string_view{liveChar});
+                prevComp = comp;
+
                 if (liveChar.empty())
                 {
                     logger.trace(


### PR DESCRIPTION
## Summary

Fixes per-protagonist detection issues that surface when LiveTransmog and EquipHide are loaded together, plus a regression on save-load to non-Kliff saves.

## Changes

- **LiveTransmog** -- stale-comp guard skips applies that would write the new character's preset to the old body during the window between the radial-swap detection and `user+0xD8` rotation. Resolves "Kliff dressed as Oongka" on save-load.
- **LiveTransmog + EquipHide** -- two new patch-resilient radial-swap AOB candidates anchor on bytes past the SafetyHook JMP overwrite zone with `dispOffset = -10`. Either mod can resolve and install regardless of load order; SafetyHook chains the two MidHooks.
- **EquipHide** -- removed the speculative `user+0xD0..+0x108` stride walk that admitted NPCs sharing the protagonist child-actor vtable. Protagonist set is now built from `CDCore::snapshot_body_cache`, which only contains bodies confirmed as controlled at some point in this session.
- **CrimsonDesertCore** -- split `invalidate_controlled_character` into `invalidate_swap_caches` (LKG + actor cache + pending key) and the full version (additionally clears the body cache). Save-load uses the full clear; in-session swaps use the swap-only clear so learned body identities survive radial swaps.
- **CrimsonDesertCore** -- corrected `walk_to_controlled_body_seh` to follow the WorldSystem chain to `ClientUserActor+0xD8` (was incorrectly using the player-static chain to `ServerUserActor+0xD8`).

## Trade

EquipHide's per-character hide masks apply to a body only after the user has been that protagonist at least once in the session. One radial cycle through Kliff -> Damiane -> Oongka populates the cache. Save-load resets it (body pool may be reallocated). Bodies the user has not yet been render with vanilla visibility instead of their per-character mask.