### PR TITLE
fix(equip-hide): detect atomic save-load via radial-swap pending key

### DIFF
--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -295,6 +295,33 @@ namespace CDCore
     void uninstall_radial_swap_hook() noexcept;
 
     /**
+     * @brief Whether a radial-swap key was stamped within the
+     *        pending-key window and has not yet been consumed by a
+     *        resolver chain walk.
+     * @details Returns true when the user has just initiated a radial
+     *          swap and the resolver has not yet caught up to publish
+     *          the new identity. Lets consumers disambiguate an
+     *          in-session protagonist swap from a save-load when both
+     *          appear as a controlled-actor pointer rotation: a swap
+     *          fired by user input has a fresh pending key; a save-load
+     *          does not.
+     *
+     *          Window matches the pending-key TTL (2 s in the current
+     *          build). Returns false outside the window, after the
+     *          resolver consumed the key, or when no key has ever been
+     *          stamped this session.
+     *
+     *          Per-DLL state (CDCore is statically linked into each
+     *          consumer): observes the pending key written by THIS
+     *          DLL's radial-swap safetyhook callback. Sibling DLLs
+     *          maintain their own copy.
+     *
+     *          Safe to call from any thread; non-blocking (two relaxed
+     *          atomic loads + a tick comparison).
+     */
+    [[nodiscard]] bool radial_swap_pending() noexcept;
+
+    /**
      * @brief Full world-reload invalidation. Clears the last-known-good
      *        identity cache, the actor->character cache, the pending
      *        radial-swap-key record, AND the body->character learning

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -934,6 +934,24 @@ namespace CDCore
         return written;
     }
 
+    bool radial_swap_pending() noexcept
+    {
+        /* Two-load probe of the pending-key record. The radial-swap
+           safetyhook callback writes deadline-then-key with release
+           ordering; the matching acquire-loads here pair with that to
+           guarantee an observer that sees a non-zero key also sees
+           the deadline written for it. A consumer (try_commit_pending)
+           sets both back to zero on commit/expiry; either zero short-
+           circuits the answer. Tick comparison uses GetTickCount64
+           for parity with the writer's clock source. */
+        const auto key = s_pendingKey.load(std::memory_order_acquire);
+        if (key == 0)
+            return false;
+        const auto deadline =
+            s_pendingDeadlineMs.load(std::memory_order_acquire);
+        return GetTickCount64() <= deadline;
+    }
+
     void invalidate_swap_caches() noexcept
     {
         // Release ordering pairs with the acquire load in

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -236,7 +236,8 @@ ToggleHotkey = V
 ShowHotkey =
 HideHotkey =
 DefaultHidden = true
-Parts = CD_Helm, CD_Helm_Acc, CD_Helm_Acc_01, CD_Helm_Acc_02, CD_Helm_Small, CD_Helm_Visione_Belt, CD_Helm_Flight
+; CD_Helm_Flight
+Parts = CD_Helm, CD_Helm_Acc, CD_Helm_Acc_01, CD_Helm_Acc_02, CD_Helm_Small, CD_Helm_Visione_Belt
 
 [Chest]
 Enabled = false

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Title for next release]
+## v1.05.00 atomic save-load fix
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed cases where loading a save while the mod was active could break the hide toggle until the game was restarted.

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -44,6 +44,33 @@ namespace EquipHide
         s_body2vcNext = 0;
     }
 
