### PR TITLE
fix(equip-hide): support game v1.05.00 patch

### DIFF
--- a/CrimsonDesertCore/include/cdcore/anchors.hpp
+++ b/CrimsonDesertCore/include/cdcore/anchors.hpp
@@ -474,16 +474,63 @@ namespace CDCore::Anchors
     // bytes past the call locks onto this site exclusively.
     // -----------------------------------------------------------------------
     inline constexpr AddrCandidate k_radialSwapKeyCandidates[] = {
-        // P1 -- post-patch-invariant tail with literal rel8 jz. Anchors
-        // entirely in the bytes past the SafetyHook displaced window
-        // (match+12 onward of the original prelude shape):
+        // P0 -- v1.05.00 full pre-patch sequence. Differences vs v1.04:
+        //   * Source register rsi -> rdi (`8B 06` -> `8B 07`).
+        //   * Sentinel emitted as `mov r14d, 0xFFFF` (41 BE ...) AFTER
+        //     the lookup call instead of `mov ecx, 0xFFFF` (B9 ...)
+        //     before it.
+        //   * Tail jmp rel8 target shifted from `EB 02` to `EB 03`.
+        // 1 unique hit on v1.05.00 at 0x1421CE795. dispOffset +2 walks
+        // forward to the same `mov [rbp+0x78], eax` hook target as the
+        // v1.04 prelude-anchored candidates.
+        {"RadialSwapKey_P0_v105_FullSequence",
+         "8B 07 89 45 78 48 8B 0D ?? ?? ?? ?? "
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "41 BE FF FF 00 00 48 85 C0 74 05 0F B7 18 EB 03",
+         ResolveMode::Direct, 2, 0},
+
+        // P0b -- v1.05.00 full pre-patch with rel8 targets wildcarded.
+        // Tolerates a future build that shifts the test-jz / movzx-jmp
+        // branch distances. Same dispOffset semantics as P0.
+        {"RadialSwapKey_P0b_v105_WildcardRel8",
+         "8B 07 89 45 78 48 8B 0D ?? ?? ?? ?? "
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "41 BE FF FF 00 00 48 85 C0 74 ?? 0F B7 18 EB ??",
+         ResolveMode::Direct, 2, 0},
+
+        // P0c -- v1.05.00 post-patch tail. Anchors past the SafetyHook
+        // displaced window (`8B 07 89 45 78` overwritten by E9 rel32):
+        //   add rcx, 0x60; lea rdx,[rbp+0x78]; call <disp32>;
+        //   mov r14d, 0xFFFF; test rax,rax; jz +5; movzx ebx,[rax];
+        //   jmp +3.
+        // Survives a sibling MidHook install in either load order (LT
+        // before EH or EH before LT) because the prelude bytes are not
+        // part of the match. dispOffset -10 walks back to the original
+        // hook target at `89 45 78` of the prelude (semantically equal
+        // to the v1.04 post-patch walk).
+        {"RadialSwapKey_P0c_v105_PostPatchFull",
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "41 BE FF FF 00 00 48 85 C0 74 05 0F B7 18 EB 03",
+         ResolveMode::Direct, -10, 0},
+
+        // P0d -- v1.05.00 post-patch with rel8 wildcards. Same -10
+        // dispOffset semantics as P0c.
+        {"RadialSwapKey_P0d_v105_PostPatchWildcardRel8",
+         "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
+         "41 BE FF FF 00 00 48 85 C0 74 ?? 0F B7 18 EB ??",
+         ResolveMode::Direct, -10, 0},
+
+        // P1 -- v1.04.00 post-patch-invariant tail with literal rel8 jz.
+        // Anchors entirely in the bytes past the SafetyHook displaced
+        // window (match+12 onward of the original prelude shape):
         //   add rcx, 0x60; lea rdx,[rbp+0x78]; call <disp32>;
         //   mov ecx, 0xFFFF; test rax,rax; jz +5; movzx ebx,[rax];
         //   jmp +2.
         // The unique movzx-ebx + jmp-+2 tail pins this site (see comment
         // block above for the sibling-handler disambiguator). dispOffset
         // -10 walks back to the original hook target at match+2 of the
-        // prelude shape (= start-of-this-anchor + 2 - 12).
+        // prelude shape (= start-of-this-anchor + 2 - 12). Inert on
+        // v1.05.00 because the sentinel encoding changed from B9 to 41 BE.
         {"RadialSwapKey_P1_PostPatchFull",
          "48 83 C1 60 48 8D 55 78 E8 ?? ?? ?? ?? "
          "B9 FF FF 00 00 48 85 C0 74 05 0F B7 18 EB 02",

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -16,7 +16,6 @@
 - IndependentToggle mode: categories sharing a hotkey flip their own state individually, preserving mixed visible/hidden configurations
 - BaldFix: runtime hair-visibility fix when helmet/cloak/mask is hidden - no PAZ patching needed. Hair/beard may occasionally disappear; re-toggling the headgear (show then hide) restores it
 - GlidingFix: prevents hidden equipment from briefly flashing visible during state transitions (e.g. exiting gliding, cutscene transitions)
-- ForceShow mode for compatibility with mods that alter default equipment visibility via PAZ patching (e.g. character replacers, armor replacers, transmog mods)
 - Hot-reload cleanup: visibility bytes restored on DLL unload
 - SEH-protected hook callback to prevent crashes if mod is outdated
 - Fully customizable settings via INI configuration
@@ -102,12 +101,6 @@ The mod is configured via the `CrimsonDesertEquipHide.ini` file:
 [General]
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
-; Set to true if you use mods that alter the default visibility of equipment
-; via PAZ patching (e.g. character replacers like 'Playing Kliff as Damiane',
-; armor replacers, transmog mods). ForceShow overrides their changes so
-; toggling equipment back to visible still works.
-; Safe to leave false if you are not using such mods.
-ForceShow = false
 ; Prevents baldness when hiding helmets/cloaks/masks
 ; Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 BaldFix = true
@@ -277,17 +270,6 @@ Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, 
 
 The active character is detected by walking the live WorldSystem pointer chain to the currently-controlled actor and decoding its built-in identity fields. Each party member visible on screen tracks its own per-character Parts list independently, so hiding armor on Damiane and then swapping back to Kliff keeps Damiane's armor hidden while Kliff renders under his own configuration. The previously-controlled character's hide state is preserved across swaps until you toggle it off explicitly.
 
-## Compatibility with Replacer Mods
-
-Set `ForceShow = true` if you use mods that alter the default visibility of equipment via PAZ patching (e.g. character replacers like "Playing Kliff as Damiane", armor replacers, transmog mods). ForceShow overrides their changes so toggling equipment back to visible still works:
-
-```ini
-[General]
-ForceShow = true
-```
-
-Safe to leave `false` if you are not using such mods.
-
 ## Known Issues
 
 | Issue | Details | Workaround |
@@ -346,6 +328,7 @@ The loader (`CrimsonDesertEquipHide.asi`) and logic DLL (`CrimsonDesertEquipHide
 - [ThirteenAG](https://github.com/ThirteenAG) -- for the Ultimate ASI Loader
 - [cursey](https://github.com/cursey) -- for SafetyHook
 - [Brodie Thiesfield](https://github.com/brofield) -- for SimpleIni
+- [Frans 'Otis_Inf' Bouma](https://github.com/FransBouma) -- for v1.05.00 AOB shift diagnosis
 - Pearl Abyss -- for Crimson Desert
 
 ## License

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -76,13 +76,6 @@ LogLevel = Info
 ; Re-load this INI automatically on save without restarting the game
 ; (filesystem-watcher driven). Set false to opt out.
 AutoReloadConfig = true
-; Set to true if you use mods that alter the default visibility of
-; equipment via PAZ patching (e.g. character replacers like
-; "Playing Kliff as Damiane", armor replacers, transmog mods).
-; ForceShow overrides their changes so toggling equipment back to
-; visible still works.
-; Safe to leave false if you are not using such mods.
-ForceShow = false
 ; Prevents baldness when hiding helmets/cloaks/masks.
 ; The game normally hides hair when a helmet is equipped -- this fix keeps
 ; hair visible when the mod hides the helmet mesh.

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide_Readme.txt
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide_Readme.txt
@@ -14,7 +14,6 @@ FEATURES:
   Shoulder, Mask, Glasses, Accessories
 - 3 User Presets: custom part groups combining parts from any category
 - Global show-all / hide-all hotkeys
-- ForceShow mode for compatibility with third-party replacer mods
 - Fully customizable settings through INI configuration
 
 INSTALLATION:
@@ -79,11 +78,6 @@ USING WITH OPTISCALER:
 
   This applies to any ASI mod. If you have other .asi mods (e.g.
   CDSprintHold), move them into the plugins folder as well.
-
-REPLACER MOD COMPATIBILITY:
-  If equipment stays invisible when toggling to visible (common with
-  third-party "Playing as" character mods), set ForceShow = true in
-  the [General] section of the INI file.
 
 CONFIGURATION:
 Edit CrimsonDesertEquipHide.ini to customize hotkeys, categories,

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,9 @@
-## [Title for next release]
+## v1.05.00 patch support + multi-protagonist fixes
 
 - NPCs are no longer accidentally stripped by the protagonist hide settings.
 - Per-character hide masks now apply correctly to each visible protagonist (after one radial-cycle through all three).
 - Fixed coexistence with Live Transmog: both mods can now be loaded together without breaking radial-menu tracking.
+- Updated for game version 1.05.00: armor hide bindings now toggle visibility correctly on the latest patch.
+- Body armor categories no longer remain visually hidden after toggling them back on.
+- Restored radial character-swap detection on game version 1.05.00.
+- Removed the `ForceShow` INI option; visible parts are now force-shown unconditionally so toggling back to visible works without configuration.

--- a/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
+++ b/CrimsonDesertEquipHide/docs/nexus-bbcode.txt
@@ -109,12 +109,6 @@ The mod can be configured by editing the [b]CrimsonDesertEquipHide.ini[/b] file:
 [General]
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
-; Set to true if you use mods that alter the default visibility of equipment
-; via PAZ patching (e.g. character replacers like 'Playing Kliff as Damiane',
-; armor replacers, transmog mods). ForceShow overrides their changes so
-; toggling equipment back to visible still works.
-; Safe to leave false if you are not using such mods.
-ForceShow = false
 ; Prevents baldness when hiding helmets/cloaks/masks
 ; Hair/beard may occasionally disappear; re-toggling the helmet (show then hide) restores it
 BaldFix = true
@@ -241,18 +235,6 @@ The active character is detected by walking the live WorldSystem pointer chain t
 
 [line]
 
-[size=5]Compatibility with Replacer Mods[/size]
-Set [b]ForceShow = true[/b] if you use mods that alter the default visibility of equipment via PAZ patching (e.g. character replacers like "Playing Kliff as Damiane", armor replacers, transmog mods). ForceShow overrides their changes so toggling equipment back to visible still works:
-
-[code]
-[General]
-ForceShow = true
-[/code]
-
-Safe to leave [b]false[/b] if you are not using such mods.
-
-[line]
-
 [size=5]User Presets[/size]
 The INI file includes three [b]UserPreset[/b] sections (UserPreset1, UserPreset2, UserPreset3) that let you create custom part groups with independent visibility control.
 
@@ -309,6 +291,7 @@ Built with [url=https://github.com/tkhquang/DetourModKit]DetourModKit[/url] for 
 [*] [url=https://github.com/ThirteenAG]ThirteenAG[/url] for the Ultimate ASI Loader
 [*] [url=https://github.com/cursey]cursey[/url] for SafetyHook
 [*] Brodie Thiesfield for SimpleIni
+[*] [url=https://github.com/FransBouma]Frans 'Otis_Inf' Bouma[/url] for v1.05.00 AOB shift diagnosis
 [*] Pearl Abyss for creating Crimson Desert
 [/list]
 

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -198,20 +198,42 @@ namespace EquipHide
      *       only shortens the verified suffix, not the match start).
      */
     inline constexpr AddrCandidate k_hookSiteCandidates[] = {
-        // P1 -- ends at cmp al, 3, does not cross the jz.
-        // Hook lands on the cmp (match + 4).
+        // P0 -- v1.05.00. The visibility byte field on PartInOutSocket
+        // shifted from +0x1C to +0x20, so the movzx disp8 byte is
+        // wildcarded. The movzx-cmp idiom plus the literal 3 sentinel
+        // are still distinctive enough for a unique CrimsonDesert.exe
+        // match (1 hit on v1.05.00 at the PartInOut site). Hook lands
+        // on the cmp at match + 4 (same offset semantics as P1; only
+        // the byte value differs, length is unchanged).
+        {"PartInOut_P0_v105_WildcardVisOffset",
+         "48 8B 45 5F 0F B6 40 ?? 3C 03",
+         ResolveMode::Direct, 4, 0},
+
+        // P0b -- v1.05.00 widened with the leading `mov r8b, 1`
+        // (41 B0 01) for extra structural pinning. Same wildcarded
+        // disp8 as P0; hook lands on the cmp at match + 7.
+        {"PartInOut_P0b_v105_PrecedingGate",
+         "41 B0 01 48 8B 45 5F 0F B6 40 ?? 3C 03",
+         ResolveMode::Direct, 7, 0},
+
+        // P1 -- v1.04.00. Ends at `cmp al, 3` and does not cross the
+        // following jz. Hook lands on the cmp at match + 4. Inert on
+        // v1.05.00 because the visibility byte sits at +0x20, not +0x1C.
         {"PartInOut_P1_DirectSite",
          "48 8B 45 5F 0F B6 40 1C 3C 03",
          ResolveMode::Direct, 4, 0},
 
-        // P2 -- ends at cmp rax, rcx, does not cross the following jz.
-        // Hook lands +0x30 inside the wider preamble.
+        // P2 -- v1.04.00 wider context. Tied to specific register
+        // assignments (r13/r15) that the v1.05.00 compiler reshuffled,
+        // so this candidate is inert on v1.05.00; retained for the
+        // v1.04.00 path.
         {"PartInOut_P2_WiderContext",
          "45 32 C0 49 8B 45 ?? 41 8B 4D ?? 48 C1 E1 04 48 03 C8 48 3B C1",
          ResolveMode::Direct, 0x30, 0},
 
-        // P3 -- ends at cmp al, 3, does not cross the jz.
-        // Hook lands on the cmp (match + 7).
+        // P3 -- v1.04.00 with the `mov r8b, 1` prefix. Ends at the cmp,
+        // does not cross the jz. Hook lands at match + 7. Inert on
+        // v1.05.00 (same reason as P1).
         {"PartInOut_P3_PrecedingGate",
          "41 B0 01 48 8B 45 5F 0F B6 40 1C 3C 03",
          ResolveMode::Direct, 7, 0},

--- a/CrimsonDesertEquipHide/src/armor_injection.cpp
+++ b/CrimsonDesertEquipHide/src/armor_injection.cpp
@@ -105,19 +105,37 @@ namespace EquipHide
                     ? get_part_map_for(charIdx)
                     : get_part_map();
 
+            int reinjected = 0;
+
             for (const auto &[hash, mask] : partMap)
             {
                 const bool hidden = is_any_category_hidden_for(mask, charIdx);
+                auto existing = lookup(mapBase, &hash);
 
                 if (!hidden)
                 {
-                    if (!cascadeOn || (mask & k_cascadeBodyMask) == 0)
-                        continue;
+                    /* Toggle-off cache flush. The engine caches a
+                       hidden render-state when our inject inserts an
+                       entry with vis=2; the cache is read from a
+                       struct field that direct vis-byte writes do not
+                       reach, so body armor stays visually hidden after
+                       toggle-off unless we re-insert with vis=0. The
+                       re-insert path below forces the engine to
+                       re-process the entry and clear its cached
+                       hidden state. Visible parts with no existing
+                       entry have nothing to flush, so skip unless the
+                       cascade-fix path needs them. */
+                    if (!existing)
+                    {
+                        if (!cascadeOn || (mask & k_cascadeBodyMask) == 0)
+                            continue;
+                    }
                 }
-
-                auto existing = lookup(mapBase, &hash);
-                if (existing)
+                else if (existing)
                 {
+                    /* Hidden category, entry already present: vis byte
+                       is updated in-place by the direct-write path; no
+                       re-insert needed. */
                     ++existing_set;
                     continue;
                 }
@@ -156,11 +174,17 @@ namespace EquipHide
                     logger.debug("  0x{:X} -- INJECTED new entry", hash);
                     ++injected;
                 }
+                else if (!hidden)
+                {
+                    logger.trace("  0x{:X} -- RE-INJECTED visible (cache flush)",
+                                 hash);
+                    ++reinjected;
+                }
             }
 
             logger.debug("ArmorInject map: {} injected, {} existing updated, "
-                         "{} skipped (no bucket key)",
-                         injected, existing_set, skipped_key);
+                         "{} re-injected, {} skipped (no bucket key)",
+                         injected, existing_set, reinjected, skipped_key);
             result = injected;
         }
         __except (EXCEPTION_EXECUTE_HANDLER)

--- a/CrimsonDesertEquipHide/src/bald_fix.cpp
+++ b/CrimsonDesertEquipHide/src/bald_fix.cpp
@@ -24,7 +24,12 @@ namespace EquipHide
     // we scan a small stack window; if the landmark is present, we defer
     // to the original evaluator without mutating any item bitmasks. No
     // ctx caching, no frequency threshold, no per-item hash heuristic.
-    static constexpr int k_stackScanDepth = 24;
+    // The scan window must be deep enough to span every wrapper frame
+    // between PostfixEval and the prefab-build call site. v1.05 added at
+    // least one additional frame on the NPC path: a 24-slot window left
+    // the landmark out of reach and the override applied to NPCs. 64
+    // slots covers the new depth with margin.
+    static constexpr int k_stackScanDepth = 64;
 
     // Dedup tables so the trace log fires at most once per ever-seen ctx.
     // Sized generously: the live build has at most 3 player protagonists

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -47,8 +47,6 @@ namespace EquipHide
             "General", "LogLevel", "INFO");
 
         DMK::Config::register_atomic<bool>(
-            "General", "ForceShow", "Force Show", flag_force_show(), false);
-        DMK::Config::register_atomic<bool>(
             "General", "BaldFix", "Bald Fix", flag_bald_fix(), true);
         DMK::Config::register_atomic<bool>(
             "General", "GlidingFix", "Gliding Fix", flag_gliding_fix(), true);
@@ -300,7 +298,7 @@ namespace EquipHide
             s_hideLocked[hashIdx] &&
             is_any_category_hidden(mask))
         {
-            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x1C);
+            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x20);
             if (s_hideLocked[hashIdx] == 2)
             {
                 *visPtr = 0;
@@ -358,7 +356,7 @@ namespace EquipHide
 
         if (is_any_category_hidden_for(charMask, charIdx))
         {
-            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x1C);
+            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x20);
             *visPtr = 2;
             if (cascadeOn && isChest)
             {
@@ -372,12 +370,6 @@ namespace EquipHide
         {
             if (cascadeOn && isChest)
                 s_hideLocked[hashIdx] = 0;
-
-            if (flag_force_show().load(std::memory_order_relaxed))
-            {
-                auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x1C);
-                *visPtr = 0;
-            }
         }
     }
 

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -19,6 +19,31 @@ namespace EquipHide
     static uintptr_t s_prevVisCtrls[k_maxProtagonists]{};
     static int s_prevCount = 0;
 
+    /* Per-body vc cache. v1.05 zeroes body+0x68 (and downstream) for
+       inactive protagonists, so the live chain walk only succeeds
+       for the currently-controlled body. The vis_ctrl pointer itself
+       stays valid across swaps within a session, so caching the last
+       successful resolution per body lets the resolver publish all
+       three protagonists' vcs after the user has cycled through them
+       once. Across save-load the engine reallocates its arenas: the
+       cached vcs are dangling and MUST be wiped or DirectWrite stomps
+       freed memory. File-scope so resolve_player_vis_ctrls can clear
+       it on the save-load transition. */
+    struct Body2VcEntry
+    {
+        uintptr_t body;
+        uintptr_t vc;
+    };
+    static Body2VcEntry s_body2vcLru[k_maxProtagonists]{};
+    static int s_body2vcNext = 0;
+
+    static void clear_body_to_vis_ctrl_cache() noexcept
+    {
+        for (auto &e : s_body2vcLru)
+            e = {0, 0};
+        s_body2vcNext = 0;
+    }
+
     /** @brief Traverse body -> vis_ctrl pointer chain. Caller MUST be SEH-protected.
      *  @details Trace-logs only when a (body -> vc) mapping is new or has
      *           changed since the last walk; successful walks with a
@@ -30,39 +55,43 @@ namespace EquipHide
     {
         if (!body)
             return 0;
+
         auto inner = read_ptr_unsafe(body, 0x68);
         if (!inner)
         {
+            for (const auto &e : s_body2vcLru)
+            {
+                if (e.body == body && e.vc != 0)
+                    return e.vc;
+            }
             DMK::Logger::get_instance().trace(
-                "body_to_vis_ctrl: body=0x{:X} inner=NULL (+0x68)", body);
+                "body_to_vis_ctrl: body=0x{:X} inner=NULL (+0x68), no cache",
+                body);
             return 0;
         }
         auto sub = read_ptr_unsafe(inner, 0x40);
         if (!sub)
         {
+            for (const auto &e : s_body2vcLru)
+            {
+                if (e.body == body && e.vc != 0)
+                    return e.vc;
+            }
             DMK::Logger::get_instance().trace(
-                "body_to_vis_ctrl: body=0x{:X} inner=0x{:X} sub=NULL (+0x40)",
-                body, inner);
+                "body_to_vis_ctrl: body=0x{:X} inner=0x{:X} sub=NULL (+0x40), "
+                "no cache", body, inner);
             return 0;
         }
         auto vc = read_ptr_unsafe(sub, 0xE8);
 
-        // Dedupe on (body, vc): only log when this body resolves to a
-        // different vc than last seen. Small fixed LRU sized to the max
-        // protagonist count -- any more is not useful for this resolver.
-        struct Entry
-        {
-            uintptr_t body, vc;
-        };
-        static Entry s_lru[k_maxProtagonists]{};
-        static int s_next = 0;
-        for (auto &e : s_lru)
+        // Update LRU on success and dedupe trace logging.
+        for (auto &e : s_body2vcLru)
         {
             if (e.body == body && e.vc == vc)
                 return vc;
         }
-        s_lru[s_next] = {body, vc};
-        s_next = (s_next + 1) % k_maxProtagonists;
+        s_body2vcLru[s_body2vcNext] = {body, vc};
+        s_body2vcNext = (s_body2vcNext + 1) % k_maxProtagonists;
 
         DMK::Logger::get_instance().trace(
             "body_to_vis_ctrl: body=0x{:X} inner=0x{:X} sub=0x{:X} vc=0x{:X}",
@@ -126,43 +155,89 @@ namespace EquipHide
                 s_prevUser = user;
             }
 
-            /* Character-swap invalidation. In-session protagonist
-               swaps (Kliff <-> Damiane <-> Oongka) rotate user+0xD8 to
-               point at a different ClientChildOnlyInGameActor without
-               touching the UserActor singleton above, so the first
-               trigger does not catch them. Without this second point
-               the LKG identity cached by CDCore against the prior
-               actor stays valid from Core's perspective and the
-               resolver's torn-read absorption returns the previous
-               character's name on any chain walk that lands on the
-               new wrapper before the slot decode catches up.
+            /* Character-swap / save-load invalidation, split by
+               transition type:
 
-               We use invalidate_swap_caches() (not the full
-               invalidate_controlled_character()) because in-session
-               swaps rotate user+0xD8 between EXISTING body pointers in
-               the pool without reallocating bodies. The body learning
-               cache (body -> character) populated by CDCore stays
-               valid across the swap; flushing it would force every
-               party member visible in the world to fall back to the
-               active character's hide mask until the user manually
-               cycled through each protagonist again, which is exactly
-               the bug this split is fixing. We only need to evict the
-               swap-scope state here: the LKG identity (so the resolver
-               does not return the OLD character on the first post-swap
-               query before the radial hook / slot decode catches up)
-               and the actor->character cache (which is bounded small
-               enough that flushing on every swap costs nothing).
+               1. controlledActor X -> 0  (entering load screen). v1.05
+                  preserves the UserActor singleton across save-load,
+                  so the s_prevUser branch above does NOT fire. The
+                  only reliable signal that the world is being torn
+                  down is user+0xD8 going NULL. We mark a deferred
+                  reload; the actual cache wipe happens on the
+                  matching 0 -> Y transition because flushing while
+                  the engine is mid-teardown can race with bodies
+                  still in flight. CDCore::invalidate_controlled_
+                  character() and the body_to_vis_ctrl LRU clear
+                  together drop every dangling vc pointer that would
+                  otherwise alias into the next save's freshly
+                  reallocated arena -- DirectWrite stomping a freed
+                  vc was the v1.05 post-load regression.
 
-               The prevControlledActor != 0 guard mirrors the
-               first-boot suppression above: on the very first tick
-               the prior value is zero and the freshly-walked pointer
-               is the initial controlled actor, so invalidating would
-               wipe a cache just populated against it. */
+               2. controlledActor 0 -> Y  (load screen -> new save).
+                  Drain the deferred reload flag: full invalidation +
+                  LRU wipe so the next resolve cycle rebuilds from
+                  scratch against the new world's bodies.
+
+               3. controlledActor X -> Y, both non-zero  (in-session
+                  Kliff <-> Damiane <-> Oongka swap). Bodies are
+                  reused from the pool and the body learning cache
+                  populated by CDCore stays valid across the swap;
+                  flushing it would force every party member to fall
+                  back to the active character's hide mask until the
+                  user manually cycled through each protagonist
+                  again. Only evict the swap-scope state here: the
+                  LKG identity (so the resolver does not return the
+                  OLD character on the first post-swap query before
+                  the radial hook / slot decode catches up) and the
+                  actor->character cache.
+
+               First-boot suppression (s_prevControlledActor != 0)
+               guards transitions where the prior value is sentinel
+               zero and the freshly-walked pointer is the initial
+               controlled actor, so invalidating would wipe a cache
+               just populated against it. */
             auto controlledActor = read_ptr_unsafe(user, 0xD8);
             static std::uintptr_t s_prevControlledActor = 0;
+            static bool s_pendingReloadInvalidation = false;
             if (controlledActor != s_prevControlledActor)
             {
-                if (s_prevControlledActor != 0)
+                if (controlledActor == 0 && s_prevControlledActor != 0)
+                {
+                    DMK::Logger::get_instance().info(
+                        "Save-load detected: controlled actor "
+                        "(0x{:X} -> 0x0); deferring full cache wipe "
+                        "until new world is live",
+                        s_prevControlledActor);
+                    s_pendingReloadInvalidation = true;
+                }
+                else if (controlledActor != 0 && s_prevControlledActor == 0 &&
+                         s_pendingReloadInvalidation)
+                {
+                    DMK::Logger::get_instance().info(
+                        "Save-load complete: new controlled actor 0x{:X}; "
+                        "wiping body cache + body_to_vis_ctrl LRU",
+                        controlledActor);
+                    CDCore::invalidate_controlled_character();
+                    clear_body_to_vis_ctrl_cache();
+                    /* Drop stale player_state too: visCtrls hold the
+                       previous save's vc pointers, and the s_prev*
+                       diff guard below would otherwise see "no
+                       change" and skip rescheduling DirectWrite. */
+                    auto &psWipe = player_state();
+                    for (int j = 0; j < k_maxProtagonists; ++j)
+                    {
+                        psWipe.visCtrls[j].store(0, std::memory_order_relaxed);
+                        psWipe.visCharIdx[j].store(-1, std::memory_order_relaxed);
+                        psWipe.armorInjected[j].store(false, std::memory_order_relaxed);
+                    }
+                    psWipe.primaryVisCtrl.store(0, std::memory_order_relaxed);
+                    psWipe.count.store(0, std::memory_order_relaxed);
+                    for (int j = 0; j < k_maxProtagonists; ++j)
+                        s_prevVisCtrls[j] = 0;
+                    s_prevCount = 0;
+                    s_pendingReloadInvalidation = false;
+                }
+                else if (s_prevControlledActor != 0 && controlledActor != 0)
                 {
                     DMK::Logger::get_instance().info(
                         "Char swap detected: controlled actor "
@@ -173,6 +248,14 @@ namespace EquipHide
                 }
                 s_prevControlledActor = controlledActor;
             }
+
+            /* Bail until the new world has a controlled actor. With
+               s_pendingReloadInvalidation still set, walking the body
+               cache against the next save's bodies before the wipe
+               re-publishes the previous save's vcs (and DirectWrite
+               then stomps freed memory). */
+            if (controlledActor == 0)
+                return;
 
             /* Controlled-character identity via the shared Core
                resolver. Core walks WorldSystem -> ActorManager ->

--- a/CrimsonDesertEquipHide/src/shared_state.cpp
+++ b/CrimsonDesertEquipHide/src/shared_state.cpp
@@ -26,7 +26,6 @@ namespace EquipHide
     static std::unordered_map<VisKey, uint8_t, VisKeyHash> s_originalVis;
     static std::atomic<bool> s_needsDirectWrite{false};
 
-    static std::atomic<bool> s_forceShow{false};
     static std::atomic<bool> s_baldFix{true};
     static std::atomic<bool> s_glidingFix{true};
     static std::atomic<bool> s_fallbackMode{false};
@@ -44,7 +43,6 @@ namespace EquipHide
     std::unordered_map<VisKey, uint8_t, VisKeyHash> &original_vis_map() { return s_originalVis; }
     std::atomic<bool> &needs_direct_write() { return s_needsDirectWrite; }
 
-    std::atomic<bool> &flag_force_show() { return s_forceShow; }
     std::atomic<bool> &flag_bald_fix() { return s_baldFix; }
     std::atomic<bool> &flag_gliding_fix() { return s_glidingFix; }
     std::atomic<bool> &flag_fallback_mode() { return s_fallbackMode; }

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -113,7 +113,6 @@ namespace EquipHide
     std::atomic<bool> &needs_direct_write();
 
     // --- Feature flags ---
-    std::atomic<bool> &flag_force_show();
     std::atomic<bool> &flag_bald_fix();
     std::atomic<bool> &flag_gliding_fix();
     std::atomic<bool> &flag_fallback_mode();

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -109,7 +109,7 @@ namespace EquipHide
                 if (!entry)
                     continue;
 
-                const auto visAddr = entry + 0x1C;
+                const auto visAddr = entry + 0x20;
                 const VisKey key{vc, visAddr};
                 s_touchedVisKeys.push_back(key);
                 auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);
@@ -133,23 +133,27 @@ namespace EquipHide
                 }
                 else
                 {
+                    /* Always force vis=0 for visible parts. Cached
+                       origVis values cannot be restored verbatim:
+                       the engine writes its own state into this byte
+                       (sample values 0xE6, 0xF6 observed in trace)
+                       with the hidden-bit (0x02) set, so restoring
+                       the cached value keeps the part hidden. */
+                    *visPtr = 0;
                     auto it = origVis.find(key);
                     if (it != origVis.end())
                     {
-                        const auto restored = (it->second == 2) ? 0 : it->second;
-                        *visPtr = static_cast<uint8_t>(restored);
-                        logger.trace("  [{}] 0x{:04X} restored (vis={}, char_idx={})",
-                                     i, hash, restored, charIdx);
+                        logger.trace("  [{}] 0x{:04X} restored (vis=0, "
+                                     "cached_orig=0x{:02X}, char_idx={})",
+                                     i, hash, it->second, charIdx);
                         origVis.erase(it);
-                        ++restoredCount;
                     }
-                    else if (flag_force_show().load(std::memory_order_relaxed))
+                    else
                     {
-                        *visPtr = 0;
-                        ++restoredCount;
                         logger.trace("  [{}] 0x{:04X} force-shown (vis=0, char_idx={})",
                                      i, hash, charIdx);
                     }
+                    ++restoredCount;
                 }
             }
         }
@@ -219,9 +223,11 @@ namespace EquipHide
             }
 
             auto *visPtr = reinterpret_cast<uint8_t *>(entryKey.addr);
-            const auto origVal = it->second;
-            const auto restored = (origVal == 2) ? 0 : origVal;
-            *visPtr = static_cast<uint8_t>(restored);
+            // Cached origVis values can carry the engine's own
+            // hidden-bit (0x02). Restoring verbatim keeps the part
+            // hidden, so write a literal 0 (same reasoning as the
+            // main restore branch above).
+            *visPtr = 0;
             it = origVis.erase(it);
             ++orphanRestored;
         }


### PR DESCRIPTION
## Summary
- Updated AOBs and struct offsets for game v1.05.00: PartInOut visibility byte 0x1C → 0x20, engine map entry vis byte 0x28 (was 0x1C in v1.04). Added wildcarded P0 candidates so the cascade tolerates further per-patch byte drift.
- Removed the `ForceShow` INI option, visible parts are now force-shown unconditionally so toggling armor back on works without configuration.
- BaldFix stack-scan depth bumped 24 → 64 to span v1.05's added wrapper frame on the NPC prefab-build path; eliminates global-on-NPC regression.
- Multi-protagonist detection: published vis-ctrls survive the v1.05 inactive-body zeroing (LRU caches the last-good vc per body), and a deferred wipe gated on `controlledActor 0`-transition keeps DirectWrite from stomping freed memory after a save-load.
- Armor toggle now re-calls `mapInsert` with `vis=0` for previously-hidden parts that just toggled visible, forcing engine cache invalidation.