+    /* Full save-load wipe shared by the X->0->Y deferred-reload
+       state machine and the atomic-swap fallback (where the engine
+       rotates user+0xD8 between two non-zero values without ever
+       publishing the null window). Both paths land here once the
+       resolver has decided "this is a new world, drop everything":
+       Core's body learning cache, the per-body vc LRU, and the
+       published player_state must all be cleared together so the
+       next resolve cycle rebuilds against the fresh arena instead
+       of stomping freed memory through stale vc pointers. */
+    static void apply_full_reload_wipe() noexcept
+    {
+        CDCore::invalidate_controlled_character();
+        clear_body_to_vis_ctrl_cache();
+        auto &psWipe = player_state();
+        for (int j = 0; j < k_maxProtagonists; ++j)
+        {
+            psWipe.visCtrls[j].store(0, std::memory_order_relaxed);
+            psWipe.visCharIdx[j].store(-1, std::memory_order_relaxed);
+            psWipe.armorInjected[j].store(false, std::memory_order_relaxed);
+        }
+        psWipe.primaryVisCtrl.store(0, std::memory_order_relaxed);
+        psWipe.count.store(0, std::memory_order_relaxed);
+        for (int j = 0; j < k_maxProtagonists; ++j)
+            s_prevVisCtrls[j] = 0;
+        s_prevCount = 0;
+    }
+
     /** @brief Traverse body -> vis_ctrl pointer chain. Caller MUST be SEH-protected.
      *  @details Trace-logs only when a (body -> vc) mapping is new or has
      *           changed since the last walk; successful walks with a
@@ -217,34 +244,84 @@ namespace EquipHide
                         "Save-load complete: new controlled actor 0x{:X}; "
                         "wiping body cache + body_to_vis_ctrl LRU",
                         controlledActor);
-                    CDCore::invalidate_controlled_character();
-                    clear_body_to_vis_ctrl_cache();
-                    /* Drop stale player_state too: visCtrls hold the
-                       previous save's vc pointers, and the s_prev*
-                       diff guard below would otherwise see "no
-                       change" and skip rescheduling DirectWrite. */
-                    auto &psWipe = player_state();
-                    for (int j = 0; j < k_maxProtagonists; ++j)
-                    {
-                        psWipe.visCtrls[j].store(0, std::memory_order_relaxed);
-                        psWipe.visCharIdx[j].store(-1, std::memory_order_relaxed);
-                        psWipe.armorInjected[j].store(false, std::memory_order_relaxed);
-                    }
-                    psWipe.primaryVisCtrl.store(0, std::memory_order_relaxed);
-                    psWipe.count.store(0, std::memory_order_relaxed);
-                    for (int j = 0; j < k_maxProtagonists; ++j)
-                        s_prevVisCtrls[j] = 0;
-                    s_prevCount = 0;
+                    apply_full_reload_wipe();
                     s_pendingReloadInvalidation = false;
                 }
                 else if (s_prevControlledActor != 0 && controlledActor != 0)
                 {
-                    DMK::Logger::get_instance().info(
-                        "Char swap detected: controlled actor "
-                        "(0x{:X} -> 0x{:X}); invalidating swap-scope "
-                        "caches (body cache preserved)",
-                        s_prevControlledActor, controlledActor);
-                    CDCore::invalidate_swap_caches();
+                    /* Atomic-swap save-load: v1.05 sometimes rotates
+                       user+0xD8 directly between two non-zero values
+                       (load-screen window shorter than the resolver's
+                       1 s poll, or the engine builds the new actor
+                       and atomically swaps without ever publishing
+                       null) which defeats the X->0->Y state machine
+                       above and would otherwise mis-classify as an
+                       in-session radial swap. Disambiguate via the
+                       Core body learning cache: every protagonist
+                       body that was ever observed as the controlled
+                       identity this session is cache-resident, so an
+                       arriving controlled actor that matches NONE of
+                       the cache's entries cannot be one of the bodies
+                       we have already learned. CDCore is statically
+                       linked into each Logic DLL, so this cache is
+                       EH-private (no race with LiveTransmog stamping
+                       its own copy first) and is only mutated by the
+                       resolver call further down in this function.
+                       Disambiguator: a real radial swap leaves a fresh
+                       pending-key record stamped by the radial-swap
+                       safetyhook callback (TTL ~2 s, consumed by the
+                       next chain walk). A save-load has no such record
+                       because
+                       the load originates from the pause/title menu,
+                       not the radial UI. So if the new actor is absent
+                       from the body cache AND no radial input was just
+                       observed, the rotation must be a new-arena
+                       allocation -- treat as save-load. The cache-size
+                       lower bound (>= 1) guards the immediate post-
+                       wipe / pre-stamp window where peekN == 0 carries
+                       no information. */
+                    std::array<CDCore::BodyCacheEntry, 3> peek;
+                    const auto peekN = CDCore::snapshot_body_cache(
+                        peek.data(), peek.size());
+                    bool inCache = false;
+                    for (std::size_t i = 0; i < peekN; ++i)
+                    {
+                        if (peek[i].body == controlledActor)
+                        {
+                            inCache = true;
+                            break;
+                        }
+                    }
+                    const bool atomicSaveLoad =
+                        peekN >= 1 && !inCache &&
+                        !CDCore::radial_swap_pending();
+
+                    if (atomicSaveLoad)
+                    {
+                        DMK::Logger::get_instance().info(
+                            "Save-load detected (atomic swap): "
+                            "controlled actor (0x{:X} -> 0x{:X}) "
+                            "absent from body cache (n={}, no pending "
+                            "radial); wiping body cache + "
+                            "body_to_vis_ctrl LRU",
+                            s_prevControlledActor, controlledActor,
+                            peekN);
+                        apply_full_reload_wipe();
+                        /* No X->0 was observed, so the deferred flag
+                           was never latched -- defensively clear so a
+                           later spurious X->0->Y cannot double-fire
+                           against this transition. */
+                        s_pendingReloadInvalidation = false;
+                    }
+                    else
+                    {
+                        DMK::Logger::get_instance().info(
+                            "Char swap detected: controlled actor "
+                            "(0x{:X} -> 0x{:X}); invalidating swap-scope "
+                            "caches (body cache preserved)",
+                            s_prevControlledActor, controlledActor);
+                        CDCore::invalidate_swap_caches();
+                    }
                 }
                 s_prevControlledActor = controlledActor;
             }


### PR DESCRIPTION
## Summary

- v1.05 sometimes rotates `user+0xD8` directly between two non-zero values without ever publishing the null window the existing X→0→Y state machine relies on, leaving the body learning cache and per-body vc LRU populated with stale pointers from the prior save's arena. DirectWrite then walks freed memory; SEH catches the worst, but the hide toggle stays broken until next session.
- Adds `CDCore::radial_swap_pending()`: acquire-loads the pending key + deadline written by the radial-swap safetyhook callback, mirror-image of the writer's release order. Lets EquipHide tell an in-session radial swap apart from a save-load (only the former leaves a fresh pending-key record stamped from the radial UI; loads originate from the pause/title menu).
- EquipHide's X→Y both-non-zero branch now wipes when the new controlled actor is absent from the body cache and no radial input is pending, logging `Save-load detected (atomic swap): controlled actor (...) absent from body cache (n=N, no pending radial); ...`. The pre-existing X→0→Y deferred-reload path is unchanged for save-loads that do publish a null window.
