### PR TITLE
feat(live-transmog): add body-mesh prefab picker and expand slot coverage

### DIFF
--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 # --- CrimsonDesertCore (shared library, monorepo sibling) ---
 # Core owns DetourModKit as its own submodule and re-exports it via PUBLIC
-# link, so this target gets the DetourModKit target transitively — no
+# link, so this target gets the DetourModKit target transitively; no
 # separate add_subdirectory for DMK is needed at this level.
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../CrimsonDesertCore/CMakeLists.txt")
     add_subdirectory(
@@ -74,7 +74,7 @@ if(EQUIPHIDE_DEV_BUILD)
     # =====================================================================
     # Dev Build: two-DLL hot-reload (loader + logic)
     # =====================================================================
-    message(STATUS "DEV BUILD enabled — building loader + logic DLL pair")
+    message(STATUS "DEV BUILD enabled: building loader + logic DLL pair")
 
     # --- Loader ASI (thin stub, no DetourModKit) ---
     # Sources live in CrimsonDesertCore; parameterized via CDCORE_LOADER_* macros.
@@ -184,7 +184,7 @@ if(rc EQUAL 0)
         endif()
     endif()
 else()
-    message(STATUS "Direct deploy skipped (file locked) — using staging")
+    message(STATUS "Direct deploy skipped (file locked); using staging")
 endif()
 ]=])
 

--- a/CrimsonDesertLiveTransmog/CMakeLists.txt
+++ b/CrimsonDesertLiveTransmog/CMakeLists.txt
@@ -31,7 +31,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(nlohmann_json)
 
-# --- Dear ImGui (compiled from source — no binary dependency) ---
+# --- Dear ImGui (compiled from source -- no binary dependency) ---
 FetchContent_Declare(
     imgui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
@@ -57,7 +57,7 @@ target_compile_options(imgui_lib PRIVATE /W0)
 
 # --- CrimsonDesertCore (shared library, monorepo sibling) ---
 # Core owns DetourModKit as its own submodule and re-exports it via PUBLIC
-# link, so this target gets the DetourModKit target transitively — no
+# link, so this target gets the DetourModKit target transitively -- no
 # separate add_subdirectory for DMK is needed at this level.
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../CrimsonDesertCore/CMakeLists.txt")
     add_subdirectory(
@@ -92,6 +92,7 @@ set(COMMON_SOURCES
     src/preset_manager.cpp
     src/part_show_suppress.cpp
     src/real_part_tear_down.cpp
+    src/prefab_wrapper_swap.cpp
 )
 
 set(ASI_SOURCES
@@ -124,7 +125,7 @@ if(TRANSMOG_DEV_BUILD)
     # =====================================================================
     # Dev Build: two-DLL hot-reload (loader + logic)
     # =====================================================================
-    message(STATUS "DEV BUILD enabled — building loader + logic DLL pair")
+    message(STATUS "DEV BUILD enabled -- building loader + logic DLL pair")
 
     # --- Loader ASI (thin stub, no DetourModKit) ---
     # Sources live in CrimsonDesertCore; parameterized via CDCORE_LOADER_* macros.
@@ -231,7 +232,7 @@ if(rc EQUAL 0)
         endif()
     endif()
 else()
-    message(STATUS "Direct deploy skipped (file locked) — using staging")
+    message(STATUS "Direct deploy skipped (file locked) -- using staging")
 endif()
 ]=])
 

--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -11,7 +11,8 @@
 ## Features
 
 - Built-in overlay GUI -- no external tools required (toggle with **Home** key)
-- In-game item browser with search-filterable dropdown, auto-categorized by slot (Helm, Chest, Cloak, Gloves, Boots)
+- In-game item browser with search-filterable dropdown, auto-categorized by slot (helm, chest, cloak, gloves, boots, necklace, lantern, glasses, mask, backpack)
+- Optional body-mesh prefab picker for swapping individual prefab variants onto a slot
 - Preset system: save, load, rename, and cycle through multiple transmog presets per character
 - Multi-character support: independent preset lists for Kliff, Damiane, and Oongka; the active preset swaps automatically when you change who you control
 - NPC armor variants and damaged variants render via automatic carrier swap

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,8 @@
-## [Title for next release]
+## Expanded Slot Coverage and Body-Mesh Prefab Picker
 
-- New feature
-- Bug fix
-- Improvement
+- Slot picker now covers 10 equipment slots (helm, chest, cloak, gloves, boots, necklace, lantern, glasses, mask, backpack) instead of the 5 armor slots only. Weapon, ring, earring, and bracelet slots are not yet supported.
+- New body-mesh prefab picker lets you pick a prefab variant to swap onto a slot, in addition to the regular item picker
+- Body-mesh prefab selections persist with your preset (saved as a new `prefabName` field; older preset files load unchanged)
+- Preset JSON format updated: slots are now stored as a keyed object (by slot name) instead of a positional array, so future slot additions will not shift older saves. Legacy array-format presets load automatically and are rewritten in the new format on next save.
+- Optional cross-slot prefab browser mode: list every body-mesh prefab in one place and apply it to its native slot from any picker
+- Removed the hard world-load timeout in the standalone overlay path. The mod now waits indefinitely for the game world to become ready (with a heartbeat log every minute) instead of giving up and warning, which prevented the overlay from initializing on slow boots.

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -16,7 +16,8 @@ Change the visual appearance of your equipped armor [b]in real time[/b] without 
 
 [list]
 [*][b]Built-in overlay[/b] -no external tools required. Press [b]Home[/b] to toggle the overlay
-[*][b]In-game item browser[/b] -searchable dropdown with all armor pieces, auto-categorized by slot (Helm, Chest, Cloak, Gloves, Boots)
+[*][b]In-game item browser[/b] -searchable dropdown auto-categorized by slot (helm, chest, cloak, gloves, boots, necklace, lantern, glasses, mask, backpack)
+[*][b]Body-mesh prefab picker[/b] -optional per-slot prefab swap for users who want to mix and match individual mesh variants beyond what the item picker exposes
 [*][b]Preset system[/b] -save, load, rename, and cycle through multiple transmog presets per character
 [*][b]Multi-character support[/b] -independent preset lists for Kliff, Damiane, and Oongka; the active preset swaps automatically when you change who you control
 [*][b]Body-type filter[/b] -hides items whose body type (male/female) does not match the active character so broken meshes stay out of the picker. Per-character override available in the overlay for body-swap mod users

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -281,6 +281,294 @@ namespace Transmog
          ResolveMode::Direct, -0x2D, 0},
     };
 
+    // -----------------------------------------------------------------------
+    // PrefabWrapperSwap module data globals (audit 2026-05-08).
+    //
+    // The PrefabWrapperSwap module previously hardcoded six absolute
+    // addresses derived from v1.05.01 RVAs. Each is now resolved through
+    // a 3-candidate cascade:
+    //
+    //   StringInfoRegistry  : MEMORY[0x145EF1DE8] -- registry struct.
+    //   StringInfoVtable    : 0x145BC4638        -- vtable sentinel filter.
+    //   LoaderRegistry      : MEMORY[0x145DDF8B0] -- partprefab name->wrapper.
+    //   ApptContainerVtable : 0x144D24358        -- partPrefabDataContainer
+    //                                              vtable; used by lookup
+    //                                              gating in
+    //                                              lookup_prefab_metadata.
+    //   NaturalPipeline     : sub_142711DF0 (RVA 0x2711DF0). Hooked.
+    //   ApptNameLookup      : sub_1424DF420 (RVA 0x24DF420). Called direct.
+    //
+    // For data globals (registry/vtable) the cascade resolves through a
+    // RIP-relative mov/lea instruction in a non-template caller. The
+    // disp32 is wildcarded; the cascade returns absolute target via
+    // ResolveMode::RipRelative.
+    //
+    // For the two function targets we use Direct mode against the
+    // function prologue. Three independent anchors per function let a
+    // future compiler shuffle the prologue without breaking resolution.
+    //
+    // Per feedback_aob_cascade_ordering: each P1 below is verified
+    // n=1 in v1.05.01 .text. P2/P3 are also unique to allow recovery
+    // when a future patch breaks P1.
+    //
+    // If these break: each candidate's comment names the anchor caller
+    // (e.g. "xref in sub_1402F58A0"). Re-find the function by name
+    // through IDA, locate the load instruction, copy the surrounding
+    // 16--32 bytes, wildcard the disp32, and verify uniqueness with
+    // mcp__ida-pro-mcp__find_bytes.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @brief StringInfoRegistry global: MEMORY[0x145EF1DE8].
+     *
+     * The 17-slot StringInfo registry struct. +0x08 holds count u32,
+     * +0x50 holds the QWORD entry-array pointer. PrefabWrapperSwap walks
+     * this registry to resolve prefab NAMES to entry wrapper-ptrs.
+     *
+     * All three candidates anchor on a `mov reg, [rip+disp32]` that
+     * loads this address. Disp32 wildcarded; rest of the 16+ byte
+     * window is unique-text in v1.05.01 .text.
+     */
+    inline constexpr AddrCandidate k_stringInfoRegistryCandidates[] = {
+        // P1 -- xref in sub_141D81F90 at 0x141D8215E. Distinctive frame
+        // shape: load char-table eax, store at [rbp+0x58], then load
+        // registry into rcx, walk +0x60, lea rdx,[rbp+0x58], then call.
+        // The local-variable disp8 (0x58) is kept literal to disambiguate.
+        {"StringInfoRegistry_P1_LoadAddCallSite",
+         "8B 45 B0 89 45 58 48 8B 0D ?? ?? ?? ?? 48 83 C1 60 48 8D 55 58",
+         ResolveMode::RipRelative, 9, 13},
+
+        // P2 -- xref in sub_142144B10 (large parser, 0x1d6f bytes). A
+        // distinctive `mov [rbp-0x6A], al` + 32-bit local-store sequence
+        // precedes a `mov r15, [rip+disp32]` registry load. The local
+        // disp32 sequence (90 00 00 00) is kept literal -- it's the
+        // local frame's outer-scope variable offset.
+        {"StringInfoRegistry_P2_OuterScopeFrame",
+         "88 45 96 89 8D 90 00 00 00 4C 8B 3D ?? ?? ?? ?? "
+         "48 8D 95 90 00 00 00 49 8D 4F 60",
+         ResolveMode::RipRelative, 12, 16},
+
+        // P3 -- xref in sub_14074DD40. Conditional load+jump shape:
+        // load r9d, test, jz, store dword to [rbp+0x70], then load
+        // registry. The 8B 4F 74 (mov ecx, [rdi+0x74]) is a stable
+        // game-struct field offset.
+        {"StringInfoRegistry_P3_CondLoadStore",
+         "8B 4F 74 85 C9 74 5C 89 4D 70 48 8B 0D ?? ?? ?? ?? "
+         "48 83 C1 60 48 8D 55 70",
+         ResolveMode::RipRelative, 13, 17},
+    };
+
+    /**
+     * @brief StringInfoVtable sentinel: 0x145BC4638.
+     *
+     * Vtable pointer used as the +0x08 sentinel of every StringInfo
+     * entry. PrefabWrapperSwap reads it to filter out non-StringInfo
+     * heap rows during walk_string_info.
+     *
+     * All three candidates anchor on a `lea rax, [rip+disp32]` write.
+     * Each candidate is in a different function so a single-function
+     * recompile cannot break all three.
+     */
+    inline constexpr AddrCandidate k_stringInfoVtableCandidates[] = {
+        // P1 -- xref in sub_1402F58A0 (0x17b0 bytes, large method).
+        // `mov ecx, [rbp+0x1C0]; call rel32; lea r15, [rip+disp32];
+        //  mov [rbp+0x1C0], r15`. The 0x1C0 stack-frame offset is
+        // sufficiently distinctive in this 6kB function.
+        {"StringInfoVtable_P1_LargeMethodAssign",
+         "8B 8D C0 01 00 00 E8 ?? ?? ?? ?? 4C 8D 3D ?? ?? ?? ?? "
+         "4C 89 BD C0 01 00 00",
+         ResolveMode::RipRelative, 14, 18},
+
+        // P2 -- xref in sub_1403174F0 (0x535 bytes). Init block:
+        // `mov [rbp-0x50], eax; xor r12d, r12d; mov [rbp-0x48], r12;
+        //  lea r13, [rip+disp32]; nop`. The trailing 0x90 nop is
+        // alignment padding kept literal -- if a future build drops
+        // the padding, P3 catches it.
+        {"StringInfoVtable_P2_R13InitBlock",
+         "89 45 B0 45 33 E4 4C 89 65 B8 4C 8D 2D ?? ?? ?? ?? 90 "
+         "48 8B 45 C8",
+         ResolveMode::RipRelative, 13, 17},
+
+        // P3 -- xref in sub_14031AC50 (0xbfd bytes). Tail block:
+        // `mov [rbp+0x40], r13; mov rsi, [rbp+0x10]; lea rdi, [rip+disp32]`.
+        // The trailing `0F 1F 40 00` is a 4-byte nop the compiler
+        // emits for branch-target alignment -- stable for this site.
+        {"StringInfoVtable_P3_TailLeaRdi",
+         "4C 89 6D 40 48 8B 75 10 48 8D 3D ?? ?? ?? ?? 0F 1F 40 00",
+         ResolveMode::RipRelative, 11, 15},
+    };
+
+    /**
+     * @brief LoaderRegistry singleton: MEMORY[0x145DDF8B0].
+     *
+     * Engine partprefab name->wrapper registry singleton. The ApptName-
+     * Lookup function (sub_1424DF420, also AOB-resolved) dereferences
+     * this and queries [+0x50]. PrefabWrapperSwap reads this on init for
+     * heap-walk enumeration of prefab wrappers.
+     */
+    inline constexpr AddrCandidate k_loaderRegistryCandidates[] = {
+        // P1 -- xref in sub_1424E44A0 at 0x1424E4771. Distinctive
+        // 64-bit add-immediate `48 81 C1 D0 00 00 00` (add rcx, 0xD0)
+        // that follows the registry load -- a stable game-struct
+        // walk-offset.
+        {"LoaderRegistry_P1_AddD0CallSite",
+         "48 8B 0D ?? ?? ?? ?? 48 81 C1 D0 00 00 00 48 8D 56 20 E8",
+         ResolveMode::RipRelative, 3, 7},
+
+        // P2 -- xref in sub_1424E44A0 at 0x1424E47AA (different site).
+        // `mov [rbp+0x07], r15; mov r14, [rip+disp32]; add r14, ...`.
+        // The 4C 89 7D 07 (mov [rbp+0x07], r15) shape is unusual and
+        // distinguishes from the first call site.
+        {"LoaderRegistry_P2_R14ReadAfterStore",
+         "4C 89 7D 07 4C 8B 35 ?? ?? ?? ?? 49 83 C6",
+         ResolveMode::RipRelative, 7, 11},
+
+        // P3 -- xref in sub_142D1E220 at 0x142D1E7F1. This is a STORE
+        // (`mov [rip+disp32], rbx`) that initializes the singleton at
+        // engine-init time, NOT a load. The disp32 still resolves to
+        // the singleton address. Distinctive surrounding context: an
+        // inline EB 03 (jmp short) and a 32-bit struct-field compare
+        // `48 3B 9E 60 00 04 00`.
+        {"LoaderRegistry_P3_InitStoreSite",
+         "48 89 03 48 89 1D ?? ?? ?? ?? EB 03 48 8B DF "
+         "48 3B 9E 60 00 04 00",
+         ResolveMode::RipRelative, 6, 10},
+    };
+
+    /**
+     * @brief ApptContainerVtable: 0x144D24358 (partPrefabDataContainer).
+     *
+     * Per sub_141E2DBB0 (AppearanceTableLoader ctor), the loader
+     * allocates two containers and assigns final vtables:
+     *   a1[0] (_appearanceContainer)     -> &off_144D24308
+     *   a1[1] (_partPrefabDataContainer) -> &off_144D24358   <-- our target
+     *
+     * Single-xref site (in sub_141E2DBB0). The vtable-write pattern is
+     * a code-generator template emitted for ~9 sibling container types,
+     * so anchoring on the lea+mov[rdi] sequence alone is not unique.
+     *
+     * Resolution strategy: AOB-resolve sub_141E2DBB0's prologue (which
+     * IS unique), then the C++ resolver walks forward through the
+     * function body to find the SECOND `48 8D 05 ?? ?? ?? ?? 48 89 07`
+     * pair (the FIRST is the intermediate vtable 0x144D242B8; the SECOND
+     * is our target). The walk-forward logic lives in
+     * prefab_wrapper_swap.cpp::resolve_appt_container_vtable.
+     *
+     * If this breaks: re-AOB sub_141E2DBB0 by its prologue, then in
+     * IDA find the second `lea rax, [rip+disp32]; mov [rdi], rax` pair
+     * inside the function. The byte offset has shifted across builds
+     * (was at +0x2BF in v1.05.01); the walk is bounded to the
+     * function's first 0x400 bytes to avoid running off into the next
+     * function.
+     */
+    inline constexpr AddrCandidate k_apptLoaderCtorCandidates[] = {
+        // P1 -- full prologue (8 callee-saved regs + frame setup).
+        // Distinctive in v1.05.01: 1 unique hit. The 41 54 41 55 41 56
+        // 41 57 (push r12-r15) is the largest possible callee-save set,
+        // typical of a 540-byte function with many locals.
+        {"ApptLoaderCtor_P1_FullPrologue",
+         "48 89 54 24 10 48 89 4C 24 08 53 55 56 57 41 54 41 55 41 56 41 57 "
+         "48 83 EC 38 48 8B F1 45 33 F6 4C 89 31 4C 89 71 08 4C 89 71 10 "
+         "4C 89 71 18 44 88 71 20",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- mid-prologue + first field-init. Skips the `mov rcx,rdx
+        // mov rax,rcx` boilerplate; anchors on the first XOR + the
+        // sequence of zero-stores into [rcx+0..0x18].
+        {"ApptLoaderCtor_P2_FieldInitChain",
+         "45 33 F6 4C 89 31 4C 89 71 08 4C 89 71 10 4C 89 71 18 "
+         "44 88 71 20 49 8B 00 48 89 41 10",
+         ResolveMode::Direct, -0x1D, 0},
+
+        // P3 -- mid-body anchor on the unique field-init shape that
+        // copies a 32-byte payload from a3 into a1+0x10..0x20: the
+        // 49 8B 00 / 48 89 41 10 / 49 8B 40 08 / 48 89 41 18 /
+        // 41 0F B6 40 10 sequence is the inline copy of {qword,qword,
+        // byte} from *a3. Unique to this loader ctor in v1.05.01.
+        // Walk-back -0x2F lands on function start.
+        {"ApptLoaderCtor_P3_PayloadCopy",
+         "44 88 71 20 49 8B 00 48 89 41 10 49 8B 40 08 48 89 41 18 "
+         "41 0F B6 40 10",
+         ResolveMode::Direct, -0x2F, 0},
+    };
+
+    /**
+     * @brief NaturalPipeline (sub_142711DF0) -- engine unlink fn.
+     *
+     * RVA 0x2711DF0. PrefabWrapperSwap installs a MidHook here to
+     * substitute Kliff src wrappers with target wrappers in the engine's
+     * unlink list (helm/cloak ghost cleanup, see ghost-helm-re memory).
+     *
+     * Function is a 6k-byte unlink pipeline with all 8 callee-saved
+     * registers pushed, so prologue is highly distinctive.
+     */
+    inline constexpr AddrCandidate k_naturalPipelineCandidates[] = {
+        // P1 -- full prologue + chkstk preamble. The 80 18 00 00 (mov
+        // eax, 0x1880) is the stack reservation passed to __chkstk.
+        // Stable for this exact function shape -- B8 imm32 will only
+        // change if the stack-allocation grows past 4kb.
+        {"NaturalPipeline_P1_FullPrologueChkstk",
+         "48 89 5C 24 10 4C 89 4C 24 20 4C 89 44 24 18 48 89 4C 24 08 "
+         "55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 80 E8 FF FF "
+         "B8 80 18 00 00",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- post-arg-spill prologue. Anchors past the four arg-
+        // home stores and on the lea rbp,[rsp-0x1780]+chkstk pair.
+        // Walk-back -5 = past `48 89 5C 24 10` to function start.
+        {"NaturalPipeline_P2_PostArgSpill",
+         "4C 89 4C 24 20 4C 89 44 24 18 48 89 4C 24 08 "
+         "55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 80 E8 FF FF "
+         "B8 80 18 00 00",
+         ResolveMode::Direct, -0x05, 0},
+
+        // P3 -- chkstk + stack adjustment + arg-shuffle. The
+        // 48 2B E0 (sub rsp, rax) is the conventional __chkstk
+        // post-call. Walk-back -0x27 to function start.
+        {"NaturalPipeline_P3_PostChkstkArgShuffle",
+         "B8 80 18 00 00 E8 ?? ?? ?? ?? 48 2B E0 4D 8B E8 48 8B DA "
+         "4C 8B F9 41 83 78",
+         ResolveMode::Direct, -0x27, 0},
+    };
+
+    /**
+     * @brief ApptNameLookup (sub_1424DF420) -- name->wrapper primitive.
+     *
+     * RVA 0x24DF420. PrefabWrapperSwap calls this directly (not hooked)
+     * to resolve partprefab names to wrapper-ptrs. Lowercases the name,
+     * interns it, queries MEMORY[0x145DDF8B0]+0x50, returns entry+8 on
+     * hit or 0 on miss.
+     */
+    inline constexpr AddrCandidate k_apptNameLookupCandidates[] = {
+        // P1 -- full prologue + frame setup + first registry load.
+        // The 48 8D 6C 24 A0 (lea rbp,[rsp-0x60]) and 48 81 EC 60 01
+        // (sub rsp, 0x160) form a unique 0x160-byte stack frame. The
+        // immediately-following `mov rsi, [rip+disp32]` loads the
+        // LoaderRegistry singleton (also resolved separately).
+        {"ApptNameLookup_P1_FullPrologue",
+         "48 89 5C 24 10 48 89 4C 24 08 55 56 57 "
+         "48 8D 6C 24 A0 48 81 EC 60 01 00 00 "
+         "48 8B 35 ?? ?? ?? ?? 33 FF 48 89 7D 28",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- post-arg-spill, before frame setup. Walk-back -10 to
+        // function start.
+        {"ApptNameLookup_P2_PostArgSpill",
+         "55 56 57 48 8D 6C 24 A0 48 81 EC 60 01 00 00 "
+         "48 8B 35 ?? ?? ?? ?? 33 FF",
+         ResolveMode::Direct, -0x0A, 0},
+
+        // P3 -- frame setup + xor edi,edi + the local-var inits.
+        // The 48 C7 45 30 05 01 00 00 (mov [rbp+0x30], 0x105) is a
+        // semantic constant (initial buffer capacity) -- stable.
+        // Walk-back -13 to function start.
+        {"ApptNameLookup_P3_LocalInitConstant",
+         "48 8D 6C 24 A0 48 81 EC 60 01 00 00 "
+         "48 8B 35 ?? ?? ?? ?? 33 FF 48 89 7D 28 "
+         "48 C7 45 30 05 01 00 00",
+         ResolveMode::Direct, -0x0D, 0},
+    };
+
     /**
      * @brief Patch site: CondPrefab evaluator secondary hash check
      *        (sub_141D5F470 at +0xC8, 0x141D5F538 on v1.02.00).
@@ -331,5 +619,315 @@ namespace Transmog
          "66 45 3B 0C 48 74 ?? FF C1 3B CA 72 ?? EB",
          ResolveMode::Direct, 0x17, 0},
     };
+
+    // -----------------------------------------------------------------------
+    // PrefabWrapperSwap module function targets (audit 2026-05-08 part 2).
+    //
+    // Four function-target cascades migrated out of prefab_wrapper_swap.cpp
+    // where they previously lived as single-anchor inline constexpr arrays.
+    // Each now has a 3-anchor cascade per the ordering rule in
+    // CrimsonDesertCore/external/DetourModKit/docs/misc/aob-signatures.md.
+    //
+    //   ApptResMgrInit  : sub_1408AF8F0 -- one-shot capture hook target;
+    //                                      reads ResMgr/loader/container.
+    //   ApptInnerLookup : sub_140350910 -- partprefab container hashtable
+    //                                      lookup primitive. Pure read.
+    //   ApptStringIntern: sub_1403016B0 -- StringInfo string-intern primitive
+    //                                      callable as `handle_t(const char*)`.
+    //   StructCopy      : sub_140352AA0 -- 0x40-byte struct-copy hot path
+    //                                      that PrefabWrapperSwap inline-hooks
+    //                                      to swap source wrapper-ptrs.
+    //
+    // Hit counts re-verified live via Cheat Engine + IDA on v1.05.01 .text
+    // before authoring. Where a function had a sibling clone (linker-emitted
+    // duplicate compiled from a templated header) and no global anchor was
+    // unique, the cascade leads with a RipRelative call-site anchor that
+    // walks an `E8 disp32` from a known caller (which IS unique) to the
+    // canonical target.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @brief ApptResMgrInit (sub_1408AF8F0) -- one-shot capture hook target.
+     *
+     * Outer ResMgr-init function. PrefabWrapperSwap installs an inline
+     * entry hook that runs the trampoline and then snapshots ResMgr at
+     * a1[5] (a1+0x28), the loader at ResMgr+0x58, and the partprefab
+     * container at loader+0x08. The hook is one-shot; subsequent calls
+     * are pass-throughs.
+     *
+     * If these break: the function pushes all 8 callee-saved registers
+     * (push rbp/rbx/rsi/rdi/r12-r15 = `40 55 53 56 57 41 54 41 55 41 56
+     * 41 57`) and then sets up a 0xF8-byte stack frame. That 13-byte
+     * push run + the chkstk-free `48 81 EC F8 00 00 00` direct alloc are
+     * the two distinguishing prologue features. Re-anchor by combining
+     * either with one of the early-body markers (TLS slot 0x58 read or
+     * the constant `204h` payload size).
+     */
+    inline constexpr AddrCandidate k_apptResMgrInitCandidates[] = {
+        // P1 -- full prologue (8 callee-saved push run + lea rbp + direct
+        // 0xF8 alloc + arg shuffle). 1 hit on v1.05.01 .text. No RIP-rel
+        // bytes inside the window so wildcards are not needed.
+        {"PrefabWrapperSwap_ApptResMgrInit_P1_FullPrologue",
+         "40 55 53 56 57 41 54 41 55 41 56 41 57 "
+         "48 8D 6C 24 E1 "
+         "48 81 EC F8 00 00 00 "
+         "4C 8B FA 4C 8B F1",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- mid-prologue: lea rbp,[rsp-0x1F] + direct alloc + arg
+        // shuffle + xor r13d,r13d. Walk-back -0x0D to function start.
+        // 1 hit on v1.05.01 .text. Survives a future build that adds or
+        // reorders early callee-save pushes (because the lea-rbp marker
+        // pins frame setup, not which regs were pushed first).
+        {"PrefabWrapperSwap_ApptResMgrInit_P2_PostPushAlloca",
+         "48 8D 6C 24 E1 48 81 EC F8 00 00 00 "
+         "4C 8B FA 4C 8B F1 45 33 ED",
+         ResolveMode::Direct, -0x0D, 0},
+
+        // P3 -- TLS-canary load body anchor. The unique `mov r12d, 204h ;
+        // mov rax, gs:58h ; add r12, [rax]` sequence reads the TLS slot
+        // into r12 to use as a per-thread scratch base (shape only this
+        // function emits in v1.05.01 -- the 204h immediate is a
+        // build-stable scratch-arena ID). Walk-back -0x2D to function
+        // start. Anchors past the prologue entirely so a prologue-shape
+        // shuffle does not sink P3.
+        {"PrefabWrapperSwap_ApptResMgrInit_P3_TlsScratchSetup",
+         "41 BC 04 02 00 00 65 48 8B 04 25 58 00 00 00 "
+         "4C 03 20 41 8D 55 10 8D 4A 30",
+         ResolveMode::Direct, -0x2D, 0},
+    };
+
+    /**
+     * @brief ApptInnerLookup (sub_140350910) -- partprefab container
+     *        hashtable lookup primitive. Pure read.
+     *
+     * Signature: `__int64(*)(table_struct*, key_wrapper_ptr_ptr*)`.
+     * `table_struct` is `container + 0x70` -- the boot-loaded primary
+     * hash table. Returns 0 on miss or `entry+0x10` on hit (a 24-byte
+     * metadata payload pointer).
+     *
+     * IMPORTANT: this function has a byte-identical sibling clone at
+     * `sub_1430C4880` (UI/render subsystem). Both implement the same
+     * primitive but only `sub_140350910` is wired to the partprefab
+     * `container+0x70` shape. P1 below leads with a RipRelative call-site
+     * anchor (in `sub_140347BB0` which calls into the canonical clone)
+     * because the function-prologue cascade alone matches BOTH copies.
+     * Per feedback_aob_cascade_ordering: any P1 with hit count >=2
+     * shadows unique fallbacks; the call-site anchor is unique and
+     * dispatches the cascade past the clone problem entirely.
+     *
+     * If these break: re-find an xref to `sub_140350910` from
+     * gameplay-side code (e.g. `sub_140347BB0` at +0x1A25 / +0x1B98 in
+     * v1.05.01) and grab the 12-byte window before the `E8 disp32` for a
+     * fresh RipRelative anchor.
+     */
+    inline constexpr AddrCandidate k_apptInnerLookupCandidates[] = {
+        // P1 -- RipRelative resolve via call site at 0x1403495D5 inside
+        // sub_140347BB0. Window: `mov ecx, [rax+disp32]` (the field-load
+        // disp32 is wildcarded since it is a stable game-struct offset
+        // but compiler-specific in encoding) + `add rcx, 0x70 ; mov rdx,
+        // rbx ; call sub_140350910`. The `48 83 C1 70` is the literal
+        // `+0x70` walk-offset that distinguishes the partprefab table from
+        // sibling tables; it is a SEMANTIC constant kept literal. `8B 88`
+        // = `mov ecx, [rax+disp32]`.
+        {"PrefabWrapperSwap_ApptInnerLookup_P1_CallSiteRipRel",
+         "8B 88 ?? ?? ?? ?? 48 83 C1 70 48 8B D3 E8 | ?? ?? ?? ??",
+         ResolveMode::RipRelative, 14, 18},
+
+        // P2 -- function prologue + early-return path. The prologue is
+        // shared with one templated clone (`sub_1430C4880`). When P1
+        // succeeds this is unused; when it fails this returns the FIRST
+        // linear-scan match which is `sub_140350910` on v1.05.01 (the
+        // canonical lookup primitive lives in the lower .text band). The
+        // `48 83 EC 20` direct alloc + `83 79 04 00` field-zero compare
+        // pin this function shape against unrelated functions.
+        {"PrefabWrapperSwap_ApptInnerLookup_P2_FullPrologueEarlyExit",
+         "4C 89 74 24 20 41 57 48 83 EC 20 "
+         "83 79 04 00 4C 8B FA 4C 8B F1 75 0E "
+         "33 C0 4C 8B 74 24 ?? 48 83 C4 20 41 5F C3",
+         ResolveMode::Direct, 0, 0},
+
+        // P3 -- prologue + post-early-exit field load. Walks one more
+        // basic block past P2 into the `mov [rsp+arg_0], rbx ; mov rbx,
+        // [rdx] ; mov [rsp+arg_10], rdi ; mov edi, [rbx+0xC]` shape. The
+        // first `?? ` is the rsp disp8 of the saved-r14 spill (compiler-
+        // owned). Same multi-hit caveat as P2 (clone shares this body).
+        {"PrefabWrapperSwap_ApptInnerLookup_P3_PrologueBodyChain",
+         "4C 89 74 24 20 41 57 48 83 EC 20 "
+         "83 79 04 00 4C 8B FA 4C 8B F1 75 0E "
+         "33 C0 4C 8B 74 24 ?? 48 83 C4 20 41 5F C3 "
+         "48 89 5C 24 30 48 8B 1A 48 89 7C 24 40 8B 7B 0C",
+         ResolveMode::Direct, 0, 0},
+    };
+
+    /**
+     * @brief ApptStringIntern (sub_1403016B0) -- string-intern primitive.
+     *
+     * Signature: `handle_t(*)(const char* utf8)`. Lowercases nothing,
+     * just returns the engine's interned-string handle expected by
+     * `sub_141D38810` and `sub_140350910`. Returns 0 for null/empty
+     * input.
+     *
+     * Like ApptInnerLookup, this function has a templated sibling clone
+     * (linker-emitted from a header). The full prologue is unique in
+     * v1.05.01 so P1 stays direct; P2 and P3 are body anchors that fall
+     * back if the prologue shifts.
+     *
+     * If these break: re-anchor on the unique `48 C7 C3 FF FF FF FF`
+     * (mov rbx, -1 = strlen-counter init) + the strncpy_s import-call
+     * `FF 15 ?? ?? ?? ??` shape -- the import slot is a __ImageImpDir
+     * entry whose location is build-stable.
+     */
+    inline constexpr AddrCandidate k_apptStringInternCandidates[] = {
+        // P1 -- full prologue + null/empty short-circuit + strlen-loop
+        // init. `48 C7 C3 FF FF FF FF` is `mov rbx, -1` -- strlen pre-
+        // decrement counter. 1 hit on v1.05.01 .text.
+        {"PrefabWrapperSwap_ApptStringIntern_P1_FullPrologue",
+         "40 56 48 83 EC 20 "
+         "48 8B F1 48 85 C9 74 52 "
+         "80 39 00 74 4D "
+         "48 89 5C 24 30 "
+         "48 C7 C3 FF FF FF FF",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- mid-body anchor on the strlen-loop interior + the back-
+        // jump (`75 F7` = jne -9 to walk to next byte while [rcx+rbx]
+        // != 0). 1 hit on v1.05.01 .text. Walk-back -0x13 to function
+        // start. Survives a prologue-shuffle that drops the `74 52` /
+        // `74 4D` short-jumps in favour of `0F 84 rel32` (only the body
+        // shape is anchored).
+        {"PrefabWrapperSwap_ApptStringIntern_P2_StrlenLoopBody",
+         "48 89 5C 24 30 48 C7 C3 FF FF FF FF "
+         "48 89 7C 24 38 48 FF C3 80 3C 19 00 75 F7",
+         ResolveMode::Direct, -0x13, 0},
+
+        // P3 -- truncated prologue (no `mov rbx, -1`). Same head as P1
+        // but stops one step earlier; survives a build that re-orders
+        // the `mov [rsp+arg_0], rbx` / `mov rbx, -1` pair. Still unique
+        // on v1.05.01 because the `74 52 ... 74 4D ... 48 89 5C 24 30`
+        // null-empty-skip-then-spill sequence is function-specific.
+        {"PrefabWrapperSwap_ApptStringIntern_P3_HeadShortPair",
+         "40 56 48 83 EC 20 "
+         "48 8B F1 48 85 C9 74 52 "
+         "80 39 00 74 4D "
+         "48 89 5C 24 30",
+         ResolveMode::Direct, 0, 0},
+    };
+
+    /**
+     * @brief StructCopy (sub_140352AA0) -- 0x40-byte struct-copy hotpath.
+     *
+     * Signature: `__int64(*)(dst, src)`. The function copies a partprefab
+     * wrapper-related struct field-by-field. PrefabWrapperSwap installs
+     * an inline hook here and (when LT-active) substitutes Kliff source
+     * wrappers with target wrappers for the duration of the copy.
+     *
+     * Function reads the engine's StringInfo vtable sentinel
+     * `0x145BC4638` via a `lea rax, [rip+disp32]` early in the body;
+     * that single RIP-rel byte is wildcarded. All other bytes in the
+     * patterns below are stable.
+     *
+     * If these break: the function's signature is `dst,src ->
+     * mov [dst], 0 ; copy src->dst ; lea rax, [vtable] ; mov [src],
+     * rax ; movzx-byte transfers from [src+8..src+0xA] into [dst+8..]`.
+     * Re-anchor on the byte-transfer block (P3 below) -- it is the most
+     * function-specific shape and the least likely to shuffle.
+     */
+    inline constexpr AddrCandidate k_structCopyCandidates[] = {
+        // P1 -- full prologue + first qword copy + vtable load. Single
+        // RIP-rel `lea rax, [rip+disp32]` wildcarded (loads
+        // `0x145BC4638`). 1 hit on v1.05.01 .text.
+        {"PrefabWrapperSwap_StructCopy_P1_FullPrologueWithVtable",
+         "48 89 5C 24 18 48 89 6C 24 20 48 89 4C 24 08 "
+         "56 57 41 56 48 83 EC 20 "
+         "4C 8B F2 48 8B F1 33 ED 48 89 29 "
+         "48 8B 02 48 89 01 48 8D 05 ?? ?? ?? ?? 48 89 02",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- truncated prologue (no RIP-rel). Stops at `48 89 29`
+        // (the `mov [rcx], rbp` zeroing of dst+0). Survives a future
+        // build that moves the vtable lea later in the function. WARNING:
+        // pattern fragment also matches `sub_140355210` (sibling). Hit
+        // count is 1 on the canonical target only when the cascade
+        // proceeds past P1 first; otherwise relies on
+        // `sanity_check_function_prologue` post-resolve.
+        {"PrefabWrapperSwap_StructCopy_P2_PrologueNoVtable",
+         "48 89 5C 24 18 48 89 6C 24 20 48 89 4C 24 08 "
+         "56 57 41 56 48 83 EC 20 "
+         "4C 8B F2 48 8B F1 33 ED 48 89 29",
+         ResolveMode::Direct, 0, 0},
+
+        // P3 -- byte-transfer body anchor. The unique 4-byte payload
+        // copy (`movzx eax, byte ptr [rdx+8/9/A] ; mov [rcx+8/9/A], al`
+        // x3) plus the `mov eax, [rdx+0xC] ; mov [rcx+0xC], eax` dword
+        // tail and the trailing `mov [rcx+0x10], rbp` zero-store. 1 hit
+        // on v1.05.01 .text. Walk-back -0x2F to function start.
+        // Patch-survival: the byte-by-byte transfer shape is what the
+        // compiler emits when struct alignment is 1 (packed); it is a
+        // strong tell of this exact function and is unlikely to shuffle.
+        {"PrefabWrapperSwap_StructCopy_P3_ByteTransferBlock",
+         "48 89 02 0F B6 42 08 88 41 08 "
+         "0F B6 42 09 88 41 09 "
+         "0F B6 42 0A 88 41 0A "
+         "8B 42 0C 89 41 0C 48 89 69 10",
+         ResolveMode::Direct, -0x2F, 0},
+    };
+
+    // -----------------------------------------------------------------------
+    // ItemNameTable bounded-window anchor patterns (audit 2026-05-08 part 3).
+    //
+    // These are NOT cascades: they are pattern strings handed to
+    // `DMK::Scanner::find_pattern` for a 0x40--0x80-byte LOCAL scan inside
+    // a function whose start has already been resolved (via
+    // `k_subTranslatorCandidates`). They live here to keep all byte-pattern
+    // string literals in one place per the audit policy.
+    //
+    // The `|` glyph marks the point where `parse_aob` should compute its
+    // pattern.offset for downstream `match + offset` arithmetic (DMK v3.0.2+
+    // applies offset internally during find_pattern).
+    //
+    // Consumed by `ItemNameTable::resolve_chain` in item_name_table.cpp.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @brief Step-1 anchor inside SubTranslator (v1.05.00 encoding).
+     *
+     * Locates `call sub_141D45270` inside `sub_14076D950`. The second
+     * `lea` encodes rsp-relative (`48 8D 4C 24 ??`, 4 bytes) instead of
+     * v1.04's rbp-relative (`48 8D 4D ??`, 3 bytes). The disp8 slots are
+     * wildcarded so a future stack-frame shift inside the same function
+     * does not require another anchor variant.
+     *
+     * Used as the FIRST pattern in a 0x80-byte scan window. Anchor offset
+     * `|` lands on the byte immediately after the `E8` opcode = start of
+     * the call's disp32.
+     */
+    inline constexpr const char *k_nametableSubTxV105Anchor =
+        "41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4C 24 ?? E8 | ?? ?? ?? ??";
+
+    /**
+     * @brief Step-1 anchor inside SubTranslator (v1.04.00 fallback).
+     *
+     * Older encoding where the second `lea` is rbp-relative. Tried after
+     * the v1.05 anchor inside the same 0x80-byte window.
+     */
+    inline constexpr const char *k_nametableSubTxV104Anchor =
+        "41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4D ?? E8 | ?? ?? ?? ??";
+
+    /**
+     * @brief Step-3 anchor inside ItemAccessor (sub_1402D75D0).
+     *
+     * Locates `mov rbx, cs:qword_145CEF370` inside the 4th hop of the
+     * name-table chain. The 6-byte prologue-tail anchor (push r14 + sub
+     * rsp,0x40 + movzx edi,word ptr [rcx]) pins the call site inside a
+     * bounded 0x40-byte scan of the function -- global uniqueness is not
+     * required because the scan is locally bounded.
+     *
+     * Anchor offset `|` lands on the start of the `48 8B 1D disp32`
+     * instruction. The disp32 is read by the consumer with `read_i32_safe`
+     * at `match + 3` for RIP-relative resolution to qword_145CEF370.
+     */
+    inline constexpr const char *k_nametableItemAccessorAnchor =
+        "41 56 48 83 EC 40 0F B7 39 | 48 8B 1D ?? ?? ?? ??";
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/carrier_defaults.hpp
+++ b/CrimsonDesertLiveTransmog/src/carrier_defaults.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "shared_state.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace Transmog
+{
+    // Per-(character, slot) default carrier item used by LT's transmog
+    // apply path AND by the prefab-wrapper-swap picker.
+    //
+    //   itemName   -- resolved through ItemNameTable::id_of() at runtime
+    //                 to produce a uint16_t carrier itemId. Drives
+    //                 SlotPopulator(itemId) for the carrier-equip path.
+    //   prefabName -- the body-mesh prefab the carrier emits when
+    //                 equipped (e.g. "cd_phm_02_sword_0015"). Used by
+    //                 PWS::populate_slot_catalogs as the picker's
+    //                 default src selection so the swap-map's source
+    //                 wrapper matches the carrier's natural emit. Empty
+    //                 string when no body-mesh swap is configured for
+    //                 this slot/character (the carrier still works as
+    //                 a plain itemId; just no prefab-level intercept).
+    //
+    // Both fields refer to the SAME logical default item per (char, slot).
+    // Centralising them here prevents the drift class where one was
+    // updated and the other forgotten (e.g. the spear-carrier test that
+    // failed because PWS src still pointed at sword_0015).
+    struct CarrierDefault
+    {
+        const char *itemName;
+        const char *prefabName;
+    };
+
+    // Character axis. Order is fixed; CarrierChar(i) maps to
+    // k_carriers[i]. New characters append at the end before Count.
+    enum class CarrierChar : std::size_t
+    {
+        Kliff = 0,
+        Damiane = 1,
+        Oongka = 2,
+        Count
+    };
+
+    inline constexpr std::size_t k_carrierCharCount =
+        static_cast<std::size_t>(CarrierChar::Count);
+
+    // 2D table indexed [character][slot]. Adding a slot = one column
+    // in each character row. Adding a character = one new row.
+    // clang-format off
+    inline constexpr CarrierDefault k_carriers[k_carrierCharCount][k_slotCount] = {
+        // ============================================================
+        // Kliff (male). Default carriers for slots 5..14 captured live
+        // via [slot-discovery] dump on 2026-05-07. prefabName values
+        // captured via in-game item-mesh mapping.
+        // ============================================================
+        {
+            { "Kliff_PlateArmor_Helm",                       "cd_phm_00_hel_00_0435_d"           }, // Helm
+            { "Kliff_PlateArmor_Armor",                      "cd_phm_00_ub_00_0435"              }, // Chest
+            { "Kliff_PlateArmor_Cloak",                      "cd_phm_00_cloak_00_0435_s"         }, // Cloak
+            { "Kliff_PlateArmor_Gloves",                     "cd_phm_00_hand_00_0435"            }, // Gloves
+            { "Kliff_Plate_Boots",                           "cd_phm_00_foot_00_0435"            }, // Boots
+            { "Hexe_Earring",                                "cd_phm_00_earring_0013_l"          }, // Earring1
+            { "Ancient_People_Earring",                      "cd_phm_00_earring_0004_r"          }, // Earring2
+            { "Titan_Necklace",                              "cd_phm_00_necklace_0017"           }, // Necklace
+            { "Antumbra_DarkDeacon_Ring",                    "cd_phm_00_ring_0018_l"             }, // Ring1
+            { "AbyssReward_EastWitch_Ring",                  "cd_phm_00_ring_00_0017_r"          }, // Ring2 (variants: _l/_r)
+            { "RedNose_Lantern",                             "cd_t0000_lantern_0003"             }, // Lantern
+            { "Kliff_Glasses",                               "cd_phm_00_glasses_0002"            }, // Glasses
+            { "Kliff_Mask",                                  "cd_phm_00_mask_00_0271_a"          }, // Mask
+            { "Aggro_Backpack",                              "cd_phm_00_bag_0053"                }, // Backpack
+            { "Daeil_Band",                                  "cd_phw_00_rinkband_0001"           }, // Bracelet (phw on male)
+            { "Legendary_Dragon_OneHandSword",               "cd_phm_01_sword_0023_r"            }, // MainHand
+            { "Legendary_Dragon_OneHandSword",               "cd_phm_01_sword_0023_l"            }, // OffHand (mirror)
+            { "GreyWolf_OneHandBow",                         "cd_phm_04_bow_0003"                }, // Ranged
+            { "Legendary_Shakatu_OneHandDagger",             "cd_phm_01_dagger_0079_r"           }, // SubWeapon
+            { "Legendary_Antumbra_TwoHandGiantBastard",      "cd_phm_02_sword_0015"              }, // TwoHandWeapon
+        },
+
+        // ============================================================
+        // Damiane (female). Demeniss Elite/Uniform Leather armor set +
+        // Pattern jewelry set + Damian_OneHandPistol Ranged. prefab
+        // values derived from `00_idea/items_to_prefabs_v105_01.tsv`.
+        // Engine uses cd_phw_* for female-specific assets and cd_phm_*
+        // for shared accessories. Some armor pieces use _index##
+        // variants -- LT's prefab-wrapper hook registers all variants
+        // of the base prefab so any one variant works as the picker
+        // default seed.
+        // ============================================================
+        {
+            { "Demian_PlateArmor_Helm_VII",                  "cd_phw_00_hel_00_0162"             }, // Helm
+            { "Damian_Demeniss_Elite_Uniform_Leather_Armor", "cd_phw_00_ub_00_0163_index01"      }, // Chest
+            { "Damian_Demeniss_Uniform_Leather_Cloak",       "cd_phw_00_cloak_00_0163_index01_t" }, // Cloak
+            { "Damian_Demeniss_Uniform_Leather_Gloves",      "cd_phw_01_hand_00_0380_index03"    }, // Gloves
+            { "Damian_Demeniss_Elite_Uniform_Leather_Boots", "cd_phw_00_foot_00_0163_index01"    }, // Boots
+            { "Pattern_Bronze_Earring",                      "cd_phm_00_earring_0017_l"          }, // Earring1
+            { "Pattern_Silver_Earring",                      "cd_phm_00_earring_0019_r"          }, // Earring2
+            { "Pattern_Copper_Necklace",                     "cd_phm_00_necklace_0026"           }, // Necklace
+            { "Hernand_Nobility_Degree_I",                   "cd_phm_00_ring_0006_r"             }, // Ring1
+            { "Hernand_Nobility_Degree_I",                   "cd_phm_00_ring_0006_r"             }, // Ring2 (same item in both rings)
+            { "Lantern",                                     ""                                  }, // Lantern (cd_t0000_* family, not in cd_ph[mw]_ map)
+            { "Kliff_Glasses",                               "cd_phm_00_glasses_0002"            }, // Glasses (Kliff fallback)
+            { "Kliff_Mask",                                  "cd_phm_00_mask_00_0271_a"          }, // Mask    (cross-char)
+            { "Aggro_Backpack",                              "cd_phm_00_bag_0053"                }, // Backpack (Kliff fallback)
+            { "Daeil_Band",                                  "cd_phw_00_rinkband_0001"           }, // Bracelet (universal)
+            { "Demian_OneHandRapier",                        "cd_phw_01_sword_0005"              }, // MainHand
+            { "Damian_OneHandShield",                        "cd_phw_03_shield_0131"             }, // OffHand (shield off-hand)
+            { "Damian_OneHandPistol",                        "cd_phm_06_pistol_0001"             }, // Ranged
+            { "Rikisis_OneHandDagger",                       "cd_phm_01_dagger_0004_r"           }, // SubWeapon
+            { "Tynion_Giant_TwoHandGiantBastard",            "cd_phw_02_sword_0002"              }, // TwoHandWeapon
+        },
+
+        // ============================================================
+        // Oongka (male orc). prefabName values derived 2026-05-08 from
+        // the save-editor companion repo's iteminfo dump. Orc-tribe
+        // assets share the cd_phm_* family (orc model is male-tier).
+        // Bilibili earring/ring use _index## minor variants; LT's
+        // body-mesh hook registers all variants of the base prefab.
+        // ============================================================
+        {
+            { "Oongka_PlateArmor_Helm_II",                   "cd_phm_00_hel_00_0439_c"           }, // Helm
+            { "Oongka_PlateArmor_Armor_II",                  "cd_phm_00_ub_00_0439"              }, // Chest
+            { "Oongka_PlateArmor_Cloak_II",                  "cd_phm_00_cloak_00_0439_s"         }, // Cloak
+            { "Oongka_PlateArmor_Gloves_II",                 "cd_phm_00_hand_00_0439"            }, // Gloves
+            { "Oongka_PlateArmor_Boots_II",                  "cd_phm_00_foot_00_0439"            }, // Boots
+            { "Bilibili_Earring",                            "cd_phm_00_earring_0008_l_index02"  }, // Earring1
+            { "WhiteHorn_Earring",                           "cd_phm_00_earring_0014_l"          }, // Earring2
+            { "Bilibili_Necklace",                           "cd_phm_00_necklace_0004_index02"   }, // Necklace
+            { "Pailune_Nobility_Degree_I",                   "cd_phm_00_ring_0006_r_index05"     }, // Ring1
+            { "Bilibili_Ring",                               "cd_phm_00_ring_0005_l_index02"     }, // Ring2
+            { "Lantern",                                     ""                                  }, // Lantern (cd_t0000_* family, not in cd_ph[mw]_ map)
+            { "",                                            ""                                  }, // Glasses (no Oongka capture)
+            { "Kliff_Mask",                                  "cd_phm_00_mask_00_0271_a"          }, // Mask    (cross-char)
+            { "Oongka_Rocket_BackPack",                      "cd_phm_00_bag_0057"                }, // Backpack (orc-tribe rocket pack)
+            { "Daeil_Band",                                  "cd_phw_00_rinkband_0001"           }, // Bracelet (universal)
+            { "Big_Horn_Tiger_OneHandAxe",                   "cd_phm_01_axe_0035_r"              }, // MainHand
+            { "Big_Horn_Tiger_OneHandAxe",                   "cd_phm_01_axe_0035_r"              }, // OffHand (1H mirror)
+            { "Orc_OneHandCannon",                           "cd_phm_13_cannon_0003_l"           }, // Ranged
+            { "Aurio_OneHandDagger",                         "cd_phm_01_dagger_0066_r"           }, // SubWeapon
+            { "Khadion_TwoHandSword",                        "cd_phm_02_sword_0010"              }, // TwoHandWeapon
+        },
+    };
+    // clang-format on
+
+    // Lookup helpers ----------------------------------------------------
+
+    inline std::optional<CarrierChar>
+    carrier_char_from_name(std::string_view name) noexcept
+    {
+        if (name == "Kliff")
+            return CarrierChar::Kliff;
+        if (name == "Damiane")
+            return CarrierChar::Damiane;
+        if (name == "Oongka")
+            return CarrierChar::Oongka;
+        return std::nullopt;
+    }
+
+    inline constexpr const CarrierDefault &
+    carrier_for(CarrierChar c, TransmogSlot s) noexcept
+    {
+        return k_carriers[static_cast<std::size_t>(c)]
+                         [static_cast<std::size_t>(s)];
+    }
+} // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/dx_overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/dx_overlay.cpp
@@ -41,7 +41,7 @@ namespace Transmog
     static HWND s_overlayHwnd = nullptr;
     static HWND s_gameHwnd = nullptr;
 
-    // D3D11 WARP device — no swap chain.
+    // D3D11 WARP device, no swap chain.
     static ID3D11Device *s_device = nullptr;
     static ID3D11DeviceContext *s_context = nullptr;
 
@@ -227,16 +227,28 @@ namespace Transmog
     {
         auto &logger = DMK::Logger::get_instance();
 
-        // Wait for game world.
+        // Wait for game world. Slow boots, intro cinematics, OS-level
+        // game updates and similar can all push this past the old
+        // 5-minute cap; with no upper bound the overlay simply waits
+        // until the world resolves OR the mod is shutting down. Heart-
+        // beat log every 60s so the wait is visible to the user, with
+        // no warning noise from a hard timeout that never made sense.
         logger.info("[dx_overlay] Waiting for game world...");
-        for (int i = 0; i < 3000; ++i)
+        for (int tick = 0;; ++tick)
         {
-            if (s_shutdownRequested.load(std::memory_order_relaxed)) return 0;
-            if (Transmog::is_world_ready()) break;
+            if (s_shutdownRequested.load(std::memory_order_relaxed))
+                return 0;
+            if (Transmog::is_world_ready())
+                break;
+            // 600 * 100ms == 60s. Log a heartbeat at each minute mark
+            // so a user looking at the log can confirm the overlay
+            // thread is still alive while they sit on a long load.
+            if (tick > 0 && (tick % 600) == 0)
+                logger.info(
+                    "[dx_overlay] Still waiting for game world ({} min)",
+                    tick / 600);
             Sleep(100);
         }
-        if (!Transmog::is_world_ready())
-        { logger.warning("[dx_overlay] World timeout"); return 0; }
 
         Sleep(2000);
         s_gameHwnd = find_game_hwnd();
@@ -250,7 +262,7 @@ namespace Transmog
         logger.info("[dx_overlay] Game {}x{}", gw, gh);
 
         // --- Overlay window (layered, never receives its own
-        //     D3D/DXGI objects — purely a GDI composite target) ---
+        //     D3D/DXGI objects, purely a GDI composite target) ---
         WNDCLASSEXW wc{sizeof(wc)};
         wc.lpfnWndProc = overlay_wndproc;
         wc.hInstance = GetModuleHandleW(nullptr);
@@ -258,7 +270,7 @@ namespace Transmog
         RegisterClassExW(&wc);
 
         GetWindowRect(s_gameHwnd, &gr);
-        // No WS_EX_TOPMOST — we position relative to the game window
+        // No WS_EX_TOPMOST: we position relative to the game window
         // each frame so the overlay doesn't cover the taskbar or appear
         // above other apps when the game isn't focused.
         s_overlayHwnd = CreateWindowExW(
@@ -380,7 +392,7 @@ namespace Transmog
 
             if (!visible)
             {
-                // Nothing to draw — sleep longer to save CPU.
+                // Nothing to draw, sleep longer to save CPU.
                 Sleep(50);
                 continue;
             }
@@ -407,7 +419,7 @@ namespace Transmog
 
             blit_to_screen();
 
-            Sleep(16); // ~60fps — sufficient for UI, reduces CPU/GDI load
+            Sleep(16); // ~60fps; sufficient for UI, reduces CPU/GDI load
         }
 
         // Cleanup.

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -1,4 +1,5 @@
 #include "item_name_table.hpp"
+#include "aob_resolver.hpp"
 #include "transmog_map.hpp"
 
 #include <DetourModKit.hpp>
@@ -418,23 +419,164 @@ namespace Transmog
     // 0x45 -> 0x46 on v1.04.00 (one-code insertion in the engine enum
     // between Boots and Cloak). Both legacy and current values accepted
     // so the mapping stays valid across patches that haven't shifted
-    // the earlier slots.
+    // the earlier slots. Live ground-truth captured 2026-05-07 via
+    // the [slot-discovery] dump's typeCode column; see
+    // reference_engine_slot_taxonomy_2026-05-07.md.
+    //
+    // Armor block (existing):
     //   0x04=Helm  0x05=Chest  0x06=Gloves  0x07=Boots
-    //   0x45/0x46=Cloak
-    // Other observed codes (explicitly rejected -- these are not
-    // transmog-compatible armor slots):
-    //   0x20=Shield, 0x53/0x54=Horse/mount armor, 0xFFFF=Quest/non-equipment,
-    //   plus any other unmapped code.
+    //   0x45/0x46=Cloak (shifted +1 on v1.04.00)
+    //
+    // Accessories:
+    //   0x08=Earring (Earring1/Earring2 share)
+    //   0x09=Necklace
+    //   0x0A=Ring (Ring1/Ring2 share)
+    //   0x37=Lantern
+    //   0x43=Backpack
+    //   0x47=Bracelet  0x48=Glasses  0x49=Mask
+    //
+    // Weapons (typeCode varies by weapon FAMILY and sometimes by
+    // character variant -- all sharing the MainHand/OffHand/Ranged/
+    // SubWeapon/TwoHandWeapon auth-table slots):
+    //   Weapon families derived from the [catalog-histogram] dump
+    //   (2026-05-07) which iterated every descriptor's typeCode and
+    //   showed sample item names. Live-equipped items provided ground
+    //   truth for confirmed entries; the rest were classified from
+    //   sample-name conventions (e.g. *_TwoHandHammer = TwoHandWeapon,
+    //   *_OneHandShotgun = Ranged). Items where the slot couldn't be
+    //   inferred from the name were left unmapped -- runtime
+    //   observation handles them when the user actually equips one.
+    //
+    //   1H families (MainHand, paired-pickered with OffHand):
+    //     0x00=1H Sword            0x01=OneHandShield (generic)
+    //     0x02=Damiane Shield      0x10=1H Axe
+    //     0x13=1H Mace             0x1D=Fist (Item_Fist_*)
+    //     0x20=Tower Shield        0x27=Rapier
+    //     0x30=Knuckle/Ring_Drill
+    //   Ranged:
+    //     0x03=Bow                 0x0D=Sprayer/utility (named BackPack)
+    //     0x22=Pistol              0x23=Musket
+    //     0x24=Shotgun             0x25=1H Cannon
+    //     0x2F=Crossbow            0x31=FlameThrower
+    //     0x32=IceThrower          0x33=LightningThrower
+    //     0x64=FishingRod
+    //   Sub-weapons:
+    //     0x0E=Dagger
+    //   2H weapons (combat + utility tools):
+    //     0x0F=2H Axe              0x11=Greatsword A
+    //     0x12=Greatsword B (NPC)  0x14=WarHammer
+    //     0x15=2H Spear/Polearm    0x1C=2H Hammer
+    //     0x1E=Drill               0x1F=Chainsaw
+    //     0x21=Halberd/Alebard     0x26=2H Cannon
+    //     0x55=Pickaxe             0x56=Iron Chain
+    //     0x57=Rake                0x58=Felling Axe (Boss_Reward_SuperWeapon)
+    //     0x59=Shovel              0x5A=Broom
+    //     0x5B=Hoe                 0x5C=Sickle/Scythe
+    //     0x5D=Work Hammer         0x5F=Saw
+    //     0x62=Stick               0x66=PriestWand
+    //     0x68=Crutch
+    //
+    //   Intentionally NOT mapped (not character transmog):
+    //     0x0B Oongka_Rocket_Helm (TransmogSlot::OongkaRocket commented)
+    //     0x17 Contribution_Flag, 0x18 Torch, 0x2B Witch_WingFan,
+    //     0x34 Poison_Stick (ambiguous; let runtime obs handle)
+    //     0x3A-0x3C PetArmor (pet/cat equipment)
+    //     0x3D-0x41 HorseArmor (mount equipment)
+    //     0x4A-0x54 WarRobot body parts (mech, not character)
+    //     0x60 Notepad/Pen, 0x6A FlatBasket, 0x6B Bucket, 0x6D Pot_Head
+    //     0xFFFF Arrow/Quiver/Quest items
+    //
+    // The 0x11 vs 0x12 split for 2H bastard swords looks like a
+    // character/gender variant axis -- they're the "same" weapon class
+    // visually but the engine tags them differently per protagonist.
+    // Both go in the TwoHandWeapon slot.
+    //
+    // More weapon-family typeCodes will surface as users equip new
+    // classes (crossbow, polearm, etc). Runtime `record_observed_slot`
+    // covers any unmapped family automatically once an item appears
+    // in the auth-table.
+    //
+    // Excluded by design (not LT-targeted):
+    //   0x0B=OongkaRocket Helm (the OongkaRocket TransmogSlot is
+    //        commented out 2026-05-07; leaving 0x0B unmapped keeps
+    //        those items out of every picker).
+    //
+    // For paired slots (weapons/earrings/rings) the static map points
+    // at the lower-indexed half of the pair; the picker UI uses
+    // `slots_share_picker` so both halves of a pair show the same
+    // items. The actual auth-table slot used at apply time is whichever
+    // TransmogSlot row the user committed against.
+    //
+    // Other observed codes explicitly rejected:
+    //   0x20=Shield, 0x53/0x54=Horse/mount armor, 0xFFFF=Quest/non-equipment.
     static TransmogSlot slot_from_type_code(std::uint16_t code) noexcept
     {
         switch (code)
         {
+        // Armor
         case 0x04: return TransmogSlot::Helm;
         case 0x05: return TransmogSlot::Chest;
         case 0x06: return TransmogSlot::Gloves;
         case 0x07: return TransmogSlot::Boots;
         case 0x45:
         case 0x46: return TransmogSlot::Cloak;
+        // Accessories
+        case 0x08: return TransmogSlot::Earring1; // shared with Earring2
+        case 0x09: return TransmogSlot::Necklace;
+        case 0x0A: return TransmogSlot::Ring1;    // shared with Ring2
+        case 0x37: return TransmogSlot::Lantern;
+        case 0x43: return TransmogSlot::Backpack;
+        case 0x47: return TransmogSlot::Bracelet;
+        case 0x48: return TransmogSlot::Glasses;
+        case 0x49: return TransmogSlot::Mask;
+        // 1H weapons -- all share MainHand (paired with OffHand)
+        case 0x00:                                 // 1H sword
+        case 0x01:                                 // shield (generic)
+        case 0x02:                                 // shield (Damiane variant)
+        case 0x10:                                 // 1H axe
+        case 0x13:                                 // 1H mace
+        case 0x1D:                                 // fist (Item_Fist_*)
+        case 0x20:                                 // tower shield
+        case 0x27:                                 // rapier
+        case 0x30: return TransmogSlot::MainHand; // knuckle / ring drill
+        // Ranged
+        case 0x03:                                 // bow
+        case 0x0D:                                 // sprayer/utility ranged
+        case 0x22:                                 // pistol
+        case 0x23:                                 // musket
+        case 0x24:                                 // shotgun
+        case 0x25:                                 // 1H cannon
+        case 0x2F:                                 // crossbow
+        case 0x31:                                 // flamethrower
+        case 0x32:                                 // ice thrower
+        case 0x33:                                 // lightning thrower
+        case 0x64: return TransmogSlot::Ranged;    // fishing rod
+        // Sub-weapons
+        case 0x0E: return TransmogSlot::SubWeapon; // dagger
+        // 2H weapons (combat + utility tools)
+        case 0x0F:                                     // 2H axe
+        case 0x11:                                     // 2H greatsword A
+        case 0x12:                                     // 2H greatsword B (Damiane/NPC)
+        case 0x14:                                     // war hammer
+        case 0x15:                                     // 2H spear / polearm
+        case 0x1C:                                     // 2H hammer
+        case 0x1E:                                     // drill
+        case 0x1F:                                     // chainsaw
+        case 0x21:                                     // halberd / alebard
+        case 0x26:                                     // 2H cannon
+        case 0x55:                                     // pickaxe
+        case 0x56:                                     // iron chain
+        case 0x57:                                     // rake
+        case 0x58:                                     // felling axe / boss super weapon
+        case 0x59:                                     // shovel
+        case 0x5A:                                     // broom
+        case 0x5B:                                     // hoe
+        case 0x5C:                                     // sickle/scythe
+        case 0x5D:                                     // work hammer
+        case 0x5F:                                     // saw
+        case 0x62:                                     // stick
+        case 0x66:                                     // priest wand
+        case 0x68: return TransmogSlot::TwoHandWeapon; // crutch
         default:   return TransmogSlot::Count;
         }
     }
@@ -508,10 +650,10 @@ namespace Transmog
         // .text from leaking in.
         const auto subTxStart = reinterpret_cast<const std::byte *>(subTranslatorAddr);
 
-        auto anchorV105 = DMK::Scanner::parse_aob(
-            "41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4C 24 ?? E8 | ?? ?? ?? ??");
-        auto anchorV104 = DMK::Scanner::parse_aob(
-            "41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4D ?? E8 | ?? ?? ?? ??");
+        auto anchorV105 =
+            DMK::Scanner::parse_aob(Transmog::k_nametableSubTxV105Anchor);
+        auto anchorV104 =
+            DMK::Scanner::parse_aob(Transmog::k_nametableSubTxV104Anchor);
         if (!anchorV105 || !anchorV104)
         {
             logger.warning("[nametable] parse_aob failed for sub_141D45270 anchors");
@@ -560,8 +702,8 @@ namespace Transmog
         // of THIS function -- global uniqueness doesn't matter, the
         // scan is locally bounded.
         const auto itemAccessorStart = reinterpret_cast<const std::byte *>(itemAccessor);
-        auto anchor3 = DMK::Scanner::parse_aob(
-            "41 56 48 83 EC 40 0F B7 39 | 48 8B 1D ?? ?? ?? ??");
+        auto anchor3 =
+            DMK::Scanner::parse_aob(Transmog::k_nametableItemAccessorAnchor);
         if (!anchor3)
         {
             logger.warning("[nametable] parse_aob failed for qword_145CEF370 anchor");
@@ -892,6 +1034,67 @@ namespace Transmog
         }
         // valid > 0 && valid == m_lastBuildValid → catalog stabilized.
 
+        // Catalog typeCode histogram. Groups every cataloged item by
+        // its `desc+0x44` typeCode and emits one log line per distinct
+        // code: count, current `slot_from_type_code` verdict, and 3
+        // sample item names. Lets the user see the FULL universe of
+        // typeCodes in one game launch instead of having to discover
+        // each one by wearing an item -- unmapped codes show with
+        // their sample names so it's obvious from the names which
+        // slot they belong in (e.g. "samples: Crossbow_Iron_I, ..." =>
+        // crossbow family => Ranged). Runs once per successful build.
+        {
+            std::unordered_map<std::uint16_t, std::vector<std::uint16_t>> bucket;
+            bucket.reserve(64);
+            for (const auto &kv : typeCodeMap)
+                bucket[kv.second].push_back(kv.first);
+
+            // Sort typeCodes descending by item count so high-volume
+            // codes show first.
+            std::vector<std::uint16_t> codes;
+            codes.reserve(bucket.size());
+            for (const auto &kv : bucket)
+                codes.push_back(kv.first);
+            std::sort(codes.begin(), codes.end(),
+                      [&](std::uint16_t a, std::uint16_t b) {
+                          return bucket[a].size() > bucket[b].size();
+                      });
+
+            logger.trace(
+                "[catalog-histogram] {} distinct typeCodes across {} items"
+                " (unmapped codes show samples so you can identify them "
+                "and add static slot_from_type_code cases)",
+                codes.size(), valid);
+
+            for (std::uint16_t code : codes)
+            {
+                auto &ids = bucket[code];
+                // Sort itemIds ascending and pick first 3 names for a
+                // stable sample window.
+                std::sort(ids.begin(), ids.end());
+                const auto take = std::min<std::size_t>(3, ids.size());
+
+                std::string samples;
+                for (std::size_t k = 0; k < take; ++k)
+                {
+                    auto it = idToName.find(ids[k]);
+                    if (k > 0) samples += ", ";
+                    samples += (it != idToName.end()) ? it->second
+                                                      : "<unknown>";
+                }
+
+                const TransmogSlot slot = slot_from_type_code(code);
+                const char *slotStr = (slot == TransmogSlot::Count)
+                                      ? "<UNMAPPED>"
+                                      : slot_name(slot);
+
+                logger.trace(
+                    "[catalog-histogram]   typeCode={:#06x} count={:>4} "
+                    "slot={:<13} samples: {}",
+                    code, ids.size(), slotStr, samples);
+            }
+        }
+
         {
             std::lock_guard<std::mutex> lk(s_tableMtx);
             m_idToName = std::move(idToName);
@@ -961,10 +1164,46 @@ namespace Transmog
     TransmogSlot ItemNameTable::category_of(uint16_t itemId) const noexcept
     {
         std::lock_guard<std::mutex> lk(s_tableMtx);
+        // Runtime-observed binding wins -- if the engine has actually
+        // equipped this itemId in a slot, we trust that over the static
+        // type-code heuristic. Lets accessory/weapon items show up in
+        // the correct picker the moment they're seen in the auth-table,
+        // even if `slot_from_type_code` doesn't know their typeCode yet.
+        if (auto obs = m_observedSlot.find(itemId);
+            obs != m_observedSlot.end())
+            return obs->second;
+
         auto it = m_typeCode.find(itemId);
         if (it == m_typeCode.end())
             return TransmogSlot::Count;
         return slot_from_type_code(it->second);
+    }
+
+    std::uint16_t ItemNameTable::type_code_of(std::uint16_t itemId) const noexcept
+    {
+        std::lock_guard<std::mutex> lk(s_tableMtx);
+        auto it = m_typeCode.find(itemId);
+        if (it == m_typeCode.end())
+            return 0xFFFFu;
+        return it->second;
+    }
+
+    void ItemNameTable::record_observed_slot(std::uint16_t itemId,
+                                             TransmogSlot slot) noexcept
+    {
+        std::lock_guard<std::mutex> lk(s_tableMtx);
+        if (slot == TransmogSlot::Count)
+        {
+            m_observedSlot.erase(itemId);
+            return;
+        }
+        m_observedSlot[itemId] = slot;
+    }
+
+    std::size_t ItemNameTable::observed_slot_count() const noexcept
+    {
+        std::lock_guard<std::mutex> lk(s_tableMtx);
+        return m_observedSlot.size();
     }
 
     ItemNameTable::BodyKind ItemNameTable::body_kind_for_character(

--- a/CrimsonDesertLiveTransmog/src/item_name_table.hpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.hpp
@@ -276,6 +276,29 @@ namespace Transmog
          */
         TransmogSlot category_of(uint16_t itemId) const noexcept;
 
+        /// Raw item-type code u16 at `desc+0x44` for the given item, or
+        /// 0xFFFF if unknown. Useful for slot-discovery research --
+        /// printing it next to the live engine slot tag reveals the
+        /// (typeCode -> slot) mapping that drives `slot_from_type_code`,
+        /// so accessory and weapon codes can be added without static
+        /// guessing.
+        std::uint16_t type_code_of(std::uint16_t itemId) const noexcept;
+
+        /// Record an observed `(itemId -> slot)` binding seen in the
+        /// engine's live auth-table. The runtime map is consulted by
+        /// `category_of()` BEFORE the static type-code map, so any
+        /// item the engine has actually equipped becomes correctly
+        /// categorized for the picker even when its `desc+0x44`
+        /// type-code isn't yet listed in the static switch. Slot ==
+        /// `TransmogSlot::Count` clears the entry. Thread-safe; cheap
+        /// (one hash insert per call).
+        void record_observed_slot(std::uint16_t itemId,
+                                  TransmogSlot slot) noexcept;
+
+        /// Number of currently-recorded runtime slot observations.
+        /// Diagnostic only.
+        std::size_t observed_slot_count() const noexcept;
+
         /// Dump the full catalog to a TSV file next to the game exe.
         /// Columns: ItemID, Slot, Variant, PlayerSafe, Name.
         void dump_catalog_tsv() const;
@@ -313,6 +336,13 @@ namespace Transmog
         std::unordered_map<uint16_t, uint16_t> m_equipType;
         std::unordered_map<uint16_t, uint8_t> m_bodyBits;
         std::unordered_map<uint16_t, uint16_t> m_typeCode; // desc+0x44 canonical item-type code
+        // Runtime-learned `itemId -> TransmogSlot` map. Populated by
+        // `record_observed_slot` (called from the slot-discovery dump
+        // when it observes live auth-table bindings). Authoritative
+        // override for the static type-code switch -- if the engine
+        // has actually equipped an item in a given slot, we trust that
+        // over any heuristic. Session-scoped (no disk persistence).
+        std::unordered_map<uint16_t, TransmogSlot> m_observedSlot;
         std::unordered_map<std::string, std::string> m_displayNames; // lowercase internal -> display
         mutable std::vector<Entry> m_sortedCache;
 

--- a/CrimsonDesertLiveTransmog/src/overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay.cpp
@@ -1,4 +1,4 @@
-// overlay.cpp — Standalone overlay path (D3D11 WARP + GDI blit).
+// overlay.cpp -- Standalone overlay path (D3D11 WARP + GDI blit).
 //
 // This TU includes overlay_ui.inl which resolves ImGui calls against
 // imgui_lib (the real ImGui compiled from source).  The ReShade path
@@ -6,12 +6,15 @@
 // function-table wrappers instead.
 
 #include "overlay.hpp"
+#include "prefab_wrapper_swap.hpp"
 #include "constants.hpp"
 #include "dx_overlay.hpp"
 #include "item_name_table.hpp"
 #include "preset_manager.hpp"
 #include "shared_state.hpp"
+#include "slot_metadata.hpp"
 #include "transmog.hpp"
+#include "transmog_apply.hpp"
 #include "transmog_map.hpp"
 
 #include <DetourModKit.hpp>
@@ -26,6 +29,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <vector>
 
 namespace Transmog
 {
@@ -73,10 +77,10 @@ namespace Transmog
         auto &logger = DMK::Logger::get_instance();
         bool hasOverlay = false;
 
-        // Always try ReShade — registers the addon tab if ReShade is loaded.
+        // Always try ReShade -- registers the addon tab if ReShade is loaded.
         if (init_reshade_overlay(hModule))
         {
-            logger.info("[overlay] ReShade detected — registered addon tab "
+            logger.info("[overlay] ReShade detected -- registered addon tab "
                         "(open ReShade with Home key)");
             hasOverlay = true;
         }
@@ -94,7 +98,7 @@ namespace Transmog
         }
 
         if (!hasOverlay)
-            logger.warning("[overlay] No overlay available — "
+            logger.warning("[overlay] No overlay available -- "
                            "mod still works via hotkeys");
         return hasOverlay;
     }

--- a/CrimsonDesertLiveTransmog/src/overlay_reshade.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay_reshade.cpp
@@ -1,4 +1,4 @@
-// overlay_reshade.cpp — ReShade addon overlay path.
+// overlay_reshade.cpp -- ReShade addon overlay path.
 //
 // This TU includes the ReShade SDK's imgui.h which defines ImGui
 // functions as inline wrappers that call through ReShade's function
@@ -12,16 +12,19 @@
 // This file must NOT see imgui_lib's include path.  The CMakeLists.txt
 // configures this TU with the ReShade SDK include directory instead.
 
+#include "prefab_wrapper_swap.hpp"
 #include "constants.hpp"
 #include "item_name_table.hpp"
 #include "preset_manager.hpp"
 #include "shared_state.hpp"
+#include "slot_metadata.hpp"
 #include "transmog.hpp"
+#include "transmog_apply.hpp"
 #include "transmog_map.hpp"
 
 #include <DetourModKit.hpp>
 
-// ReShade SDK headers — imgui.h here is from external/reshade-sdk/include
+// ReShade SDK headers -- imgui.h here is from external/reshade-sdk/include
 // and provides the function-table wrappers, NOT the real ImGui.
 #pragma warning(push, 0)
 #include <imgui.h>
@@ -32,6 +35,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <vector>
 
 namespace Transmog
 {
@@ -43,7 +47,7 @@ namespace Transmog
     static HMODULE s_reshadeModule = nullptr;
     static bool s_reshadeActive = false;
 
-    // ReShade tab callback — content is drawn directly inside the
+    // ReShade tab callback -- content is drawn directly inside the
     // ReShade addon tab; no ImGui::Begin/End window management needed.
     static void draw_reshade_overlay(reshade::api::effect_runtime *)
     {

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -85,6 +85,9 @@ static constexpr int64_t k_hoverDebounceMs = 300;
 // Instant Apply mode: applies transmog immediately on hover, pick,
 // slot toggle, and clear -- no Apply All click needed.  Off by default
 // because each action triggers a tear-down + SlotPopulator cycle.
+// Prefab-mode (cross-slot prefab browser) does NOT honour this --
+// hover-apply on prefabs needs additional carrier-borrow plumbing
+// that's not yet shipped. Click-to-pick still works in prefab mode.
 static bool s_autoApply = false;
 
 // When true, preserve the search text between picker opens so the
@@ -107,6 +110,18 @@ struct SlotUIState
     bool hideVariants = false;      // hide NPC variants (carrier items)
     bool hideBodyMismatch = true;   // hide items whose body type doesn't
                                     // match the active character's
+    // Prefab-only mode. When true the picker hides the items list and
+    // its filters and shows ALL body-mesh prefabs across every slot,
+    // labeled with their native slot. Picking a prefab applies it to
+    // the prefab's native slot (not necessarily the popup slot) so the
+    // user can browse the full prefab catalog from any slot's picker.
+    bool prefabMode = false;
+    // Prefab-mode-only Exact filter: when true, the prefab-mode list
+    // only shows prefabs whose derived slot (slot_for_prefab_name)
+    // matches the popup's slot category. Defaults true so opening
+    // Helm's picker in prefab mode shows only Helm-family prefabs;
+    // user can untick to see the full cross-slot catalog.
+    bool prefabExactFilter = true;
     // Hover-apply debounce state.  We track which item the cursor is
     // on and when it first landed there.  Apply fires only after the
     // cursor has settled on the same item for k_hoverDebounceMs,
@@ -121,6 +136,23 @@ struct SlotUIState
     int navIndex = -1;
     int lastVisibleCount = 0;
     bool navMoved{false}; // true only on the frame a nav button was pressed
+    // When the user picks a prefab from this slot's picker, we surface
+    // the prefab name on the slot button so the UI shows
+    // "[prefab] cd_nhw_no_ub_20027" instead of the carrier item's
+    // display name. Empty string == no prefab picked. Session-only
+    // (matches prefab-wrapper-swap selections; no JSON persistence).
+    std::string pickedPrefabName;
+
+    // Snapshot of the slot's carrier state BEFORE the first prefab
+    // pick auto-borrowed Kliff's plate item. Captured on first pick
+    // (priorCarrierSaved -> true) and restored when the user picks
+    // the "(no body-mesh override)" entry to clear the prefab.
+    // Restoring the original Wellsknight (or whatever the user's
+    // active preset had) lets the slot revert visually instead of
+    // staying stuck on the Kliff plate carrier after a clear.
+    bool     priorCarrierSaved   = false;
+    bool     priorCarrierActive  = false;
+    uint16_t priorCarrierItemId  = 0;
 };
 
 static SlotUIState s_slotUI[Transmog::k_slotCount]{};
@@ -164,8 +196,19 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
                                    Transmog::TransmogSlot slotCategory,
                                    uint16_t &targetItemId,
                                    bool autoApply,
-                                   std::size_t slotIdx)
+                                   std::size_t slotIdx,
+                                   int *outPrefabIdx = nullptr)
 {
+    // outPrefabIdx contract:
+    //   nullptr  : caller doesn't care about prefab picks (legacy path).
+    //   non-null : initialized to -1 by the caller; set to a body-mesh
+    //              catalog index (>= 0) when the user picks a prefab in
+    //              the popup. The function also clears targetItemId on
+    //              prefab pick so the caller's existing carrier-clear
+    //              path runs naturally; -1 on commit means a real item
+    //              (or "(none)") was picked, in which case the caller
+    //              should clear any prior body-mesh selection so the
+    //              two states stay mutually exclusive.
     bool committed = false;
     if (!ImGui::BeginPopup(popupId))
         return false;
@@ -192,17 +235,41 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
     //        that bucket failed to render via runtime transmog, so
     //        hiding them by default keeps the picker free of
     //        non-functional items.
-    ImGui::Checkbox("Exact", &ui.exactFilter);
-    ImGui::SameLine();
-    ImGui::Checkbox("Safe only", &ui.hideIncompatible);
-    ImGui::SameLine();
-    ImGui::Checkbox("Hide variants", &ui.hideVariants);
-    ImGui::SameLine();
-    ImGui::Checkbox("Hide cross-body", &ui.hideBodyMismatch);
-    if (ImGui::IsItemHovered())
-        ui_tooltip("Hide items whose body type (male/female) "
-                   "doesn't match the active character. Cross-body "
-                   "items may render with broken meshes.");
+    // Body-aware filters only matter for the 5 armor slots (Helm/Chest/
+    // Cloak/Gloves/Boots) where the body-mesh family is gender-specific
+    // (cd_phm_* vs cd_phw_*). Accessory + weapon slots share their
+    // mesh families across genders, so the filter has no effect there
+    // and the checkboxes just create confusion -- hide them.
+    const bool isArmorSlotPickerHeader =
+        Transmog::slot_meta(slotCategory).partShowHashKey != nullptr;
+    if (!ui.prefabMode)
+    {
+        ImGui::Checkbox("Exact", &ui.exactFilter);
+        if (isArmorSlotPickerHeader)
+        {
+            ImGui::SameLine();
+            ImGui::Checkbox("Safe only", &ui.hideIncompatible);
+            ImGui::SameLine();
+            ImGui::Checkbox("Hide variants", &ui.hideVariants);
+            ImGui::SameLine();
+            ImGui::Checkbox("Hide cross-body", &ui.hideBodyMismatch);
+            if (ImGui::IsItemHovered())
+                ui_tooltip("Hide items whose body type (male/female) "
+                           "doesn't match the active character. Cross-body "
+                           "items may render with broken meshes.");
+        }
+    }
+    else
+    {
+        ui_text_disabled("Prefabs mode (cross-slot)");
+        ImGui::SameLine();
+        ImGui::Checkbox("Exact##prefab_exact", &ui.prefabExactFilter);
+        if (ImGui::IsItemHovered())
+            ui_tooltip(
+                "Limit the list to prefabs whose body-mesh family "
+                "matches this slot. Untick to browse the full cross-"
+                "slot catalog.");
+    }
 
     ImGui::SetNextItemWidth(320.0f);
     if (ImGui::IsWindowAppearing())
@@ -248,6 +315,34 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
             ui.navMoved = true;
         }
     }
+    // Prefabs toggle: only meaningful for slots that have a body-mesh
+    // carrier (default source from k_defaultSrcByEnumSlot OR an INI
+    // Pair_N_Source). Accessory slots without a mesh carrier
+    // (Earring1/2, Necklace, Ring1/2) get -1 from selection_src_index
+    // so the toggle is hidden -- there's no point browsing prefabs
+    // from a slot that can never receive one. Force prefabMode off
+    // for those slots so a pre-existing true value doesn't blank
+    // the popup.
+    {
+        const bool slotHasCarrier =
+            (Transmog::PrefabWrapperSwap::selection_src_index(
+                 slotCategory) >= 0);
+        if (slotHasCarrier)
+        {
+            ImGui::SameLine();
+            ImGui::Checkbox("Prefabs##picker_prefab_mode",
+                            &ui.prefabMode);
+            if (ImGui::IsItemHovered())
+                ui_tooltip("Browse all body-mesh prefabs across every "
+                           "slot. The search bar filters across the "
+                           "merged prefab list. Picking applies to the "
+                           "prefab's native slot.");
+        }
+        else if (ui.prefabMode)
+        {
+            ui.prefabMode = false;
+        }
+    }
 
     const auto &table = Transmog::ItemNameTable::instance();
     const auto &entries = table.sorted_entries();
@@ -274,7 +369,9 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
 
     // "None" / clear entry at the top of the scroll region.
     // Hover-preview shows bare head/body (empty slot) via the
-    // active+none path in apply_single_slot.
+    // active+none path in apply_single_slot. Suppressed in
+    // prefabMode where the popup is a prefab-browser only.
+    if (!ui.prefabMode)
     {
         const bool selected = (targetItemId == 0);
         if (ImGui::Selectable("(none -- id 0)##picker_none", selected))
@@ -367,10 +464,30 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
     s_filtered.reserve(entries.size());
     int filteredByCategory = 0;
     int filteredByUnsafe = 0;
+    int shown = 0;
+    // Body-aware filters (Safe / Hide variants / Hide cross-body) only
+    // apply to the 5 armor slots (Helm/Chest/Cloak/Gloves/Boots) where
+    // the body-mesh family is gender-specific (cd_phm_* vs cd_phw_*).
+    // Earrings/Necklace/Rings/Lantern/Glasses/Mask/Backpack/Bracelet
+    // and weapons share their mesh families across genders, so the
+    // gender / body-kind filter just hides perfectly-good options.
+    // partShowHashKey is non-null exactly for the 5 armor slots in
+    // slot_metadata.hpp -- reuse that table as the gate.
+    const bool isArmorSlot =
+        Transmog::slot_meta(slotCategory).partShowHashKey != nullptr;
+
+    if (!ui.prefabMode)
+    {
     for (std::size_t idx = 0; idx < entries.size(); ++idx)
     {
         const auto &e = entries[idx];
-        if (ui.exactFilter && e.category != slotCategory)
+        // Exact filter accepts the slot itself OR its picker partner
+        // (Earring1/2, Ring1/2, MainHand/OffHand share items because
+        // their descriptor typeCodes are identical -- see
+        // ItemNameTable::category_of which returns the lower-indexed
+        // half for these pairs).
+        if (ui.exactFilter &&
+            !Transmog::slots_share_picker(e.category, slotCategory))
         {
             ++filteredByCategory;
             continue;
@@ -378,7 +495,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         const bool nonHumanoid = (e.bodyKind == BK::NonHumanoid);
         const bool incompatible =
             (e.category == Transmog::TransmogSlot::Count) || nonHumanoid;
-        if (ui.hideIncompatible && incompatible)
+        if (isArmorSlot && ui.hideIncompatible && incompatible)
         {
             ++filteredByUnsafe;
             continue;
@@ -391,12 +508,12 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
                 (e.bodyKind == BK::Both) ||
                 (charBody == BK::Generic) ||
                 (e.bodyKind == charBody));
-        if (ui.hideBodyMismatch && !bodyMatches)
+        if (isArmorSlot && ui.hideBodyMismatch && !bodyMatches)
         {
             ++filteredByUnsafe;
             continue;
         }
-        if (ui.hideVariants && e.hasVariantMeta)
+        if (isArmorSlot && ui.hideVariants && e.hasVariantMeta)
         {
             ++filteredByUnsafe;
             continue;
@@ -407,7 +524,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         s_filtered.push_back(idx);
     }
 
-    const int shown = static_cast<int>(s_filtered.size());
+    shown = static_cast<int>(s_filtered.size());
 
     // Pass 2: render the filtered rows. bodyMatches is recomputed
     // here rather than cached from pass 1 because the per-item flag
@@ -418,13 +535,20 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         const auto &e = entries[s_filtered[row]];
         const bool nonHumanoid = (e.bodyKind == BK::NonHumanoid);
         const bool ambiguousBody = (e.bodyKind == BK::Ambiguous);
+        // Body-mesh family is gender-specific only for the 5 armor
+        // slots (cd_phm_* vs cd_phw_*). Accessory + weapon slots share
+        // their meshes across genders, so a "BODY MISMATCH" or
+        // "UNCERTAIN BODY" tag would be misleading. Treat every entry
+        // as body-matching for non-armor slots so the colour/tag flow
+        // below collapses to plain `usesCarrier` (cyan) or untagged.
         const bool bodyMatches =
-            !nonHumanoid && (
+            !isArmorSlot ||
+            (!nonHumanoid && (
                 ambiguousBody ||
                 (e.bodyKind == BK::Generic) ||
                 (e.bodyKind == BK::Both) ||
                 (charBody == BK::Generic) ||
-                (e.bodyKind == charBody));
+                (e.bodyKind == charBody)));
 
         // Tag items with visible badges:
         //   - "CRASH RISK"  -> !isPlayerCompatible (red)
@@ -450,8 +574,10 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         const bool crossBodyCarrier = !bodyMatches && e.hasVariantMeta;
         // Only flag ambiguous when it's actually a carrier item and
         // not already bucketed as cross-body (it isn't -- ambiguous
-        // passes bodyMatches above).
-        const bool ambiguousCarrier = ambiguousBody && e.hasVariantMeta;
+        // passes bodyMatches above). Suppressed entirely on non-armor
+        // slots where body kind is irrelevant.
+        const bool ambiguousCarrier =
+            isArmorSlot && ambiguousBody && e.hasVariantMeta;
         if (crashRisk)
             tag = "non-player -- CRASH RISK";
         else if (crossBodyCarrier)
@@ -580,6 +706,208 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         else
             ui_text_disabled("no matches");
     }
+    } // if (!ui.prefabMode)
+
+    // --- Body-Mesh Prefab section ---
+    //
+    // Mirrors the carrier picker but for raw body-mesh prefabs. Picking
+    // an entry here is equivalent to setting a body-mesh override on
+    // the slot: the engine still equips the player's actual carrier
+    // item, but the body-mesh hook substitutes the wrapper at apply
+    // time so the visible mesh becomes the chosen prefab. The source
+    // wrapper is auto-derived from the slot's INI source pair (the
+    // Kliff carrier defaults). When outPrefabIdx is null the caller
+    // doesn't want this section -- skip it so legacy callers see no
+    // change.
+    if (outPrefabIdx != nullptr)
+    {
+        namespace PWS = Transmog::PrefabWrapperSwap;
+
+        ImGui::Separator();
+        if (ui.prefabMode)
+        {
+            // --- Cross-slot prefab browser ---
+            //
+            // Walks every TransmogSlot's catalog, applies the search
+            // filter, and labels each entry with its native slot.
+            // Clicking applies the prefab to its NATIVE slot (not the
+            // popup slot) -- the popup is just an entry point for
+            // browsing the merged catalog. This way the user can pick
+            // any prefab from any slot's picker.
+            ui_text_disabled(
+                "All Prefabs (search filters across every slot)");
+
+            // After populate_slot_catalogs unified the per-slot vectors
+            // (every slot now holds the FULL prefab set), iterating
+            // every slot would push each prefab 20x with a meaningless
+            // [Type] tag. Iterate slot 0 only and derive the visual
+            // [Type] label per row from the prefab name's prefix
+            // (slot_metadata's prefabPrefixMale/Female columns).
+            //
+            // Pass 1 builds a flat index of catalog positions matching
+            // the search filter; pass 2 manually clips to the visible
+            // scroll window (see manual virtualization comment below).
+            const auto &cat0 = PWS::slot_catalog(
+                static_cast<Transmog::TransmogSlot>(0));
+            const std::size_t catalogedTotal = cat0.size();
+
+            static thread_local std::vector<std::uint32_t> s_prefabFlat;
+            s_prefabFlat.clear();
+            for (std::size_t pi = 0; pi < cat0.size(); ++pi)
+            {
+                if (!name_contains_ci(cat0[pi].name, ui.searchBuf))
+                    continue;
+                if (ui.prefabExactFilter)
+                {
+                    auto derived = Transmog::slot_for_prefab_name(
+                        cat0[pi].name);
+                    if (!derived.has_value() ||
+                        !Transmog::slots_share_prefab_family(
+                            *derived, slotCategory))
+                        continue;
+                }
+                s_prefabFlat.push_back(
+                    static_cast<std::uint32_t>(pi));
+            }
+            const std::size_t totalShown = s_prefabFlat.size();
+
+            // Derive a slot label from a prefab name. Substring-based
+            // via slot_for_prefab_name() so NPC families (cd_nhw_*,
+            // cd_nhm_*), other player roles (cd_pdm_*, cd_pgm_*, ...)
+            // and accessory families (cd_t0000_*) all classify
+            // correctly. See slot_metadata.hpp for the priority table.
+            auto label_for_prefab = [&](const std::string &name) -> const char * {
+                if (auto slot = Transmog::slot_for_prefab_name(name))
+                    return Transmog::slot_meta(*slot).displayName;
+                return "?";
+            };
+
+            // Manual virtualization (ImGuiListClipper symbol clashes
+            // between imgui_lib and the ReShade SDK headers when this
+            // .inl is compiled into both TUs). Skip off-screen rows by
+            // emitting a top/bottom Dummy spacer of the right height,
+            // and only Selectable() the visible window. Net cost per
+            // frame: O(visible_rows) instead of O(totalShown). For the
+            // observed lag this drops from ~5000 emits to ~30.
+            const float rowH = ImGui::GetTextLineHeightWithSpacing();
+            const float scrollY = ImGui::GetScrollY();
+            const float winH = ImGui::GetWindowHeight();
+            const int total = static_cast<int>(totalShown);
+            int firstVis = static_cast<int>(scrollY / rowH) - 1;
+            int lastVis = static_cast<int>(
+                (scrollY + winH) / rowH) + 2;
+            if (firstVis < 0) firstVis = 0;
+            if (lastVis > total) lastVis = total;
+            if (firstVis > total) firstVis = total;
+
+            if (firstVis > 0)
+                ImGui::Dummy(ImVec2(0.0f, firstVis * rowH));
+            {
+                for (int row = firstVis; row < lastVis; ++row)
+                {
+                    const auto pi = static_cast<std::size_t>(
+                        s_prefabFlat[static_cast<std::size_t>(row)]);
+                    const auto &pe = cat0[pi];
+                    const char *natName = label_for_prefab(pe.name);
+                    char pickerId[224];
+                    if (pe.is_loaded)
+                    {
+                        std::snprintf(
+                            pickerId, sizeof(pickerId),
+                            "[%s] %s##all_prefab_%zu",
+                            natName, pe.name.c_str(), pi);
+                    }
+                    else
+                    {
+                        std::snprintf(
+                            pickerId, sizeof(pickerId),
+                            "[%s] %s  (unloaded)##all_prefab_%zu",
+                            natName, pe.name.c_str(), pi);
+                    }
+                    if (ImGui::Selectable(pickerId))
+                    {
+                        if (!pe.is_loaded)
+                            continue;
+                        // Per-slot catalogs were identical right after
+                        // populate_slot_catalogs seeded them from the
+                        // shared StringInfo walk, but
+                        // enumerate_loader_registry_into_catalog adds
+                        // slot-specific NPC entries (helm-only to Helm,
+                        // chest-only to Chest, etc.) and re-sorts each
+                        // slot independently. Indexing a popup-slot
+                        // selection by cat0's pi therefore points at a
+                        // DIFFERENT prefab in the popup slot's catalog
+                        // and the row label drifts off the row the user
+                        // actually clicked. Resolve by name through
+                        // adopt_into_slot_and_select, which finds the
+                        // matching entry in slotCategory's catalog (or
+                        // inserts a copy when the prefab is unique to
+                        // cat0) and returns the index that is valid for
+                        // slotCategory specifically.
+                        const auto adoptedIdx =
+                            PWS::adopt_into_slot_and_select(
+                                slotCategory,
+                                static_cast<Transmog::TransmogSlot>(0),
+                                static_cast<int>(pi));
+                        if (adoptedIdx < 0)
+                            continue;
+                        // Tell the caller a prefab was picked on the
+                        // popup slot so its existing
+                        // pickedPrefabName / carrier-borrow path runs.
+                        if (outPrefabIdx)
+                            *outPrefabIdx = adoptedIdx;
+                        committed = true;
+                        DMK::Logger::get_instance().info(
+                            "[picker] prefabs-mode pick: popupSlot={} "
+                            "label={} adoptedIdx={} name='{}'",
+                            Transmog::slot_name(slotCategory),
+                            natName, adoptedIdx, pe.name.c_str());
+                        ImGui::CloseCurrentPopup();
+                    }
+                    // Instant Apply intentionally NOT wired for prefab
+                    // mode this release -- click-to-pick remains the
+                    // only commit path here. Hover-apply needs extra
+                    // carrier-borrow plumbing that's a follow-up.
+                }
+            }
+            if (lastVis < total)
+                ImGui::Dummy(ImVec2(0.0f, (total - lastVis) * rowH));
+            if (catalogedTotal == 0)
+            {
+                ui_text_disabled(
+                    "no prefabs cataloged yet -- catalog may still "
+                    "be populating, try Refresh");
+            }
+            else if (totalShown == 0)
+            {
+                ui_text_disabled("no matches");
+            }
+        }
+        else
+        {
+            // Prefab catalog rendering is gated to prefabMode=true
+            // (the cross-slot browser block above). The user said the
+            // per-slot prefab list bloats the items dropdown, so when
+            // prefabMode is OFF we don't render rows at all -- only
+            // expose the clear-override option when an active prefab
+            // selection exists, so the user can always undo without
+            // having to flip the prefabMode toggle on first.
+            const int curTgt = PWS::selection_tgt_index(slotCategory);
+            if (curTgt >= 0)
+            {
+                char clrLabel[64];
+                std::snprintf(clrLabel, sizeof(clrLabel),
+                              "(clear active prefab override)##prefab_clr");
+                if (ImGui::Selectable(clrLabel))
+                {
+                    if (outPrefabIdx) *outPrefabIdx = -2;
+                    committed = true;
+                    ImGui::CloseCurrentPopup();
+                }
+            }
+        }
+    }
+
     // Clamp nav index to the actual visible count so stale values
     // from a wider filter don't point past the end of the list.
     ui.lastVisibleCount = shown;
@@ -625,8 +953,15 @@ static int s_renameIndex = -1;
 {
     const auto &mappings = Transmog::slot_mappings();
     const auto &lastIds = Transmog::last_applied_ids();
+    const auto &forceApply = Transmog::force_apply_pending();
     for (std::size_t i = 0; i < Transmog::k_slotCount; ++i)
     {
+        // A force-apply flag means the user re-picked something on the
+        // same carrier id (e.g. a different body-mesh prefab on the
+        // existing 0x1521 helm). The staged/lastIds comparison alone
+        // would miss it because the carrier id is unchanged.
+        if (forceApply[i])
+            return true;
         const uint16_t staged =
             mappings[i].active ? mappings[i].targetItemId : uint16_t{0};
         if (staged != lastIds[i])
@@ -639,8 +974,18 @@ static int s_renameIndex = -1;
 // persisted slots -- i.e. the user edited rows in the overlay but has
 // not committed the change back into the JSON preset via Save. Used to
 // tint the Save button so unsaved work is visible.
+//
+// Prefab picks are session-only: when one is active, the slot's live
+// `mappings[i].targetItemId` was force-borrowed by
+// `force_active_character_carrier_for_picked_slots()` to the active
+// character's carrier id, NOT the user's saved itemId. The saved
+// itemId snapshot is captured into `priorCarrierActive/ItemId` on the
+// first prefab pick. Compare THAT against the JSON when a prefab pick
+// is in flight, otherwise the Save button stays "Save *" forever even
+// when the saved state matches.
 [[nodiscard]] static bool has_pending_save() noexcept
 {
+    namespace PWS = Transmog::PrefabWrapperSwap;
     const auto *p = Transmog::PresetManager::instance().active_preset();
     if (!p)
         return false;
@@ -648,12 +993,203 @@ static int s_renameIndex = -1;
     const auto &mappings = Transmog::slot_mappings();
     for (std::size_t i = 0; i < Transmog::k_slotCount; ++i)
     {
-        if (mappings[i].active != p->slots[i].active)
+        // Disabled slots are forced off in the dispatcher and hidden
+        // from the picker; their saved row is left untouched on disk
+        // and may diverge from `mappings[i]` (which we forced false).
+        // Don't let that divergence light up the Save button.
+        if (!Transmog::slot_enabled(i))
+            continue;
+
+        const auto tslot = static_cast<Transmog::TransmogSlot>(i);
+
+        // Live prefab name from PWS (source of truth for the session,
+        // re-read every frame so picker mutations and preset loads
+        // both surface here).
+        const int tgtIdx = PWS::selection_tgt_index(tslot);
+        std::string stagedPrefabName;
+        if (tgtIdx >= 0)
+        {
+            const auto &cat = PWS::slot_catalog(tslot);
+            if (static_cast<std::size_t>(tgtIdx) < cat.size())
+                stagedPrefabName = cat[tgtIdx].name;
+        }
+
+        // Prefab name mismatch -> pending. Covers both directions:
+        // user added/changed a prefab AND user cleared a saved one.
+        if (stagedPrefabName != p->slots[i].prefabName)
             return true;
-        if (mappings[i].targetItemId != p->slots[i].itemId)
+
+        // When the saved preset row has a prefab, the carrier itemId
+        // and active flag are implementation details: save_path clears
+        // itemName (so saved itemId=0) while apply_to_state writes
+        // mappings[i].targetItemId = auto-borrowed Kairos carrier.
+        // Comparing those two would light up Save permanently. Skip
+        // the active/itemId compare for prefab rows -- the prefab
+        // name match above is the only check that's meaningful here.
+        if (!p->slots[i].prefabName.empty())
+            continue;
+
+        // Plain carrier slot. If the user has a session-only prefab
+        // pick on this slot (saved preset has no prefab, live PWS
+        // does), the prefab-name compare above already returned
+        // pending -- so we won't reach here. priorCarrierSaved still
+        // matters for the inverse: user is mid-pick, hasn't applied,
+        // and the snapshot holds the originally-saved carrier.
+        const auto &ui = s_slotUI[i];
+        const bool prefabBorrow = ui.priorCarrierSaved;
+        const bool stagedActive =
+            prefabBorrow ? ui.priorCarrierActive : mappings[i].active;
+        const std::uint16_t stagedItemId =
+            prefabBorrow ? ui.priorCarrierItemId : mappings[i].targetItemId;
+        if (stagedActive != p->slots[i].active)
+            return true;
+        if (stagedItemId != p->slots[i].itemId)
             return true;
     }
     return false;
+}
+
+// Identify the "Kairos" character -- the default-carrier preset whose
+// chest item resolves to `cd_phm_00_ub_00_0435` wrappers (Kliff's
+// canonical body-mesh source). The body-mesh hook's swap-map source
+// only matches when this character's gear is loaded, so picking a
+// body-mesh prefab while another character (e.g. Wellsknight) is
+// active must temporarily borrow Kairos's slot itemIds.
+//
+// Resolution policy (in order):
+//   1. Exact name match "Kliff" -- the canonical default carrier.
+//   2. First character returned by character_names().
+//
+// Documented this way so adding a new "Kairos"-equivalent character
+// later is a one-line change. Returns empty string only if the
+// PresetManager has no characters at all (impossible at runtime).
+[[nodiscard]] static std::string kairos_character_name()
+{
+    const auto &pm = Transmog::PresetManager::instance();
+    const auto names = pm.character_names();
+    for (const auto &n : names)
+    {
+        if (n == "Kliff")
+            return n;
+    }
+    return names.empty() ? std::string{} : names.front();
+}
+
+// Borrow the Kairos preset's slot itemIds into the live slot_mappings.
+// Body-mesh swap matches by SOURCE wrapper (e.g. `0435`), which is
+// only resident when the matching carrier item is loaded. When the
+// user picks a body-mesh prefab while controlling another character,
+// the engine has Wellsknight wrappers loaded and the hook never fires.
+// Forcing Kairos's itemIds into slot_mappings makes the engine load
+// Kairos's gear, which loads the source wrappers, which the hook
+// then substitutes with the chosen prefab.
+//
+// Side-effect contract (intentional):
+//   - mutates slot_mappings()[*].targetItemId / .active for slots
+//     where the user has an active body-mesh prefab pick.
+//   - DOES NOT mutate PresetManager state (no set_active_character,
+//     no save). The user's saved preset is untouched.
+//
+// Slots WITHOUT a pickedPrefabName are left alone so the user can
+// stack a body-mesh override on chest while keeping Wellsknight's
+// helm/gloves visible.
+// Clear all picked-prefab UI state and deactivate the body-mesh hook.
+// Called BEFORE preset switches so the prefab swap is torn down before
+// the new preset's items are equipped -- otherwise the hook would still
+// substitute against the old src wrappers, causing weird state across
+// the transition.
+// Clear UI/PWS selections for slots that had a body-mesh prefab pick,
+// and return the set of slot indices that were cleared. The caller is
+// responsible for the post-apply_to_state lastIds reconciliation: for
+// each cleared slot, if the new preset's carrier equals lastIds[i], the
+// caller must zero lastIds[i] so the apply pass tears down the prior
+// body-mesh fake (otherwise the natural-pipeline cleanup hook never
+// fires and the swap stays visible). When carriers differ, lastIds is
+// left intact so the regular tear_down_fake path runs.
+static std::array<bool, Transmog::k_slotCount>
+clear_all_picked_prefabs_and_deactivate()
+{
+    namespace PWS = Transmog::PrefabWrapperSwap;
+    std::array<bool, Transmog::k_slotCount> hadPick{};
+    for (std::size_t i = 0; i < Transmog::k_slotCount; ++i)
+    {
+        hadPick[i] = !s_slotUI[i].pickedPrefabName.empty();
+        s_slotUI[i].pickedPrefabName.clear();
+        s_slotUI[i].priorCarrierSaved = false;
+        const auto tslot = static_cast<Transmog::TransmogSlot>(i);
+        // Clear the body-mesh tgt selection. Source is left intact so
+        // future picks reuse the same auto-seeded src.
+        const int curSrc = PWS::selection_src_index(tslot);
+        PWS::set_selection(tslot, curSrc, -1);
+    }
+    // Selections only -- the actual swap-map rebuild happens on the
+    // next apply via notify_apply_starting (apply-only lifecycle,
+    // mirroring the carrier hybrid pattern).
+    return hadPick;
+}
+
+static void force_active_character_carrier_for_picked_slots()
+{
+    // For each slot with a picked prefab, force the carrier item to
+    // the ACTIVE CHARACTER's carrier (from carrier_defaults.hpp via
+    // default_carrier_for_slot). The PWS swap is keyed by the source
+    // wrapper that THAT character's body emits, so we need the
+    // matching carrier to make the source wrapper resident at apply
+    // time. Previously hardcoded to "Kliff" -- which forced Kliff's
+    // plate item onto Damiane / Oongka when they had any prefab
+    // selection active, breaking their carrier-equip path.
+    auto &mappings = Transmog::slot_mappings();
+    const auto &activeChar =
+        Transmog::PresetManager::instance().active_character();
+    for (std::size_t i = 0; i < Transmog::k_slotCount; ++i)
+    {
+        if (s_slotUI[i].pickedPrefabName.empty())
+            continue;
+        const auto carrierId = Transmog::default_carrier_for_slot(
+            static_cast<Transmog::TransmogSlot>(i), activeChar);
+        if (carrierId == 0)
+            continue;  // Item catalog isn't ready yet -- skip.
+        // Snapshot the slot's prior carrier state on the FIRST pick
+        // so a later body-mesh clear can restore it (revert to the
+        // user's underlying preset gear instead of leaving Kliff
+        // plate stuck on the slot). Subsequent re-picks don't
+        // overwrite -- the original state is what we want to revert
+        // to, not whatever Kliff plate we last force-borrowed.
+        if (!s_slotUI[i].priorCarrierSaved)
+        {
+            s_slotUI[i].priorCarrierSaved  = true;
+            s_slotUI[i].priorCarrierActive = mappings[i].active;
+            s_slotUI[i].priorCarrierItemId = mappings[i].targetItemId;
+        }
+        // Snapshot prior state to detect "did this call actually
+        // change anything for this slot". Without the change check
+        // below the function fires force_apply_pending on every
+        // already-stable slot every time the user re-picks any other
+        // slot, causing unrelated slots to tear down + re-apply on
+        // each pick.
+        const bool prevActive = mappings[i].active;
+        const std::uint16_t prevTargetItemId = mappings[i].targetItemId;
+        mappings[i].active = true;
+        mappings[i].targetItemId = carrierId;
+        const bool changed =
+            (prevActive != mappings[i].active) ||
+            (prevTargetItemId != mappings[i].targetItemId);
+        // When the new carrier id equals the last-applied id, the
+        // apply pipeline would short-circuit on the `targetId == prevId`
+        // early-out and never re-run. Set the per-slot force-apply flag
+        // so the dispatcher bypasses that early-out while keeping
+        // lastIds[i] intact -- Phase A `tear_down_fake` then runs
+        // against the prior carrier and the engine's natural-pipeline
+        // hook cleans up the prior body-mesh tgt wrapper. In the OTHER
+        // case (lastIds differ) the apply path already runs
+        // tear-old-then-equip-new naturally, so the flag is harmless.
+        // Gated on `changed` so already-stable slots (carrier was
+        // already carrierId, mapping unchanged) don't get force-applied
+        // when the user re-picks an unrelated slot.
+        auto &lastIds = Transmog::last_applied_ids();
+        if (changed && lastIds[i] == carrierId)
+            Transmog::force_apply_pending()[i] = true;
+    }
 }
 
 // --- draw_overlay_content ---
@@ -711,6 +1247,13 @@ static void draw_overlay_content()
         ui_tooltip("Apply changes immediately on hover, "
                    "pick, toggle, and clear -- no Apply All "
                    "needed");
+    ImGui::SameLine();
+    ui_text_disabled("(?)");
+    if (ImGui::IsItemHovered())
+        ui_tooltip("Prefab picker (Prefabs checkbox inside the popup) "
+                   "does NOT honour Instant Apply this release. Click "
+                   "a prefab row to commit it; hover-preview is items-"
+                   "only for now.");
 
     ImGui::SameLine();
     ImGui::Checkbox("Keep Search Text", &s_keepSearchText);
@@ -892,8 +1435,38 @@ static void draw_overlay_content()
 
                 if (ImGui::Selectable(label, isActive))
                 {
+                    // Tear down any active body-mesh prefab picks
+                    // BEFORE switching presets. Otherwise the hook
+                    // keeps substituting the old src wrappers while
+                    // the new preset's items are being equipped, which
+                    // produces stale visuals across the transition.
+                    const auto hadPick =
+                        clear_all_picked_prefabs_and_deactivate();
                     pm.set_active_preset(i);
                     pm.apply_to_state();
+                    // Post-apply_to_state reconciliation: for each
+                    // slot where a body-mesh pick was just cleared AND
+                    // the new preset's carrier equals last_applied
+                    // (the early-out case), set the force-apply flag
+                    // so the dispatcher bypasses the `targetId ==
+                    // prevId` early-out while leaving lastIds intact
+                    // -- Phase A `tear_down_fake` then runs against
+                    // the prior carrier and the natpipe-hook cleans
+                    // up the prior body-mesh tgt wrapper. When
+                    // carriers differ the regular tear_down_fake path
+                    // already handles cleanup naturally, so the flag
+                    // is harmless.
+                    auto &lastIds = Transmog::last_applied_ids();
+                    auto &mods = Transmog::slot_mappings();
+                    for (std::size_t s = 0; s < Transmog::k_slotCount;
+                         ++s)
+                    {
+                        if (hadPick[s] &&
+                            mods[s].targetItemId == lastIds[s])
+                        {
+                            Transmog::force_apply_pending()[s] = true;
+                        }
+                    }
                     manual_apply();
                     pm.save();
                 }
@@ -990,9 +1563,16 @@ static void draw_overlay_content()
         ui_text_disabled("Toggle which slots the next Apply All will touch.");
 
         {
+            // "All" tracks ENABLED slots only -- disabled slots
+            // (multi-prefab non-armor, duplicate-tag; see
+            // slot_metadata.hpp `enabled` doc) are forced off in the
+            // dispatcher, so including them in the "All" check would
+            // make the box stay unticked forever.
             bool allActive = true;
             for (std::size_t i = 0; i < k_slotCount; ++i)
             {
+                if (!Transmog::slot_enabled(i))
+                    continue;
                 if (!mappings[i].active)
                 {
                     allActive = false;
@@ -1002,7 +1582,11 @@ static void draw_overlay_content()
             if (ImGui::Checkbox("All", &allActive))
             {
                 for (std::size_t i = 0; i < k_slotCount; ++i)
+                {
+                    if (!Transmog::slot_enabled(i))
+                        continue;
                     mappings[i].active = allActive;
+                }
                 if (s_autoApply)
                 {
                     flag_enabled().store(true,
@@ -1019,24 +1603,82 @@ static void draw_overlay_content()
 
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
+            // Skip disabled slots entirely -- the row, picker popup,
+            // and label-sync logic below would all be misleading for
+            // a slot that never reaches the dispatcher. The slot's
+            // mapping is left as-is on disk so re-enabling later
+            // restores prior selections without preset migration.
+            if (!Transmog::slot_enabled(i))
+                continue;
+
             auto &m = mappings[i];
             auto &ui = s_slotUI[i];
             const char *slotLabel = slot_name(static_cast<TransmogSlot>(i));
 
-            ImGui::PushID(static_cast<int>(i) + 100);
-
-            if (ImGui::Checkbox(slotLabel, &m.active) && s_autoApply)
+            // Lazy sync: when the PWS module has a target selection
+            // for this slot but the UI label is empty, derive the
+            // label from the catalog. Covers boot-time auto-apply
+            // (preset's stored prefabName resolved by PWS after the
+            // heap walk completes) and any other path that mutates
+            // PWS selections without going through the picker.
             {
-                flag_enabled().store(true, std::memory_order_relaxed);
-                manual_apply_slot(i);
+                namespace PWS = Transmog::PrefabWrapperSwap;
+                const auto tslot = static_cast<TransmogSlot>(i);
+                const int tgtIdx = PWS::selection_tgt_index(tslot);
+                if (tgtIdx >= 0 && ui.pickedPrefabName.empty())
+                {
+                    const auto &cat = PWS::slot_catalog(tslot);
+                    if (static_cast<std::size_t>(tgtIdx) < cat.size())
+                        ui.pickedPrefabName = cat[tgtIdx].name;
+                }
+                else if (tgtIdx < 0 && !ui.pickedPrefabName.empty())
+                {
+                    ui.pickedPrefabName.clear();
+                }
             }
 
-            ImGui::SameLine(s_standaloneMode ? 160.0f : 120.0f);
+            ImGui::PushID(static_cast<int>(i) + 100);
+
+            if (ImGui::Checkbox(slotLabel, &m.active))
+            {
+                // Toggling active alone may not change the staged id
+                // -- e.g. an active-none slot (active=true, targetId=0)
+                // unticked back to inactive both yield staged=0, so
+                // has_pending_changes would miss the toggle and the
+                // Apply All button would stay grayed out. Set the
+                // force-apply flag so the UI sees a pending change and
+                // the dispatcher's slotNeedsWork picks the slot up
+                // (its hasActiveNone path already handles the apply
+                // semantics; the flag just guarantees the slot is
+                // considered).
+                force_apply_pending()[i] = true;
+                if (s_autoApply)
+                {
+                    flag_enabled().store(true, std::memory_order_relaxed);
+                    manual_apply_slot(i);
+                }
+            }
+
+
+            // Bumped 2026-05-07 from 160/120 -> 200/170 so the longer
+            // slot names ("TwoHandWeapon", "MainHand", "SubWeapon")
+            // don't overlap the picker button.
+            ImGui::SameLine(s_standaloneMode ? 200.0f : 170.0f);
 
             // --- Picker button ---
             {
                 std::string pickerLabel;
-                if (m.targetItemId == 0)
+                // When the user has picked a body-mesh prefab on this
+                // slot, surface the prefab name on the button instead
+                // of the carrier item's display name -- the carrier
+                // is now an implementation detail (Kairos's gear
+                // forced behind the scenes to feed the source wrapper).
+                const bool showPrefabLabel = !ui.pickedPrefabName.empty();
+                if (showPrefabLabel)
+                {
+                    pickerLabel = ui.pickedPrefabName + " [prefab]";
+                }
+                else if (m.targetItemId == 0)
                 {
                     pickerLabel = "(none)";
                 }
@@ -1057,14 +1699,26 @@ static void draw_overlay_content()
                 }
 
                 char btnLabel[192];
-                std::snprintf(btnLabel, sizeof(btnLabel),
-                              "%s  [0x%04X]##pick", pickerLabel.c_str(),
-                              m.targetItemId);
+                if (showPrefabLabel)
+                    std::snprintf(btnLabel, sizeof(btnLabel),
+                                  "%s##pick", pickerLabel.c_str());
+                else
+                    std::snprintf(btnLabel, sizeof(btnLabel),
+                                  "%s  [0x%04X]##pick", pickerLabel.c_str(),
+                                  m.targetItemId);
 
                 const float bw = s_standaloneMode ? 520.0f : 380.0f;
                 ImGui::SetNextItemWidth(bw);
                 ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign,
                                     ImVec2(0.02f, 0.5f));
+                // Tint the button cyan when a body-mesh prefab is
+                // picked so the override is visually distinct from
+                // an ordinary carrier slot.
+                if (showPrefabLabel)
+                {
+                    ImGui::PushStyleColor(ImGuiCol_Text,
+                                          ImVec4(0.30f, 0.85f, 1.00f, 1.0f));
+                }
                 if (ImGui::Button(btnLabel, ImVec2(bw, 0.0f)))
                 {
                     if (tableReady)
@@ -1074,26 +1728,170 @@ static void draw_overlay_content()
                         ImGui::OpenPopup("##slot_picker");
                     }
                 }
+                if (showPrefabLabel)
+                    ImGui::PopStyleColor(); // Text
                 ImGui::PopStyleVar(); // ButtonTextAlign
 
+                // outPrefabIdx contract from the popup:
+                //   -1: popup did NOT touch the body-mesh (real item
+                //       or "(none) item" was picked) -- leave any
+                //       prior body-mesh selection alone.
+                //   -2: explicit "clear body-mesh override" pick.
+                //   >=0: prefab N picked.
+                int prefabIdx = -1;
                 if (tableReady &&
                     draw_item_picker_popup(
                         "##slot_picker", ui,
                         static_cast<TransmogSlot>(i),
                         m.targetItemId,
-                        s_autoApply, i))
+                        s_autoApply, i,
+                        &prefabIdx))
                 {
                     std::snprintf(ui.hexBuf, sizeof(ui.hexBuf), "%04X",
                                   m.targetItemId);
 
-                    if (s_autoApply)
-                    {
-                        flag_enabled().store(true,
-                                             std::memory_order_relaxed);
-                        manual_apply_slot(i);
-                    }
+                    namespace PWS = Transmog::PrefabWrapperSwap;
+                    const auto tslot = static_cast<TransmogSlot>(i);
+                    const int curSrc = PWS::selection_src_index(tslot);
 
+                    if (prefabIdx >= 0 || prefabIdx == -2)
                     {
+                        // Body-mesh interaction. Selection only --
+                        // the swap map is rebuilt on the next apply
+                        // via notify_apply_starting (apply-only
+                        // lifecycle, mirroring the carrier pattern).
+                        PWS::set_selection(
+                            tslot, curSrc,
+                            (prefabIdx >= 0) ? prefabIdx : -1);
+
+                        // Update the per-slot UI label state. On a
+                        // prefab pick (>= 0) we pull the name straight
+                        // out of the catalog; on an explicit clear
+                        // (-2) we drop the label so the row reverts
+                        // to showing the carrier item.
+                        if (prefabIdx >= 0)
+                        {
+                            const auto &cat = PWS::slot_catalog(tslot);
+                            if (static_cast<std::size_t>(prefabIdx) <
+                                cat.size())
+                            {
+                                ui.pickedPrefabName =
+                                    cat[static_cast<std::size_t>(prefabIdx)]
+                                        .name;
+                            }
+                            // Force the carrier into the ACTIVE
+                            // CHARACTER's carrier so the source wrapper
+                            // (e.g. cd_phw_00_ub_00_0163_index01 for
+                            // Damiane chest) becomes resident and the
+                            // swap-map hook can match it. Without this
+                            // step, picking a prefab while controlling
+                            // Wellsknight leaves the engine with
+                            // Wellsknight wrappers and the hook never
+                            // fires. (Used to be hardcoded to Kliff;
+                            // now per-character so Damiane / Oongka get
+                            // their own carriers, not Kliff's.)
+                            force_active_character_carrier_for_picked_slots();
+                        }
+                        else
+                        {
+                            // Explicit body-mesh clear (-2): drop the
+                            // label AND restore the slot's carrier to
+                            // whatever the user had before the prefab
+                            // pick auto-borrowed Kliff. Without this
+                            // restore, the slot stays stuck on the
+                            // Kliff plate carrier (e.g. 0x1521 for
+                            // helm) instead of reverting to the user's
+                            // underlying preset gear (e.g. Wellsknight
+                            // 0x1520).
+                            ui.pickedPrefabName.clear();
+                            if (ui.priorCarrierSaved)
+                            {
+                                m.active = ui.priorCarrierActive;
+                                m.targetItemId = ui.priorCarrierItemId;
+                                ui.priorCarrierSaved = false;
+                            }
+                        }
+
+                        // Set the force-apply flag UNCONDITIONALLY
+                        // (regardless of s_autoApply). When the new
+                        // carrier id equals the prior one (e.g.
+                        // re-picking a body-mesh prefab on the same
+                        // Kliff carrier 0x1521), staged/lastIds match,
+                        // so without this flag has_pending_changes
+                        // returns false -- the Apply All button would
+                        // stay grayed out and a manual apply would
+                        // hit the dispatcher's `targetId == prevId`
+                        // early-out anyway. Setting the flag ensures
+                        // (a) the Apply All button activates and
+                        // (b) the dispatcher bypasses the early-out
+                        // while leaving lastIds[i] intact, so Phase A
+                        // `tear_down_fake` runs against 0x1521 and
+                        // the engine's natural-pipeline hook
+                        // substitutes src->tgt to clean up the prior
+                        // body-mesh target wrapper. When ids differ
+                        // (e.g. body-mesh clear that restored
+                        // Wellsknight 0x1520 over the prior Kliff
+                        // 0x1521), the dispatcher's own change
+                        // detection covers it -- the flag is harmless.
+                        if (last_applied_ids()[i] == m.targetItemId)
+                            force_apply_pending()[i] = true;
+                        if (s_autoApply)
+                        {
+                            flag_enabled().store(
+                                true, std::memory_order_relaxed);
+                            manual_apply_slot(i);
+                        }
+                        DMK::Logger::get_instance().info(
+                            "[picker] slot={} BODY-MESH "
+                            "{}={} (srcSeeded={}) -- carrier=0x{:04X} "
+                            "auto-applied",
+                            slotLabel,
+                            (prefabIdx >= 0) ? "prefabIdx" : "cleared",
+                            (prefabIdx >= 0) ? prefabIdx : 0,
+                            curSrc >= 0, m.targetItemId);
+                    }
+                    else
+                    {
+                        // Real item or "(none) item" pick. The carrier
+                        // itemId was already updated by the popup. We
+                        // also drop any prior body-mesh prefab label
+                        // for this slot -- picking a real item is the
+                        // user's signal to revert to plain carrier
+                        // mode. The existing body-mesh swap selection
+                        // is also cleared via reactivate so the two
+                        // states stay mutually exclusive.
+                        const bool hadPrior = !ui.pickedPrefabName.empty();
+                        if (hadPrior)
+                        {
+                            ui.pickedPrefabName.clear();
+                            PWS::set_selection(tslot, curSrc, -1);
+                            // Drop the saved prior-carrier snapshot.
+                            // The user explicitly picked a new real
+                            // item, so the popup-set m.targetItemId is
+                            // authoritative -- restoring the prior
+                            // carrier here would clobber the fresh
+                            // pick.
+                            ui.priorCarrierSaved = false;
+                        }
+                        // Set the force-apply flag UNCONDITIONALLY so
+                        // has_pending_changes also returns true when
+                        // the user clears a prefab pick onto a real
+                        // item that happens to share the prior
+                        // auto-borrowed Kliff carrier id (e.g. helm
+                        // 0x1521 → 0x1521). Without it the Apply All
+                        // button would stay grayed out. Different-id
+                        // case is covered by the dispatcher's normal
+                        // change detection -- flag is harmless.
+                        if (hadPrior &&
+                            last_applied_ids()[i] == m.targetItemId)
+                            force_apply_pending()[i] = true;
+                        if (s_autoApply)
+                        {
+                            flag_enabled().store(
+                                true, std::memory_order_relaxed);
+                            manual_apply_slot(i);
+                        }
+
                         const auto name = (m.targetItemId == 0)
                                               ? std::string("(none)")
                                               : table.name_of(m.targetItemId);
@@ -1124,6 +1922,14 @@ static void draw_overlay_content()
                 std::snprintf(ui.hexBuf, sizeof(ui.hexBuf), "%04X",
                               m.targetItemId);
 
+            // When a body-mesh prefab is active on this slot the
+            // carrier itemId is auto-borrowed (Kairos plate) and the
+            // user shouldn't be editing it directly -- show the hex
+            // disabled+dim with an explanatory tooltip so it's clear
+            // the body-mesh prefab is the source of truth, and the
+            // hex is a peek at the underlying carrier.
+            const bool prefabActive = !ui.pickedPrefabName.empty();
+            ImGui::BeginDisabled(prefabActive);
             ImGui::SetNextItemWidth(64.0f);
             if (ImGui::InputText(
                     "##hex", ui.hexBuf, sizeof(ui.hexBuf),
@@ -1133,7 +1939,17 @@ static void draw_overlay_content()
                 unsigned long val = std::strtoul(ui.hexBuf, nullptr, 16);
                 m.targetItemId = static_cast<uint16_t>(val);
             }
-            ui.editing = ImGui::IsItemActive();
+            ui.editing = !prefabActive && ImGui::IsItemActive();
+            ImGui::EndDisabled();
+            if (prefabActive && ImGui::IsItemHovered())
+            {
+                ui_tooltip(
+                    "Auto-borrowed carrier id (Kairos plate). The "
+                    "body-mesh prefab is the visual override; this "
+                    "hex is just the engine plumbing. Clear the "
+                    "prefab via the picker's '(none) prefab' to "
+                    "edit the carrier directly.");
+            }
 
             // Quick-clear button.
             ImGui::SameLine();
@@ -1141,10 +1957,115 @@ static void draw_overlay_content()
             {
                 m.targetItemId = 0;
                 std::snprintf(ui.hexBuf, sizeof(ui.hexBuf), "0000");
+                // X clears both carrier and any body-mesh override on
+                // this slot -- the user's intent is "remove everything
+                // visible from this slot". Mirrors the (none) pick.
+                if (!ui.pickedPrefabName.empty())
+                {
+                    namespace PWS = Transmog::PrefabWrapperSwap;
+                    const auto tslot = static_cast<TransmogSlot>(i);
+                    const int curSrc = PWS::selection_src_index(tslot);
+                    ui.pickedPrefabName.clear();
+                    PWS::set_selection(tslot, curSrc, -1);
+                }
                 if (s_autoApply)
                 {
                     flag_enabled().store(true, std::memory_order_relaxed);
                     manual_apply_slot(i);
+                }
+            }
+
+            // Cross-class limitation marker for weapon slots. Each
+            // weapon prefab carries its own bone-binding + attachment-
+            // socket data (which skeleton bone it parents to, which
+            // socket transform it uses, hand offsets, sheath pose).
+            // The engine resolves those bindings from the REAL equipped
+            // item's class -- not from the LT swap target -- so a
+            // mismatched-class transmog renders into the wrong socket
+            // (or no socket) and goes invisible. Tooltip emphasises the
+            // practical rule: match the prefab's class to whatever
+            // weapon family the player has equipped right now.
+            {
+                const auto tslotMarker = static_cast<TransmogSlot>(i);
+                const bool isWeaponSlot =
+                    tslotMarker == TransmogSlot::MainHand ||
+                    tslotMarker == TransmogSlot::OffHand ||
+                    tslotMarker == TransmogSlot::Ranged ||
+                    tslotMarker == TransmogSlot::SubWeapon ||
+                    tslotMarker == TransmogSlot::TwoHandWeapon;
+                if (isWeaponSlot)
+                {
+                    ImGui::SameLine();
+                    ui_text_disabled("(?)");
+                    if (ImGui::IsItemHovered())
+                    {
+                        const bool isTwoHand =
+                            tslotMarker == TransmogSlot::TwoHandWeapon;
+                        ui_tooltip(
+                            isTwoHand
+                            ? "EXPERIMENTAL.\n"
+                              "\n"
+                              "Heads-up: in this game, tools (pickaxe,\n"
+                              "mallet, etc.) share the same engine slot\n"
+                              "as 2H weapons. Setting a transmog here\n"
+                              "may also affect the tool you have\n"
+                              "equipped. Investigation ongoing.\n"
+                              "\n"
+                              "Best practice: pick a transmog from the\n"
+                              "SAME weapon family you have equipped.\n"
+                              "Sword on a sword, spear on a spear, 1H\n"
+                              "on a 1H, 2H on a 2H -- always renders\n"
+                              "correctly, drawn or sheathed.\n"
+                              "\n"
+                              "Why the limit exists:\n"
+                              "Each weapon prefab carries its own\n"
+                              "bone-binding and attachment-socket data\n"
+                              "(which bone it parents to, which socket\n"
+                              "transform it uses, hand offsets, sheath\n"
+                              "pose). The engine looks those bindings\n"
+                              "up from the REAL equipped item's class --\n"
+                              "not from this transmog target -- so a\n"
+                              "mismatched-class swap lands in the wrong\n"
+                              "socket and goes invisible.\n"
+                              "\n"
+                              "Examples:\n"
+                              " - 2H prefab while a 1H is equipped:\n"
+                              "   mesh shows on the back; the real 1H\n"
+                              "   goes invisible when drawn.\n"
+                              " - Spear/hammer prefab while a sword is\n"
+                              "   equipped: invisible when drawn\n"
+                              "   (sheathed on back still renders).\n"
+                              " - Same family (sword<->sword, etc.):\n"
+                              "   renders correctly in every pose."
+                            : "EXPERIMENTAL.\n"
+                              "\n"
+                              "Best practice: pick a transmog from the\n"
+                              "SAME weapon family you have equipped.\n"
+                              "Sword on a sword, spear on a spear, 1H\n"
+                              "on a 1H, 2H on a 2H -- always renders\n"
+                              "correctly, drawn or sheathed.\n"
+                              "\n"
+                              "Why the limit exists:\n"
+                              "Each weapon prefab carries its own\n"
+                              "bone-binding and attachment-socket data\n"
+                              "(which bone it parents to, which socket\n"
+                              "transform it uses, hand offsets, sheath\n"
+                              "pose). The engine looks those bindings\n"
+                              "up from the REAL equipped item's class --\n"
+                              "not from this transmog target -- so a\n"
+                              "mismatched-class swap lands in the wrong\n"
+                              "socket and goes invisible.\n"
+                              "\n"
+                              "Examples:\n"
+                              " - 2H prefab while a 1H is equipped:\n"
+                              "   mesh shows on the back; the real 1H\n"
+                              "   goes invisible when drawn.\n"
+                              " - Spear/hammer prefab while a sword is\n"
+                              "   equipped: invisible when drawn\n"
+                              "   (sheathed on back still renders).\n"
+                              " - Same family (sword<->sword, etc.):\n"
+                              "   renders correctly in every pose.");
+                    }
                 }
             }
 
@@ -1170,13 +2091,31 @@ static void draw_overlay_content()
         ImGui::PushStyleColor(ImGuiCol_ButtonActive,
                               ImVec4(1.00f, 0.72f, 0.20f, 1.0f));
     }
+    // Body-mesh catalog is populated asynchronously by a boot thread
+    // (heap walk ~1-5s). If the user has any body-mesh selection while
+    // the catalog is still loading, block Apply -- the swap map cannot
+    // resolve source wrappers without the catalog and an apply would
+    // silently produce a no-op (or worse, partial substitution).
+    namespace PWS = Transmog::PrefabWrapperSwap;
+    const bool catalogLoading =
+        PWS::has_any_selection() && !PWS::is_catalog_populated();
+
+    ImGui::BeginDisabled(catalogLoading);
     if (ImGui::Button(pending ? "Apply All *" : "Apply All"))
     {
         flag_enabled().store(true, std::memory_order_relaxed);
         manual_apply();
     }
+    ImGui::EndDisabled();
     if (pending)
         ImGui::PopStyleColor(3);
+
+    if (catalogLoading)
+    {
+        ImGui::SameLine();
+        ui_text_colored(ImVec4(0.85f, 0.75f, 0.20f, 1.0f),
+                        "(loading body-mesh catalog...)");
+    }
 
     ImGui::SameLine();
 
@@ -1189,7 +2128,16 @@ static void draw_overlay_content()
     ImGui::SameLine();
 
     if (ImGui::Button("Capture Outfit"))
+    {
+        // Capture replaces the current state with the live equipped
+        // outfit, so any session-only prefab picks must surrender too
+        // -- otherwise the cyan label hides the captured gear and a
+        // later "(none) prefab" would restore the stale pre-capture
+        // carrier from `priorCarrierItemId`. Clears PWS + s_slotUI
+        // state in one shot; capture_outfit then writes fresh mappings.
+        clear_all_picked_prefabs_and_deactivate();
         capture_outfit();
+    }
 
     ImGui::SameLine();
 

--- a/CrimsonDesertLiveTransmog/src/part_show_suppress.cpp
+++ b/CrimsonDesertLiveTransmog/src/part_show_suppress.cpp
@@ -1,5 +1,6 @@
 #include "part_show_suppress.hpp"
 #include "shared_state.hpp"
+#include "slot_metadata.hpp"
 
 #include <DetourModKit.hpp>
 
@@ -27,22 +28,19 @@ namespace Transmog::PartShowSuppress
         std::array<uint32_t, 4> hashes; // zero-terminated, unused = 0
     };
 
-    // Slot name -> TransmogSlot index mapping. Kept separate from
-    // s_slotHashes so init can look up each slot by its CD_* string.
-    struct SlotNameEntry
-    {
-        std::size_t slot;
-        const char *name;
-    };
+    // The (TransmogSlot -> "CD_*") slot-name table sourced from
+    // slot_metadata.hpp's `partShowHashKey` field. Only the 5 original
+    // armor slots have CD_* slot-suffix hashes in IndexedStringA --
+    // accessory and weapon slots store nullptr there and are filtered
+    // out below. (Replaces a local 5-entry table; extending the
+    // TransmogSlot enum is now safe -- nullptr trailing entries are
+    // skipped explicitly.)
 
-    static constexpr std::array<SlotNameEntry, k_slotCount> k_slotNames = {{
-        {static_cast<std::size_t>(TransmogSlot::Helm),   "CD_Helm"},
-        {static_cast<std::size_t>(TransmogSlot::Chest),  "CD_Upperbody"},
-        {static_cast<std::size_t>(TransmogSlot::Cloak),  "CD_Cloak"},
-        {static_cast<std::size_t>(TransmogSlot::Gloves), "CD_Hand"},
-        {static_cast<std::size_t>(TransmogSlot::Boots),  "CD_Foot"},
-    }};
-
+    // s_slotHashes stays sized to k_slotCount because callers index it
+    // by TransmogSlot value (which can be any of the 20 entries). The
+    // 15 trailing slots have all-zero hashes and act as a no-op for
+    // suppression -- correct behavior since accessories don't use
+    // this hash-driven path.
     static std::array<SlotHashes, k_slotCount> s_slotHashes{};
     static std::atomic<bool> s_slotHashesReady{false};
 
@@ -88,24 +86,33 @@ namespace Transmog::PartShowSuppress
         auto &logger = DMK::Logger::get_instance();
         std::size_t resolved = 0;
 
+        // Walk slot_metadata; only rows where partShowHashKey is set
+        // (the 5 armor slots) participate in IndexedStringA-driven
+        // suppression. Other rows (accessories, weapons) keep their
+        // zero-initialized s_slotHashes entry as a no-op so set_mask
+        // calls for those bits silently pass through.
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
-            s_slotHashes[i].slot = k_slotNames[i].slot;
+            s_slotHashes[i].slot = i;
             s_slotHashes[i].hashes = {0, 0, 0, 0};
 
-            auto it = nameToHash.find(k_slotNames[i].name);
+            const char *partShowKey = k_slotMetadata[i].partShowHashKey;
+            if (!partShowKey || partShowKey[0] == '\0')
+                continue;
+
+            auto it = nameToHash.find(partShowKey);
             if (it == nameToHash.end())
             {
                 logger.warning(
                     "[dispatch] slot hash missing: '{}' not found in "
                     "IndexedStringA -- suppression for slot {} disabled",
-                    k_slotNames[i].name, k_slotNames[i].slot);
+                    partShowKey, i);
                 continue;
             }
 
             s_slotHashes[i].hashes[0] = it->second;
             logger.info("[dispatch] slot hash resolved: {} = 0x{:X}",
-                        k_slotNames[i].name, it->second);
+                        partShowKey, it->second);
             ++resolved;
         }
 

--- a/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
+++ b/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
@@ -1,0 +1,2631 @@
+#include "prefab_wrapper_swap.hpp"
+#include "aob_resolver.hpp"
+#include "carrier_defaults.hpp"
+#include "preset_manager.hpp"
+#include "shared_state.hpp"
+#include "slot_metadata.hpp"
+#include "transmog.hpp"
+
+#include <DetourModKit.hpp>
+
+#include <Windows.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace Transmog::PrefabWrapperSwap
+{
+    // --- Constants ---
+    //
+    // StringInfo registry @ MEMORY[0x145EF1DE8]:
+    //   +0x08 count u32, +0x50 array_ptr (QWORD entry-ptrs)
+    // Per-entry layout (CE-verified):
+    //   +0x00 hash, +0x08 vtable (== 0x145BC4638),
+    //   +0x18 wrapper-ptr, +0x20 inline name (NUL-terminated)
+    //
+    // Wrapper layout:
+    //   +0x00 string ptr, +0x10 refcount i32,
+    //   +0x14 mode flag, +0x15 tombstone
+
+    // Layout / sanity constants (compile-time only; not patchable).
+    constexpr std::size_t    k_inlineNameOff         = 0x20;
+    constexpr std::size_t    k_wrapperPtrOff         = 0x18;
+    constexpr std::size_t    k_extNameMax            = 256;
+    constexpr std::uint32_t  k_minPlausibleCount     = 100;
+    constexpr std::uint32_t  k_maxPlausibleCount     = 200000;
+
+    // --- Runtime-resolved data globals (audit 2026-05-08) ---
+    //
+    // Hardcoded RVAs and absolute addresses were replaced with AOB
+    // cascades (see aob_resolver.hpp::k_stringInfoRegistryCandidates et
+    // al). The cascade resolves at init(); these atomics carry the
+    // resolved address into the hot path. Zero indicates "not yet
+    // resolved" -- every consumer must check for non-zero before
+    // dereferencing.
+    //
+    // Atomics are used because init() runs on the main thread but the
+    // hot path (walk_string_info, enumerate_loader_registry_into_catalog)
+    // can run on the background population thread. x64 qword stores are
+    // naturally atomic on aligned data; the explicit atomic gives the
+    // compiler the memory fence it needs.
+    static std::atomic<std::uintptr_t> s_stringInfoRegistry{0};
+    static std::atomic<std::uintptr_t> s_stringInfoVtable{0};
+    static std::atomic<std::uintptr_t> s_loaderRegistrySingleton{0};
+    static std::atomic<std::uintptr_t> s_apptContainerVtable{0};
+
+    // (Removed 2026-05-07: k_maxPairs / k_pathBufSize. Both backed
+    // the deleted INI Pair config -- no callers remain.)
+
+    // --- AOB for sub_14270B030 (resource binder) ---
+    //
+    // sub_14270B030 is called by sub_14270AD50 to bind resolved
+    // resources into a record's slots:
+    //   sub_14270B030(charState, entry+16, charState, entry, &v14)  // PRIMARY
+    //   sub_14270B030(charState, entry+24, charState, entry, &v13)  // SECONDARY
+    //
+    // The PRIMARY bind installs the full-string-lookup result (e.g.
+    // target prefab `_0395_c`). The SECONDARY bind installs the
+    // suffix-variant-lookup result (extracted suffix `_c`). When our
+    // pointer-swap changes a wrapper from `_d` (Kliff helm) to `_c`
+    // (target prefab), the secondary bind creates a NEW scene-graph
+    // node keyed on the `_c` suffix in a DIFFERENT class table that
+    // LT's tear_down doesn't traverse -- causing the helm to leak when
+    // the user clears or switches presets.
+    //
+    // Fix: hook this function and SKIP the secondary bind for any
+    // record whose wrapper matches one of our active target wrappers.
+    // The primary bind still happens (target prefab visible). The
+    // secondary suffix-variant bind is skipped (no leak).
+    //
+    // Detection: sub_14270B030 is variadic; va arg is at [rbp+0x60].
+    // Distinguishing primary-vs-secondary at the hook: a2 == entry+24
+    // means secondary (where entry == a4).
+    //
+    // First 50 bytes are a unique prologue + frame setup + first arg
+    // load (`mov rdi, [r12]; test rdi, rdi`); rel32 jcc disp32 after
+    // that varies, so we anchor on the prologue alone.
+    // (Removed 2026-05-07: AOB tables for sub_14275AC00 ResourceBinder,
+    // sub_14271A720 EngineUnlink, sub_1402F94B0 SmartPtrRelease, and
+    // sub_1427127D0 Factory. These supported the legacy helm-leak fix
+    // path -- ResourceBinder gating, factory orphan tracking, and
+    // do_reverse_write force-destroy cleanup. The natural-pipeline
+    // hook on sub_142711DF0 now handles cleanup at the unlink layer
+    // by substituting Kliff src wrappers with target wrappers in the
+    // engine's unlink list, so none of those primitives are referenced
+    // anymore. Verified live 2026-05-05: clear-all + save-reload runs
+    // clean without them. See diff snapshots in
+    // docs/research/ghost-helm-snapshots/diff-2026-05-05-cold/.)
+
+    // 4 inline AOB cascades migrated to aob_resolver.hpp on 2026-05-08
+    // (audit pass 2):
+    //   k_apptResMgrInitCandidates    -- sub_1408AF8F0 capture hook
+    //   k_apptInnerLookupCandidates   -- sub_140350910 lookup primitive
+    //                                    (renamed from k_apptLookupCandidates)
+    //   k_apptStringInternCandidates  -- sub_1403016B0 string intern
+    //   k_structCopyCandidates        -- sub_140352AA0 struct copy hot path
+    //
+    // Each is now a 3-anchor cascade per aob-signatures.md ordering rules.
+    // See aob_resolver.hpp for the cascade definitions and per-anchor docs.
+
+    // Offset within container where the boot-loaded hash table struct
+    // begins. The boot loader (sub_1424E15F0) populates `container +
+    // 0x70` via insert primitive sub_1424E6E00. The lookup primitive
+    // sub_140350910 takes the SAME table-struct pointer.
+    static constexpr std::size_t k_apptHashTableOff = 0x70;
+
+    // (Removed 2026-05-07: legacy INI Pair config. The Pair struct,
+    // s_pairs[k_maxPairs] static array, s_enabled gate flag, and the
+    // s_bindings input-binding guard vector all supported the old
+    // [Research]-section INI keys (PrefabWrapperSwap_Pair{1..8} +
+    // ToggleHotkey). All gone -- selection is overlay-driven, no
+    // INI keys remain.)
+    static std::atomic<bool> s_active{false};
+
+    // Resolved wrapper address map: source_wrapper_ptr → target_wrapper_ptr.
+    // Built when activation hotkey is pressed; cleared on deactivation.
+    // Read-only on hot path (no locks needed -- pointer-equality lookup
+    // against an immutable map snapshot).
+    static std::mutex                                 s_mapMtx;
+    static std::unordered_map<std::uintptr_t, std::uintptr_t> s_swapMap;
+
+    using StructCopyFn = std::int64_t(__fastcall *)(std::int64_t, std::int64_t);
+    static StructCopyFn s_orig = nullptr;
+
+    // Set of target wrapper addresses (the values in s_swapMap). Used
+    // by the secondary-bind hook to detect "is this record one of our
+    // substituted ones?" by comparing the entry's wrapper-ptr at +0
+    // against this set.
+    static std::unordered_set<std::uintptr_t> s_targetWrappers;
+
+    // Destination tracking: every record we substituted, with its
+    // original Kliff wrapper. On deactivate, we walk this vector and
+    // write the original wrapper back into the dest slot. This reverses
+    // our wrapper-substitution at the engine-state level, so LT's
+    // tear_down (which walks the auth-table) finds records with
+    // ORIGINAL wrappers (the ones it knows about) and can tear them
+    // down cleanly. Without this, our substitutions create scene-graph
+    // entries LT cannot reach via its auth-table-driven tear-down,
+    // leading to stale renders (the helm leak being most visible).
+    struct SubstRecord
+    {
+        std::uintptr_t destAddr;       // dest record's wrapper-ptr slot (= a1 + 0)
+        std::uintptr_t origWrapper;    // Kliff wrapper that was at *a2 before substitute
+    };
+    static std::mutex             s_substLogMtx;
+    static std::vector<SubstRecord> s_substLog;
+    static constexpr std::size_t  k_maxSubstLog = 256;
+
+    // (Removed 2026-05-07: ResourceBinderFn / s_origBinder /
+    // s_secondarySkipCount + FactoryFn / s_origFactory + LeakedStruct
+    // tracking (s_leakedMtx, s_leakedStructs, k_maxLeakedStructs,
+    // s_factoryHitCount, s_factoryTrackCount). All of these supported
+    // the legacy helm-leak fix path that the natpipe hook on
+    // sub_142711DF0 has obsoleted.)
+
+    // (Removed 2026-05-07: EngineUnlinkFn / s_engineUnlink and
+    // SmartPtrReleaseFn / s_smartPtrRelease typedefs + statics.
+    // Their consumers -- release_orphan_via_smartptr +
+    // do_reverse_write -- were removed in the same pass; the natpipe
+    // hook on sub_142711DF0 handles cleanup without these primitives.)
+
+    // Natural-pipeline unlink (sub_142711DF0) -- RVA 0x2711DF0. Called by
+    // safeTearDown (sub_14078BB20) and other unmount paths with a list
+    // of asset wrappers to unlink from parent+88 records. The function
+    // is content-keyed: it walks parent+88 looking for records whose
+    // wrapper field == one of the wrappers in the input list.
+    //
+    // ROOT CAUSE OF HELM GHOST (verified live 2026-05-05):
+    //   ExpandToMeshes returns u16=0x4213 (Kliff helm name).
+    //   safeTearDown resolves 0x4213 -> wrapper 0x4104E394BE0 (engine's
+    //   StringInfo entry's +0x18 = the SECOND src instance LT tracks).
+    //   But LT's pointer-swap (sub_140352AA0) installed target wrapper
+    //   0x4104A4B7C80 in parent+88's record. Engine searches for Kliff
+    //   src, doesn't find it, no unlink, helm renderable persists.
+    //
+    // FIX: hook this function entry, walk RDX's wrapper list, and for
+    // each entry that matches a Kliff src in s_swapMap, replace with
+    // the corresponding target. Engine then matches the target in
+    // parent+88, unlinks correctly, helm cleans up.
+    //
+    // After the call returns we RESTORE the original wrappers so the
+    // caller's refcount-release loop on the list decrements the same
+    // wrapper it incremented (no refcount imbalance).
+    using NaturalPipelineFn = std::int64_t(__fastcall *)(
+        std::int64_t a1, std::uint64_t *a2, std::uint64_t *a3);
+    static NaturalPipelineFn s_origNaturalPipeline = nullptr;
+    static std::atomic<std::uint64_t> s_natpipeHitCount{0};
+    static std::atomic<std::uint64_t> s_natpipeSubstCount{0};
+    static std::atomic<std::uint64_t> s_natpipeListEntries{0};
+    // sub_142711DF0 -- engine unlink fn. Resolved through
+    // k_naturalPipelineCandidates cascade in aob_resolver.hpp at install
+    // time (audit 2026-05-08); RVA literal removed.
+
+    // sub_1424DF420 -- name-based prefab lookup primitive.
+    // Signature: `__int64 fn(__int64 unused_a1, const char* name)`.
+    // Lowercases the name, interns it via sub_1403016B0, then queries
+    // the engine's name->wrapper registry at MEMORY[0x145DDF8B0]+0x50
+    // via sub_140FD6430. Returns entry+8 on hit (the value field of
+    // the registry entry, typically a wrapper-ptr or metadata-ptr)
+    // or 0 on miss. Pure read-only.
+    //
+    // This replaces the AppearanceTableLoader chain (sub_141D38810 /
+    // sub_140350910) which queries different sub-tables that don't
+    // contain partprefab names. The MEMORY[0x145DDF8B0] registry has
+    // 15,298 entries (live) including character body-mesh prefabs --
+    // the right table for our use case.
+    //
+    // Resolved through k_apptNameLookupCandidates cascade in
+    // aob_resolver.hpp at install time (audit 2026-05-08); RVA literal
+    // removed.
+
+    // Auto-deactivate-on-preset-switch state. After F10 activates and
+    // the user applies a body-mesh preset, we record those itemIds. The
+    // next apply with DIFFERENT itemIds is treated as a switch-away
+    // and triggers deactivate_for_clear before its substitutions can
+    // re-bind target wrappers to the new gear.
+    static std::mutex s_lastApplyMtx;
+    static std::uint16_t s_lastApplyItems[5] = {0, 0, 0, 0, 0};
+    static bool          s_lastApplyValid    = false;
+
+    // --- AppearanceTableLoader integration state (Goal A #5) ---
+    //
+    // Captured by the one-shot hook on sub_1408AF8F0. After capture,
+    // s_apptContainer is the heap object whose vtable (read-only check)
+    // matches k_apptContainerVtable below.
+    //
+    // Loader chain (verified 2026-05-06 via IDA decompile):
+    //   sub_1408AF8F0(a1)         -- entry; we snapshot a1 (outer struct)
+    //     v85 = a1[5] (= a1+40)   -- ResMgr (the 17-slot)
+    //     sub_14086A000(v85, ...) -- inside, allocates loader and stores
+    //                                at v85[11] (= ResMgr+88)
+    //
+    // After the trampoline returns, ResMgr is at *(QWORD*)(a1+40) and
+    // the loader is at *(QWORD*)(ResMgr+88). The PartPrefab container
+    // is at *(QWORD*)(loader+8) -- vtable 0x144D24308.
+    //
+    // The hook installs once, snapshots, and disarms its capture flag.
+    // Subsequent calls (which DO occur during world reload) are
+    // pass-through; we do NOT re-capture because the original boot
+    // singleton is the one used by every PartPrefab consumer.
+    // PartPrefab container vtable -- now resolved at init() through
+    // k_apptLoaderCtorCandidates + walk-forward (see
+    // resolve_appt_container_vtable). Stored in s_apptContainerVtable.
+    // Per sub_141E2DBB0 (the AppearanceTableLoader constructor), the
+    // loader allocates two containers and assigns final vtables:
+    //   a1[0] (_appearanceContainer)       -> off_144D24308 (v1.05.01)
+    //   a1[1] (_partPrefabDataContainer)   -> off_144D24358 (v1.05.01)
+    // <-- WE WANT THE SECOND ONE. The walk-forward helper picks the
+    // SECOND `lea rax,[rip+disp32]; mov [rdi],rax` pair inside the
+    // ctor.
+    static constexpr std::size_t k_apptResMgrOff       = 0x40;
+    static constexpr std::size_t k_apptLoaderOff       = 0x88;
+    static constexpr std::size_t k_apptContainerOff    = 0x08;
+
+    static std::atomic<std::uintptr_t> s_apptContainer{0};
+    static std::atomic<bool>           s_apptCaptureDone{false};
+    // s_apptResMgr / s_apptLoader / s_apptForceLoadEnabled removed
+    // 2026-05-07: only the container snapshot is consumed by
+    // lookup_prefab_metadata; ResMgr/Loader were write-only state and
+    // ForceLoad was a stub-only INI flag.
+
+    // Lookup primitives, resolved by AOB at init. Both must be
+    // non-null for lookup_prefab_metadata to succeed; they are
+    // resolved in init() before the capture hook is installed so we
+    // can invoke them as soon as the snapshot lands.
+    using ApptStringInternFn =
+        std::uintptr_t (__fastcall *)(const char *);
+    using ApptLookupFn = std::int64_t (__fastcall *)(
+        std::uintptr_t table_struct,
+        std::uintptr_t *key_wrapper_ptr);
+    // Name-based wrapper lookup. Pass any name string; receives back
+    // the value field (entry+8) of the matching registry entry, or 0
+    // on miss. Internally lowercases the name and interns it before
+    // querying MEMORY[0x145DDF8B0]+0x50. RVA-resolved at init.
+    using ApptNameLookupFn =
+        std::int64_t (__fastcall *)(std::int64_t unused_a1,
+                                    const char *name);
+    static ApptStringInternFn s_apptStringIntern = nullptr;
+    static ApptLookupFn       s_apptLookup       = nullptr;
+    static ApptNameLookupFn   s_apptNameLookup   = nullptr;
+
+    // Trampoline for the sub_1408AF8F0 entry hook.
+    using ApptResMgrInitFn = char (__fastcall *)(
+        std::int64_t a1, void *a2);
+    static ApptResMgrInitFn s_apptResMgrInitOrig = nullptr;
+
+    // Wrapper +0x40 slot inside the scene-graph struct (vtable 0x144ED9730).
+    static constexpr std::size_t k_sceneGraphWrapperOff = 0x40;
+    // Slot-id u32 lives at struct+0x48 (the factory writes *a3 there).
+    static constexpr std::size_t k_sceneGraphSlotIdOff  = 0x48;
+    // Helm slot ID -- the only slot that needs scene-graph reverse-write,
+    // because helm is the only pair with a suffix mismatch (`_d` -> `_c`)
+    // that routes through a separate scene-graph branch the engine's
+    // tear-down can't reach via runtime-resource-pointer equality. Other
+    // pairs preserve their suffix and unlink naturally on next apply,
+    // so reverting their +0x40 just confuses rendering (visible as
+    // chest/cloak clipping on preset-switch).
+    static constexpr std::uint32_t k_helmSlotId = 0xAA9A;
+
+    static std::atomic<std::uint64_t> s_callCount{0};
+    static std::atomic<std::uint64_t> s_substCount{0};
+
+    // --- SEH-isolated read/write helpers ---
+
+    static std::uint64_t read_qword_seh(const void *p) noexcept
+    {
+        std::uint64_t out = 0;
+        [&]() __declspec(noinline) {
+            __try { out = *static_cast<const volatile std::uint64_t *>(p); }
+            __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; }
+        }();
+        return out;
+    }
+
+    static std::uint32_t read_dword_seh(const void *p) noexcept
+    {
+        std::uint32_t out = 0;
+        [&]() __declspec(noinline) {
+            __try { out = *static_cast<const volatile std::uint32_t *>(p); }
+            __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; }
+        }();
+        return out;
+    }
+
+    static bool write_qword_seh(void *p, std::uint64_t value) noexcept
+    {
+        bool ok = false;
+        [&]() __declspec(noinline) {
+            __try { *static_cast<volatile std::uint64_t *>(p) = value; ok = true; }
+            __except (EXCEPTION_EXECUTE_HANDLER) { ok = false; }
+        }();
+        return ok;
+    }
+
+    static std::size_t read_cstr_seh(const void *p, char *out, std::size_t cap) noexcept
+    {
+        if (!p || cap == 0) return SIZE_MAX;
+        std::size_t len = SIZE_MAX;
+        [&]() __declspec(noinline) {
+            __try {
+                const auto *src = static_cast<const volatile char *>(p);
+                for (std::size_t i = 0; i < cap; ++i) {
+                    const char c = src[i];
+                    out[i] = c;
+                    if (c == 0) { len = i; return; }
+                }
+                out[cap - 1] = 0;
+                len = SIZE_MAX;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER) { len = SIZE_MAX; }
+        }();
+        return len;
+    }
+
+    // Bulk SEH-wrapped memcpy. One exception frame for the whole copy
+    // instead of one per field -- collapses ~5 SEH-guarded per-entry reads
+    // into a single 128B local copy during the StringInfo walk.
+    static bool bulk_copy_seh(const void *src, void *dst, std::size_t size) noexcept
+    {
+        bool ok = false;
+        [&]() __declspec(noinline) {
+            __try { std::memcpy(dst, src, size); ok = true; }
+            __except (EXCEPTION_EXECUTE_HANDLER) { ok = false; }
+        }();
+        return ok;
+    }
+
+    // Bumps a wrapper's refcount via Interlocked, gated on the same
+    // condition sub_14079DA20 uses (refcount field >= 0). No-op if
+    // wrapper is the sentinel or refcount is already negative
+    // ("static, do not refcount").
+    static void increment_wrapper_refcount(std::uintptr_t wrapper) noexcept
+    {
+        const auto vtableSentinel =
+            s_stringInfoVtable.load(std::memory_order_acquire);
+        if (wrapper == vtableSentinel || wrapper < 0x10000ULL)
+            return;
+        [&]() __declspec(noinline) {
+            __try {
+                auto *rc = reinterpret_cast<volatile LONG *>(wrapper + 16);
+                if (*rc >= 0)
+                    InterlockedIncrement(rc);
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER) {}
+        }();
+    }
+
+    // --- AppearanceTableLoader hook callback ---
+    //
+    // SafetyHook entry hook on sub_1408AF8F0. We invoke the trampoline
+    // first (so the engine's allocation path runs unmodified), then
+    // snapshot ResMgr / loader / container by walking the doc'd chain:
+    //
+    //   ResMgr     = *(QWORD*)(a1 + 0x40)
+    //   loader     = *(QWORD*)(ResMgr + 0x88)
+    //   container  = *(QWORD*)(loader + 0x08)
+    //
+    // After capture we validate the container's vtable
+    // (0x144D24308 == PartPrefabDataContainer) before publishing the
+    // pointers atomically. A single capture is enough -- subsequent
+    // sub_1408AF8F0 calls are pass-throughs.
+    static char __fastcall on_appt_resmgr_init(
+        std::int64_t a1, void *a2) noexcept
+    {
+        // Run the engine's path first. The capture must read fields
+        // that sub_14086A000 (called inside) populates.
+        char rv = 0;
+        if (s_apptResMgrInitOrig) {
+            [&]() __declspec(noinline) {
+                __try { rv = s_apptResMgrInitOrig(a1, a2); }
+                __except (EXCEPTION_EXECUTE_HANDLER) { rv = 0; }
+            }();
+        }
+
+        // Already captured? Pass-through.
+        if (s_apptCaptureDone.load(std::memory_order_acquire))
+            return rv;
+
+        auto &logger = DMK::Logger::get_instance();
+
+        std::uintptr_t resMgr    = 0;
+        std::uintptr_t loader    = 0;
+        std::uintptr_t container = 0;
+        std::uintptr_t vtable    = 0;
+        [&]() __declspec(noinline) {
+            __try {
+                resMgr = *reinterpret_cast<volatile std::uintptr_t *>(
+                    static_cast<std::uintptr_t>(a1) + k_apptResMgrOff);
+                if (resMgr < 0x10000ULL) return;
+                loader = *reinterpret_cast<volatile std::uintptr_t *>(
+                    resMgr + k_apptLoaderOff);
+                if (loader < 0x10000ULL) return;
+                container = *reinterpret_cast<volatile std::uintptr_t *>(
+                    loader + k_apptContainerOff);
+                if (container < 0x10000ULL) return;
+                vtable = *reinterpret_cast<volatile std::uintptr_t *>(
+                    container);
+            } __except (EXCEPTION_EXECUTE_HANDLER) {
+                resMgr = 0; loader = 0; container = 0; vtable = 0;
+            }
+        }();
+
+        // Validate. If any field is bogus, log and let the next call
+        // try again. This is safe: pass-through behavior is preserved.
+        const auto expectedVtable =
+            s_apptContainerVtable.load(std::memory_order_acquire);
+        if (container == 0 || vtable != expectedVtable) {
+            logger.debug(
+                "[prefab-swap] AppearanceTableLoader capture "
+                "deferred: a1=0x{:X} resMgr=0x{:X} loader=0x{:X} "
+                "container=0x{:X} vt=0x{:X} (expected 0x{:X})",
+                static_cast<std::uintptr_t>(a1),
+                resMgr, loader, container, vtable,
+                expectedVtable);
+            return rv;
+        }
+
+        s_apptContainer.store(container, std::memory_order_release);
+        s_apptCaptureDone.store(true, std::memory_order_release);
+
+        logger.info(
+            "[prefab-swap] AppearanceTableLoader captured: "
+            "resMgr=0x{:X} loader=0x{:X} container=0x{:X} "
+            "(vtable 0x{:X} verified)",
+            resMgr, loader, container, vtable);
+        return rv;
+    }
+
+    // (Removed 2026-05-07: aob_scan_for_container fallback +
+    // try_capture_container_via_aob wrapper. Both were a dormant
+    // fallback path for the case where the chain-based ResMgrInit
+    // hook missed; in practice the hook fires reliably and the
+    // fallback was never triggered. The full-memory writable-heap
+    // vtable scan was overkill for a path with no callers.)
+
+    // --- AppearanceTableLoader public API ---
+
+    bool is_loader_ready() noexcept
+    {
+        // The new RVA-resolved name lookup (sub_1424DF420) is self-
+        // contained: it queries MEMORY[0x145DDF8B0]+0x50 directly,
+        // so we no longer need the container capture / AOB scan
+        // machinery. Just check the function pointer is wired.
+        return s_apptNameLookup != nullptr;
+    }
+
+    std::uintptr_t lookup_prefab_metadata(const char *name) noexcept
+    {
+        if (!name || !*name) return 0;
+        if (!s_apptNameLookup) return 0;
+
+        // sub_1424DF420 handles the full lookup chain internally:
+        // lowercase → intern → query the global registry at
+        // MEMORY[0x145DDF8B0]+0x50. Returns entry+8 on hit (the
+        // value field; non-zero implies the prefab is registered
+        // and has a wrapper alive somewhere in the engine), or 0 on
+        // miss. Pure read-only; safe from any thread.
+        std::uintptr_t result = 0;
+        [&]() __declspec(noinline) {
+            __try {
+                result = static_cast<std::uintptr_t>(
+                    s_apptNameLookup(0, name));
+            } __except (EXCEPTION_EXECUTE_HANDLER) {
+                result = 0;
+            }
+        }();
+        return result;
+    }
+
+    // (Removed 2026-05-07: force_load_prefab documented stub.
+    // The orchestration call to sub_141E237C0 was out-of-scope research
+    // work that never landed; the public-API stub returned false in all
+    // builds. Removed alongside the s_apptForceLoadEnabled INI flag and
+    // the PrefabWrapperSwap_AttemptForceLoad INI key.)
+
+    // --- Per-slot catalog state (Goal B) ---
+    //
+    // Built lazily on first overlay open via populate_slot_catalogs().
+    // Each catalog holds the prefabs whose inline name starts with the
+    // slot-specific sub-prefix (e.g. "cd_phm_00_hel_00_"). Selection
+    // indices index into the catalog vector. -1 means "unset".
+    //
+    // Catalog mutex is separate from s_mapMtx so the UI thread can
+    // refresh without serializing with the active hot path. The hot
+    // path never reads catalogs; it reads s_swapMap (rebuilt from the
+    // catalog selections on hotkey press).
+    static std::mutex                                          s_catalogMtx;
+    static std::array<std::vector<PrefabEntry>,
+                      static_cast<std::size_t>(
+                          Transmog::TransmogSlot::Count)>      s_slotCatalogs;
+    // Per-slot picker selection state. Sentinel -1 means "no selection";
+    // any non-negative value indexes into the slot's catalog. The arrays
+    // are sized to TransmogSlot::Count, so the brace-init list cannot use
+    // a fixed length without drifting whenever a new slot is added. A
+    // helper returns an array filled with -1 instead, making the count a
+    // function of the enum size automatically.
+    static constexpr auto k_initialSelectionIndices = []() {
+        constexpr auto N =
+            static_cast<std::size_t>(Transmog::TransmogSlot::Count);
+        std::array<int, N> a{};
+        for (std::size_t i = 0; i < N; ++i)
+            a[i] = -1;
+        return a;
+    }();
+    static std::array<int,
+                      static_cast<std::size_t>(
+                          Transmog::TransmogSlot::Count)>      s_selSrcIdx
+        = k_initialSelectionIndices;
+    static std::array<int,
+                      static_cast<std::size_t>(
+                          Transmog::TransmogSlot::Count)>      s_selTgtIdx
+        = k_initialSelectionIndices;
+    static std::atomic<bool>                                   s_catalogPopulated{false};
+
+    // Slot prefix tables. The engine uses `cd_phm_*` for male body
+    // prefabs and `cd_phw_*` for female; both variants live in the
+    // same StringInfo registry and can be transmogged interchangeably.
+    // We carry parallel tables so classification matches either.
+    //
+    //   Helm   -> "cd_ph[mw]_00_hel_00_"
+    //   Chest  -> "cd_ph[mw]_00_ub_00_"
+    //   Cloak  -> "cd_ph[mw]_00_cloak_00_"
+    //   Gloves -> "cd_ph[mw]_00_hand_00_"
+    //   Boots  -> "cd_ph[mw]_00_foot_00_"
+    //
+    // `slot_prefix_str` returns the male variant (used by the UI for
+    // default name-stripping); the UI also strips the female variant
+    // when present, so cd_phw_* entries display compactly too.
+    // Body-mesh prefab prefixes per TransmogSlot. The body-mesh-swap
+    // module is armor-family ONLY; accessory/utility slots (Earring*,
+    // Necklace, Ring*, Lantern, Glasses, Mask, Backpack, Bracelet) do
+    // not live under cd_phm_*/cd_phw_* prefab families and are excluded
+    // by giving them an empty prefix. Callers (slot_prefix_str /
+    // populate_slot_catalogs / resolve_pairs_into_map) treat an empty
+    // string as "this slot is not body-mesh-swappable" -- the picker
+    // dropdown for that slot stays empty and the user routes through
+    // the normal carrier-based transmog path instead.
+    // (Removed 2026-05-07: k_slotPrefixes / k_slotPrefixesFemale.
+    // Per-slot prefab prefixes now live on slot_metadata.hpp's single
+    // SlotMetadata table -- access via slot_meta(slot).prefabPrefixMale
+    // and slot_meta(slot).prefabPrefixFemale. Same content; one source
+    // of truth for both genders alongside displayName, gameTag, and
+    // partShowHashKey.)
+
+    // --- Shared StringInfo walker (Phase 1 fast path) ---
+    //
+    // Extracted out of resolve_pairs_into_map so populate_slot_catalogs
+    // can reuse the bulk-copy + vtable filter + prefix gate without
+    // duplicating the SEH-isolated read setup. The visitor receives the
+    // entry pointer, decoded name, wrapper-ptr (entry+0x18) and hash
+    // (entry+0x00) for each entry whose vtable matches the StringInfo
+    // sentinel and whose inline name starts with `prefix`.
+    //
+    // Long-name entries (external string at +0x20 instead of inline)
+    // bypass the prefix gate and use Path B (wrapper-chain decode), so
+    // any caller passing a non-empty prefix still gets long names that
+    // happen to match the prefix in their decoded form.
+    //
+    // Returns total entries walked; logs walk timing at info level.
+    using EntryVisitor = std::function<void(
+        std::uintptr_t entry, const char *name,
+        std::uintptr_t wrapper, std::uint32_t hash)>;
+    static std::uint32_t walk_string_info(
+        const char *prefix, EntryVisitor visitor) noexcept
+    {
+        auto &logger = DMK::Logger::get_instance();
+        const std::size_t prefixLen = prefix ? std::strlen(prefix) : 0;
+
+        const auto regAbs =
+            s_stringInfoRegistry.load(std::memory_order_acquire);
+        if (regAbs < 0x10000ULL) {
+            logger.warning(
+                "[prefab-swap] walk_string_info: registry not "
+                "resolved (s_stringInfoRegistry=0). Returning 0 "
+                "entries; the picker dropdown will be empty until "
+                "init() succeeds.");
+            return 0;
+        }
+        const auto regAddr = reinterpret_cast<const void *>(regAbs);
+        const auto registryPtr = read_qword_seh(regAddr);
+        if (registryPtr < 0x10000ULL) return 0;
+        const auto count = read_dword_seh(
+            reinterpret_cast<const void *>(registryPtr + 8));
+        const auto arrayPtr = read_qword_seh(
+            reinterpret_cast<const void *>(registryPtr + 80));
+        if (count < k_minPlausibleCount || count > k_maxPlausibleCount ||
+            arrayPtr < 0x10000ULL)
+            return 0;
+
+        // Bulk-copy entry-pointer array (Phase 1 optimization) so the
+        // inner loop reads from process memory without a per-element
+        // SEH frame. Falls back to per-entry SEH reads if the bulk
+        // copy faults.
+        std::vector<std::uintptr_t> entryPtrs;
+        const std::size_t arrayBytes =
+            static_cast<std::size_t>(count) * sizeof(std::uintptr_t);
+        bool bulkOk = false;
+        if (arrayBytes > 0) {
+            entryPtrs.resize(count);
+            bulkOk = bulk_copy_seh(
+                reinterpret_cast<const void *>(arrayPtr),
+                entryPtrs.data(), arrayBytes);
+        }
+
+        const auto walkStart = std::chrono::steady_clock::now();
+        std::uint32_t scanned = 0;
+        std::uint32_t vtMatched = 0;
+        std::uint32_t prefMatched = 0;
+
+        // Same 128B header copy: covers vtable @ +8, wrapper-ptr @
+        // +0x18, and the inline-name region @ +0x20.
+        constexpr std::size_t k_headerBytes = 0x80;
+        alignas(8) std::uint8_t header[k_headerBytes];
+
+        // Path-B fallback decode for long names whose +0x20 holds an
+        // external string ptr instead of an inline NUL-terminated name.
+        auto decode_long_name =
+            [](std::uintptr_t entry, char *buf, std::size_t cap) -> bool
+        {
+            const auto wrapperPtr = read_qword_seh(
+                reinterpret_cast<const void *>(entry + k_wrapperPtrOff));
+            if (wrapperPtr < 0x10000ULL) return false;
+            const auto strPtr = read_qword_seh(
+                reinterpret_cast<const void *>(wrapperPtr));
+            if (strPtr < 0x10000ULL) return false;
+            const auto extLen = read_cstr_seh(
+                reinterpret_cast<const void *>(strPtr), buf, cap);
+            return extLen != SIZE_MAX && extLen > 0;
+        };
+
+        // Snapshot the resolved sentinel ONCE per walk -- avoids an
+        // atomic load per entry on a 30k-entry hot loop.
+        const auto vtableSentinel =
+            s_stringInfoVtable.load(std::memory_order_acquire);
+        if (vtableSentinel < 0x10000ULL) {
+            logger.warning(
+                "[prefab-swap] walk_string_info: StringInfo vtable "
+                "sentinel not resolved -- aborting walk");
+            return 0;
+        }
+
+        char buf[k_extNameMax + 1] = {0};
+        for (std::uint32_t i = 0; i < count; ++i) {
+            const std::uintptr_t entryPtr = bulkOk
+                ? entryPtrs[i]
+                : read_qword_seh(reinterpret_cast<const void *>(
+                      arrayPtr + 8ULL * i));
+            if (entryPtr < 0x10000ULL) continue;
+            ++scanned;
+
+            if (!bulk_copy_seh(reinterpret_cast<const void *>(entryPtr),
+                               header, k_headerBytes))
+                continue;
+
+            const std::uintptr_t vtable =
+                *reinterpret_cast<const std::uintptr_t *>(header + 8);
+            if (vtable != vtableSentinel) continue;
+            ++vtMatched;
+
+            // Prefix gate (only for inline-name entries -- skipped for
+            // long-name entries that route through Path B below).
+            const unsigned char first = header[k_inlineNameOff];
+            const bool printableLead =
+                (first >= 'a' && first <= 'z') ||
+                (first >= 'A' && first <= 'Z') ||
+                (first >= '0' && first <= '9') ||
+                first == '_' || first == '/' || first == '.';
+            if (prefixLen > 0 && printableLead &&
+                std::memcmp(header + k_inlineNameOff, prefix, prefixLen) != 0)
+                continue;
+            ++prefMatched;
+
+            // Decode name from local header (Path A) or fall back to
+            // wrapper-chain (Path B) for long external strings.
+            buf[0] = 0;
+            bool decoded = false;
+            {
+                const char *src =
+                    reinterpret_cast<const char *>(header + k_inlineNameOff);
+                const std::size_t maxLen = k_headerBytes - k_inlineNameOff;
+                std::size_t L = 0;
+                while (L < maxLen && src[L] != 0) ++L;
+                if (L > 0 && L < maxLen) {
+                    bool printable = true;
+                    for (std::size_t k = 0; k < L; ++k) {
+                        const unsigned char c =
+                            static_cast<unsigned char>(src[k]);
+                        if (!((c >= 'a' && c <= 'z') ||
+                              (c >= 'A' && c <= 'Z') ||
+                              (c >= '0' && c <= '9') ||
+                              c == '_' || c == '/' || c == '.' || c == '-'))
+                        { printable = false; break; }
+                    }
+                    if (printable) {
+                        std::memcpy(buf, src, L);
+                        buf[L] = 0;
+                        decoded = true;
+                    }
+                }
+            }
+            if (!decoded) {
+                if (!decode_long_name(entryPtr, buf, k_extNameMax))
+                    continue;
+                // Re-apply prefix filter to long-name entries that
+                // dodged the inline-prefix gate above.
+                if (prefixLen > 0 &&
+                    std::strncmp(buf, prefix, prefixLen) != 0)
+                    continue;
+            }
+
+            const std::uintptr_t entryWrapper =
+                *reinterpret_cast<const std::uintptr_t *>(
+                    header + k_wrapperPtrOff);
+            const std::uint32_t entryHash =
+                *reinterpret_cast<const std::uint32_t *>(header);
+
+            visitor(entryPtr, buf, entryWrapper, entryHash);
+        }
+
+        const auto walkMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - walkStart)
+                .count();
+        logger.info(
+            "[prefab-swap] StringInfo walk: count={} scanned={} "
+            "vtable-pass={} prefix-pass={} prefix=\"{}\" ({}ms)",
+            count, scanned, vtMatched, prefMatched,
+            (prefix && prefix[0]) ? prefix : "(none)", walkMs);
+
+        return scanned;
+    }
+
+    // Heap-walk for partprefabdyeslot-style wrappers (the registry pool
+    // 0x4104A* in CE notation). Used as Pass-2 fallback when StringInfo
+    // doesn't carry an entry for a configured name. Mirrors the heap
+    // walk in resolve_pairs_into_map -- kept as its own helper so
+    // apply_selections_to_swap_map can reuse it.
+    //
+    // For each name in `names`, appends matching wrapper addresses to
+    // `outSrcByName` (ALL matches per name) and writes the FIRST
+    // matching wrapper to `outTgtByName` (single-substitution target).
+    // Caller passes parallel vectors keyed by index.
+    static void heap_walk_partprefab_for_names(
+        const std::vector<std::string>                  &srcNames,
+        const std::vector<std::string>                  &tgtNames,
+        std::vector<std::vector<std::uintptr_t>>        &outSrcByIdx,
+        std::vector<std::uintptr_t>                     &outTgtByIdx) noexcept
+    {
+        if (srcNames.size() != outSrcByIdx.size() ||
+            tgtNames.size() != outTgtByIdx.size())
+            return;
+        SYSTEM_INFO si;
+        GetSystemInfo(&si);
+        const std::uintptr_t addrEnd =
+            reinterpret_cast<std::uintptr_t>(si.lpMaximumApplicationAddress);
+        std::uintptr_t addr =
+            reinterpret_cast<std::uintptr_t>(si.lpMinimumApplicationAddress);
+        while (addr < addrEnd) {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (VirtualQuery(reinterpret_cast<LPCVOID>(addr),
+                             &mbi, sizeof(mbi)) == 0)
+                break;
+            const auto regionBase =
+                reinterpret_cast<std::uintptr_t>(mbi.BaseAddress);
+            const auto regionSize = mbi.RegionSize;
+            const bool committed = (mbi.State == MEM_COMMIT);
+            const bool writable =
+                (mbi.Protect & (PAGE_READWRITE | PAGE_WRITECOPY |
+                                PAGE_EXECUTE_READWRITE)) != 0;
+            const bool guarded =
+                (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) != 0;
+            if (committed && writable && !guarded &&
+                regionSize >= 0x40 && regionSize < 0x40000000ULL)
+            {
+                const auto end = regionBase + regionSize - 0x40;
+                for (std::uintptr_t p = regionBase; p < end; p += 8) {
+                    const auto v = read_qword_seh(
+                        reinterpret_cast<const void *>(p));
+                    if (v != p + 0x18) continue;
+                    const auto len = read_dword_seh(
+                        reinterpret_cast<const void *>(p + 8));
+                    if (len == 0 || len >= k_extNameMax) continue;
+                    char nameBuf[k_extNameMax + 1] = {0};
+                    const auto rlen = read_cstr_seh(
+                        reinterpret_cast<const void *>(p + 0x18),
+                        nameBuf, k_extNameMax);
+                    if (rlen == SIZE_MAX || rlen != len) continue;
+
+                    for (std::size_t k = 0; k < srcNames.size(); ++k) {
+                        if (!srcNames[k].empty() &&
+                            std::strcmp(nameBuf, srcNames[k].c_str()) == 0)
+                            outSrcByIdx[k].push_back(p);
+                    }
+                    for (std::size_t k = 0; k < tgtNames.size(); ++k) {
+                        if (outTgtByIdx[k] == 0 &&
+                            !tgtNames[k].empty() &&
+                            std::strcmp(nameBuf, tgtNames[k].c_str()) == 0)
+                            outTgtByIdx[k] = p;
+                    }
+                }
+            }
+            addr = regionBase + regionSize;
+            if (regionSize == 0) break;
+        }
+    }
+
+    // (Removed 2026-05-07: resolve_pairs_into_map. The StringInfo-based
+    // resolver was the engine for the legacy [Research] INI Pair config
+    // (PrefabWrapperSwap_Pair{1..8}_Source/_Target). With INI gone,
+    // its only caller -- on_hotkey -- removed too, the function is
+    // dead. apply_selections_to_swap_map() drives swap-map construction
+    // from the picker UI now and reads pre-cached PrefabEntry::wrappers
+    // from the catalog -- no walk, no INI lookup. Body deleted; the
+    // matching helpers it inlined (decode_name, try_parse_hex_addr,
+    // longest-common-prefix probe, partprefabdyeslot heap walk) all
+    // went with it.)
+
+    // --- Per-slot catalog API (Goal B) ---
+
+    const char *slot_prefix_str(Transmog::TransmogSlot slot) noexcept
+    {
+        const auto idx = static_cast<std::size_t>(slot);
+        if (idx >= Transmog::k_slotCount) return "";
+        return Transmog::k_slotMetadata[idx].prefabPrefixMale;
+    }
+
+    bool is_catalog_populated() noexcept
+    {
+        return s_catalogPopulated.load(std::memory_order_acquire);
+    }
+
+    const std::vector<PrefabEntry> &slot_catalog(
+        Transmog::TransmogSlot slot) noexcept
+    {
+        // Static empty fallback so the reference return is always
+        // valid even before the catalog has been populated.
+        static const std::vector<PrefabEntry> s_empty;
+        const auto idx = static_cast<std::size_t>(slot);
+        if (idx >= s_slotCatalogs.size()) return s_empty;
+        return s_slotCatalogs[idx];
+    }
+
+    int selection_src_index(Transmog::TransmogSlot slot) noexcept
+    {
+        const auto idx = static_cast<std::size_t>(slot);
+        if (idx >= s_selSrcIdx.size()) return -1;
+        return s_selSrcIdx[idx];
+    }
+
+    int selection_tgt_index(Transmog::TransmogSlot slot) noexcept
+    {
+        const auto idx = static_cast<std::size_t>(slot);
+        if (idx >= s_selTgtIdx.size()) return -1;
+        return s_selTgtIdx[idx];
+    }
+
+    void set_selection(Transmog::TransmogSlot slot,
+                       int srcIdx, int tgtIdx) noexcept
+    {
+        const auto idx = static_cast<std::size_t>(slot);
+        if (idx >= s_selSrcIdx.size()) return;
+        // Clamp to catalog bounds; -1 explicitly allowed for "unset".
+        const auto catSize =
+            static_cast<int>(s_slotCatalogs[idx].size());
+        if (srcIdx < -1 || srcIdx >= catSize) srcIdx = -1;
+        if (tgtIdx < -1 || tgtIdx >= catSize) tgtIdx = -1;
+        s_selSrcIdx[idx] = srcIdx;
+        s_selTgtIdx[idx] = tgtIdx;
+    }
+
+    int adopt_into_slot_and_select(Transmog::TransmogSlot intoSlot,
+                                   Transmog::TransmogSlot fromSlot,
+                                   int fromIdx) noexcept
+    {
+        const auto into = static_cast<std::size_t>(intoSlot);
+        const auto from = static_cast<std::size_t>(fromSlot);
+        if (into >= s_slotCatalogs.size()) return -1;
+        if (from >= s_slotCatalogs.size()) return -1;
+        if (fromIdx < 0) return -1;
+        std::scoped_lock lk(s_catalogMtx);
+        if (static_cast<std::size_t>(fromIdx) >= s_slotCatalogs[from].size())
+            return -1;
+        const auto entry = s_slotCatalogs[from][fromIdx]; // copy
+        // Dedup by name in intoSlot's catalog.
+        auto &dst = s_slotCatalogs[into];
+        int existing = -1;
+        for (std::size_t i = 0; i < dst.size(); ++i) {
+            if (dst[i].name == entry.name) { existing = static_cast<int>(i); break; }
+        }
+        const int newIdx =
+            (existing >= 0)
+                ? existing
+                : (dst.push_back(entry), static_cast<int>(dst.size() - 1));
+        s_selTgtIdx[into] = newIdx;
+        return newIdx;
+    }
+
+    bool has_any_selection() noexcept
+    {
+        for (std::size_t i = 0; i < s_selSrcIdx.size(); ++i) {
+            if (s_selSrcIdx[i] >= 0 && s_selTgtIdx[i] >= 0)
+                return true;
+        }
+        return false;
+    }
+
+    // --- Loader-registry enumeration (Goal C: NPC body-mesh pickup) ---
+    //
+    // The StringInfo registry at MEMORY[0x145EF1DE8] holds the prefab
+    // wrappers that are *currently resident* in the player-character
+    // pipeline (typically just the player's loaded set). Body-mesh
+    // prefabs for NPCs (cd_nh*) and unloaded player variants live in a
+    // SECOND registry: the AppearanceTableLoader's own name table at
+    // MEMORY[0x145DDF8B0] + 0x50 (singleton dereferenced once at boot).
+    //
+    // Layout (verified live 2026-05-06, 15,298 entries on a fresh boot):
+    //   table_struct = *(QWORD*)0x145DDF8B0 + 0x50
+    //     +0x00 bucket_count u32
+    //     +0x04 count        u32
+    //     +0x08 capacity     u32
+    //     +0x10 bucket_array
+    //     +0x18 data_array_ptr -> pointer[count]
+    //
+    //   data_array[i] -> entry_struct (24 bytes typical)
+    //     +0x00 hash u32 + region u32
+    //     +0x08 key_wrapper_ptr (interned-name wrapper)
+    //     +0x10 value_wrapper_ptr (the partprefabdyeslot wrapper our
+    //                              hook substitutes -- this is the
+    //                              one we want to add to the catalog)
+    //
+    //   wrapper_ptr (+0x10 in entry):
+    //     +0x00 ptr-to-self+0x18 (string interner self-pointer)
+    //     +0x08 length u32
+    //     +0x0C hash u32
+    //     +0x18 inline NUL-terminated name
+    //
+    // Naming convention difference vs StringInfo:
+    //   File path : cd_nhw_00_no_ub_00_20027  (with _00_ markers)
+    //   Reg key   : cd_nhw_no_ub_20027        (no _00_ markers)
+    // Slot classification needs to handle BOTH forms -- we look for the
+    // bare slot tag (`_hel_`, `_ub_`, `_cloak_`, `_hand_`, `_foot_`)
+    // rather than the `_<tag>_00_` form used by StringInfo entries.
+    //
+    // Wrappers from this registry are merged into existing catalog
+    // entries by name (deduped + sorted within each PrefabEntry's
+    // wrappers vector); names not yet in the catalog are inserted as
+    // fresh entries with the registry wrapper as the sole instance.
+    // Loader registry singleton -- resolved through s_loaderRegistry-
+    // Singleton at init() (was hardcoded 0x145DDF8B0). The +0x50 offset
+    // walks into the table struct: a stable game-ABI offset, kept literal.
+    constexpr std::size_t    k_loaderRegistryTableOff     = 0x50;
+
+    static std::size_t enumerate_loader_registry_into_catalog() noexcept
+    {
+        auto &logger = DMK::Logger::get_instance();
+        const auto walkStart = std::chrono::steady_clock::now();
+        constexpr std::size_t k_slotN =
+            static_cast<std::size_t>(Transmog::TransmogSlot::Count);
+
+        // Slot tag substrings (BARE form -- registry uses no `_00_` markers).
+        // Each row is a null-terminated list of substring patterns; an
+        // entry is added to the slot if ANY pattern matches. The
+        // classifier loop OR's across patterns AND across slots (a 1H
+        // sword name lands in MainHand AND OffHand AND SubWeapon's
+        // catalog, a ring lands in both Ring1 and Ring2). Single-tag
+        // rows still work; trailing nullptrs terminate the list.
+        //
+        // Gendered weapon slots accept BOTH `_phm_*` (male model) and
+        // `_phw_*` (female model) prefixes so Damiane's `cd_phw_01_*`
+        // weapons land in the same catalogs Kliff's `cd_phm_01_*`
+        // counterparts do. Without this the secondary-paired and
+        // female-character weapon catalogs end up empty and src
+        // seeding fails (which hides the Prefabs picker checkbox).
+        // Ranged covers bows (_04_), pistols (_06_), and cannons
+        // (_13_) for the cross-character ranged families captured in
+        // carrier_defaults.hpp.
+        static constexpr std::size_t k_slotTagMax = 8;
+        static constexpr const char *k_slotTagPatterns[k_slotN][k_slotTagMax] = {
+            { "_hel_",            nullptr },                                // Helm
+            { "_ub_",              nullptr },                                // Chest
+            { "_cloak_",           nullptr },                                // Cloak
+            { "_hand_",            nullptr },                                // Gloves
+            { "_foot_",            nullptr },                                // Boots
+            { "_earring_",         nullptr },                                // Earring1
+            { "_earring_",         nullptr },                                // Earring2
+            { "_necklace_",        nullptr },                                // Necklace
+            { "_ring_",            nullptr },                                // Ring1 (paired)
+            { "_ring_",            nullptr },                                // Ring2
+            { "_lantern_",         nullptr },                                // Lantern
+            { "_glasses_",         nullptr },                                // Glasses
+            { "_mask_00_",         nullptr },                                // Mask
+            { "_bag_0",            nullptr },                                // Backpack
+            { "_rinkband_",        nullptr },                                // Bracelet
+            { "_phm_01_",          "_phw_01_",         nullptr },            // MainHand
+            { "_phm_01_",          "_phw_01_",         "_03_shield_",
+              nullptr },                                                     // OffHand (1H + shields)
+            { "_phm_04_",          "_phw_04_",
+              "_phm_06_",          "_phw_06_",
+              "_phm_13_",          "_phw_13_",         nullptr },            // Ranged
+            { "_phm_01_dagger_",   "_phw_01_dagger_",  nullptr },            // SubWeapon
+            { "_phm_02_",          "_phw_02_",         nullptr },            // TwoHandWeapon
+        };
+
+        // Snapshot resolved sentinel (one atomic load per scan).
+        const auto vtableSentinel =
+            s_stringInfoVtable.load(std::memory_order_acquire);
+
+        // Step 1: dereference the singleton, walk to the table struct.
+        const auto singletonAbs =
+            s_loaderRegistrySingleton.load(std::memory_order_acquire);
+        if (singletonAbs < 0x10000ULL) {
+            logger.warning(
+                "[prefab-swap] Loader registry singleton not "
+                "resolved -- skip enumeration");
+            return 0;
+        }
+        const auto singletonPtr = read_qword_seh(
+            reinterpret_cast<const void *>(singletonAbs));
+        if (singletonPtr < 0x10000ULL) {
+            logger.warning(
+                "[prefab-swap] Loader registry singleton "
+                "@0x{:X} unreadable -- skip enumeration",
+                singletonAbs);
+            return 0;
+        }
+        const std::uintptr_t tableStruct =
+            singletonPtr + k_loaderRegistryTableOff;
+
+        // Step 2: read count + data_array_ptr, sanity-check.
+        const auto count = read_dword_seh(
+            reinterpret_cast<const void *>(tableStruct + 0x04));
+        const auto dataArrayPtr = read_qword_seh(
+            reinterpret_cast<const void *>(tableStruct + 0x18));
+        if (count == 0 || count > 100000 || dataArrayPtr < 0x10000ULL) {
+            logger.warning(
+                "[prefab-swap] Loader registry sanity failed: "
+                "count={} dataArrayPtr=0x{:X} (table @0x{:X}) -- "
+                "skip enumeration",
+                count, dataArrayPtr, tableStruct);
+            return 0;
+        }
+
+        // Step 3: bulk-copy the data-array pointer table (Phase-1 perf
+        // pattern -- one SEH frame for the whole array, then per-entry
+        // reads against process memory).
+        std::vector<std::uintptr_t> entryPtrs;
+        const std::size_t arrayBytes =
+            static_cast<std::size_t>(count) * sizeof(std::uintptr_t);
+        bool bulkOk = false;
+        if (arrayBytes > 0) {
+            entryPtrs.resize(count);
+            bulkOk = bulk_copy_seh(
+                reinterpret_cast<const void *>(dataArrayPtr),
+                entryPtrs.data(), arrayBytes);
+        }
+
+        // Step 4: walk entries, classify by slot tag, collect (name,
+        // wrapper) pairs into per-slot vectors. Deferred merge into
+        // s_slotCatalogs after the walk so the catalog mutex isn't
+        // held during the scan.
+        struct Pending {
+            std::string    name;
+            std::uintptr_t wrapper;
+        };
+        std::array<std::vector<Pending>, k_slotN> pending;
+        for (auto &v : pending) v.reserve(512);
+
+        std::uint32_t scanned     = 0;
+        std::uint32_t prefixMatch = 0;
+        char nameBuf[k_extNameMax + 1] = {0};
+
+        for (std::uint32_t i = 0; i < count; ++i) {
+            const std::uintptr_t entry = bulkOk
+                ? entryPtrs[i]
+                : read_qword_seh(reinterpret_cast<const void *>(
+                      dataArrayPtr + 8ULL * i));
+            if (entry < 0x10000ULL) continue;
+            ++scanned;
+
+            // Read KEY wrapper-ptr at entry+0x08. The KEY wrapper holds
+            // the inline prefab name in the standard partprefabdyeslot
+            // format (+0x18 string buffer) -- the same format the body-
+            // mesh hook substitutes by pointer equality. The +0x10
+            // VALUE wrapper is a metadata struct (counts/IDs), not a
+            // name-bearing wrapper, so reading +0x18 there gives junk
+            // and the prefix gate filters everything out.
+            const auto wrapper = read_qword_seh(
+                reinterpret_cast<const void *>(entry + 0x08));
+            if (wrapper < 0x10000ULL) continue;
+            // Skip the StringInfo vtable sentinel (registry can hold
+            // metadata-only entries that aren't partprefab wrappers).
+            if (wrapper == vtableSentinel) continue;
+
+            // Read inline name at wrapper+0x18 (max 96 chars per spec
+            // but we use k_extNameMax==256 for the buffer cap).
+            constexpr std::size_t k_loaderNameCap = 96;
+            const auto rlen = read_cstr_seh(
+                reinterpret_cast<const void *>(wrapper + 0x18),
+                nameBuf, k_loaderNameCap);
+            if (rlen == SIZE_MAX || rlen == 0) continue;
+
+            // Body-mesh prefix gate: cd_ph (player) OR cd_nh (NPC).
+            // Cheap byte-compare avoids strlen on every entry.
+            if (!(nameBuf[0] == 'c' && nameBuf[1] == 'd' &&
+                  nameBuf[2] == '_'))
+                continue;
+            if (!(nameBuf[3] == 'p' || nameBuf[3] == 'n'))
+                continue;
+            if (nameBuf[4] != 'h') continue;
+            ++prefixMatch;
+
+            // Slot classification by bare tag substring. NO break:
+            // names matching multiple slots (e.g. `cd_phm_01_dagger_*`
+            // matches both MainHand's `_phm_01_` and SubWeapon's
+            // `_phm_01_dagger_`) intentionally land in every matching
+            // catalog. This is what populates the secondary paired
+            // slots (Ring2, OffHand) so their src can seed and the
+            // Prefabs picker checkbox shows.
+            for (std::size_t si = 0; si < k_slotN; ++si) {
+                bool matched = false;
+                for (std::size_t pi = 0; pi < k_slotTagMax; ++pi) {
+                    const char *pat = k_slotTagPatterns[si][pi];
+                    if (!pat) break;
+                    if (std::strstr(nameBuf, pat) != nullptr) {
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched) continue;
+                Pending p;
+                p.name    = std::string(nameBuf, rlen);
+                p.wrapper = wrapper;
+                pending[si].push_back(std::move(p));
+            }
+        }
+
+        // Step 5: merge into s_slotCatalogs. Two cases per pending:
+        //   a) name already present -> append wrapper to existing
+        //      PrefabEntry::wrappers (sorted + deduped).
+        //   b) name absent -> insert a fresh PrefabEntry with the
+        //      registry wrapper as the sole instance.
+        std::array<std::size_t, k_slotN> addedCount{};
+        std::array<std::size_t, k_slotN> mergedCount{};
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            for (std::size_t si = 0; si < k_slotN; ++si) {
+                auto &cat = s_slotCatalogs[si];
+                // Build an index for O(1) name->idx lookup. The
+                // catalogs are alphabetically sorted by name at this
+                // point so we could lower_bound, but a hash map is
+                // simpler and the catalogs are small (<2k entries).
+                std::unordered_map<std::string, std::size_t> idxByName;
+                idxByName.reserve(cat.size() * 2);
+                for (std::size_t ei = 0; ei < cat.size(); ++ei)
+                    idxByName.emplace(cat[ei].name, ei);
+
+                for (auto &p : pending[si]) {
+                    const auto it = idxByName.find(p.name);
+                    if (it != idxByName.end()) {
+                        // Merge: append + sort + unique.
+                        auto &e = cat[it->second];
+                        e.wrappers.push_back(p.wrapper);
+                        std::sort(e.wrappers.begin(), e.wrappers.end());
+                        e.wrappers.erase(
+                            std::unique(e.wrappers.begin(),
+                                        e.wrappers.end()),
+                            e.wrappers.end());
+                        ++mergedCount[si];
+                    } else {
+                        // Insert fresh entry.
+                        PrefabEntry e;
+                        e.name      = p.name;
+                        e.wrappers  = {p.wrapper};
+                        e.hash      = 0;     // filled by enrichment
+                        e.metadata  = 0;     // filled by enrichment
+                        e.is_loaded = true;  // wrapper present
+                        idxByName.emplace(e.name, cat.size());
+                        cat.push_back(std::move(e));
+                        ++addedCount[si];
+                    }
+                }
+
+                // Re-sort catalog alphabetically (insertions broke
+                // the invariant). Dedup by name as defensive measure
+                // -- shouldn't fire because idxByName guards inserts,
+                // but cheap relative to the sort.
+                std::sort(cat.begin(), cat.end(),
+                          [](const PrefabEntry &a, const PrefabEntry &b) {
+                              return a.name < b.name;
+                          });
+                cat.erase(std::unique(cat.begin(), cat.end(),
+                                      [](const PrefabEntry &a,
+                                         const PrefabEntry &b) {
+                                          return a.name == b.name;
+                                      }),
+                          cat.end());
+            }
+        }
+
+        const auto walkMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - walkStart)
+                .count();
+        std::size_t totalAdded = 0;
+        std::size_t totalMerged = 0;
+        for (std::size_t i = 0; i < k_slotN; ++i) {
+            totalAdded  += addedCount[i];
+            totalMerged += mergedCount[i];
+        }
+        logger.info(
+            "[prefab-swap] Loader registry enumeration: "
+            "walked={} entries, scanned={} body-mesh-prefix={} "
+            "added {} new prefabs, merged {} into existing "
+            "(helm={} chest={} cloak={} gloves={} boots={}) ({}ms)",
+            count, scanned, prefixMatch, totalAdded, totalMerged,
+            addedCount[0], addedCount[1], addedCount[2],
+            addedCount[3], addedCount[4], walkMs);
+
+        return totalAdded;
+    }
+
+    std::size_t populate_slot_catalogs() noexcept
+    {
+        auto &logger = DMK::Logger::get_instance();
+        const auto walkStart = std::chrono::steady_clock::now();
+
+        // Build a single shared catalog from one StringInfo walk; copy
+        // it into every slot's local vector. Per-slot tag filtering was
+        // removed 2026-05-08 -- accessory slots (Earring/Necklace) had
+        // empty filter tags and produced empty catalogs, and the
+        // gendered-prefix variants left several female-side picker
+        // dropdowns empty (e.g. cd_phw_00_ring_* has 0 entries while
+        // Damiane's actual ring carriers are cd_phm_00_ring_*). With
+        // every slot showing the full body-mesh family the user can
+        // pick anything; the search box already filters by name.
+        constexpr std::size_t k_slotN =
+            static_cast<std::size_t>(Transmog::TransmogSlot::Count);
+        std::array<std::vector<PrefabEntry>, k_slotN> local;
+
+        // Broad prefix gates the walk to body-mesh entries. The 3-char
+        // gate "cd_" admits ALL character-prefab families:
+        //   cd_phm_00_*       player human male
+        //   cd_phw_00_*       player human female
+        //   cd_nhm_*          NPC human male
+        //   cd_nhw_*          NPC human female (incl. cd_nhw_00_no_*)
+        //   cd_t0000_*        gender-shared accessory family (lanterns)
+        //   cd_m0001_*        creature/monster mesh families
+        //   cd_*              any future variant the engine ships
+        // The vtable filter (0x145BC4638) inside walk_string_info drops
+        // the bulk of non-body StringInfo entries before this visitor
+        // ever runs.
+        constexpr const char *k_broadPrefix = "cd_";
+
+        std::vector<PrefabEntry> shared;
+        const auto total = walk_string_info(
+            k_broadPrefix,
+            [&](std::uintptr_t /*entry*/, const char *name,
+                std::uintptr_t wrapper, std::uint32_t hash) {
+                if (wrapper < 0x10000ULL) return;
+                // Seed with the StringInfo wrapper as the canonical
+                // first instance; the boot-time heap walk below merges
+                // parallel pool wrappers (0x4104A*) into the same
+                // vector. metadata + is_loaded are filled in below
+                // once the catalog is sorted.
+                PrefabEntry e;
+                e.name      = std::string(name);
+                e.wrappers  = {wrapper};
+                e.hash      = hash;
+                e.metadata  = 0;     // filled post-walk
+                e.is_loaded = true;  // wrapper present
+                shared.push_back(std::move(e));
+            });
+        (void)total;
+
+        // Sort + dedup once on the shared catalog, then copy to each
+        // slot. Sorting before copy means the slot vectors are already
+        // sorted (the per-slot sort/dedup pass below becomes a no-op
+        // for them -- left in place to handle any future per-slot
+        // additions, e.g. enumerate_loader_registry_into_catalog).
+        std::sort(shared.begin(), shared.end(),
+                  [](const PrefabEntry &a, const PrefabEntry &b) {
+                      return a.name < b.name;
+                  });
+        shared.erase(std::unique(shared.begin(), shared.end(),
+                                 [](const PrefabEntry &a,
+                                    const PrefabEntry &b) {
+                                     return a.name == b.name;
+                                 }),
+                     shared.end());
+        for (std::size_t i = 0; i < k_slotN; ++i)
+            local[i] = shared;
+
+        // Sort each slot's entries alphabetically (UX) and dedup by
+        // name (StringInfo can carry parallel allocations of the same
+        // name; the dropdown should show one row per logical prefab).
+        std::array<std::size_t, k_slotN> counts{};
+        for (std::size_t i = 0; i < k_slotN; ++i) {
+            auto &v = local[i];
+            std::sort(v.begin(), v.end(),
+                      [](const PrefabEntry &a, const PrefabEntry &b) {
+                          return a.name < b.name;
+                      });
+            v.erase(std::unique(v.begin(), v.end(),
+                                [](const PrefabEntry &a,
+                                   const PrefabEntry &b) {
+                                    return a.name == b.name;
+                                }),
+                    v.end());
+            counts[i] = v.size();
+        }
+
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            for (std::size_t i = 0; i < k_slotN; ++i)
+                s_slotCatalogs[i] = std::move(local[i]);
+            // Reset selections that point past the new catalog size --
+            // a refresh after the catalog shrinks would otherwise leave
+            // stale indices referencing freed entries.
+            for (std::size_t i = 0; i < k_slotN; ++i) {
+                const auto sz = static_cast<int>(s_slotCatalogs[i].size());
+                if (s_selSrcIdx[i] >= sz) s_selSrcIdx[i] = -1;
+                if (s_selTgtIdx[i] >= sz) s_selTgtIdx[i] = -1;
+            }
+
+            // Auto-seed of src selections from INI pairs has been
+            // MOVED below to run AFTER enumerate_loader_registry_into_
+            // catalog(). That call adds thousands of entries and re-
+            // sorts each slot's vector, which would invalidate any
+            // index seeded here.
+        }
+
+        // --- Heap-walk merge: cache parallel-pool wrappers per name ---
+        //
+        // The StringInfo walk above seeded each PrefabEntry with the
+        // entry+0x18 wrapper (pool 0x4104E*). The engine ALSO sources
+        // wrappers from a parallel partprefabdyeslot pool (e.g.
+        // 0x4104A*) which is NOT in StringInfo. Previously each picker
+        // pick re-walked all writable heap regions to find these (~7s
+        // per pick). Walk ONCE here at boot for ALL cataloged names --
+        // single pass cost is the same for N names as for 1 because
+        // the dominant cost is the heap traversal itself.
+        //
+        // Pass empty tgtNames so only the src side runs; we want all
+        // wrappers per name regardless of src/tgt classification (the
+        // catalog is symmetric -- any entry can be either role).
+        const auto hwStart = std::chrono::steady_clock::now();
+        std::vector<std::string> allNames;
+        struct LocRef { std::size_t slot, idx; };
+        std::vector<LocRef> allLocs;
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            std::size_t reserve = 0;
+            for (std::size_t si = 0; si < k_slotN; ++si)
+                reserve += s_slotCatalogs[si].size();
+            allNames.reserve(reserve);
+            allLocs.reserve(reserve);
+            for (std::size_t si = 0; si < k_slotN; ++si) {
+                for (std::size_t ei = 0;
+                     ei < s_slotCatalogs[si].size(); ++ei)
+                {
+                    allNames.push_back(s_slotCatalogs[si][ei].name);
+                    allLocs.push_back({si, ei});
+                }
+            }
+        }
+
+        std::vector<std::vector<std::uintptr_t>> outBySrc(allNames.size());
+        std::vector<std::uintptr_t>              outTgt(allNames.size(), 0);
+        std::size_t totalWrappers = 0;
+        if (!allNames.empty()) {
+            heap_walk_partprefab_for_names(
+                allNames, /*tgtNames=*/{}, outBySrc, outTgt);
+
+            std::scoped_lock lk(s_catalogMtx);
+            for (std::size_t i = 0; i < allLocs.size(); ++i) {
+                const auto si = allLocs[i].slot;
+                const auto ei = allLocs[i].idx;
+                if (si >= s_slotCatalogs.size() ||
+                    ei >= s_slotCatalogs[si].size())
+                    continue;
+                auto &e = s_slotCatalogs[si][ei];
+                for (auto w : outBySrc[i]) e.wrappers.push_back(w);
+                std::sort(e.wrappers.begin(), e.wrappers.end());
+                e.wrappers.erase(
+                    std::unique(e.wrappers.begin(), e.wrappers.end()),
+                    e.wrappers.end());
+                totalWrappers += e.wrappers.size();
+            }
+        }
+        const auto hwMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - hwStart)
+                .count();
+
+        // --- Loader-registry enumeration (Goal C) ---
+        //
+        // Pulls in NPC + unloaded body-mesh prefabs from the
+        // AppearanceTableLoader's name registry at
+        // MEMORY[0x145DDF8B0]+0x50 (15k+ entries). StringInfo walk
+        // above only sees prefabs currently bound into the player
+        // pipeline; this fills in the rest so the picker can target
+        // any body-mesh asset the engine knows about.
+        //
+        // Order matters: runs AFTER the StringInfo walk + heap walk
+        // (so existing entries get their parallel-pool wrappers
+        // merged first), and BEFORE metadata enrichment (so newly
+        // added entries also get their metadata cross-reference).
+        enumerate_loader_registry_into_catalog();
+
+        // Cross-slot union pass. enumerate_loader_registry adds NPC
+        // entries to a SINGLE slot per name (the one whose tag pattern
+        // matches, e.g. `cd_nhw_no_ub_20027` lands only in Chest).
+        // The cross-slot prefab-mode tab in the picker reads slot 0's
+        // catalog and expects a true union, so without this pass all
+        // chest-only / cloak-only / boots-only / gloves-only NPC
+        // additions are invisible in any other slot's prefab dropdown.
+        // Merge by name (preserve wrappers/metadata of the first row
+        // seen for that name) and copy the resulting union back into
+        // every LT-managed slot.
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            std::unordered_map<std::string, PrefabEntry> unionByName;
+            unionByName.reserve(20000);
+            for (std::size_t si = 0; si < k_slotN; ++si) {
+                for (const auto &e : s_slotCatalogs[si]) {
+                    auto [it, inserted] = unionByName.emplace(e.name, e);
+                    if (!inserted) {
+                        // Same name already present -- merge wrapper
+                        // pointers so the union row carries every
+                        // pool variant (parallel-pool wrappers vary
+                        // across slot-specific enumerate adds).
+                        auto &dst = it->second.wrappers;
+                        for (auto w : e.wrappers) dst.push_back(w);
+                        std::sort(dst.begin(), dst.end());
+                        dst.erase(std::unique(dst.begin(), dst.end()),
+                                  dst.end());
+                    }
+                }
+            }
+            std::vector<PrefabEntry> unionVec;
+            unionVec.reserve(unionByName.size());
+            for (auto &kv : unionByName)
+                unionVec.push_back(std::move(kv.second));
+            std::sort(unionVec.begin(), unionVec.end(),
+                      [](const PrefabEntry &a, const PrefabEntry &b) {
+                          return a.name < b.name;
+                      });
+            for (std::size_t si = 0; si < k_slotN; ++si)
+                s_slotCatalogs[si] = unionVec;
+            // Selection indices were valid against pre-union catalogs.
+            // Re-clamp / re-resolve by name so any picks survive the
+            // re-sort. NOTE: this assumes selections were set by name
+            // earlier (preset_manager does this); session-only picks
+            // made before populate_slot_catalogs runs will have
+            // already been clamped to the post-enumerate sort, so the
+            // additional re-sort here may shift their indices. The
+            // runtime cost is one bounds clamp; acceptable.
+            for (std::size_t i = 0; i < k_slotN; ++i) {
+                const auto sz = static_cast<int>(s_slotCatalogs[i].size());
+                if (s_selSrcIdx[i] >= sz) s_selSrcIdx[i] = -1;
+                if (s_selTgtIdx[i] >= sz) s_selTgtIdx[i] = -1;
+            }
+        }
+
+        // (Removed 2026-05-07: INI-pair src auto-seed block. Read
+        // s_pairs[k_maxPairs] (always empty since INI keys are gone)
+        // and seeded s_selSrcIdx for matching slots. The hardcoded
+        // k_defaultSrcByEnumSlot defaults below now own the seeding.)
+
+        // --- AppearanceTableLoader metadata enrichment ---
+        //
+        // Cross-references each catalog entry against the engine's
+        // name->wrapper registry at MEMORY[0x145DDF8B0]+0x50 via
+        // sub_1424DF420 (RVA-resolved). Cheap: no full-heap AOB scan
+        // anymore, just one direct call per name. The legacy AOB
+        // fallback for the AppearanceTableLoader container is now
+        // dormant -- the new primitive is self-contained.
+
+        // For every catalog entry seeded above (StringInfo-resident),
+        // ask the loader whether it knows about the same name. We
+        // record the metadata pointer so the picker / future force-
+        // load logic can verify the engine's catalog membership.
+        // is_loaded stays true here -- the entry came from a
+        // StringInfo walk so a wrapper IS resident.
+        //
+        // Iterating the loader's full 252,480-entry container to
+        // surface NOT-YET-loaded prefabs would require walking the
+        // hash-bucket structure inside the container. The bucket
+        // shape is documented (vtable 0x144D24308, +0x68/+0x70 hash
+        // buckets) but iteration semantics + lock acquisition
+        // discipline are not. The safer path is the on-demand lookup
+        // already exposed via `lookup_prefab_metadata` -- the picker
+        // can call it when the user types a name not in the catalog
+        // and surface a synthetic "(unloaded)" entry on a hit.
+        //
+        // SEH-isolated: lookup may touch engine memory if the loader
+        // captured during this populate cycle.
+        std::size_t metaEnriched = 0;
+        if (is_loader_ready())
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            for (auto &cat : s_slotCatalogs) {
+                for (auto &e : cat) {
+                    const auto m = lookup_prefab_metadata(e.name.c_str());
+                    if (m) {
+                        e.metadata = m;
+                        ++metaEnriched;
+                    }
+                }
+            }
+        }
+        if (is_loader_ready()) {
+            logger.info(
+                "[prefab-swap] Catalog metadata enrichment: "
+                "{} entries cross-referenced against the "
+                "AppearanceTableLoader catalog.",
+                metaEnriched);
+        } else {
+            logger.debug(
+                "[prefab-swap] Catalog metadata enrichment "
+                "skipped -- AppearanceTableLoader not yet captured.");
+        }
+
+        // Publish AFTER the heap-walk merge so apply paths waiting on
+        // the catalog see fully-resolved wrapper vectors (no partial
+        // single-wrapper data leaking into the swap map).
+        s_catalogPopulated.store(true, std::memory_order_release);
+
+        // Seed default Kliff source-carrier selection per slot. These
+        // are the canonical "Kairos / Kliff plate" mesh names every
+        // protagonist transmog rides on (Kliff today; Oongka and
+        // Damiane fall back to the same defaults until per-character
+        // selection lands). The user picks targets via the dropdown;
+        // the source side stays sticky to these defaults so picking a
+        // target alone is enough to render a swap.
+        //
+        // Per-slot default src prefab names live in
+        // carrier_defaults.hpp::k_carriers[char][slot].prefabName.
+        // Picks the row matching the currently-active character (falls
+        // back to Kliff if not yet set or unrecognized). The loop
+        // below skips empty prefab strings so adding a slot without
+        // a captured default for the current character is safe -- no
+        // null-deref's. (Replaces 2026-05-07 trap where the prior
+        // k_defaultSrcByEnumSlot was sized 5 with trailing nullptrs
+        // that crashed strcmp once a non-armor slot populated.)
+        const auto &activeChar =
+            Transmog::PresetManager::instance().active_character();
+        const auto seedChar =
+            Transmog::carrier_char_from_name(activeChar)
+                .value_or(Transmog::CarrierChar::Kliff);
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            for (std::size_t i = 0; i < k_slotN; ++i) {
+                if (s_selSrcIdx[i] >= 0) continue;  // already chosen
+                const char *target = Transmog::carrier_for(
+                    seedChar, static_cast<Transmog::TransmogSlot>(i))
+                    .prefabName;
+                if (!target || target[0] == '\0') continue;  // no default for this slot
+                const auto &cat = s_slotCatalogs[i];
+                for (std::size_t k = 0; k < cat.size(); ++k) {
+                    if (cat[k].name == target) {
+                        s_selSrcIdx[i] = static_cast<int>(k);
+                        break;
+                    }
+                }
+            }
+        }
+
+        const auto walkMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - walkStart)
+                .count();
+        logger.info(
+            "[prefab-swap] Catalog populated: helm={} chest={} "
+            "cloak={} gloves={} boots={} ({}ms)",
+            counts[0], counts[1], counts[2], counts[3], counts[4],
+            walkMs);
+        logger.info(
+            "[prefab-swap] Catalog wrappers cached: {} names, "
+            "{} total wrappers ({}ms heap walk)",
+            allNames.size(), totalWrappers, hwMs);
+
+        std::size_t totalCount = 0;
+        for (auto c : counts) totalCount += c;
+        return totalCount;
+    }
+
+    std::size_t apply_selections_to_swap_map() noexcept
+    {
+        auto &logger = DMK::Logger::get_instance();
+
+        // Snapshot per-slot plans entirely from the catalog. All
+        // wrappers (StringInfo entry+0x18 + parallel-pool variants
+        // recovered by the boot heap walk) are pre-cached in
+        // PrefabEntry::wrappers, so this hot path is O(N) over the
+        // configured slots -- no I/O, no heap walk. Picker-driven
+        // re-applies should land in <1ms here.
+        constexpr std::size_t k_slotN =
+            static_cast<std::size_t>(Transmog::TransmogSlot::Count);
+        struct SlotPlan {
+            std::string                  srcName;
+            std::string                  tgtName;
+            std::vector<std::uintptr_t>  srcWrappers; // from catalog
+            std::uintptr_t               tgtWrapper{0};
+        };
+        std::array<SlotPlan, k_slotN> plans;
+        // Read the active character FRESH on every apply (mirrors the
+        // pattern in transmog_apply.cpp::apply_all_transmog where
+        // PresetManager::active_character() drives default_carrier_for_slot
+        // and needs_carrier per-call). The PWS source per slot must
+        // match the body the active character emits; otherwise the
+        // hook's pointer-equality substitution never matches and the
+        // swap silently does nothing. This avoids the prior bug where
+        // s_selSrcIdx was seeded once at boot (against whichever
+        // character PresetManager had then -- usually Kliff fallback)
+        // and never updated when the engine rotated to Damiane/Oongka.
+        const auto &activeChar =
+            Transmog::PresetManager::instance().active_character();
+        const auto activeCC =
+            Transmog::carrier_char_from_name(activeChar)
+                .value_or(Transmog::CarrierChar::Kliff);
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            for (std::size_t i = 0; i < k_slotN; ++i) {
+                const auto tgtIdx = s_selTgtIdx[i];
+                if (tgtIdx < 0) continue;
+                auto &cat = s_slotCatalogs[i];
+                if (tgtIdx >= static_cast<int>(cat.size()))
+                    continue;
+
+                // src resolution priority:
+                //   1. Active character's carrier_defaults prefabName
+                //      matched by name in the slot's catalog. This is
+                //      the authoritative source identity when the
+                //      currently controlled character is known. Boot-
+                //      seeded s_selSrcIdx can be stale (seeded for
+                //      whichever character PresetManager held when
+                //      populate_slot_catalogs ran -- usually Kliff
+                //      fallback) and never updates on character swap.
+                //   2. Boot-seeded s_selSrcIdx as a fallback when the
+                //      character lookup fails (empty prefabName or
+                //      name not in slot catalog).
+                //   3. Cross-slot catalog (slot 0 / cat0) lookup +
+                //      adoption: if the slot's own catalog never got
+                //      the carrier prefab (paired secondary slots
+                //      whose tag patterns missed at boot, or prefabs
+                //      that simply weren't in the loader registry),
+                //      copy the entry from cat0 into this slot's
+                //      catalog so the swap plan can build.
+                //
+                // Without 3., paired slots and any slot whose carrier
+                // missed the boot tag classification would silently
+                // apply nothing -- the picker checkbox would show but
+                // picks would be no-ops.
+                std::size_t resolvedSrcIdx = SIZE_MAX;
+                const char *expectedSrc = Transmog::carrier_for(
+                    activeCC,
+                    static_cast<Transmog::TransmogSlot>(i)).prefabName;
+                if (expectedSrc && expectedSrc[0] != '\0') {
+                    for (std::size_t k = 0; k < cat.size(); ++k) {
+                        if (cat[k].name == expectedSrc) {
+                            resolvedSrcIdx = k;
+                            break;
+                        }
+                    }
+                    // Cross-slot fallback: borrow from cat0. After
+                    // populate_slot_catalogs all slots seeded from
+                    // the same shared StringInfo walk, then registry
+                    // enrichment added slot-specific entries to each.
+                    // cat0 is therefore the densest catalog for this
+                    // missing-name lookup. Adopt by name (no allocator
+                    // surprises -- adopt is just a vector push).
+                    if (resolvedSrcIdx == SIZE_MAX &&
+                        !s_slotCatalogs.empty())
+                    {
+                        const auto &cat0 = s_slotCatalogs[0];
+                        for (std::size_t k = 0; k < cat0.size(); ++k) {
+                            if (cat0[k].name == expectedSrc) {
+                                cat.push_back(cat0[k]);
+                                resolvedSrcIdx = cat.size() - 1;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (resolvedSrcIdx == SIZE_MAX) {
+                    const auto srcIdx = s_selSrcIdx[i];
+                    if (srcIdx >= 0 &&
+                        srcIdx < static_cast<int>(cat.size()))
+                        resolvedSrcIdx = static_cast<std::size_t>(srcIdx);
+                }
+                if (resolvedSrcIdx == SIZE_MAX) continue;
+
+                plans[i].srcName     = cat[resolvedSrcIdx].name;
+                plans[i].tgtName     = cat[tgtIdx].name;
+                // Copy the FULL pre-cached wrapper vector. The engine
+                // may pick any parallel-pool instance at copy time, so
+                // s_swapMap must contain entries for all of them.
+                plans[i].srcWrappers = cat[resolvedSrcIdx].wrappers;
+                // Target uses the canonical wrapper (first element).
+                // The engine dedupes by content/hash internally, so a
+                // single tgt instance is sufficient as the swap value.
+                if (!cat[tgtIdx].wrappers.empty())
+                    plans[i].tgtWrapper = cat[tgtIdx].wrappers.front();
+            }
+        }
+
+        // Fresh heap walk for the source names of selected slots.
+        // The cataloged `wrappers` field can be incomplete for prefabs
+        // that have many parallel-pool instances (boot scan reliably
+        // finds 9 instances of cd_phm_00_ub_00_0435 via heap walk, but
+        // populate_slot_catalogs's batched walk seems to harvest only
+        // a subset depending on heap residency at scan time). The
+        // body-mesh hook substitutes by pointer equality, so missing
+        // wrappers = missing substitutions = no visible swap.
+        //
+        // Re-walk for the small set of currently-selected source names
+        // here -- at most 5 names, runs in ~1-2s. Only fires on picker
+        // pick / F10 reactivation, not on hot-path apply.
+        std::vector<std::string> srcNamesForWalk;
+        std::vector<std::size_t> srcSlotIdx;
+        for (std::size_t i = 0; i < k_slotN; ++i) {
+            if (!plans[i].srcName.empty()) {
+                srcNamesForWalk.push_back(plans[i].srcName);
+                srcSlotIdx.push_back(i);
+            }
+        }
+        if (!srcNamesForWalk.empty()) {
+            std::vector<std::vector<std::uintptr_t>> outBySrc(
+                srcNamesForWalk.size());
+            std::vector<std::uintptr_t> outTgt(
+                srcNamesForWalk.size(), 0);
+            heap_walk_partprefab_for_names(
+                srcNamesForWalk, /*tgtNames=*/{},
+                outBySrc, outTgt);
+            for (std::size_t k = 0; k < srcNamesForWalk.size(); ++k) {
+                auto &dst = plans[srcSlotIdx[k]].srcWrappers;
+                for (auto w : outBySrc[k]) dst.push_back(w);
+                std::sort(dst.begin(), dst.end());
+                dst.erase(std::unique(dst.begin(), dst.end()), dst.end());
+            }
+        }
+
+        // Build s_swapMap atomically under s_mapMtx.
+        std::size_t resolved = 0;
+        {
+            std::scoped_lock lk(s_mapMtx);
+            s_swapMap.clear();
+            s_targetWrappers.clear();
+            for (std::size_t i = 0; i < k_slotN; ++i) {
+                auto &p = plans[i];
+                if (p.srcName.empty() || p.tgtName.empty()) continue;
+                if (p.srcWrappers.empty() || p.tgtWrapper == 0) {
+                    logger.warning(
+                        "[prefab-swap]   slot[{}] UNRESOLVED "
+                        "\"{}\" -> \"{}\" (srcWrappers={} tgtWrapper="
+                        "0x{:X})",
+                        i, p.srcName, p.tgtName,
+                        p.srcWrappers.size(), p.tgtWrapper);
+                    continue;
+                }
+                for (auto sw : p.srcWrappers)
+                    s_swapMap.emplace(sw, p.tgtWrapper);
+                s_targetWrappers.insert(p.tgtWrapper);
+                ++resolved;
+                logger.debug(
+                    "[prefab-swap]   slot[{}] RESOLVED \"{}\" "
+                    "({} src) -> \"{}\" (0x{:X})",
+                    i, p.srcName, p.srcWrappers.size(),
+                    p.tgtName, p.tgtWrapper);
+            }
+        }
+        return resolved;
+    }
+
+    // Reactivate using the current per-slot dropdown selections. This
+    // is the auto-apply path triggered when the slot-row body combos
+    // change in the overlay -- it reproduces the F10 toggle's
+    // deactivate-then-activate cycle so the new selection becomes
+    // visible without requiring a hotkey press.
+    std::size_t reactivate_with_selections() noexcept
+    {
+        auto &logger = DMK::Logger::get_instance();
+        if (!s_orig) return 0;  // hook not installed -- nothing to do
+        if (s_active.load(std::memory_order_acquire)) {
+            // Cleanly tear down the prior substitution (scene-graph
+            // +0x40 reverts + staging-record reverse-write) so the new
+            // map doesn't double-bind the previous targets.
+            deactivate_for_clear();
+        }
+        if (!has_any_selection()) {
+            // Nothing left to bind -- stay deactivated.
+            return 0;
+        }
+        const auto resolved = apply_selections_to_swap_map();
+        if (resolved == 0) {
+            logger.warning(
+                "[prefab-swap] reactivate_with_selections: no "
+                "slot selections resolved -- staying INACTIVE");
+            return 0;
+        }
+        s_active.store(true, std::memory_order_release);
+        s_callCount.store(0, std::memory_order_relaxed);
+        s_substCount.store(0, std::memory_order_relaxed);
+        {
+            std::scoped_lock lk(s_lastApplyMtx);
+            s_lastApplyValid = false;
+            std::memset(s_lastApplyItems, 0, sizeof(s_lastApplyItems));
+        }
+        logger.info(
+            "[prefab-swap] reactivated via UI selections "
+            "({} slot(s) bound)",
+            resolved);
+        return resolved;
+    }
+
+    // (Removed 2026-05-07: on_resource_binder + on_factory. These
+    // were the legacy helm-leak fix path -- ResourceBinder gating to
+    // skip suffix-variant secondary binds, and the factory hook to
+    // capture (struct, kliff_source) for `do_reverse_write` to undo on
+    // deactivate. The natural-pipeline hook on sub_142711DF0
+    // substitutes wrappers in the engine's unlink list at the right
+    // moment without needing either of these. Verified live
+    // 2026-05-05.)
+
+    // --- Hook callback ---
+
+    static std::int64_t __fastcall on_struct_copy(
+        std::int64_t a1, std::int64_t a2)
+    {
+        const auto trampoline = s_orig;
+        if (!trampoline)
+            return 0;
+
+        // Cheap guards before any indirect read.
+        if (!s_active.load(std::memory_order_acquire))
+            return trampoline(a1, a2);
+        if (!Transmog::in_transmog().load(std::memory_order_relaxed))
+            return trampoline(a1, a2);
+        if (a2 < 0x10000)
+            return trampoline(a1, a2);
+
+        s_callCount.fetch_add(1, std::memory_order_relaxed);
+
+        const auto srcWrapper = read_qword_seh(
+            reinterpret_cast<const void *>(a2));
+        // Filter the StringInfo vtable sentinel: a2 sometimes points
+        // at the entry's +0x08 vtable slot rather than its wrapper-ptr
+        // slot, in which case srcWrapper would equal the sentinel
+        // address (0x145BC4638 in v1.05.01). Resolved via
+        // k_stringInfoVtableCandidates (audit 2026-05-08); zero here
+        // would mean cascade failed, so the equality test simply
+        // never matches and the swap-map lookup proceeds unchanged.
+        const auto siVtable =
+            s_stringInfoVtable.load(std::memory_order_acquire);
+        if (srcWrapper < 0x10000ULL || srcWrapper == siVtable)
+            return trampoline(a1, a2);
+
+        std::uintptr_t tgtWrapper = 0;
+        {
+            std::scoped_lock lk(s_mapMtx);
+            const auto it = s_swapMap.find(srcWrapper);
+            if (it == s_swapMap.end())
+                return trampoline(a1, a2);
+            tgtWrapper = it->second;
+        }
+
+        // Bump target's refcount BEFORE substitution so that the
+        // destination's eventual decrement-on-destruct stays balanced.
+        increment_wrapper_refcount(tgtWrapper);
+
+        // Substitute: caller's source struct (a2) now points at our
+        // target wrapper. sub_140352AA0 will move the wrapper-ptr to
+        // dest+0 and write sentinel back to source+0 (so the caller's
+        // cleanup sees a sentinel and skips decrement of the now-
+        // unreferenced original wrapper -- a small +1 leak we tolerate).
+        if (!write_qword_seh(reinterpret_cast<void *>(a2), tgtWrapper)) {
+            // Substitute failed -- pass through. We still leaked a
+            // refcount bump on tgtWrapper; rare path, accept it.
+            return trampoline(a1, a2);
+        }
+
+        const auto sc = s_substCount.fetch_add(
+            1, std::memory_order_relaxed);
+        if (sc < 50) {
+            // Diagnostic for first N substitutions.
+            DMK::Logger::get_instance().info(
+                "[prefab-swap] SWAP src=0x{:X} -> tgt=0x{:X} "
+                "(subst #{})",
+                srcWrapper, tgtWrapper, sc + 1);
+        }
+
+        // Run the trampoline -- it MOVEs *a2 (our target wrapper) to
+        // *a1 (dest+0) and sentinels *a2.
+        const auto rc = trampoline(a1, a2);
+
+        // Track the dest so deactivate_for_clear can reverse-write the
+        // original Kliff wrapper, restoring engine state to a form LT's
+        // auth-table-driven tear_down can walk cleanly.
+        {
+            std::scoped_lock lk(s_substLogMtx);
+            if (s_substLog.size() < k_maxSubstLog) {
+                s_substLog.push_back(
+                    {static_cast<std::uintptr_t>(a1), srcWrapper});
+            }
+        }
+
+        return rc;
+    }
+
+    // Natural-pipeline unlink hook (sub_142711DF0).
+    //
+    // Walks RDX's wrapper list at hook entry. For each entry whose
+    // wrapper matches a Kliff src in s_swapMap, substitutes to the
+    // corresponding target. Calls trampoline. Restores the
+    // originals afterwards so the caller's refcount-release loop on
+    // the list operates on the same wrappers it incremented.
+    //
+    // Verbose logging:
+    //   - HOOK ENTRY: hit#, a1 (body), list ptr, count, return address.
+    //   - PER ENTRY[i]: orig wrapper, swap-map decision (SUBST or
+    //                   PASSTHROUGH), tgt if substituted.
+    //   - POST-CALL:   substitutions performed, list count.
+    //   - RESTORE:     each restoration, final list state.
+    static std::int64_t __fastcall on_natural_pipeline(
+        std::int64_t a1,
+        std::uint64_t *a2,
+        std::uint64_t *a3)
+    {
+        const auto trampoline = s_origNaturalPipeline;
+        if (!trampoline)
+            return 0;
+
+        // Always passthrough when LT inactive (avoid hot-path cost
+        // when feature isn't engaged).
+        if (!s_active.load(std::memory_order_acquire))
+            return trampoline(a1, a2, a3);
+
+        auto &logger = DMK::Logger::get_instance();
+        const auto hitSeq =
+            s_natpipeHitCount.fetch_add(1, std::memory_order_relaxed) + 1;
+        const auto callerRa = reinterpret_cast<std::uintptr_t>(
+            _ReturnAddress());
+
+        // Read the list shape: a2 -> { data: u64*, count: u32, ... }
+        // Stride 16 bytes per entry: (wrapper_qword, byte_flag, padding).
+        std::uint64_t *listData = nullptr;
+        std::uint32_t  listCount = 0;
+        if (a2) {
+            const auto raw = read_qword_seh(a2);
+            listData = reinterpret_cast<std::uint64_t *>(raw);
+            listCount = read_dword_seh(
+                reinterpret_cast<const char *>(a2) + 8);
+        }
+
+        s_natpipeListEntries.fetch_add(
+            listCount, std::memory_order_relaxed);
+
+        // Empty-list fast path: engine fires sub_142711DF0 from many
+        // call sites (e.g. caller_ra=0x14034A1FF in render/animation
+        // tick) with listCount=0 -- nothing for us to do, and logging
+        // every such call floods the trace stream. Skip the hook body
+        // entirely; just call the trampoline.
+        constexpr std::uint32_t k_maxEntries = 64;
+        std::uint64_t saved[k_maxEntries] = {};
+        std::uint32_t substCount = 0;
+        const auto cnt =
+            (listCount < k_maxEntries) ? listCount : k_maxEntries;
+
+        if (!listData || cnt == 0)
+            return trampoline(a1, a2, a3);
+
+        // Walk the list under SEH and substitute matching src wrappers.
+        // PASSTHROUGH entries (wrapper not in swap map / low addr)
+        // intentionally don't log -- the engine queries many unrelated
+        // wrappers and the noise drowns out the rare SUBST events that
+        // matter for the body-mesh cleanup path.
+        for (std::uint32_t i = 0; i < cnt; ++i) {
+            const auto orig = read_qword_seh(&listData[i * 2]);
+            saved[i] = orig;
+            if (orig < 0x10000ULL)
+                continue;
+
+            // Lookup in swap map (read-only on hot path; map is
+            // immutable while s_active is true per LT design).
+            std::uintptr_t tgt = 0;
+            {
+                std::scoped_lock lk(s_mapMtx);
+                auto it = s_swapMap.find(
+                    static_cast<std::uintptr_t>(orig));
+                if (it != s_swapMap.end())
+                    tgt = it->second;
+            }
+
+            if (tgt == 0)
+                continue;
+
+            if (write_qword_seh(&listData[i * 2],
+                                static_cast<std::uint64_t>(tgt))) {
+                ++substCount;
+                logger.trace(
+                    "[natpipe-hook] hit#{} entry[{}] SUBST 0x{:X} -> "
+                    "0x{:X} (src -> tgt) caller_ra=0x{:X}",
+                    hitSeq, i, orig, tgt, callerRa);
+            } else {
+                logger.warning(
+                    "[natpipe-hook] hit#{} entry[{}] write FAULTED -- "
+                    "skipping",
+                    hitSeq, i);
+            }
+        }
+
+        s_natpipeSubstCount.fetch_add(
+            substCount, std::memory_order_relaxed);
+
+        // Run the natural pipeline. Engine walks parent+88 looking
+        // for our target wrappers, finds them, unlinks them.
+        const auto result = trampoline(a1, a2, a3);
+
+        // No substitutions -> no restore needed and no log output;
+        // fall through and return without further work.
+        if (substCount == 0)
+            return result;
+
+        // Restore originals so the caller's refcount-release loop on
+        // the list decs the same wrappers it inc'd.
+        std::uint32_t restored = 0;
+        for (std::uint32_t i = 0; i < cnt; ++i) {
+            if (saved[i] == 0) continue;
+            const auto cur = read_qword_seh(&listData[i * 2]);
+            if (cur == saved[i]) continue; // not substituted
+            if (write_qword_seh(&listData[i * 2], saved[i]))
+                ++restored;
+        }
+        logger.trace(
+            "[natpipe-hook] hit#{} done: substituted {} restored {} "
+            "result=0x{:X}",
+            hitSeq, substCount, restored,
+            static_cast<std::uintptr_t>(result));
+        return result;
+    }
+
+    // --- Init / shutdown ---
+
+    // (Removed 2026-05-07: copy_to_buf utility + on_hotkey toggle
+    // path. The legacy F10 toggle was retired when activation became
+    // driven by the overlay's per-slot picker. copy_to_buf was a
+    // helper for the old INI pair-string buffers, which no longer
+    // exist.)
+
+    void register_config()
+    {
+        // Body-mesh swap has no INI keys. The hook installs at boot;
+        // source defaults are hardcoded per-character (k_kliffCarriers
+        // etc.); target selection is user-driven via the overlay
+        // picker.
+    }
+
+    bool init()
+    {
+        auto &logger = DMK::Logger::get_instance();
+
+        // --- RipRelative singleton cascades ---
+        //
+        // Four data-pointer cascades that earlier hardcoded literals
+        // (StringInfoRegistry, StringInfoVtable, LoaderRegistry,
+        // ApptContainerVtable). Stored into atomic globals consumed
+        // by walk_string_info, the AppearanceTableLoader enumerator,
+        // and the container-vtable filter. Cascade misses are
+        // non-fatal: each consumer treats a zero atomic as a soft
+        // bypass (catalog walk returns empty, vtable filter accepts
+        // all entries) so the rest of init() still completes.
+        {
+            const auto siReg = resolve_address(
+                k_stringInfoRegistryCandidates,
+                "StringInfoRegistry");
+            if (siReg) {
+                s_stringInfoRegistry.store(
+                    siReg, std::memory_order_release);
+                logger.info(
+                    "[prefab-swap] StringInfoRegistry resolved at "
+                    "0x{:X}", siReg);
+            } else {
+                logger.warning(
+                    "[prefab-swap] StringInfoRegistry cascade FAILED "
+                    "-- catalog walk will return 0 entries.");
+            }
+
+            const auto siVt = resolve_address(
+                k_stringInfoVtableCandidates,
+                "StringInfoVtable");
+            if (siVt) {
+                s_stringInfoVtable.store(
+                    siVt, std::memory_order_release);
+                logger.info(
+                    "[prefab-swap] StringInfoVtable resolved at "
+                    "0x{:X}", siVt);
+            } else {
+                logger.warning(
+                    "[prefab-swap] StringInfoVtable cascade FAILED "
+                    "-- StringInfo entry filter degraded.");
+            }
+
+            const auto loaderReg = resolve_address(
+                k_loaderRegistryCandidates,
+                "LoaderRegistry");
+            if (loaderReg) {
+                s_loaderRegistrySingleton.store(
+                    loaderReg, std::memory_order_release);
+                logger.info(
+                    "[prefab-swap] LoaderRegistry resolved at "
+                    "0x{:X}", loaderReg);
+            } else {
+                logger.warning(
+                    "[prefab-swap] LoaderRegistry cascade FAILED "
+                    "-- AppearanceTableLoader enumeration disabled.");
+            }
+
+            // ApptContainerVtable: the cascade locates the
+            // AppearanceTableLoader ctor (sub_141E2DBB0). Walk
+            // forward inside its first 0x400 bytes for the SECOND
+            // `48 8D 05 ?? ?? ?? ?? 48 89 07` pair -- the FIRST is
+            // the intermediate `_appearanceContainer` vtable
+            // (0x144D242B8); the SECOND is the
+            // `_partPrefabDataContainer` vtable (0x144D24358) we
+            // want. Bounded scan; on miss, the container-vtable
+            // filter is skipped (read-only, so missing the check
+            // just removes a sentinel, not a correctness guarantee).
+            const auto ctorAbs = resolve_address(
+                k_apptLoaderCtorCandidates,
+                "ApptLoaderCtor");
+            if (ctorAbs) {
+                const auto *body =
+                    reinterpret_cast<const std::uint8_t *>(ctorAbs);
+                constexpr std::size_t k_scanLen = 0x400;
+                std::uintptr_t resolved = 0;
+                std::size_t leaPairs = 0;
+                for (std::size_t i = 0; i + 10 <= k_scanLen; ++i) {
+                    if (body[i] == 0x48 && body[i + 1] == 0x8D
+                        && body[i + 2] == 0x05
+                        && body[i + 7] == 0x48
+                        && body[i + 8] == 0x89
+                        && body[i + 9] == 0x07) {
+                        ++leaPairs;
+                        if (leaPairs == 2) {
+                            std::int32_t disp = 0;
+                            std::memcpy(&disp, body + i + 3,
+                                        sizeof(disp));
+                            const std::uintptr_t instrEnd =
+                                ctorAbs + i + 7;
+                            resolved = instrEnd
+                                + static_cast<std::intptr_t>(disp);
+                            break;
+                        }
+                    }
+                }
+                if (resolved) {
+                    s_apptContainerVtable.store(
+                        resolved, std::memory_order_release);
+                    logger.info(
+                        "[prefab-swap] ApptContainerVtable resolved "
+                        "at 0x{:X} (ctor 0x{:X}, lea#2)",
+                        resolved, ctorAbs);
+                } else {
+                    logger.warning(
+                        "[prefab-swap] ApptContainerVtable: ctor "
+                        "0x{:X} contained <2 `lea+mov [rdi]` pairs "
+                        "in 0x{:X} bytes -- vtable filter disabled.",
+                        ctorAbs, k_scanLen);
+                }
+            } else {
+                logger.warning(
+                    "[prefab-swap] ApptContainerVtable cascade "
+                    "FAILED -- container vtable filter disabled.");
+            }
+        }
+
+        const auto addr = resolve_address(
+            k_structCopyCandidates,
+            std::size(k_structCopyCandidates),
+            "PrefabWrapperSwap_StructCopy");
+        if (!addr) {
+            logger.warning(
+                "[prefab-swap] AOB scan failed -- feature disabled");
+            return false;
+        }
+        if (!sanity_check_function_prologue(addr)) {
+            logger.warning(
+                "[prefab-swap] resolved 0x{:X} but prologue check "
+                "failed -- feature disabled",
+                addr);
+            return false;
+        }
+
+        StructCopyFn trampoline = nullptr;
+        auto &hookMgr = DMK::HookManager::get_instance();
+        auto result = hookMgr.create_inline_hook(
+            "PrefabWrapperSwap_StructCopy", addr,
+            reinterpret_cast<void *>(on_struct_copy),
+            reinterpret_cast<void **>(&trampoline));
+        if (!result.has_value()) {
+            logger.warning(
+                "[prefab-swap] hook install failed: {}",
+                DetourModKit::Hook::error_to_string(result.error()));
+            return false;
+        }
+
+        s_orig = trampoline;
+        s_active.store(false, std::memory_order_release);
+
+        logger.info(
+            "[prefab-swap] installed at 0x{:X} (INACTIVE -- "
+            "press the toggle hotkey to resolve pairs and activate). "
+            "Hook gates on Transmog::in_transmog() so real-item flow is "
+            "untouched.",
+            addr);
+
+        // ResourceBinder + Factory hooks REMOVED 2026-05-05.
+        //
+        // Both were part of the *old* helm-leak fix attempt:
+        //   - ResourceBinder gate skipped suffix-mismatched secondary
+        //     binds (`_d -> _c`) to prevent duplicate scene-graph entries.
+        //   - Factory hook tracked the resulting orphans so
+        //     `do_reverse_write` could force-destroy them on deactivate.
+        //
+        // The natural-pipeline hook on sub_142711DF0 (installed below)
+        // now handles the leak at the unlink layer by substituting
+        // Kliff src wrappers with target wrappers in the engine's
+        // unlink list. The engine's content-keyed search then matches
+        // and unlinks correctly via its own natural pipeline. No
+        // secondary-bind gating or orphan tracking required.
+        //
+        // Verified live 2026-05-05: clear-all + save-reload cycles run
+        // clean with these hooks disabled. See diff snapshots in
+        // docs/research/ghost-helm-snapshots/diff-2026-05-05-cold/.
+
+        // (Removed 2026-05-07: EngineUnlink + SmartPtrRelease address
+        // resolution. Both feed dead-code paths -- their consumers
+        // release_orphan_via_smartptr / do_reverse_write were removed
+        // in the same pass, and the natpipe hook on sub_142711DF0
+        // handles cleanup without them.)
+
+        // Natural-pipeline unlink hook (sub_142711DF0). Substitutes
+        // Kliff src wrappers with target wrappers in the input
+        // list before the engine walks parent+88 looking for matches.
+        // Resolved through k_naturalPipelineCandidates cascade
+        // (3 anchors, see aob_resolver.hpp). On cascade failure the
+        // helm/cloak leak persists but the rest of the mod still loads.
+        {
+            const auto natpipeAbs = resolve_address(
+                k_naturalPipelineCandidates,
+                std::size(k_naturalPipelineCandidates),
+                "PrefabWrapperSwap_NaturalPipeline");
+            if (!natpipeAbs) {
+                logger.warning(
+                    "[prefab-swap] NaturalPipeline AOB resolve "
+                    "FAILED -- helm/cloak leak will persist. Other "
+                    "swap features remain active.");
+            } else if (!sanity_check_function_prologue(natpipeAbs)) {
+                // Prologue sanity gate (cdcore/prologue_check). Same
+                // contract as the StructCopy install -- guards against
+                // a cascade that picked up a fragment of an unrelated
+                // function after a future patch reshuffles bytes.
+                logger.warning(
+                    "[prefab-swap] NaturalPipeline resolved at "
+                    "0x{:X} but prologue check failed -- skipping "
+                    "install. Helm/cloak leak will persist.",
+                    natpipeAbs);
+            } else {
+                logger.info(
+                    "[prefab-swap] NaturalPipeline resolved at 0x{:X} "
+                    "(sub_142711DF0 -- pre-unlink wrapper-list walker; "
+                    "substitutes src -> tgt at hook entry).",
+                    natpipeAbs);
+                NaturalPipelineFn natpipeTrampoline = nullptr;
+                auto natpipeResult = hookMgr.create_inline_hook(
+                    "PrefabWrapperSwap_NaturalPipeline", natpipeAbs,
+                    reinterpret_cast<void *>(on_natural_pipeline),
+                    reinterpret_cast<void **>(&natpipeTrampoline));
+                if (!natpipeResult.has_value()) {
+                    logger.warning(
+                        "[prefab-swap] NaturalPipeline hook "
+                        "install FAILED: {} -- helm/cloak leak will "
+                        "persist.",
+                        DetourModKit::Hook::error_to_string(
+                            natpipeResult.error()));
+                } else {
+                    s_origNaturalPipeline = natpipeTrampoline;
+                    logger.info(
+                        "[prefab-swap] NaturalPipeline hook "
+                        "INSTALLED at 0x{:X}. Inactive when LT "
+                        "swap is OFF; substitutes Kliff src wrappers "
+                        "with target in the natural unlink list "
+                        "while LT is active.",
+                        natpipeAbs);
+                }
+            }
+        }
+
+        // --- AppearanceTableLoader (Goal A #5) hooks ---
+        //
+        // Resolve the lookup primitives FIRST so by the time the
+        // capture hook fires, lookups are immediately callable. AOB
+        // failure is non-fatal -- lookup_prefab_metadata returns 0
+        // and the picker falls back to StringInfo-only behavior.
+        //
+        // The PRIMARY lookup is sub_1424DF420 -- a self-contained
+        // name->wrapper primitive that operates on
+        // MEMORY[0x145DDF8B0]+0x50. Resolved through
+        // k_apptNameLookupCandidates cascade (3 anchors, see
+        // aob_resolver.hpp). On cascade failure the picker falls back
+        // to StringInfo-only behavior; lookup_prefab_metadata returns 0.
+        {
+            const auto fnAbs = resolve_address(
+                k_apptNameLookupCandidates,
+                std::size(k_apptNameLookupCandidates),
+                "PrefabWrapperSwap_ApptNameLookup");
+            if (!fnAbs) {
+                logger.warning(
+                    "[prefab-swap] ApptNameLookup AOB resolve "
+                    "FAILED -- lookup_prefab_metadata will return 0; "
+                    "picker falls back to StringInfo-only behavior.");
+            } else if (!sanity_check_function_prologue(fnAbs)) {
+                logger.warning(
+                    "[prefab-swap] ApptNameLookup resolved at 0x{:X} "
+                    "but prologue check failed -- skipping. "
+                    "lookup_prefab_metadata will return 0.",
+                    fnAbs);
+            } else {
+                s_apptNameLookup =
+                    reinterpret_cast<ApptNameLookupFn>(fnAbs);
+                logger.info(
+                    "[prefab-swap] ApptNameLookup resolved at 0x{:X} "
+                    "(sub_1424DF420 -- name->wrapper lookup against "
+                    "MEMORY[0x145DDF8B0]+0x50).",
+                    fnAbs);
+            }
+        }
+
+        const auto stringInternAddr = resolve_address(
+            k_apptStringInternCandidates,
+            std::size(k_apptStringInternCandidates),
+            "PrefabWrapperSwap_ApptStringIntern");
+        if (stringInternAddr) {
+            s_apptStringIntern =
+                reinterpret_cast<ApptStringInternFn>(stringInternAddr);
+            logger.info(
+                "[prefab-swap] ApptStringIntern resolved at "
+                "0x{:X} (sub_1403016B0 -- StringInfo intern primitive "
+                "for AppearanceTableLoader lookups)",
+                stringInternAddr);
+        } else {
+            logger.warning(
+                "[prefab-swap] ApptStringIntern AOB scan failed "
+                "-- AppearanceTableLoader lookups disabled.");
+        }
+
+        const auto apptLookupAddr = resolve_address(
+            k_apptInnerLookupCandidates,
+            std::size(k_apptInnerLookupCandidates),
+            "PrefabWrapperSwap_ApptInnerLookup");
+        if (apptLookupAddr) {
+            s_apptLookup =
+                reinterpret_cast<ApptLookupFn>(apptLookupAddr);
+            logger.info(
+                "[prefab-swap] ApptLookup resolved at 0x{:X} "
+                "(sub_141D38810 -- PartPrefab container lookup; pure "
+                "read-only, returns 24B metadata or 0 on miss)",
+                apptLookupAddr);
+        } else {
+            logger.warning(
+                "[prefab-swap] ApptLookup AOB scan failed "
+                "-- AppearanceTableLoader lookups disabled.");
+        }
+
+        // Capture hook on sub_1408AF8F0. Entry hook; we run the
+        // trampoline first then read the populated chain. Capture is
+        // a one-shot; subsequent calls are pass-throughs.
+        const auto apptInitAddr = resolve_address(
+            k_apptResMgrInitCandidates,
+            std::size(k_apptResMgrInitCandidates),
+            "PrefabWrapperSwap_ApptResMgrInit");
+        if (apptInitAddr) {
+            ApptResMgrInitFn apptInitTrampoline = nullptr;
+            auto apptResult = hookMgr.create_inline_hook(
+                "PrefabWrapperSwap_ApptResMgrInit", apptInitAddr,
+                reinterpret_cast<void *>(on_appt_resmgr_init),
+                reinterpret_cast<void **>(&apptInitTrampoline));
+            if (!apptResult.has_value()) {
+                logger.warning(
+                    "[prefab-swap] ApptResMgrInit hook install "
+                    "FAILED: {} -- AppearanceTableLoader capture "
+                    "disabled; picker will only see StringInfo-resident "
+                    "prefabs.",
+                    DetourModKit::Hook::error_to_string(
+                        apptResult.error()));
+            } else {
+                s_apptResMgrInitOrig = apptInitTrampoline;
+                logger.info(
+                    "[prefab-swap] ApptResMgrInit hook INSTALLED "
+                    "at 0x{:X} (sub_1408AF8F0 entry; will snapshot "
+                    "ResMgr/loader/container on first fire). Capture "
+                    "is one-shot; subsequent calls are pass-throughs.",
+                    apptInitAddr);
+            }
+        } else {
+            logger.warning(
+                "[prefab-swap] ApptResMgrInit AOB scan failed "
+                "-- AppearanceTableLoader capture disabled; picker "
+                "will only see StringInfo-resident prefabs.");
+        }
+
+        // Boot-time auto-scan: kick off a detached thread that waits
+        // for the world to be ready, then walks StringInfo to populate
+        // the per-slot catalog (this also triggers the heap-walk merge
+        // for parallel-pool wrappers and seeds the hardcoded Kliff
+        // source defaults). The catalog is the single source of truth
+        // for the picker UI and the apply-time swap-map rebuild.
+        std::thread([]() {
+            auto &log = DMK::Logger::get_instance();
+            // Wait for world ready -- poll forever (detached thread,
+            // ~few KB of sleeping stack; OS reaps on process exit).
+            // No cap needed since save-load auto-refresh in the
+            // worker handles steady-state catalog rotation, and the
+            // user never has to manually re-trigger this walk.
+            while (!Transmog::is_world_ready()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            }
+            log.info(
+                "[prefab-swap] boot-scan: world ready, populating "
+                "per-slot catalog...");
+            populate_slot_catalogs();
+
+            // Re-sync the active preset's body-mesh selections now
+            // that the catalog is populated. Presets loaded before
+            // the heap walk finished have their prefabName values
+            // unresolved; this retroactive apply lands them. Then
+            // trigger the apply pipeline so the swap activates --
+            // mirrors the load-time auto-apply path the item-name
+            // table uses when its deferred catalog scan completes.
+            Transmog::PresetManager::instance().apply_to_state();
+            Transmog::manual_apply();
+            log.info(
+                "[prefab-swap] boot-scan: preset prefabs "
+                "re-synced and apply scheduled.");
+        }).detach();
+        return true;
+    }
+
+    void shutdown()
+    {
+        s_active.store(false, std::memory_order_release);
+        s_orig = nullptr;
+        {
+            std::scoped_lock lk(s_substLogMtx);
+            s_substLog.clear();
+        }
+        {
+            std::scoped_lock lk(s_catalogMtx);
+            for (auto &v : s_slotCatalogs) v.clear();
+            s_selSrcIdx.fill(-1);
+            s_selTgtIdx.fill(-1);
+        }
+        s_catalogPopulated.store(false, std::memory_order_release);
+        std::scoped_lock lk(s_mapMtx);
+        s_swapMap.clear();
+        s_targetWrappers.clear();
+        s_callCount.store(0, std::memory_order_relaxed);
+        s_substCount.store(0, std::memory_order_relaxed);
+
+        // Reset AppearanceTableLoader capture state. Do NOT null the
+        // lookup function pointers -- they're trampoline-resolved
+        // addresses and HookManager owns the trampoline lifetime; on
+        // the next init() they will be re-resolved.
+        s_apptContainer.store(0, std::memory_order_relaxed);
+        s_apptCaptureDone.store(false, std::memory_order_release);
+        s_apptResMgrInitOrig = nullptr;
+        s_apptStringIntern   = nullptr;
+        s_apptLookup         = nullptr;
+        s_apptNameLookup     = nullptr;
+    }
+
+    bool is_active() { return s_active.load(std::memory_order_acquire); }
+
+    bool is_target_wrapper(std::uintptr_t wrapperPtr) noexcept
+    {
+        // Lock-free read against an immutable-on-hot-path snapshot.
+        // Set is mutated only inside resolve_pairs_into_map() at
+        // activation; SMO-add hook firing concurrently with that
+        // activation would race, but in practice the user F10s well
+        // before triggering a switch. Worst-case race = a stale
+        // false-negative for one frame on first activation.
+        return s_targetWrappers.find(wrapperPtr) != s_targetWrappers.end();
+    }
+
+    std::size_t target_wrappers_count() noexcept
+    {
+        return s_targetWrappers.size();
+    }
+
+    // (Removed 2026-05-07: heap_scan_for_qword + same_heap_region +
+    // release_orphan_via_smartptr + do_reverse_write. The whole
+    // dead-code chain supported the legacy helm-leak fix path
+    // (force-destroy of orphan body-mesh structs on deactivate). Once
+    // the natural-pipeline hook on sub_142711DF0 took over scene-graph
+    // cleanup, do_reverse_write was hard-coded to a tracking-list
+    // clear (k_skipReverseWrite=true) and never actually called from
+    // anywhere. Removed alongside their s_engineUnlink /
+    // s_smartPtrRelease consumers.)
+
+    void notify_apply_starting(const std::uint16_t (&itemIds)[5])
+    {
+        // Apply-only activation lifecycle. Mirrors the carrier hybrid
+        // pattern: picker mutations only update s_selSrcIdx/s_selTgtIdx
+        // (pending state); the actual swap-map rebuild + activation
+        // happens here, at the start of each apply pass. If the user
+        // cleared all selections, this deactivates cleanly.
+        if (!s_orig) return;  // hook not installed -- nothing to do
+
+        // reactivate_with_selections() handles all three paths:
+        //   - has_any_selection()  -> deactivate (if needed) + rebuild + activate
+        //   - !has_any_selection() -> deactivate (if active), stay inactive
+        // It is also safe to call when already in the desired state
+        // (deactivate is idempotent; rebuild is cheap from cached
+        // catalog wrappers).
+        reactivate_with_selections();
+
+        // Record itemIds so notify_apply_finished can stash them for
+        // diagnostics (preset-switch detection is no longer needed --
+        // every apply rebuilds the swap map fresh from selections).
+        std::scoped_lock lk(s_lastApplyMtx);
+        std::memcpy(s_lastApplyItems, itemIds, sizeof(s_lastApplyItems));
+        s_lastApplyValid = true;
+    }
+
+    void notify_apply_finished(const std::uint16_t (&itemIds)[5])
+    {
+        if (!s_active.load(std::memory_order_acquire)) return;
+        std::scoped_lock lk(s_lastApplyMtx);
+        std::memcpy(s_lastApplyItems, itemIds, sizeof(s_lastApplyItems));
+        s_lastApplyValid = true;
+    }
+
+    // (Removed 2026-05-07: reverse_write_tracked no-op stub. Was
+    // empty since 2026-05-05; call site in transmog_apply.cpp also
+    // removed.)
+
+    void deactivate_for_clear()
+    {
+        if (!s_active.load(std::memory_order_acquire))
+            return;
+        s_active.store(false, std::memory_order_release);
+
+        // Swap map and target-wrapper set are PRESERVED across
+        // deactivate cycles -- F10 re-activate is instant (no heap
+        // walk). Clear only on shutdown or explicit re-resolve. The
+        // active flag alone gates substitution; preserved map is fine.
+        //
+        // Engine cleanup is now driven by the natural-pipeline hook on
+        // sub_142711DF0, which substitutes src -> tgt
+        // wrappers in the engine's unlink list at hook entry. No
+        // explicit reverse-write, force-destroy, or smart-ptr-release
+        // is performed here.
+        DMK::Logger::get_instance().info(
+            "[prefab-swap] DEACTIVATED -- swap map RETAINED for "
+            "next activation. Engine cleanup deferred to natural-"
+            "pipeline hook.");
+    }
+
+} // namespace Transmog::PrefabWrapperSwap

--- a/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.hpp
+++ b/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#include "shared_state.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Pointer-swap body-mesh override.
+//
+// Hooks `sub_140352AA0` (the 96B record-copy operator). When LT is
+// inside an `apply_transmog` call (`Transmog::in_transmog() == true`)
+// AND the source record's intermediate-wrapper pointer matches a
+// registered Source, the wrapper-ptr is swapped to a registered
+// Target before the copy completes.
+//
+// The wrapper for each StringInfo entry lives at `*(QWORD*)(entry +
+// 0x18)`. Our INI configures NAMES (e.g. "cd_phm_00_ub_00_0435"); on
+// activation we walk the StringInfo registry at MEMORY[0x145EF1DE8],
+// resolve each name to its entry, and read the wrapper-ptr from the
+// entry's +0x18. The hook then matches by wrapper-ptr equality.
+//
+// Refcount handling: `Target` wrapper is `_InterlockedIncrement`'d
+// before substitution (so the destination's eventual destruction-time
+// decrement is balanced). `Source` wrapper's leftover +1 (from the
+// pre-copy bump in `sub_14079DA20`) is left in place; net effect is a
+// per-substitution +1 leak on the source -- acceptable for these small
+// wrapper allocations that StringInfo keeps alive for the session.
+//
+// Why this doesn't break inventory (unlike the prior `sub_142719500`
+// substitution): the gate is `in_transmog()`, which is set ONLY when
+// LT itself is calling SlotPopulator with a fake item. The engine's
+// own real-item flow (inventory checks, equip validation) runs with
+// the gate FALSE so the hook is a pass-through.
+//
+// No INI keys. The hook installs unconditionally at boot; per-slot
+// source defaults are hardcoded (see k_kliffCarriers in
+// transmog_apply.cpp and k_defaultSrcByEnumSlot in this file's .cpp);
+// target selection is user-driven via the overlay picker.
+
+namespace Transmog::PrefabWrapperSwap
+{
+    void register_config();
+    bool init();
+    void shutdown();
+    bool is_active();
+
+    /// Programmatic deactivation. Clears the swap map and disarms the
+    /// active flag -- equivalent to the hotkey toggle when active. Used
+    /// by `Transmog::clear_all_transmog` so a "Clear" action also
+    /// removes any pointer-swap effect (otherwise the re-apply-real
+    /// pass would re-substitute target wrappers and the user would
+    /// stay in the body-mesh override outfit instead of restoring the
+    /// carrier's mesh). Idempotent.
+    void deactivate_for_clear();
+
+    // (Removed 2026-05-07: reverse_write_tracked declaration. The
+    // function was a no-op stub since 2026-05-05 because the
+    // natural-pipeline hook on sub_142711DF0 handles cleanup.)
+
+    /// Notify the module of an upcoming apply's slot itemIds. If swap
+    /// is active AND the previous apply's recorded itemIds differ from
+    /// these, treat this as a preset-switch and `deactivate_for_clear`
+    /// before the new apply so substitutions don't re-bind target
+    /// wrappers to the new gear. The first apply post-activation
+    /// records its itemIds without deactivating.
+    void notify_apply_starting(const std::uint16_t (&itemIds)[5]);
+
+    /// Notify the module of a completed apply's slot itemIds. Records
+    /// them so the next `notify_apply_starting` can detect a switch.
+    /// No-op when inactive.
+    void notify_apply_finished(const std::uint16_t (&itemIds)[5]);
+
+    /// Read-only membership check against the resolved target-wrapper
+    /// set (the values in s_swapMap). Used by the SMO-add block hook to
+    /// decide whether to sentinel-swap an asset wrapper during the
+    /// deactivate window. Lock-free read of an immutable-on-hot-path
+    /// snapshot -- see s_targetWrappers comment.
+    [[nodiscard]] bool is_target_wrapper(std::uintptr_t wrapperPtr) noexcept;
+
+    /// Current count of resolved target wrappers. Used by the SMO-add
+    /// block hook for diagnostic logging.
+    [[nodiscard]] std::size_t target_wrappers_count() noexcept;
+
+    // --- Per-slot dropdown catalog (Goal B) ---
+    //
+    // The catalog is built by walking StringInfo with a broad
+    // body-mesh prefix ("cd_phm_00_") and classifying each matched
+    // entry into one of the 5 transmog slots by sub-prefix. Once
+    // populated, `slot_catalog(slot)` returns the per-slot vector
+    // sorted alphabetically by name -- ready to feed an ImGui combo.
+    //
+    // The dropdown state (per-slot src/tgt index) lives in this module
+    // alongside the existing s_swapMap / s_targetWrappers so
+    // `apply_selections_to_swap_map()` can rebuild the swap from
+    // selections in one place. No disk persistence -- selections are
+    // session-scoped only.
+
+    struct PrefabEntry
+    {
+        std::string                  name;      // e.g. "cd_phm_00_hel_00_0395_c"
+        // ALL known wrapper instances for this prefab name. The first
+        // element is the canonical "asset wrapper" from StringInfo's
+        // entry+0x18 (pool 0x4104E*); subsequent elements are parallel
+        // allocations recovered by the boot-time heap walk (e.g. pool
+        // 0x4104A* partprefabdyeslot). Empty vector when the prefab is
+        // present in the AppearanceTableLoader catalog but not yet
+        // loaded into StringInfo (no wrapper resident).
+        std::vector<std::uintptr_t>  wrappers;
+        std::uint32_t                hash;      // entry+0x00 / metadata+0x10
+        // 24-byte metadata pointer returned by the AppearanceTableLoader
+        // lookup primitive (see lookup_prefab_metadata). 0 if either the
+        // loader was not captured at startup or the name is absent from
+        // the loader's table. Owned by the engine; never freed by us.
+        std::uintptr_t               metadata{0};
+        // True iff at least one usable wrapper is currently resident in
+        // StringInfo (i.e. the engine can render this prefab right now
+        // without an async load). When false, the picker may still show
+        // the entry to the user but selecting it is a best-effort
+        // operation -- a force-load pass may be required.
+        bool                         is_loaded{false};
+    };
+
+    // --- AppearanceTableLoader integration (Goal A #5) ---
+    //
+    // The PartPrefab table is a 252,480-entry container the engine
+    // builds at boot from .pappt parser output. Its loader instance
+    // lives at `[[ResMgr+0x40]+0x88]` -- captured by hooking the first
+    // call to `sub_1408AF8F0` (game-init). The container itself is
+    // `loader+8`, vtable `0x144D24308`.
+    //
+    // We expose a read-only lookup against this container so the picker
+    // can surface prefabs that exist in the engine's catalog but are
+    // not yet StringInfo-resident (i.e. have no live wrapper). No INI
+    // keys in this module.
+
+    /// Returns the 24-byte AppearanceTableLoader metadata pointer for
+    /// `name` if present in the boot-loaded PartPrefab container.
+    /// Returns 0 on miss OR if the loader was not captured at startup.
+    /// Pure read-only -- safe to call from the UI thread.
+    [[nodiscard]] std::uintptr_t lookup_prefab_metadata(
+        const char *name) noexcept;
+
+    /// True if the AppearanceTableLoader hook fired and we hold valid
+    /// snapshots of partPrefabContainer.
+    [[nodiscard]] bool is_loader_ready() noexcept;
+
+    // (Removed 2026-05-07: force_load_prefab declaration. Was a
+    // documented stub gated on PrefabWrapperSwap_AttemptForceLoad
+    // INI; the orchestration call is out-of-scope and the stub
+    // always returned false.)
+
+    /// Idempotent. Walks StringInfo with prefix "cd_phm_00_" once and
+    /// classifies entries into per-slot vectors (sorted by name).
+    /// Returns total entries cataloged. Does NOT mutate s_swapMap or
+    /// activation state. Safe to call from the UI thread.
+    std::size_t populate_slot_catalogs() noexcept;
+
+    /// True after a successful populate_slot_catalogs.
+    [[nodiscard]] bool is_catalog_populated() noexcept;
+
+    /// Slot-prefix string used for catalog classification (also
+    /// useful for the UI to strip the prefix from dropdown labels).
+    [[nodiscard]] const char *slot_prefix_str(
+        Transmog::TransmogSlot slot) noexcept;
+
+    /// Per-slot catalog (sorted by name). Returns an empty vector for
+    /// slots that have not been populated yet (e.g. catalog walk hasn't
+    /// run, or the slot has no matching prefabs in StringInfo).
+    [[nodiscard]] const std::vector<PrefabEntry> &slot_catalog(
+        Transmog::TransmogSlot slot) noexcept;
+
+    /// Selection indices per slot. -1 = unset; 0..N-1 = index into the
+    /// slot's catalog. UI reads/writes these.
+    [[nodiscard]] int selection_src_index(
+        Transmog::TransmogSlot slot) noexcept;
+    [[nodiscard]] int selection_tgt_index(
+        Transmog::TransmogSlot slot) noexcept;
+    void set_selection(Transmog::TransmogSlot slot,
+                       int srcIdx, int tgtIdx) noexcept;
+
+    /// Cross-slot adoption. Copies the PrefabEntry at
+    /// `fromSlot`'s catalog index `fromIdx` into `intoSlot`'s catalog
+    /// (deduped by name -- if `intoSlot`'s catalog already has an
+    /// entry with the same name, the existing index is reused). Sets
+    /// `intoSlot`'s tgt selection to the resulting index. Source
+    /// selection on `intoSlot` is left untouched.
+    ///
+    /// Used by the overlay's "Prefabs" cross-slot browse mode so the
+    /// user can apply, say, a 2H weapon prefab onto the MainHand slot
+    /// without auto-routing the apply to the prefab's native slot.
+    /// The engine's record-copy hook is slot-agnostic; correctness of
+    /// the resulting render is the user's concern.
+    ///
+    /// Returns the new tgt index on success, -1 on bad slot/index.
+    int adopt_into_slot_and_select(
+        Transmog::TransmogSlot intoSlot,
+        Transmog::TransmogSlot fromSlot,
+        int fromIdx) noexcept;
+
+    /// Rebuilds s_swapMap from current per-slot selections. Replaces
+    /// the legacy pair-config-driven resolve when called. Reads ALL
+    /// pre-cached wrapper instances per name from the catalog (the
+    /// boot-time heap walk merges parallel pool allocations into
+    /// PrefabEntry::wrappers); no I/O or heap walk on this hot path.
+    /// Returns the count of slot pairs successfully bound. Safe to
+    /// call when inactive -- this only resolves; it does NOT toggle
+    /// activation.
+    std::size_t apply_selections_to_swap_map() noexcept;
+
+    /// True if at least one slot has BOTH a src AND tgt selection set.
+    /// Activation handlers should prefer apply_selections_to_swap_map
+    /// over resolve_pairs_into_map when this is true.
+    [[nodiscard]] bool has_any_selection() noexcept;
+
+    /// Reactivate using the current per-slot dropdown selections. If
+    /// already active, deactivates first to clean up the previous
+    /// substitutions (scene-graph + staging) before rebuilding the swap
+    /// map from the new selections and re-arming. When all selections
+    /// are cleared, deactivates and stays inactive. Returns the count
+    /// of slots successfully bound.
+    ///
+    /// Used by the slot-row dropdowns for auto-apply on selection
+    /// change (no F10 required) -- mirrors the carrier-item picker
+    /// flow in the overlay where any change immediately reapplies that
+    /// slot.
+    std::size_t reactivate_with_selections() noexcept;
+} // namespace Transmog::PrefabWrapperSwap

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -1,7 +1,10 @@
 #include "preset_manager.hpp"
+#include "prefab_wrapper_swap.hpp"
 #include "constants.hpp"
 #include "item_name_table.hpp"
+#include "slot_metadata.hpp"
 #include "transmog.hpp"
+#include "transmog_apply.hpp"
 #include "transmog_map.hpp"
 
 #include <DetourModKit.hpp>
@@ -17,10 +20,15 @@ namespace Transmog
 
     static json slot_to_json(const PresetSlot &s)
     {
-        return json{
+        json j{
             {"active", s.active},
             {"itemName", s.itemName},
         };
+        // Only emit prefabName when set, to keep the JSON tidy for
+        // the common (no body-mesh override) case.
+        if (!s.prefabName.empty())
+            j["prefabName"] = s.prefabName;
+        return j;
     }
 
     static PresetSlot slot_from_json(const json &j)
@@ -28,6 +36,7 @@ namespace Transmog
         PresetSlot s;
         s.active = j.value("active", false);
         s.itemName = j.value("itemName", std::string());
+        s.prefabName = j.value("prefabName", std::string());
 
         if (s.itemName.empty())
             return s;
@@ -56,13 +65,35 @@ namespace Transmog
         return s;
     }
 
+    // Keyed-object slot serialization. Old format was a positional
+    // array (slots[0]=Helm, [1]=Chest, ...) which broke whenever the
+    // TransmogSlot enum gained a row -- legacy presets shifted by
+    // one. Object form keys each slot by its slot_metadata display
+    // name ("Helm", "Chest", ...) so the JSON survives enum
+    // additions/removals as long as the names stay stable.
+    //
+    // Migration is automatic: preset_from_json accepts BOTH the
+    // legacy array form AND the new object form. The next save
+    // rewrites every loaded file in object form.
+    //
+    // Disabled slots and default-empty rows are omitted from the
+    // object to keep the JSON tidy. A completely-empty preset
+    // serializes as `{"slots": {}}`.
     static json preset_to_json(const Preset &p)
     {
-        json slotsArr = json::array();
-        for (std::size_t i = 0; i < k_slotCount; ++i)
-            slotsArr.push_back(slot_to_json(p.slots[i]));
-
-        return json{{"name", p.name}, {"slots", slotsArr}};
+        json slotsObj = json::object();
+        for (std::size_t i = 0; i < k_slotCount; ++i) {
+            const auto &s = p.slots[i];
+            if (!Transmog::slot_enabled(i))
+                continue;
+            const bool defaultRow = !s.active && s.itemName.empty() &&
+                                    s.prefabName.empty();
+            if (defaultRow)
+                continue;
+            slotsObj[Transmog::slot_meta(static_cast<TransmogSlot>(i))
+                         .displayName] = slot_to_json(s);
+        }
+        return json{{"name", p.name}, {"slots", slotsObj}};
     }
 
     static Preset preset_from_json(const json &j)
@@ -70,11 +101,52 @@ namespace Transmog
         Preset p;
         p.name = j.value("name", std::string("Unnamed"));
 
-        if (j.contains("slots") && j["slots"].is_array())
+        if (!j.contains("slots"))
+            return p;
+
+        const auto &slotsJ = j["slots"];
+
+        // New format: object keyed by slot displayName.
+        if (slotsJ.is_object())
         {
-            auto &arr = j["slots"];
-            for (std::size_t i = 0; i < k_slotCount && i < arr.size(); ++i)
-                p.slots[i] = slot_from_json(arr[i]);
+            for (auto it = slotsJ.begin(); it != slotsJ.end(); ++it)
+            {
+                bool matched = false;
+                for (std::size_t i = 0; i < k_slotCount; ++i)
+                {
+                    const auto &m = k_slotMetadata[i];
+                    if (it.key() == m.displayName)
+                    {
+                        p.slots[i] = slot_from_json(it.value());
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched)
+                {
+                    DMK::Logger::get_instance().warning(
+                        "[preset] '{}' has unknown slot key '{}' -- "
+                        "ignored (slot may have been renamed or "
+                        "removed)",
+                        p.name, it.key());
+                }
+            }
+            return p;
+        }
+
+        // Legacy format: positional array. Indices map directly to
+        // TransmogSlot enum order. Auto-migrated to object form on
+        // next save.
+        if (slotsJ.is_array())
+        {
+            DMK::Logger::get_instance().info(
+                "[preset] '{}' loaded from legacy array format -- "
+                "next save will rewrite as keyed object",
+                p.name);
+            for (std::size_t i = 0;
+                 i < k_slotCount && i < slotsJ.size();
+                 ++i)
+                p.slots[i] = slot_from_json(slotsJ[i]);
         }
         return p;
     }
@@ -298,6 +370,24 @@ namespace Transmog
         return &it->second.presets[static_cast<std::size_t>(idx)];
     }
 
+    const Preset *PresetManager::active_preset_of(
+        const std::string &charName) const
+    {
+        // Read-only sibling of active_preset() that targets an arbitrary
+        // character. Used by the body-mesh prefab picker to borrow the
+        // Kairos (default-carrier) preset's itemIds while leaving the
+        // manager's active_character untouched -- mutating active_character
+        // here would side-trigger load-detect / radial-swap state and
+        // cascade into a save.
+        auto it = m_characters.find(charName);
+        if (it == m_characters.end() || it->second.presets.empty())
+            return nullptr;
+
+        auto idx = std::clamp(it->second.activePreset, 0,
+                              static_cast<int>(it->second.presets.size()) - 1);
+        return &it->second.presets[static_cast<std::size_t>(idx)];
+    }
+
     Preset *PresetManager::active_preset_mut()
     {
         auto it = m_characters.find(m_activeCharacter);
@@ -470,8 +560,81 @@ namespace Transmog
         // apply runs, breaking drop detection.
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
+            // Disabled slots (multi-prefab non-armor / duplicate-tag
+            // -- see slot_metadata.hpp `enabled` doc) cannot be applied
+            // and are hidden from the picker. A legacy preset saved
+            // before these slots were disabled may still carry
+            // active=true with a non-zero itemId. Force everything off
+            // here so downstream code (lastIds clearing, carrier-borrow,
+            // PWS sync below) doesn't see a stale ticked state for a
+            // slot the user has no way to interact with.
+            if (!Transmog::slot_enabled(i))
+            {
+                mappings[i].active = false;
+                mappings[i].targetItemId = 0;
+                continue;
+            }
+
             mappings[i].active = p->slots[i].active;
             mappings[i].targetItemId = p->slots[i].itemId;
+
+            // Body-mesh slots only persist `prefabName`; the carrier
+            // itemId is derived here from the active character's
+            // default Kliff/Damiane/Oongka plate set. This keeps the
+            // user-facing JSON clean (no spurious "Kliff_PlateArmor_*"
+            // names cluttering body-mesh-only preset entries).
+            if (mappings[i].targetItemId == 0 &&
+                !p->slots[i].prefabName.empty())
+            {
+                const auto carrier = Transmog::default_carrier_for_slot(
+                    static_cast<TransmogSlot>(i), m_activeCharacter);
+                if (carrier != 0)
+                {
+                    mappings[i].targetItemId = carrier;
+                    mappings[i].active = true;
+                }
+            }
+        }
+
+        // Sync body-mesh prefab selections. For each slot, if the
+        // preset stores a prefabName, look it up in the slot's catalog
+        // and set the PWS target index. Empty prefabName clears the
+        // target (slot reverts to plain carrier rendering). When the
+        // catalog isn't yet populated (boot heap walk in progress)
+        // resolution silently misses; the boot thread re-runs
+        // apply_to_state when populate_slot_catalogs finishes so the
+        // selection lands as soon as the data is available.
+        namespace PWS = Transmog::PrefabWrapperSwap;
+        for (std::size_t i = 0; i < k_slotCount; ++i)
+        {
+            const auto tslot = static_cast<TransmogSlot>(i);
+            const int curSrc = PWS::selection_src_index(tslot);
+            // Force-clear any persisted PWS selection on disabled
+            // slots so a legacy preset's body-mesh prefab can't keep
+            // a target index live (which the natural-pipeline hook
+            // would otherwise still apply against).
+            if (!Transmog::slot_enabled(i))
+            {
+                PWS::set_selection(tslot, curSrc, -1);
+                continue;
+            }
+            const auto &name = p->slots[i].prefabName;
+            if (name.empty())
+            {
+                PWS::set_selection(tslot, curSrc, -1);
+                continue;
+            }
+            const auto &cat = PWS::slot_catalog(tslot);
+            int found = -1;
+            for (std::size_t k = 0; k < cat.size(); ++k)
+            {
+                if (cat[k].name == name)
+                {
+                    found = static_cast<int>(k);
+                    break;
+                }
+            }
+            PWS::set_selection(tslot, curSrc, found);
         }
     }
 
@@ -482,15 +645,55 @@ namespace Transmog
 
         auto &mappings = slot_mappings();
         const auto &table = ItemNameTable::instance();
+        namespace PWS = Transmog::PrefabWrapperSwap;
 
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
+            // Disabled slots (multi-prefab non-armor / duplicate-tag,
+            // see slot_metadata.hpp) are WIP -- don't bloat the JSON
+            // with their current in-memory state. Leaving p.slots[i]
+            // default-constructed serializes the row as
+            // `{"active":false,"itemName":""}` so the array indexing
+            // stays positional but the entry is empty. Any stale data
+            // from an older preset (saved before the slot was
+            // disabled) is discarded on the next save.
+            if (!Transmog::slot_enabled(i))
+                continue;
+
             p.slots[i].active = mappings[i].active;
             p.slots[i].itemId = mappings[i].targetItemId;
-            // id 0 means "none" -- don't resolve a name for it.
-            // The catalog's entry at index 0 is a real item
-            // (Pyeonjeon_Arrow) and saving that name would cause
-            // the preset to load an unintended item on reresolve.
+
+            // Capture the active body-mesh prefab name (target side
+            // of the swap) so it is restored on next load. The src
+            // side is the hardcoded Kliff default and need not be
+            // persisted.
+            const auto tslot = static_cast<TransmogSlot>(i);
+            const int tgtIdx = PWS::selection_tgt_index(tslot);
+            if (tgtIdx >= 0)
+            {
+                const auto &cat = PWS::slot_catalog(tslot);
+                if (static_cast<std::size_t>(tgtIdx) < cat.size())
+                    p.slots[i].prefabName = cat[tgtIdx].name;
+            }
+
+            // When a body-mesh prefab is set, the carrier itemId is
+            // an internal implementation detail (the auto-borrowed
+            // Kairos plate that feeds the source wrapper). Don't
+            // persist itemName for these slots -- the JSON only
+            // shows the user-meaningful prefabName, and load-time
+            // re-derives the carrier via default_carrier_for_slot.
+            if (!p.slots[i].prefabName.empty())
+            {
+                p.slots[i].itemName.clear();
+                continue;
+            }
+
+            // Plain carrier slot (no body-mesh override). Resolve
+            // itemName for round-trip persistence. id 0 means "none"
+            // -- don't resolve a name for it; the catalog's entry at
+            // index 0 is a real item (Pyeonjeon_Arrow) and saving
+            // that name would cause the preset to load an unintended
+            // item on reresolve.
             if (table.ready() && mappings[i].targetItemId != 0)
                 p.slots[i].itemName = table.name_of(mappings[i].targetItemId);
             else

--- a/CrimsonDesertLiveTransmog/src/preset_manager.hpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.hpp
@@ -21,6 +21,12 @@ namespace Transmog
         // The sole persistent identifier in the preset JSON. Resolved
         // to `itemId` at load time or after the deferred catalog scan.
         std::string itemName;
+        // Optional body-mesh prefab name (e.g. "cd_nhw_no_ub_20027").
+        // Empty when this slot has no body-mesh override. Resolved
+        // against PrefabWrapperSwap::slot_catalog() in apply_to_state;
+        // if the catalog isn't yet populated (boot heap walk still
+        // running) the resolution retries when the catalog finishes.
+        std::string prefabName;
     };
 
     struct Preset
@@ -106,6 +112,14 @@ namespace Transmog
 
         /// Apply the active preset's slot data to the global slot_mappings.
         void apply_to_state() const;
+
+        /// Look up the *active* preset for an arbitrary character without
+        /// changing the manager's currently-selected character. Used by
+        /// the body-mesh prefab picker to "borrow" the Kairos (default-
+        /// carrier) preset's slot itemIds when the user is editing on a
+        /// different character. Returns nullptr if the character is
+        /// unknown or has no presets.
+        const Preset *active_preset_of(const std::string &charName) const;
 
         /// Capture current slot_mappings into a Preset.
         static Preset capture_from_state(const std::string &name = "");

--- a/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
+++ b/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
@@ -1,6 +1,9 @@
 #include "aob_resolver.hpp"
+#include "item_name_table.hpp"
 #include "real_part_tear_down.hpp"
 #include "shared_state.hpp"
+#include "slot_metadata.hpp"
+#include "transmog_map.hpp"
 
 #include <DetourModKit.hpp>
 
@@ -9,6 +12,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cstring>
+#include <string>
 
 namespace Transmog::RealPartTearDown
 {
@@ -42,6 +46,25 @@ namespace Transmog::RealPartTearDown
         // patch reshaping the struct is immediately visible in the log
         // (the container ptr + entry offsets are not AOB-anchored).
         std::atomic<bool> g_loggedFirstEntry{false};
+
+        // Auth-table verbose dump tracker. Fires the full enumeration
+        // once per distinct (a1, count) pair so character switches and
+        // table resizes re-emit the slot inventory, but a single
+        // session of stable equip state doesn't spam the log on every
+        // tear-down call. Used by the slot-discovery research pass --
+        // helps decide whether a character actually has live entries
+        // for tags beyond the documented Helm/Chest/Gloves/Boots/Cloak
+        // (0x03/0x04/0x05/0x06/0x10) set. The dump function itself is
+        // defined below the layout constants because it reads them.
+        std::atomic<std::uintptr_t> g_lastDumpedA1{0};
+        std::atomic<std::uint32_t>  g_lastDumpedCount{0};
+        // Hash over the entry-array's primary IDs so the dedupe also
+        // catches gear changes within the same (a1, count) -- without
+        // it, the auth table's `count` is the slot-array capacity (not
+        // the equipped count: empty slots persist as 0xFFFF sentinels)
+        // so equip/unequip never bumps count and the prior dedupe key
+        // wouldn't re-fire after the first dump per actor.
+        std::atomic<std::uint64_t>  g_lastDumpedContentHash{0};
 
         // ---- Runtime struct layout for the PartDef/auth-table container ----
         //
@@ -87,12 +110,218 @@ namespace Transmog::RealPartTearDown
         constexpr std::uintptr_t k_entryGateOffset          = 0x10;
 
         constexpr std::uint32_t k_maxPlausibleEntries      = 0x1000;
-        constexpr std::uint16_t k_minPlausibleSlotTag      = 0x0003;
-        constexpr std::uint16_t k_maxPlausibleSlotTag      = 0x0010;
+        // Slot-tag range covers the full engine taxonomy: 0x00..0x15.
+        // Tag 0x0E is engine-unused but harmless to include in the
+        // range -- the auth-table walk simply never finds an entry
+        // for it. See reference_engine_slot_taxonomy_2026-05-07.md.
+        constexpr std::uint16_t k_minPlausibleSlotTag      = 0x0000;
+        constexpr std::uint16_t k_maxPlausibleSlotTag      = 0x0015;
 
         [[nodiscard]] bool plausible_slot_tag(std::uint16_t tag) noexcept
         {
             return tag >= k_minPlausibleSlotTag && tag <= k_maxPlausibleSlotTag;
+        }
+
+        // Engine-only slot tags absent from `TransmogSlot` (and therefore
+        // from `slot_metadata.hpp::k_slotMetadata`) but still part of the
+        // engine taxonomy. Both kept here so the dump emits a readable
+        // label instead of "?". `is_documented_slot` deliberately returns
+        // false for these so the dump still flags them as NEW SLOT TAG
+        // candidates the mod has not lifted into TransmogSlot yet.
+        [[nodiscard]] const char *engine_only_slot_name(
+            std::uint16_t tag) noexcept
+        {
+            switch (tag)
+            {
+                case 0x000E: return "Unknown";
+                case 0x0015: return "OongkaRocket";
+                default:     return "?";
+            }
+        }
+
+        // Slot label resolver. Defers to `slot_metadata.hpp` (single
+        // source of truth for per-slot static data) when the tag maps to
+        // a `TransmogSlot`; falls back to the engine-only override table
+        // for the two tags LT does not manage.
+        [[nodiscard]] const char *known_slot_name(std::uint16_t tag) noexcept
+        {
+            if (const auto s = slot_from_game_tag(static_cast<std::int16_t>(tag)))
+                return slot_meta(*s).displayName;
+            return engine_only_slot_name(tag);
+        }
+
+        // A tag is "documented" iff it round-trips through `slot_metadata`
+        // (and therefore has a `TransmogSlot` enum entry). The two
+        // engine-only tags (0x000E Unknown, 0x0015 OongkaRocket) live
+        // outside the enum on purpose, so they fall through to the
+        // false branch and get flagged in the dump.
+        [[nodiscard]] bool is_documented_slot(std::uint16_t tag) noexcept
+        {
+            return slot_from_game_tag(static_cast<std::int16_t>(tag)).has_value();
+        }
+
+        // Friendly name for the LT-internal TransmogSlot category that
+        // ItemNameTable::category_of returns when classifying an item
+        // by its descriptor (independent of the auth-table slot tag).
+        // Defers to slot_name() which knows every TransmogSlot enum
+        // entry; "Other" is the catch-all for items whose descriptor
+        // type-code didn't classify (returned TransmogSlot::Count).
+        [[nodiscard]] const char *transmog_category_str(
+            TransmogSlot s) noexcept
+        {
+            if (s == TransmogSlot::Count)
+                return "Other";
+            return slot_name(s);
+        }
+
+        // Walks every live entry in the auth table once per (a1, count)
+        // change and logs (index, slotTag, primary, gate-non-null) plus
+        // the resolved item name + LT-classified category. SEH-guarded
+        // by the caller's __try; container/arrayBase/count have already
+        // been validated by the caller. Cheap: at most
+        // k_maxPlausibleEntries iterations and emits one log line per
+        // live entry. Item-name resolution falls back to "<unresolved>"
+        // when ItemNameTable hasn't built (e.g. early in load).
+        void dump_full_auth_table_if_changed(
+            std::uintptr_t a1,
+            std::uintptr_t arrayBase,
+            std::uint32_t  count) noexcept
+        {
+            // Cheap pre-pass: FNV-1a 64-bit hash over the primary IDs
+            // so equip/unequip events (which leave count unchanged) are
+            // visible to the dedupe gate. ~20 entries * 2 bytes hashed
+            // per call -- negligible. Caller's __try frame covers the
+            // volatile reads.
+            std::uint64_t contentHash = 0xCBF29CE484222325ULL;
+            for (std::uint32_t i = 0; i < count; ++i)
+            {
+                const auto entry = arrayBase + k_entryStride * i;
+                const auto primary =
+                    *reinterpret_cast<volatile std::uint16_t *>(
+                        entry + k_entryPrimaryWordOffset);
+                contentHash ^= static_cast<std::uint64_t>(primary);
+                contentHash *= 0x100000001B3ULL;
+            }
+
+            const auto prevA1    = g_lastDumpedA1.load(std::memory_order_acquire);
+            const auto prevCount = g_lastDumpedCount.load(std::memory_order_acquire);
+            const auto prevHash  = g_lastDumpedContentHash.load(std::memory_order_acquire);
+            if (prevA1 == a1 && prevCount == count && prevHash == contentHash)
+                return;
+
+            // Stamp the dedupe tracker only when ItemNameTable is ready
+            // -- otherwise the first dump fires from the early load-
+            // detect retry probe (which runs ~1s before the catalog
+            // is built), names show as "<unresolved>", and we'd never
+            // re-dump once stamped. By deferring the stamp until names
+            // resolve, the dump re-fires up to a couple times during
+            // the load window (cheap: one log batch per retry tick)
+            // and lands its FINAL emission with full item names.
+            auto &logger = DMK::Logger::get_instance();
+            auto &itemTable = ItemNameTable::instance();
+            const bool  itemTableReady = itemTable.size() > 0;
+            if (itemTableReady)
+            {
+                g_lastDumpedA1.store(a1, std::memory_order_release);
+                g_lastDumpedCount.store(count, std::memory_order_release);
+                g_lastDumpedContentHash.store(contentHash, std::memory_order_release);
+            }
+
+            logger.trace(
+                "[slot-discovery] auth-table dump begin a1=0x{:X} "
+                "arrayBase=0x{:X} count={} stride={:#x} slotTag@+{:#x} "
+                "ItemNameTable={}",
+                static_cast<std::uint64_t>(a1),
+                static_cast<std::uint64_t>(arrayBase),
+                count,
+                static_cast<std::uint64_t>(k_entryStride),
+                static_cast<std::uint64_t>(k_entrySlotTagOffset),
+                itemTableReady ? "ready" : "not-ready");
+
+            std::uint32_t live = 0;
+            std::uint32_t documented = 0;
+            std::uint32_t newTags = 0;
+            for (std::uint32_t i = 0; i < count; ++i)
+            {
+                const auto entry = arrayBase + k_entryStride * i;
+                const auto primary =
+                    *reinterpret_cast<volatile std::uint16_t *>(
+                        entry + k_entryPrimaryWordOffset);
+                const auto gate =
+                    *reinterpret_cast<volatile std::uint64_t *>(
+                        entry + k_entryGateOffset);
+                const auto tag =
+                    *reinterpret_cast<volatile std::uint16_t *>(
+                        entry + k_entrySlotTagOffset);
+
+                const bool isLive = !(primary == 0xFFFF || primary == 0)
+                                    && gate != 0;
+                if (!isLive)
+                    continue;
+
+                ++live;
+                const bool documentedTag = is_documented_slot(tag);
+                if (documentedTag)
+                    ++documented;
+                else
+                    ++newTags;
+
+                const char *tagName = known_slot_name(tag);
+                const char *newTagMarker =
+                    documentedTag ? "" : "  *** NEW SLOT TAG ***";
+
+                if (!itemTableReady)
+                {
+                    // Catalog not built yet -- skip the resolved fields
+                    // entirely (they would all be default-init noise:
+                    // equipType=0, typeCode=0xFFFF, cat=Other) and just
+                    // print the raw engine-side fields. This branch
+                    // re-fires on the next probe tick once names land.
+                    logger.trace(
+                        "[slot-discovery]   [{:>2}] tag={:#06x} ({:<12}) "
+                        "primary={:#06x} <unresolved>{}",
+                        i, tag, tagName, primary, newTagMarker);
+                    continue;
+                }
+
+                std::string itemName = itemTable.name_of(primary);
+                if (itemName.empty())
+                    itemName = "<unresolved>";
+
+                const char *categoryStr =
+                    transmog_category_str(itemTable.category_of(primary));
+                const std::uint16_t equipType = itemTable.equip_type_of(primary);
+                const std::uint16_t typeCode  = itemTable.type_code_of(primary);
+
+                // Auto-record (itemId -> TransmogSlot) for the picker
+                // catalog. The engine just told us which slot this item
+                // belongs in -- ground truth that overrides the static
+                // type-code heuristic. Skips when the tag has no
+                // TransmogSlot mapping (e.g. tag 0x0E "Unknown" or 0x15
+                // OongkaRocket -- both intentionally not in TransmogSlot).
+                if (auto tslot = slot_from_game_slot(static_cast<std::int16_t>(tag));
+                    tslot.has_value())
+                {
+                    itemTable.record_observed_slot(primary, *tslot);
+                }
+
+                logger.trace(
+                    "[slot-discovery]   [{:>2}] tag={:#06x} ({:<12}) "
+                    "primary={:#06x} equipType={:#06x} typeCode={:#06x} "
+                    "cat={:<13} name=\"{}\"{}",
+                    i, tag, tagName, primary, equipType, typeCode,
+                    categoryStr, itemName, newTagMarker);
+            }
+
+            logger.trace(
+                "[slot-discovery] auth-table dump end live={} "
+                "documented={} new_tags={} runtime_obs_total={} "
+                "(NEW SLOT TAG entries are candidates for TransmogSlot "
+                "enum extension; runtime_obs_total counts session-wide "
+                "(itemId->slot) bindings the picker now uses to override "
+                "static type-code mapping)",
+                live, documented, newTags,
+                itemTableReady ? itemTable.observed_slot_count() : std::size_t{0});
         }
 
         // First-byte prologue sanity check. Thin wrapper that defers to
@@ -169,7 +398,18 @@ namespace Transmog::RealPartTearDown
             // whose slot entries are not yet populated -- placeholder or
             // mid-wiring. The upper bound rejects torn reads that would
             // otherwise pass the lower bound by accident.
-            return count >= 1 && count <= k_maxPlausibleEntries;
+            const bool ready =
+                count >= 1 && count <= k_maxPlausibleEntries;
+
+            // Passive slot-discovery: dump the auth table the moment a
+            // ready actor first appears (and again whenever a1 or count
+            // changes -- character swap, table resize). Fires before any
+            // tear-down call lands, so we get visibility even if the
+            // user never toggles LT for a given character.
+            if (ready)
+                dump_full_auth_table_if_changed(a1, arrayBase, count);
+
+            return ready;
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -335,6 +575,12 @@ namespace Transmog::RealPartTearDown
                     static_cast<std::uint64_t>(k_entrySlotTagOffset),
                     static_cast<std::uint64_t>(g0));
             }
+
+            // Verbose slot-discovery dump: enumerates every live entry
+            // so additional slot tags (lower body, mask, neck, etc.)
+            // populated by the engine for the active character become
+            // visible. One-shot per distinct (a1, count) pair.
+            dump_full_auth_table_if_changed(a1, arrayBase, count);
 
             std::uintptr_t foundEntry = 0;
             std::uint16_t  itemWord   = 0;

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -43,10 +43,11 @@ namespace Transmog
     static std::atomic<__int64> s_playerA1{0};
     static std::atomic<uintptr_t> s_worldSystemPtr{0};
     static std::array<bool, k_slotCount> s_realDamaged{};
-    static std::array<std::uint16_t, 5> s_lastAppliedRealIds{};
+    static std::array<std::uint16_t, k_slotCount> s_lastAppliedRealIds{};
     static std::atomic<bool> s_clearPending{false};
     static std::atomic<std::size_t> s_pendingSlotIndex{k_slotCount};
     static std::array<std::uint16_t, k_slotCount> s_lastAppliedCarrierIds{};
+    static std::array<bool, k_slotCount> s_forceApplyPending{};
     static std::atomic<std::uintptr_t> s_swapStaleComp{0};
 
     ResolvedAddresses &resolved_addrs() { return s_resolvedAddrs; }
@@ -76,8 +77,9 @@ namespace Transmog
     }
     std::atomic<uintptr_t> &world_system_ptr() { return s_worldSystemPtr; }
     std::array<bool, k_slotCount> &real_damaged() { return s_realDamaged; }
-    std::array<std::uint16_t, 5> &last_applied_real_ids() { return s_lastAppliedRealIds; }
+    std::array<std::uint16_t, k_slotCount> &last_applied_real_ids() { return s_lastAppliedRealIds; }
     std::array<std::uint16_t, k_slotCount> &last_applied_carrier_ids() { return s_lastAppliedCarrierIds; }
+    std::array<bool, k_slotCount> &force_apply_pending() { return s_forceApplyPending; }
     std::atomic<bool> &clear_pending() { return s_clearPending; }
     std::atomic<std::size_t> &pending_slot_index() { return s_pendingSlotIndex; }
     std::atomic<std::uintptr_t> &swap_stale_comp() { return s_swapStaleComp; }

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -24,13 +24,57 @@ namespace Transmog
 
     // --- Transmog slot definitions ---
 
+    // Order is preset-format-stable: existing slots 0..4 (Helm..Boots)
+    // MUST keep their indices so legacy presets load unchanged. New
+    // accessory/utility slots append after Boots. Engine slot tags for
+    // each entry are listed below; resolved via game_slot_from_transmog.
     enum class TransmogSlot : uint8_t
     {
-        Helm,
-        Chest,
-        Cloak,
-        Gloves,
-        Boots,
+        Helm,           // engine tag 0x03
+        Chest,          // engine tag 0x04
+        Cloak,          // engine tag 0x10
+        Gloves,         // engine tag 0x05
+        Boots,          // engine tag 0x06
+        Earring1,       // engine tag 0x07
+        Earring2,       // engine tag 0x08
+        Necklace,       // engine tag 0x09
+        Ring1,          // engine tag 0x0A
+        Ring2,          // engine tag 0x0B
+        Lantern,        // engine tag 0x0F
+        Glasses,        // engine tag 0x11
+        Mask,           // engine tag 0x12
+        Backpack,       // engine tag 0x13
+        Bracelet,       // engine tag 0x14
+        // Weapons -- visible meshes on character but live in the
+        // cd_phw_* prefab family, not cd_phm_*. prefab_wrapper_swap
+        // module skips them (empty prefixes) so they go through the
+        // carrier-only path.
+        MainHand,      // engine tag 0x00 (mainhand 1H)
+        OffHand,       // engine tag 0x01 (offhand / shield / 1H mirror)
+        Ranged,         // engine tag 0x02 (bow/pistol)
+        SubWeapon,      // engine tag 0x0C (dagger/axe family)
+        TwoHandWeapon,  // engine tag 0x0D (greatsword)
+        // Tag 0x0E is engine-unused for all three protagonists in any
+        // observed save. Commented out 2026-05-07 -- we don't know what
+        // it does and didn't want it in the UI picker. The slot-discovery
+        // dump still labels it "Unknown" so it stays visible in logs;
+        // re-add by uncommenting AND restoring the matching commented-
+        // out rows (same checklist as OongkaRocket below).
+        // Experimental,   // engine tag 0x0E
+        // OongkaRocket -- engine tag 0x15 (Oongka-only "Rocket Helm").
+        // Removed from the UI picker on 2026-05-07 because Kliff and
+        // Damiane reject this slot (engine metadata doesn't include
+        // tag 0x15 for them) and the slot adds no transmog value for
+        // the typical case. Re-add later by uncommenting AND restoring
+        // the matching commented-out rows in:
+        //   transmog_map.cpp        (k_slotNames, slot_from_game_slot,
+        //                            game_slot_from_transmog)
+        //   transmog_apply.cpp      (k_kliffCarriers, k_damianeCarriers,
+        //                            k_oongkaCarriers, k_gameSlotTags,
+        //                            k_tearDownSlots, k_clearSlots)
+        //   prefab_wrapper_swap.cpp (k_slotPrefixes, k_slotPrefixesFemale,
+        //                            k_slotTags, k_slotTagPatterns)
+        // OongkaRocket,   // engine tag 0x15
         Count
     };
 
@@ -97,14 +141,31 @@ namespace Transmog
     /// SlotPopulator so the mesh gets restored. Cleared on full clear.
     std::array<bool, k_slotCount> &real_damaged();
 
-    /// Snapshot of auth-table real itemId per armor slot at last apply.
-    /// Compared against live auth state to detect real-armor swaps.
-    std::array<std::uint16_t, 5> &last_applied_real_ids();
+    /// Snapshot of auth-table real itemId per slot at last apply,
+    /// indexed by TransmogSlot enum (0..k_slotCount-1). Compared
+    /// against live auth state to detect real-item swaps. Originally
+    /// 5-armor only; widened to all supported slots on 2026-05-07 so
+    /// real-item changes on accessories and weapon slots (e.g. tool
+    /// vs. 2H sword sharing engine slot tag 0x0D) trigger re-apply.
+    /// Slots LT does not actively manage stay zeroed.
+    std::array<std::uint16_t, k_slotCount> &last_applied_real_ids();
 
     /// Carrier itemIds used in the last apply, indexed by TransmogSlot.
     /// 0 means no carrier was used (direct apply). Used by tear-down
     /// Phase A to find the correct scene-graph identity.
     std::array<std::uint16_t, k_slotCount> &last_applied_carrier_ids();
+
+    /// Per-slot one-shot "force apply" flag. When true the next apply
+    /// for that slot bypasses the `targetId == prevId` early-out and
+    /// forces slotNeedsWork in apply_all_transmog, while leaving
+    /// last_applied_ids[i] intact so Phase A `tear_down_fake` still
+    /// runs against the prior carrier. Used by the body-mesh picker
+    /// when re-picking a prefab on the same carrier (e.g. 0x1521 →
+    /// 0x1521 with a different src→tgt wrapper map): without this the
+    /// dispatcher would skip Phase A entirely and the prior body-mesh
+    /// target wrapper would never get cleaned up by the engine's
+    /// natural-pipeline hook. Cleared by the dispatcher after read.
+    std::array<bool, k_slotCount> &force_apply_pending();
 
     /// When true the debounce worker runs clear instead of apply.
     /// Set by manual_clear, consumed by the worker.

--- a/CrimsonDesertLiveTransmog/src/slot_metadata.hpp
+++ b/CrimsonDesertLiveTransmog/src/slot_metadata.hpp
@@ -1,0 +1,283 @@
+#pragma once
+
+#include "shared_state.hpp"
+
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace Transmog
+{
+    // Single source of truth for per-slot static metadata. Indexed by
+    // TransmogSlot enum value (`SlotMetadata.slot == TransmogSlot(i)`).
+    //
+    // Adding a new slot = one row added below. Adding a new per-slot
+    // attribute = one new field on this struct + one column populated
+    // per row. All consumers (transmog_map.cpp, transmog_apply.cpp,
+    // prefab_wrapper_swap.cpp, part_show_suppress.cpp) read this
+    // table; no parallel slot tables anywhere else.
+    struct SlotMetadata
+    {
+        TransmogSlot   slot;             // == array index, asserted at compile time
+        std::int16_t   gameTag;          // engine slot tag (sub_148EB6700-verified)
+        const char    *displayName;      // "Helm", "Chest", ... (UI / log labels)
+        const char    *prefabPrefixMale; // PWS catalog prefix for male characters
+        const char    *prefabPrefixFemale; // PWS catalog prefix for female characters
+        // PartShowSuppress IndexedStringA hash key (CD_*). nullptr when
+        // the slot does NOT participate in PartShowSuppress (only the
+        // 5 armor slots have CD_* hashes; accessory/weapon slots use
+        // different suppression mechanisms or none at all).
+        const char    *partShowHashKey;
+        // Master enable flag. When false, the slot is omitted from the
+        // overlay slot picker AND skipped in the apply/clear dispatcher,
+        // so even a preset that loaded with `active=true` for this slot
+        // becomes a no-op until the flag is flipped back on.
+        //
+        // Currently disabled slots fall into two unsolved categories:
+        //
+        // (A) MULTI-PREFAB NON-ARMOR slots (rings, earrings, brackets,
+        //     all weapon slots, sub-weapons): a single equipped item
+        //     emits MORE THAN ONE prefab into the engine's render list,
+        //     so the current "swap one source wrapper -> one target
+        //     wrapper" pipeline in prefab_wrapper_swap drops 2nd/3rd
+        //     prefabs and leaves the visual half-applied. Needs
+        //     refactor to either (1) widen the swap map to N->M or
+        //     (2) drive the swap from the auth-table mod array which
+        //     already enumerates every contributing prefab.
+        //
+        // (B) DUPLICATE-TAG slots (Ring1/Ring2 share tag 0x0A/0x0B,
+        //     Earring1/Earring2 share 0x07/0x08, MainHand/OffHand
+        //     share dual-wield instances of the same item-id): the
+        //     SlotPopulator hook upstream sees one record per engine
+        //     tag and cannot disambiguate which UI slot the user
+        //     targeted. Need to identify the disambiguator field on
+        //     the swap-entry record (likely a sub-index byte at a
+        //     yet-unmapped offset; engine slot taxonomy memory file
+        //     2026-05-07 has the candidate offsets).
+        //
+        // Both classes are flipped back on by replacing `false` with
+        // `true` in the row below AND landing the corresponding
+        // refactor; the slot is otherwise fully wired through the
+        // metadata table -- no other code paths gate on the slot
+        // identity once `enabled` is true.
+        bool           enabled;
+    };
+
+    inline constexpr SlotMetadata k_slotMetadata[k_slotCount] = {
+        // slot               gameTag  displayName       prefabPrefixMale          prefabPrefixFemale       partShowHashKey   enabled
+        // -- 5 armor slots: original transmog targets, fully working via PartShowSuppress + cd_phm_/cd_phw_ wrapper swap.
+        { TransmogSlot::Helm,          0x03, "Helm",          "cd_phm_00_hel_00_",      "cd_phw_00_hel_00_",     "CD_Helm"      , true  },
+        { TransmogSlot::Chest,         0x04, "Chest",         "cd_phm_00_ub_00_",       "cd_phw_00_ub_00_",      "CD_Upperbody" , true  },
+        { TransmogSlot::Cloak,         0x10, "Cloak",         "cd_phm_00_cloak_00_",    "cd_phw_00_cloak_00_",   "CD_Cloak"     , true  },
+        { TransmogSlot::Gloves,        0x05, "Gloves",        "cd_phm_00_hand_00_",     "cd_phw_00_hand_00_",    "CD_Hand"      , true  },
+        { TransmogSlot::Boots,         0x06, "Boots",         "cd_phm_00_foot_00_",     "cd_phw_00_foot_00_",    "CD_Foot"      , true  },
+        // -- DISABLED (multi-prefab + duplicate-tag): rings/earrings emit
+        //    multiple prefabs per item AND share tags within a pair, so
+        //    SlotPopulator can't tell Ring1 from Ring2. See SlotMetadata
+        //    `enabled` doc-block above for the refactor plan.
+        { TransmogSlot::Earring1,      0x07, "Earring1",      "",                       "",                      nullptr        , false },
+        { TransmogSlot::Earring2,      0x08, "Earring2",      "",                       "",                      nullptr        , false },
+        // -- Necklace: single-prefab single-tag, treated like an armor slot.
+        { TransmogSlot::Necklace,      0x09, "Necklace",      "",                       "",                      nullptr        , true  },
+        { TransmogSlot::Ring1,         0x0A, "Ring1",         "cd_phm_00_ring_",        "cd_phw_00_ring_",       nullptr        , false },
+        { TransmogSlot::Ring2,         0x0B, "Ring2",         "cd_phm_00_ring_",        "cd_phw_00_ring_",       nullptr        , false },
+        // Lantern uses cd_t0000_* on both genders (gender-shared family).
+        { TransmogSlot::Lantern,       0x0F, "Lantern",       "cd_t0000_lantern_",      "cd_t0000_lantern_",     nullptr        , true  },
+        { TransmogSlot::Glasses,       0x11, "Glasses",       "cd_phm_00_glasses_",     "cd_phw_00_glasses_",    nullptr        , true  },
+        { TransmogSlot::Mask,          0x12, "Mask",          "cd_phm_00_mask_00_",     "cd_phw_00_mask_00_",    nullptr        , true  },
+        { TransmogSlot::Backpack,      0x13, "Backpack",      "cd_phm_00_bag_0",        "cd_phw_00_bag_0",       nullptr        , true  },
+        // Bracelet uses cd_phw_*_rinkband_ on BOTH genders (phw natively,
+        // even for male characters -- engine quirk verified live).
+        // DISABLED: multi-prefab non-armor slot.
+        { TransmogSlot::Bracelet,      0x14, "Bracelet",      "cd_phw_00_rinkband_",    "cd_phw_00_rinkband_",   nullptr        , false },
+        // -- DISABLED (weapon family): every weapon slot below emits
+        //    multiple prefabs per item (mesh + scabbard + FX + binds),
+        //    and MainHand/OffHand additionally share tag space when
+        //    dual-wielding. Need a separate cd_phw_* weapon pipeline
+        //    + sub-index disambiguation in SlotPopulator before re-
+        //    enabling. Tracked in memory file `engine_slot_taxonomy_
+        //    2026-05-07` Tier 3.
+        { TransmogSlot::MainHand,     0x00, "MainHand",     "cd_phm_01_",             "cd_phw_01_",            nullptr        , false },
+        { TransmogSlot::OffHand,      0x01, "OffHand",      "cd_phm_01_",             "cd_phw_01_",            nullptr        , false },
+        { TransmogSlot::Ranged,        0x02, "Ranged",        "cd_phm_04_",             "cd_phw_04_",            nullptr        , false },
+        { TransmogSlot::SubWeapon,     0x0C, "SubWeapon",     "cd_phm_01_dagger_",      "cd_phw_01_dagger_",     nullptr        , false },
+        // displayName intentionally trimmed to "TwoHand" (was "TwoHandWeapon")
+        // to fit the overlay's slot column. Used everywhere `slot_name()`
+        // is read; engine-side diagnostics still call this slot's gameTag
+        // 0x0D which game_slot_name returns this same trimmed string for.
+        { TransmogSlot::TwoHandWeapon, 0x0D, "TwoHand",       "cd_phm_02_",             "cd_phw_02_",            nullptr        , false },
+        // Tag 0x0E "Experimental" and 0x15 "OongkaRocket" intentionally
+        // omitted -- see TransmogSlot enum comments in shared_state.hpp.
+    };
+
+    static_assert(sizeof(k_slotMetadata) / sizeof(k_slotMetadata[0]) == k_slotCount,
+                  "k_slotMetadata length must match TransmogSlot::Count");
+
+    // Compile-time index/slot drift check. The constexpr loop expands
+    // into per-row static_asserts so a misordered or duplicated row is
+    // caught at build time rather than at runtime.
+    namespace detail
+    {
+        constexpr bool slot_metadata_indices_match()
+        {
+            for (std::size_t i = 0; i < k_slotCount; ++i) {
+                if (k_slotMetadata[i].slot != static_cast<TransmogSlot>(i))
+                    return false;
+            }
+            return true;
+        }
+    }
+    static_assert(detail::slot_metadata_indices_match(),
+                  "k_slotMetadata row order must match TransmogSlot enum order "
+                  "(SlotMetadata.slot at row i must equal TransmogSlot(i)).");
+
+    // Direct accessor by enum value. O(1).
+    inline constexpr const SlotMetadata &slot_meta(TransmogSlot s) noexcept
+    {
+        return k_slotMetadata[static_cast<std::size_t>(s)];
+    }
+
+    // Master enable check. Disabled slots are hidden from the slot
+    // picker and short-circuited in the apply/clear dispatcher. See
+    // SlotMetadata::enabled doc-block for the refactor blockers.
+    inline constexpr bool slot_enabled(TransmogSlot s) noexcept
+    {
+        return slot_meta(s).enabled;
+    }
+    inline constexpr bool slot_enabled(std::size_t i) noexcept
+    {
+        return i < k_slotCount && k_slotMetadata[i].enabled;
+    }
+
+    // Reverse lookup: engine slot tag -> TransmogSlot. Returns
+    // std::nullopt for tags LT does not manage (e.g. 0x0E or 0x15).
+    // Linear search over 20 entries -- cheap, called sparingly.
+    inline std::optional<TransmogSlot> slot_from_game_tag(std::int16_t gameTag) noexcept
+    {
+        for (const auto &m : k_slotMetadata) {
+            if (m.gameTag == gameTag)
+                return m.slot;
+        }
+        return std::nullopt;
+    }
+
+    // Map a body-mesh prefab name to its logical slot. Substring-based
+    // so it works for ALL role-prefix variants:
+    //
+    //   Player:    cd_phm_*, cd_phw_*       (human male/female)
+    //   NPC:       cd_nhm_*, cd_nhw_*, cd_ndm_*
+    //   Other:     cd_pdm_*, cd_pgm_*, cd_pom_*, cd_ptm_*
+    //   Accessory: cd_t0000_lantern_*       (no role prefix)
+    //   Mount:     cd_m0001_*               (suffix-driven)
+    //
+    // The numeric role chunk `_NN_` (e.g. `_02_` for 2H weapons,
+    // `_13_` for 1H cannons) is extracted regardless of the role
+    // prefix so a future `cd_xxx_02_sword_*` family inherits the 2H
+    // classification automatically. Specific weapon-type tags
+    // (dagger, alebard, pike, ...) are checked first because they
+    // have unambiguous slot mappings; ambiguous tags (sword, axe,
+    // hammer, cannon, mace, lance, fist) fall through to the numeric
+    // role for 1H vs 2H vs ranged disambiguation.
+    //
+    // Returns std::nullopt for prefabs that match nothing the
+    // picker should label (e.g. environmental meshes, food items).
+    inline std::optional<TransmogSlot>
+    slot_for_prefab_name(const std::string &name) noexcept
+    {
+        const auto has = [&](const char *tag) noexcept {
+            return name.find(tag) != std::string::npos;
+        };
+
+        // Extract the first `_NN_` (two-digit) numeric role marker
+        // after the `cd_<role>_` prefix. -1 when absent (NPC, t0000,
+        // m0001 families). Cheap manual scan; no <regex> dependency.
+        int roleNum = -1;
+        for (std::size_t i = 0; i + 4 <= name.size(); ++i) {
+            if (name[i] == '_' &&
+                std::isdigit(static_cast<unsigned char>(name[i + 1])) &&
+                std::isdigit(static_cast<unsigned char>(name[i + 2])) &&
+                name[i + 3] == '_') {
+                roleNum = (name[i + 1] - '0') * 10 +
+                          (name[i + 2] - '0');
+                break;
+            }
+        }
+
+        // --- Specific-name weapons (unambiguous slot) ---
+        if (has("_dagger_"))
+            return TransmogSlot::SubWeapon;
+        if (has("_alebard_") || has("_pike_") ||
+            has("_spear_")   || has("_greekfire_") ||
+            has("_icethrower_") || has("_lightningthrower_") ||
+            has("_warhammer_") || has("_flexiblewarhammer_"))
+            return TransmogSlot::TwoHandWeapon;
+        if (has("_kiteshield_") || has("_towershield_") ||
+            has("_shield_"))
+            return TransmogSlot::OffHand;
+        if (has("_arw_")     || has("_bow_") ||
+            has("_crossbow_") || has("_pistol_") ||
+            has("_musket_")  || has("_shotgun_") ||
+            has("_bomb_")    || has("_blowpipe_"))
+            return TransmogSlot::Ranged;
+
+        // --- Ambiguous weapon tags: disambiguate by numeric role ---
+        // Convention from the v1.05.01 prefab catalog (TSV scan):
+        //   _01_ = 1H, _02_ = 2H, _03_ = shield, _04..06,08,10,13 = ranged.
+        if (has("_sword_") || has("_axe_") || has("_mace_") ||
+            has("_lance_") || has("_hammer_") || has("_cannon_") ||
+            has("_fist_")) {
+            switch (roleNum) {
+                case 2: case 12:
+                    return TransmogSlot::TwoHandWeapon;
+                case 4: case 5: case 6: case 8: case 10: case 13:
+                    return TransmogSlot::Ranged;
+                default:
+                    return TransmogSlot::MainHand;
+            }
+        }
+
+        // --- Body parts (substring tags work across all role prefixes) ---
+        if (has("_hel_"))      return TransmogSlot::Helm;
+        if (has("_ub_"))       return TransmogSlot::Chest;
+        if (has("_cloak_"))    return TransmogSlot::Cloak;
+        if (has("_hand_"))     return TransmogSlot::Gloves;
+        if (has("_foot_"))     return TransmogSlot::Boots;
+        if (has("_earring_"))  return TransmogSlot::Earring1;
+        if (has("_necklace_")) return TransmogSlot::Necklace;
+        if (has("_rinkband_")) return TransmogSlot::Bracelet;
+        if (has("_ring_"))     return TransmogSlot::Ring1;
+        if (has("_lantern_"))  return TransmogSlot::Lantern;
+        if (has("_glasses_"))  return TransmogSlot::Glasses;
+        if (has("_mask_"))     return TransmogSlot::Mask;
+        if (has("_bag_"))      return TransmogSlot::Backpack;
+
+        return std::nullopt;
+    }
+
+    // Picker-side compatibility: when the user opens slot X's picker
+    // in prefab mode with the Exact filter on, prefabs whose
+    // `slot_for_prefab_name()` is in the same equivalence group as X
+    // should still pass. Pair-slots (Ring1/Ring2, Earring1/Earring2,
+    // MainHand/OffHand) share their body-mesh family.
+    inline bool slots_share_prefab_family(TransmogSlot a,
+                                          TransmogSlot b) noexcept
+    {
+        if (a == b) return true;
+        const auto pair = [](TransmogSlot x, TransmogSlot p1,
+                             TransmogSlot p2) noexcept {
+            return x == p1 || x == p2;
+        };
+        if (pair(a, TransmogSlot::Earring1, TransmogSlot::Earring2) &&
+            pair(b, TransmogSlot::Earring1, TransmogSlot::Earring2))
+            return true;
+        if (pair(a, TransmogSlot::Ring1, TransmogSlot::Ring2) &&
+            pair(b, TransmogSlot::Ring1, TransmogSlot::Ring2))
+            return true;
+        if (pair(a, TransmogSlot::MainHand, TransmogSlot::OffHand) &&
+            pair(b, TransmogSlot::MainHand, TransmogSlot::OffHand))
+            return true;
+        return false;
+    }
+} // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -1,5 +1,6 @@
 #include "transmog.hpp"
 #include "aob_resolver.hpp"
+#include "prefab_wrapper_swap.hpp"
 #include "constants.hpp"
 #include "indexed_string_table.hpp"
 #include "input_handler.hpp"
@@ -8,6 +9,7 @@
 #include "preset_manager.hpp"
 #include "real_part_tear_down.hpp"
 #include "shared_state.hpp"
+#include "slot_metadata.hpp"
 #include "overlay.hpp"
 #include "transmog_apply.hpp"
 #include "transmog_hooks.hpp"
@@ -68,6 +70,8 @@ namespace Transmog
         // ensure that InputManager::start() runs after this call (handled
         // in init() further down).
         register_hotkeys();
+
+        PrefabWrapperSwap::register_config();
 
         DMK::Config::load(INI_FILE);
         DMK::Config::log_all();
@@ -230,8 +234,30 @@ namespace Transmog
 
             logger.info("=== CAPTURE: {} equipment slots ===", entryCount);
 
+            namespace PWS = Transmog::PrefabWrapperSwap;
+
+            // Capture is "snapshot what the user is currently
+            // equipped with". Any session-only PWS prefab picks must
+            // be cleared so the captured carrier itemIds become the
+            // visible state -- otherwise the cyan prefab label would
+            // hide the captured gear behind a stale prefab pick.
+            // Disabled slots are skipped entirely (the dispatcher
+            // won't service them; writing any captured state into
+            // their mapping just bloats the in-memory rows the next
+            // Save would already drop on disk per slot_metadata.hpp).
             for (std::size_t i = 0; i < k_slotCount; ++i)
             {
+                if (!Transmog::slot_enabled(i))
+                    continue;
+                const auto tslot = static_cast<TransmogSlot>(i);
+                const int curSrc = PWS::selection_src_index(tslot);
+                PWS::set_selection(tslot, curSrc, -1);
+            }
+
+            for (std::size_t i = 0; i < k_slotCount; ++i)
+            {
+                if (!Transmog::slot_enabled(i))
+                    continue;
                 slot_mappings()[i].active = true;
                 slot_mappings()[i].targetItemId = 0;
             }
@@ -250,6 +276,13 @@ namespace Transmog
                 if (tmSlot.has_value() && itemId != 0 && itemId != 0xFFFF)
                 {
                     auto idx = static_cast<std::size_t>(*tmSlot);
+                    if (!Transmog::slot_enabled(idx))
+                    {
+                        logger.info(
+                            "    -> Skipping {} (slot disabled)",
+                            slot_name(*tmSlot));
+                        continue;
+                    }
                     slot_mappings()[idx].targetItemId = itemId;
                     ++captured;
                     logger.info("    -> Captured as {} target", slot_name(*tmSlot));
@@ -275,8 +308,26 @@ namespace Transmog
             return;
         }
 
+        // Capture-style snapshot: skip disabled slots so we don't
+        // bloat in-memory rows for slots the dispatcher won't service.
+        // PWS picks are intentionally NOT preserved -- this function is
+        // a "what is the user wearing right now" snapshot, mirroring
+        // capture_outfit, and any session-only prefab pick should
+        // surrender to the captured itemId so the visible state matches.
+        namespace PWS = Transmog::PrefabWrapperSwap;
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
+            if (!Transmog::slot_enabled(i))
+                continue;
+            const auto tslot = static_cast<TransmogSlot>(i);
+            const int curSrc = PWS::selection_src_index(tslot);
+            PWS::set_selection(tslot, curSrc, -1);
+        }
+
+        for (std::size_t i = 0; i < k_slotCount; ++i)
+        {
+            if (!Transmog::slot_enabled(i))
+                continue;
             slot_mappings()[i].active = true;
             slot_mappings()[i].targetItemId = 0;
         }
@@ -296,7 +347,12 @@ namespace Transmog
 
                 auto tmSlot = slot_from_game_slot(gameSlot);
                 if (tmSlot.has_value() && itemId != 0 && itemId != 0xFFFF)
-                    slot_mappings()[static_cast<std::size_t>(*tmSlot)].targetItemId = itemId;
+                {
+                    const auto idx = static_cast<std::size_t>(*tmSlot);
+                    if (!Transmog::slot_enabled(idx))
+                        continue;
+                    slot_mappings()[idx].targetItemId = itemId;
+                }
             }
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
@@ -785,6 +841,8 @@ namespace Transmog
             }
         }
 
+        PrefabWrapperSwap::init();
+
         start_load_detect_thread();
         ensure_apply_worker_started();
 
@@ -826,6 +884,8 @@ namespace Transmog
         // installed and when the matching uninstall has already run
         // from a sibling consumer.
         CDCore::uninstall_radial_swap_hook();
+
+        PrefabWrapperSwap::shutdown();
 
         // Full DMK teardown: removes every managed hook (BatchEquip,
         // VEC, PartAddShow), stops and clears the InputManager poller

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -1,9 +1,12 @@
 #include "transmog_apply.hpp"
+#include "prefab_wrapper_swap.hpp"
+#include "carrier_defaults.hpp"
 #include "item_name_table.hpp"
 #include "part_show_suppress.hpp"
 #include "preset_manager.hpp"
 #include "real_part_tear_down.hpp"
 #include "shared_state.hpp"
+#include "slot_metadata.hpp"
 #include "transmog_map.hpp"
 #include "transmog_worker.hpp"
 
@@ -58,6 +61,23 @@ namespace Transmog
     constexpr std::ptrdiff_t k_compEntryItemIdOffset     = 0x08;
     constexpr std::ptrdiff_t k_compEntrySlotTagOffset    = 0xC8;
 
+    // (TransmogSlot, engine slot tag) pairs the dispatcher iterates for
+    // tear-down + the auth-table real-id snapshot. Sourced from
+    // slot_metadata.hpp's single per-slot table; the local TearDownSlot
+    // alias keeps existing call sites (`td.slot`, `td.gameTag`) reading
+    // unchanged. Order matches TransmogSlot enum -- previously it was
+    // hand-arranged with the 5 armor slots first by historical accident,
+    // which had no semantic meaning.
+    using TearDownSlot = SlotMetadata;
+    static constexpr auto &k_tearDownSlots = k_slotMetadata;
+    static constexpr std::size_t k_tearDownCount = k_slotCount;
+
+    // Forward decls -- both functions are defined further down this
+    // TU. apply_transmog needs them for the bypass-during-direct-apply
+    // path that fixes cross-class accessory teardown.
+    bool needs_carrier(uint16_t itemId, const std::string &charName);
+    static bool set_char_class_bypass(uintptr_t addr, uint8_t val) noexcept;
+
     void apply_transmog(__int64 a1, uint16_t targetId)
     {
         auto slotPop = slot_populator_fn();
@@ -76,10 +96,35 @@ namespace Transmog
         alignas(16) uint8_t swapEntry[256]{};
         initEntry(reinterpret_cast<__int64>(swapEntry));
 
+        // 2026-05-08 reinstated: enable charClass bypass for cross-
+        // class direct applies. The 2026-05-07 attempt was scoped to
+        // fixing cross-character WEAPON visibility (gated separately
+        // at equipslotinfo.entries[N].etl_hashes -- bypass here doesn't
+        // help that case). What it DOES fix: cross-class accessory
+        // teardown for slots without a Damiane/Oongka-specific carrier
+        // family (Mask, etc.). Without bypass, SlotPopulator's class
+        // check silently rejects the equip, the auth-table never gets
+        // a row, and Phase A's tear_down_by_item_id no-ops because
+        // safeFn(a1, hash, slotTag) walks auth and finds nothing --
+        // the scene mesh ends up orphaned and stuck. With bypass on,
+        // SlotPopulator writes the auth row, tear-down anchors on it,
+        // scene cleanup succeeds. Cost: two memory writes per cross-
+        // class direct apply, only when needs_carrier returns true.
+        const auto &activeChar =
+            PresetManager::instance().active_character();
+        const bool useBypass = needs_carrier(targetId, activeChar);
+        const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
+        bool bypassApplied = false;
+        if (useBypass && bypassAddr)
+            bypassApplied = set_char_class_bypass(bypassAddr, 0xEB);
+
         in_transmog().store(true, std::memory_order_relaxed);
         slotPop(a1, reinterpret_cast<unsigned __int16 *>(itemData),
                 reinterpret_cast<__int64>(swapEntry));
         in_transmog().store(false, std::memory_order_relaxed);
+
+        if (bypassApplied)
+            set_char_class_bypass(bypassAddr, 0x74);
     }
 
     // ── Default carrier set (per character) ─────────────────────────────
@@ -94,36 +139,12 @@ namespace Transmog
     // If a name fails to resolve the slot falls back to direct equip
     // (which may silently fail for NPC/variant items).
 
-    static constexpr const char *k_kliffCarriers[] = {
-        "Kliff_PlateArmor_Helm",   // TransmogSlot::Helm
-        "Kliff_PlateArmor_Armor",  // TransmogSlot::Chest
-        "Kliff_PlateArmor_Cloak",  // TransmogSlot::Cloak
-        "Kliff_PlateArmor_Gloves", // TransmogSlot::Gloves
-        "Kliff_Plate_Boots",       // TransmogSlot::Boots
-    };
-
-    static constexpr const char *k_damianeCarriers[] = {
-        "Demian_PlateArmor_Helm_I",   // TransmogSlot::Helm
-        "Demian_Leather_Armor",       // TransmogSlot::Chest
-        "Demian_Leather_Cloak",       // TransmogSlot::Cloak
-        "Demian_Leather_Gloves_I",    // TransmogSlot::Gloves
-        "Demian_Plate_Boots_III",     // TransmogSlot::Boots
-    };
-
-    // Oongka carriers. Despite sharing 3/4 male-body classifier
-    // tokens with Kliff, the engine rejects Kliff-equip-type (0x0004)
-    // items at Oongka's equip gate -- Oongka's slot class is 0x0001.
-    // Native Oongka_* items pass the gate cleanly; the hybrid then
-    // patches their +0x42 over a Kliff target so Oongka can wear
-    // cross-character armor visuals.
-    static constexpr const char *k_oongkaCarriers[] = {
-        "Oongka_PlateArmor_Helm_II",   // TransmogSlot::Helm
-        "Oongka_Basic_Leather_Armor",  // TransmogSlot::Chest
-        "Oongka_Basic_Leather_Cloak",  // TransmogSlot::Cloak
-        "Oongka_Basic_Leather_Gloves", // TransmogSlot::Gloves
-        "Oongka_PlateArmor_Boots_II",  // TransmogSlot::Boots
-    };
-
+    // Per-character default carrier item-names live in
+    // carrier_defaults.hpp::k_carriers[character][slot].itemName.
+    // ItemNameTable resolves each to a uint16_t carrier itemId at
+    // runtime. This function picks the right row for the active
+    // character and falls back to Kliff if the character-specific
+    // entry isn't catalog-resident.
     uint16_t default_carrier_for_slot(
         TransmogSlot slot, const std::string &charName)
     {
@@ -134,21 +155,20 @@ namespace Transmog
         if (!table.ready())
             return 0;
 
-        const char *name = k_kliffCarriers[idx];
-        if (charName == "Damiane")
-            name = k_damianeCarriers[idx];
-        else if (charName == "Oongka")
-            name = k_oongkaCarriers[idx];
+        const auto charOpt = carrier_char_from_name(charName);
+        const auto cc = charOpt.value_or(CarrierChar::Kliff);
 
+        const char *name = carrier_for(cc, slot).itemName;
         auto id = table.id_of(name);
         if (id.has_value())
             return *id;
 
         // Fallback: if a character-specific carrier name did not
         // resolve (missing from catalog, renamed), try Kliff's set.
-        if (name != k_kliffCarriers[idx])
+        if (cc != CarrierChar::Kliff)
         {
-            auto kliff = table.id_of(k_kliffCarriers[idx]);
+            auto kliff = table.id_of(
+                carrier_for(CarrierChar::Kliff, slot).itemName);
             return kliff.value_or(0);
         }
         return 0;
@@ -179,6 +199,21 @@ namespace Transmog
         // the NPC variant descriptor gets swapped in for visuals
         // while a clean carrier supplies the rule list.
         if (table.has_variant_meta(itemId))
+            return true;
+
+        // Damiane and Oongka ALWAYS use the carrier-hybrid path. The
+        // tribe-gender_list filter (verified 2026-05-08 across 6 helms:
+        // Catfish/Madacus/Brimstone/Hyena reject Oongka, Marni-Devotee
+        // and Oongka_PlateArmor_Helm_III work) rejects most cross-body
+        // items at the engine's class gate, producing INVISIBLE renders
+        // even when equip_type matches. Forcing the carrier path on
+        // every Damiane/Oongka apply uses the charClassBypass +
+        // equip-type patch combo that was already proven to bypass both
+        // class and tribe checks. Kliff keeps the cheaper direct-apply
+        // path because his items are the engine's reference set; only
+        // genuinely cross-class targets (NPC variants, etc.) trigger
+        // the carrier path for him via the equip_type check below.
+        if (charName == "Damiane" || charName == "Oongka")
             return true;
 
         // Equip-type mismatch: the item's +0x42 slot class doesn't
@@ -445,15 +480,9 @@ namespace Transmog
     //     apply_transmog_with_carrier.
     //   - State: only updates lastIds, carrier, suppress for this slot.
 
-    // Game slot tags per TransmogSlot index. Must stay in sync with
-    // k_tearDownSlots inside apply_all_transmog.
-    static constexpr std::uint16_t k_gameSlotTags[k_slotCount] = {
-        0x0003, // Helm
-        0x0004, // Chest
-        0x0010, // Cloak
-        0x0005, // Gloves
-        0x0006, // Boots
-    };
+    // (Removed 2026-05-07: k_gameSlotTags array. Use
+    // slot_meta(slot).gameTag from slot_metadata.hpp instead -- single
+    // source of truth for per-slot gameTag mappings.)
 
     void apply_single_slot_transmog(__int64 a1, std::size_t slotIdx)
     {
@@ -496,15 +525,25 @@ namespace Transmog
         suppress_vec().store(true, std::memory_order_release);
 
         const uint16_t prevId = lastIds[slotIdx];
-        const uint16_t gameTag = k_gameSlotTags[slotIdx];
+        const uint16_t gameTag = static_cast<uint16_t>(
+            k_slotMetadata[slotIdx].gameTag);
 
         // Compute target: active slot with non-zero id → transmog,
         // otherwise clear this slot.
         const uint16_t targetId =
             (m.active && m.targetItemId != 0) ? m.targetItemId : 0;
 
+        // One-shot force flag set by the body-mesh picker when re-picking
+        // a prefab on the same carrier id. Bypasses the equality early-out
+        // so Phase A still runs against the real prevId, driving the
+        // engine's natural-pipeline hook to clean up the prior tgt
+        // wrapper. Read-and-clear.
+        const bool forceApply = force_apply_pending()[slotIdx];
+        if (forceApply)
+            force_apply_pending()[slotIdx] = false;
+
         // Early-out: nothing changed for this slot.
-        if (targetId == prevId && targetId != 0)
+        if (targetId == prevId && targetId != 0 && !forceApply)
         {
             logger.trace("apply_single_slot: slot={} id={:#06x} unchanged",
                          slotIdx, targetId);
@@ -664,7 +703,9 @@ namespace Transmog
             const std::uint16_t slotReal =
                 RealPartTearDown::is_ready()
                     ? RealPartTearDown::get_real_item_id(
-                          reinterpret_cast<void *>(a1), k_gameSlotTags[k])
+                          reinterpret_cast<void *>(a1),
+                          static_cast<std::uint16_t>(
+                              k_slotMetadata[k].gameTag))
                     : 0;
             if (sm.targetItemId != 0 &&
                 static_cast<uint16_t>(sm.targetItemId) == slotReal)
@@ -742,6 +783,13 @@ namespace Transmog
         logger.trace("[dispatch] apply_all_transmog entry a1={:#018x}",
                      static_cast<uint64_t>(a1));
 
+        // (Removed 2026-05-07: legacy PrefabWrapperSwap::
+        // reverse_write_tracked() call. The function was a no-op
+        // since 2026-05-05 because the natural-pipeline hook on
+        // sub_142711DF0 handles cleanup by substituting wrapper
+        // pointers in the engine's unlink list -- no staging revert
+        // is needed.)
+
         // Body has rotated past the stale one (or no swap was in
         // flight) -- this apply will run against the live body, so
         // any captured stale value is now obsolete. CAS-clear under
@@ -764,28 +812,44 @@ namespace Transmog
         // Snapshot lastIds for diagnostic logging.
         const std::array<uint16_t, k_slotCount> prevIds = lastIds;
 
+        // One-shot per-slot "force apply" snapshot (read-and-clear).
+        // Set by the body-mesh picker when the user re-picks a prefab
+        // on the same carrier id (e.g. 0x1521 → 0x1521 with a different
+        // src→tgt wrapper map). Without this signal the dispatcher would
+        // see `wouldBe == prevIds[i]` and skip both presetChanged AND
+        // slotNeedsWork, which means Phase A `tear_down_fake` never runs
+        // for the slot and the engine's natural-pipeline hook never gets
+        // driven to clean up the prior tgt wrapper. With this set the
+        // dispatcher behaves as if the slot's preset had genuinely
+        // changed, while leaving prevIds[i] intact so Phase A still
+        // tears down the prior carrier.
+        std::array<bool, k_slotCount> forceApply{};
+        {
+            auto &fa = force_apply_pending();
+            for (std::size_t i = 0; i < k_slotCount; ++i)
+            {
+                forceApply[i] = fa[i];
+                fa[i] = false;
+            }
+        }
+
         // Early-out: skip all work if neither the preset nor the real
         // armor has changed since the last successful apply. Drops
         // spurious re-apply cycles fired by BatchEquip/VEC for non-armor
         // events (weapon swaps, ring changes, etc.).
         //
-        // Slot tag order here must match k_tearDownSlots inside the
-        // tear-down block: Helm(3), Chest(4), Gloves(5), Boots(6),
-        // Cloak(16). TransmogSlot enum indices differ -- we translate.
-        static constexpr std::uint16_t k_earlyOutSlotTags[5] = {
-            0x0003, 0x0004, 0x0005, 0x0006, 0x0010};
-        static constexpr TransmogSlot k_earlyOutSlots[5] = {
-            TransmogSlot::Helm, TransmogSlot::Chest,
-            TransmogSlot::Gloves, TransmogSlot::Boots,
-            TransmogSlot::Cloak};
-
-        std::array<std::uint16_t, 5> liveRealIds{};
+        // liveRealIds is indexed by TransmogSlot enum value (0..k_slotCount-1)
+        // and populated by walking k_tearDownSlots which already enumerates
+        // every supported slot with its engine tag. Slots LT does not
+        // manage stay zeroed.
+        std::array<std::uint16_t, k_slotCount> liveRealIds{};
         if (RealPartTearDown::is_ready())
         {
-            for (std::size_t k = 0; k < 5; ++k)
+            for (const auto &td : k_tearDownSlots)
             {
-                liveRealIds[k] = RealPartTearDown::get_real_item_id(
-                    reinterpret_cast<void *>(a1), k_earlyOutSlotTags[k]);
+                const auto idx = static_cast<std::size_t>(td.slot);
+                liveRealIds[idx] = RealPartTearDown::get_real_item_id(
+                    reinterpret_cast<void *>(a1), td.gameTag);
             }
         }
 
@@ -797,7 +861,7 @@ namespace Transmog
                 const auto &m = mappings[i];
                 const uint16_t wouldBe =
                     (m.active && m.targetItemId != 0) ? m.targetItemId : 0;
-                if (wouldBe != prevIds[i])
+                if (wouldBe != prevIds[i] || forceApply[i])
                 {
                     presetChanged = true;
                     break;
@@ -805,9 +869,9 @@ namespace Transmog
             }
 
             bool realChanged = false;
-            for (std::size_t k = 0; k < 5; ++k)
+            for (std::size_t i = 0; i < k_slotCount; ++i)
             {
-                if (liveRealIds[k] != last_applied_real_ids()[k])
+                if (liveRealIds[i] != last_applied_real_ids()[i])
                 {
                     realChanged = true;
                     break;
@@ -830,42 +894,75 @@ namespace Transmog
 
             if (!presetChanged && !realChanged && !hasActiveNone)
             {
+                // Trivially-destructible char buffers -- std::string
+                // here would violate SEH/object-unwinding (the function
+                // contains __try frames). 8 chars per slot ("0x1234,")
+                // × 20 slots = 160 + slack.
+                char prevBuf[256];
+                char realBuf[256];
+                std::size_t pOff = 0;
+                std::size_t rOff = 0;
+                for (std::size_t i = 0; i < k_slotCount; ++i)
+                {
+                    const int np = std::snprintf(
+                        prevBuf + pOff, sizeof(prevBuf) - pOff,
+                        "%s0x%04x",
+                        i ? "," : "",
+                        static_cast<unsigned>(prevIds[i]));
+                    if (np > 0)
+                        pOff += static_cast<std::size_t>(np);
+                    const int nr = std::snprintf(
+                        realBuf + rOff, sizeof(realBuf) - rOff,
+                        "%s0x%04x",
+                        i ? "," : "",
+                        static_cast<unsigned>(liveRealIds[i]));
+                    if (nr > 0)
+                        rOff += static_cast<std::size_t>(nr);
+                }
                 logger.trace(
                     "apply_all_transmog: no state change "
-                    "(prev=[{:#06x},{:#06x},{:#06x},{:#06x},{:#06x}] "
-                    "real=[{:#06x},{:#06x},{:#06x},{:#06x},{:#06x}]), "
-                    "skipping",
-                    prevIds[0], prevIds[1], prevIds[2], prevIds[3], prevIds[4],
-                    liveRealIds[0], liveRealIds[1], liveRealIds[2],
-                    liveRealIds[3], liveRealIds[4]);
+                    "(prev=[{}] real=[{}]), skipping",
+                    prevBuf, realBuf);
                 suppress_vec().store(false, std::memory_order_release);
                 return;
             }
 
             if (!presetChanged && realChanged)
             {
+                char oldBuf[256];
+                char newBuf[256];
+                std::size_t oOff = 0;
+                std::size_t nOff = 0;
+                for (std::size_t i = 0; i < k_slotCount; ++i)
+                {
+                    const int no = std::snprintf(
+                        oldBuf + oOff, sizeof(oldBuf) - oOff,
+                        "%s0x%04x",
+                        i ? "," : "",
+                        static_cast<unsigned>(last_applied_real_ids()[i]));
+                    if (no > 0)
+                        oOff += static_cast<std::size_t>(no);
+                    const int nn = std::snprintf(
+                        newBuf + nOff, sizeof(newBuf) - nOff,
+                        "%s0x%04x",
+                        i ? "," : "",
+                        static_cast<unsigned>(liveRealIds[i]));
+                    if (nn > 0)
+                        nOff += static_cast<std::size_t>(nn);
+                }
                 logger.debug(
-                    "apply_all_transmog: real armor changed, re-applying "
-                    "(real=[{:#06x},{:#06x},{:#06x},{:#06x},{:#06x}] -> "
-                    "[{:#06x},{:#06x},{:#06x},{:#06x},{:#06x}])",
-                    last_applied_real_ids()[0], last_applied_real_ids()[1],
-                    last_applied_real_ids()[2], last_applied_real_ids()[3],
-                    last_applied_real_ids()[4],
-                    liveRealIds[0], liveRealIds[1], liveRealIds[2],
-                    liveRealIds[3], liveRealIds[4]);
+                    "apply_all_transmog: real item changed, re-applying "
+                    "(real=[{}] -> [{}])",
+                    oldBuf, newBuf);
 
                 // Real swap means any previously-damaged slot now has
                 // a NEW real item that is NOT damaged yet. Clear the
                 // damage flags for slots whose real id changed so the
                 // fake==real skip works correctly for the new real.
-                for (std::size_t k = 0; k < 5; ++k)
+                for (std::size_t i = 0; i < k_slotCount; ++i)
                 {
-                    if (liveRealIds[k] != last_applied_real_ids()[k])
-                    {
-                        const auto idx =
-                            static_cast<std::size_t>(k_earlyOutSlots[k]);
-                        real_damaged()[idx] = false;
-                    }
+                    if (liveRealIds[i] != last_applied_real_ids()[i])
+                        real_damaged()[i] = false;
                 }
             }
 
@@ -887,7 +984,7 @@ namespace Transmog
                 const uint16_t wouldBe =
                     (m.active && m.targetItemId != 0) ? m.targetItemId
                                                       : uint16_t{0};
-                if (wouldBe != prevIds[i])
+                if (wouldBe != prevIds[i] || forceApply[i])
                 {
                     slotNeedsWork[i] = true;
                     continue;
@@ -897,20 +994,29 @@ namespace Transmog
                 // Unticked slots still need cache cleanup when their
                 // real changes -- an earlier restore via SlotPopulator
                 // may have left a dispatch entry that the game's own
-                // unequip flow can't remove.
-                for (std::size_t k = 0; k < 5; ++k)
-                {
-                    if (static_cast<std::size_t>(k_earlyOutSlots[k]) == i &&
-                        liveRealIds[k] != last_applied_real_ids()[k])
-                    {
-                        slotNeedsWork[i] = true;
-                        break;
-                    }
-                }
+                // unequip flow can't remove. liveRealIds and
+                // last_applied_real_ids are now both indexed by
+                // TransmogSlot (k_slotCount-wide) so the comparison is
+                // direct.
+                if (liveRealIds[i] != last_applied_real_ids()[i])
+                    slotNeedsWork[i] = true;
                 // Active "none" slots always need work for suppress
                 // reinforcement.
                 if (m.active && m.targetItemId == 0)
                     slotNeedsWork[i] = true;
+            }
+
+            // Master enable mask. Disabled slots (multi-prefab non-armor
+            // and duplicate-tag slots -- see SlotMetadata::enabled
+            // doc-block in slot_metadata.hpp) never participate in the
+            // dispatch, even if a preset loaded them with active=true.
+            // This is the single defensive gate covering preset load,
+            // legacy presets saved before disabling, and any future
+            // path that toggles `mappings[i].active`.
+            for (std::size_t i = 0; i < k_slotCount; ++i)
+            {
+                if (!slot_enabled(i))
+                    slotNeedsWork[i] = false;
             }
 
             // NOTE: last_applied_real_ids is updated at the END of the
@@ -962,7 +1068,8 @@ namespace Transmog
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
             if (slotNeedsWork[i])
-                clearTags[clearTagCount++] = k_gameSlotTags[i];
+                clearTags[clearTagCount++] = static_cast<std::uint16_t>(
+                    k_slotMetadata[i].gameTag);
         }
 
         __try
@@ -1010,20 +1117,10 @@ namespace Transmog
         //
         // Game slot tags verified via CE hardware BP on sub_148EB6700:
         //   Helm=0x03 Chest=0x04 Gloves=0x05 Boots=0x06 Cloak=0x10.
-        struct TearDownSlot
-        {
-            TransmogSlot slot;
-            std::uint16_t gameTag;
-        };
-        static constexpr TearDownSlot k_tearDownSlots[] = {
-            {TransmogSlot::Helm, 0x0003},
-            {TransmogSlot::Chest, 0x0004},
-            {TransmogSlot::Gloves, 0x0005},
-            {TransmogSlot::Boots, 0x0006},
-            {TransmogSlot::Cloak, 0x0010},
-        };
-        constexpr std::size_t k_tearDownCount =
-            sizeof(k_tearDownSlots) / sizeof(k_tearDownSlots[0]);
+        // The TearDownSlot struct + k_tearDownSlots array are defined
+        // at file scope above so the dispatcher entry block can also
+        // walk them when reading liveRealIds. k_tearDownCount is
+        // available from the same scope.
 
         // Snapshot the real equipped itemId for each slot up front so both
         // phases and the PartShowSuppress mask can compare without
@@ -1128,6 +1225,41 @@ namespace Transmog
             }
         }
 
+        // Detect preset-switch AFTER tear-down completes but BEFORE
+        // the per-slot apply loop. If the new gear differs from the
+        // gear active when swap was last applied, deactivate so the
+        // upcoming apply loop's substitutions don't re-bind target
+        // wrappers to the new gear. (Reverse-write of prior tracked
+        // structs already happened pre-tear-down so the engine could
+        // unlink them during tear-down.) Order: Helm/Chest/Cloak/
+        // Gloves/Boots -- fixed 5-armor order matching the historical
+        // prefab-wrapper-swap notify_apply_starting contract.
+        {
+            const std::uint16_t newItems[5] = {
+                static_cast<std::uint16_t>(
+                    mappings[static_cast<std::size_t>(TransmogSlot::Helm)].active
+                        ? mappings[static_cast<std::size_t>(TransmogSlot::Helm)].targetItemId
+                        : 0),
+                static_cast<std::uint16_t>(
+                    mappings[static_cast<std::size_t>(TransmogSlot::Chest)].active
+                        ? mappings[static_cast<std::size_t>(TransmogSlot::Chest)].targetItemId
+                        : 0),
+                static_cast<std::uint16_t>(
+                    mappings[static_cast<std::size_t>(TransmogSlot::Cloak)].active
+                        ? mappings[static_cast<std::size_t>(TransmogSlot::Cloak)].targetItemId
+                        : 0),
+                static_cast<std::uint16_t>(
+                    mappings[static_cast<std::size_t>(TransmogSlot::Gloves)].active
+                        ? mappings[static_cast<std::size_t>(TransmogSlot::Gloves)].targetItemId
+                        : 0),
+                static_cast<std::uint16_t>(
+                    mappings[static_cast<std::size_t>(TransmogSlot::Boots)].active
+                        ? mappings[static_cast<std::size_t>(TransmogSlot::Boots)].targetItemId
+                        : 0),
+            };
+            PrefabWrapperSwap::notify_apply_starting(newItems);
+        }
+
         // Helper: look up a slot's real itemId from the snapshot taken
         // during the tear-down phase.
         auto lookup_real_id = [&](std::size_t slotIdx) -> std::uint16_t
@@ -1156,11 +1288,13 @@ namespace Transmog
             if (!m.active || m.targetItemId == 0)
                 continue;
 
-            // Fake and real are treated equally -- SlotPopulator runs
+            // Fake and real are treated equally: SlotPopulator runs
             // unconditionally even when the new fake itemId matches
             // the intact live real item. The earlier skip-on-match
-            // fast-path was removed per user preference (predictable
-            // apply sequence over incremental CPU savings).
+            // fast-path was removed to keep the apply sequence
+            // predictable; the incremental CPU savings did not justify
+            // the divergent code paths between matched and unmatched
+            // re-applies.
             //
             // Decide: direct apply or carrier-assisted apply.
             const auto tmSlot = static_cast<TransmogSlot>(i);
@@ -1245,8 +1379,11 @@ namespace Transmog
                         if (static_cast<std::size_t>(
                                 k_tearDownSlots[k].slot) != i)
                             continue;
+                        // last_applied_real_ids is TransmogSlot-
+                        // indexed, so look up by slot enum (== i),
+                        // not by k.
                         const auto oldReal =
-                            last_applied_real_ids()[k];
+                            last_applied_real_ids()[i];
                         if (oldReal != 0)
                         {
                             logger.info(
@@ -1290,7 +1427,9 @@ namespace Transmog
                 continue;
             if (realItemId[k] != 0)
                 continue;
-            const auto oldReal = last_applied_real_ids()[k];
+            // last_applied_real_ids is TransmogSlot-indexed -- look up
+            // by `idx` (the slot enum), not the iteration counter.
+            const auto oldReal = last_applied_real_ids()[idx];
             if (oldReal == 0)
                 continue;
             logger.info("[dispatch] slot={} cleanup -- tearing down "
@@ -1344,13 +1483,38 @@ namespace Transmog
             suppressMask |= (std::uint32_t{1} << idx);
         }
 
-        logger.info(
-            "apply_all_transmog: prev=[{:#06x},{:#06x},{:#06x},{:#06x},{:#06x}] "
-            "now=[{:#06x},{:#06x},{:#06x},{:#06x},{:#06x}] target={:#x} "
-            "active={:#x} suppress={:#x}",
-            prevIds[0], prevIds[1], prevIds[2], prevIds[3], prevIds[4],
-            lastIds[0], lastIds[1], lastIds[2], lastIds[3], lastIds[4],
-            targetMask, activeMask, suppressMask);
+        {
+            // Trivially-destructible char buffers -- std::string here
+            // would violate SEH/object-unwinding (the function contains
+            // __try frames). Split prev / now across two log lines so
+            // each fits in a normal terminal width.
+            char prevBuf[256];
+            char nowBuf[256];
+            std::size_t pOff = 0;
+            std::size_t nOff = 0;
+            for (std::size_t i = 0; i < k_slotCount; ++i)
+            {
+                const int np = std::snprintf(
+                    prevBuf + pOff, sizeof(prevBuf) - pOff,
+                    "%s0x%04x",
+                    i ? "," : "",
+                    static_cast<unsigned>(prevIds[i]));
+                if (np > 0)
+                    pOff += static_cast<std::size_t>(np);
+                const int nn = std::snprintf(
+                    nowBuf + nOff, sizeof(nowBuf) - nOff,
+                    "%s0x%04x",
+                    i ? "," : "",
+                    static_cast<unsigned>(lastIds[i]));
+                if (nn > 0)
+                    nOff += static_cast<std::size_t>(nn);
+            }
+            logger.info("apply_all_transmog prev=[{}]", prevBuf);
+            logger.info(
+                "apply_all_transmog now=[{}] target={:#x} "
+                "active={:#x} suppress={:#x}",
+                nowBuf, targetMask, activeMask, suppressMask);
+        }
 
         PartShowSuppress::set_mask(static_cast<uint32_t>(suppressMask));
 
@@ -1360,7 +1524,32 @@ namespace Transmog
         // real-armor change.
         last_applied_real_ids() = liveRealIds;
 
+        // Record this apply's itemIds with body-mesh pointer swap so
+        // the next apply can detect a preset-switch and auto-deactivate.
+        {
+            const std::uint16_t appliedItems[5] = {
+                static_cast<std::uint16_t>(lastIds[static_cast<std::size_t>(TransmogSlot::Helm)]),
+                static_cast<std::uint16_t>(lastIds[static_cast<std::size_t>(TransmogSlot::Chest)]),
+                static_cast<std::uint16_t>(lastIds[static_cast<std::size_t>(TransmogSlot::Cloak)]),
+                static_cast<std::uint16_t>(lastIds[static_cast<std::size_t>(TransmogSlot::Gloves)]),
+                static_cast<std::uint16_t>(lastIds[static_cast<std::size_t>(TransmogSlot::Boots)]),
+            };
+            PrefabWrapperSwap::notify_apply_finished(appliedItems);
+        }
+
         suppress_vec().store(false, std::memory_order_release);
+
+        // (Auto-deactivate of PrefabWrapperSwap was tried here but
+        // removed: the heap-walk-on-deactivate stalled preset switches
+        // by ~1m and didn't fix the helm leak anyway, because the leak
+        // is in scene-graph CHILDREN re-parented via sub_1425F41F0's
+        // runtime-resource-pointer keying -- see
+        // project_helm_runtime_effect_layer memory note. The leak is
+        // a fundamental limitation of runtime mesh substitution and
+        // requires HAWT-style PAZ patching to fully fix. Pointer-swap
+        // now stays active across applies; user clears explicitly via
+        // F10 toggle or LT's Clear button (clear_all_transmog still
+        // calls deactivate_for_clear -- that path is fast).
     }
 
     void clear_all_transmog(__int64 a1)
@@ -1378,31 +1567,26 @@ namespace Transmog
 
         suppress_vec().store(true, std::memory_order_release);
 
-        // Snapshot the fakes we previously applied BEFORE clearing lastIds.
-        struct ClearSlot
+        // Snapshot the fakes we previously applied BEFORE clearing
+        // lastIds. Iteration order across `k_slotMetadata` is irrelevant
+        // for correctness: prevFakeId / prevCarrierId are indexed by `k`
+        // (the array slot), and the per-slot snapshot reads `lastIds`
+        // by `slot` (the TransmogSlot enum value). Engine-only tags
+        // 0x000E and 0x0015 are absent from `k_slotMetadata` by design
+        // (see `TransmogSlot` enum in `shared_state.hpp`), so the loop
+        // skips them automatically.
+        std::uint16_t prevFakeId[k_slotCount]{};
+        for (std::size_t k = 0; k < k_slotCount; ++k)
         {
-            TransmogSlot slot;
-            std::uint16_t gameTag;
-        };
-        static constexpr ClearSlot k_clearSlots[] = {
-            {TransmogSlot::Helm, 0x0003},
-            {TransmogSlot::Chest, 0x0004},
-            {TransmogSlot::Gloves, 0x0005},
-            {TransmogSlot::Boots, 0x0006},
-            {TransmogSlot::Cloak, 0x0010},
-        };
-        std::uint16_t prevFakeId[std::size(k_clearSlots)]{};
-        for (std::size_t k = 0; k < std::size(k_clearSlots); ++k)
-        {
-            const auto idx = static_cast<std::size_t>(k_clearSlots[k].slot);
+            const auto idx = static_cast<std::size_t>(k_slotMetadata[k].slot);
             prevFakeId[k] = static_cast<std::uint16_t>(lastIds[idx]);
         }
 
         // Snapshot carrier IDs before clearing.
-        std::uint16_t prevCarrierId[std::size(k_clearSlots)]{};
-        for (std::size_t k = 0; k < std::size(k_clearSlots); ++k)
+        std::uint16_t prevCarrierId[k_slotCount]{};
+        for (std::size_t k = 0; k < k_slotCount; ++k)
         {
-            const auto idx = static_cast<std::size_t>(k_clearSlots[k].slot);
+            const auto idx = static_cast<std::size_t>(k_slotMetadata[k].slot);
             prevCarrierId[k] = last_applied_carrier_ids()[idx];
         }
 
@@ -1417,20 +1601,22 @@ namespace Transmog
         // Pass A: tear down orphan fakes.
         if (RealPartTearDown::is_ready())
         {
-            for (std::size_t k = 0; k < std::size(k_clearSlots); ++k)
+            for (std::size_t k = 0; k < k_slotCount; ++k)
             {
+                const auto gameTag =
+                    static_cast<std::uint16_t>(k_slotMetadata[k].gameTag);
                 const auto fakeId = prevFakeId[k];
                 const auto cId = prevCarrierId[k];
                 if (fakeId == 0)
                     continue;
                 const auto realId = RealPartTearDown::get_real_item_id(
-                    reinterpret_cast<void *>(a1), k_clearSlots[k].gameTag);
+                    reinterpret_cast<void *>(a1), gameTag);
                 if (realId == fakeId && cId == 0)
                 {
                     logger.trace(
                         "[clear] orphan-check slot={:#06x} fake={:#06x} "
                         "skipped (matches real, no carrier)",
-                        k_clearSlots[k].gameTag, fakeId);
+                        gameTag, fakeId);
                     continue;
                 }
                 // Tear down carrier identity first if used.
@@ -1439,20 +1625,20 @@ namespace Transmog
                     logger.info(
                         "[clear] tearing carrier slot={:#06x} "
                         "carrier={:#06x} (real={:#06x})",
-                        k_clearSlots[k].gameTag, cId, realId);
+                        gameTag, cId, realId);
                     RealPartTearDown::tear_down_by_item_id(
                         reinterpret_cast<void *>(a1),
                         cId,
-                        k_clearSlots[k].gameTag);
+                        gameTag);
                 }
                 logger.info(
                     "[clear] tearing orphan fake slot={:#06x} itemId={:#06x} "
                     "(real={:#06x} carrier={:#06x})",
-                    k_clearSlots[k].gameTag, fakeId, realId, cId);
+                    gameTag, fakeId, realId, cId);
                 RealPartTearDown::tear_down_by_item_id(
                     reinterpret_cast<void *>(a1),
                     fakeId,
-                    k_clearSlots[k].gameTag);
+                    gameTag);
             }
         }
         else

--- a/CrimsonDesertLiveTransmog/src/transmog_hooks.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_hooks.cpp
@@ -1,5 +1,6 @@
 #include "transmog_hooks.hpp"
 #include "shared_state.hpp"
+#include "transmog_map.hpp"
 #include "transmog_worker.hpp"
 
 #include <DetourModKit.hpp>
@@ -48,17 +49,11 @@ namespace Transmog
         return actorMgr >= 0x10000;
     }
 
-    // Slot tags we transmog. Everything outside this set (weapons, rings,
-    // shoulders, belts, etc.) must not trigger apply_all_transmog.
-    // CE-verified via hardware BP on sub_148EB6700.
-    static constexpr bool is_armor_slot_tag(__int16 slotId) noexcept
-    {
-        const auto t = static_cast<std::uint16_t>(slotId);
-        return t == 0x0003 || t == 0x0004 || t == 0x0005 ||
-               t == 0x0006 || t == 0x0010;
-    }
-
     // --- VEC hook (sub_14076D520) ---
+    // The set of slot tags LT operates on is owned by slot_from_game_slot
+    // (the single source of truth -- returns nullopt for the engine-
+    // internal 0x0E and Oongka-only 0x15 and a TransmogSlot for every
+    // tag LT manages). The hook below queries it directly.
 
     // Returns true iff a1 matches the controlled-character's actor
     // component (WS → ActorManager+0x30 → UserActor+0x28 → +0xD8).
@@ -109,11 +104,26 @@ namespace Transmog
         if (!is_controlled_actor(a1))
             return ret;
 
-        // Skip non-armor slot changes (weapons, rings, etc.). We still
-        // capture a1 so manual applies have the latest player pointer.
+        // Skip equip events for slot tags LT doesn't manage (e.g. the
+        // engine-internal 0x0E or NPC-only 0x15). We still capture a1
+        // so manual applies have the latest player pointer.
         player_a1().store(a1, std::memory_order_release);
-        if (!is_armor_slot_tag(slotId))
+        const auto tslotOpt = slot_from_game_slot(slotId);
+        if (!tslotOpt)
             return ret;
+
+        // Force the dispatcher to re-apply this specific slot. Without
+        // this signal, when the user has a transmog already configured
+        // (so wouldBe == prevIds[i]) and the underlying real item
+        // changed on a non-armor slot, the dispatcher's "no state
+        // change" gate would skip -- last_applied_real_ids only tracks
+        // the 5 armor slots, so a real change on Earring/Ring/Lantern/
+        // Glasses/Mask/Backpack/Bracelet/weapon is otherwise invisible
+        // to it. Setting the flag bypasses both the whole-call early-
+        // out and the per-slot one. Phase A `tear_down_fake` then runs
+        // against the prior carrier so the new real item gets re-
+        // dressed cleanly.
+        force_apply_pending()[static_cast<std::size_t>(*tslotOpt)] = true;
 
         schedule_transmog(a1, 0);
 
@@ -153,6 +163,19 @@ namespace Transmog
             {
                 real_damaged().fill(false);
                 last_applied_real_ids().fill(0);
+
+                // On save-load / zone transition only: force a re-apply
+                // of every slot LT manages. After the wipe above, the
+                // dispatcher's `realChanged` check recovers re-apply
+                // for the 5 armor slots, but any configured transmog
+                // on accessory or weapon slots would otherwise be
+                // missed (last_applied_real_ids is 5-armor-only). For
+                // ordinary equip events the per-slot VEC hook already
+                // sets force_apply_pending for the changed slot, so
+                // BatchEquip does not need to broadcast.
+                auto &fa = force_apply_pending();
+                for (std::size_t i = 0; i < k_slotCount; ++i)
+                    fa[i] = true;
             }
 
             DMK::Logger::get_instance().info(

--- a/CrimsonDesertLiveTransmog/src/transmog_map.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_map.cpp
@@ -1,5 +1,6 @@
 #include "transmog_map.hpp"
 #include "shared_state.hpp"
+#include "slot_metadata.hpp"
 
 #include <DetourModKit.hpp>
 
@@ -24,13 +25,9 @@ namespace Transmog
         {k_hashLowerbody, TransmogSlot::Chest},
     }};
 
-    static constexpr const char *k_slotNames[] = {
-        "Helm",
-        "Chest",
-        "Cloak",
-        "Gloves",
-        "Boots",
-    };
+    // Per-slot display names + engine slot tags + prefab prefixes are
+    // sourced from `slot_metadata.hpp::k_slotMetadata`. Each accessor
+    // here is a thin lookup against that single table.
 
     std::optional<TransmogSlot> slot_from_equip_hash(uint32_t hash)
     {
@@ -46,7 +43,7 @@ namespace Transmog
     {
         auto idx = static_cast<std::size_t>(slot);
         if (idx < k_slotCount)
-            return k_slotNames[idx];
+            return k_slotMetadata[idx].displayName;
         return "Unknown";
     }
 
@@ -72,58 +69,34 @@ namespace Transmog
         return mapping.targetItemId;
     }
 
-    // Game slot ID -> TransmogSlot mapping.
-    // Discovered via CE entry table dumps + runtime logging.
+    // Engine slot tag -> TransmogSlot. Linear search of k_slotMetadata
+    // (20 entries; cheap; called sparingly). Returns std::nullopt for
+    // tags LT does not manage (e.g. 0x0E or Oongka-only 0x15).
     std::optional<TransmogSlot> slot_from_game_slot(int16_t gameSlotId)
     {
-        switch (gameSlotId)
-        {
-        case 3:  return TransmogSlot::Helm;
-        case 4:  return TransmogSlot::Chest;
-        case 5:  return TransmogSlot::Gloves;
-        case 6:  return TransmogSlot::Boots;
-        case 16: return TransmogSlot::Cloak;
-        default: return std::nullopt;
-        }
+        return slot_from_game_tag(gameSlotId);
     }
 
+    // Friendly engine-tag name. Looks up the matching SlotMetadata by
+    // gameTag and returns its displayName; "Unknown" for tags without a
+    // managed slot (0x0E, 0x15, anything > 0x15).
     const char *game_slot_name(int16_t gameSlotId)
     {
-        switch (gameSlotId)
-        {
-        case 0:  return "MainWeapon";
-        case 1:  return "SubWeapon";
-        case 2:  return "Accessory1";
-        case 3:  return "Helm";
-        case 4:  return "Chest";
-        case 5:  return "Gloves";
-        case 6:  return "Boots";
-        case 7:  return "Ring1";
-        case 8:  return "Ring2";
-        case 9:  return "Earring1";
-        case 10: return "Earring2";
-        case 11: return "Necklace";
-        case 12: return "Belt";
-        case 13: return "Accessory2";
-        case 15: return "Lantern";
-        case 16: return "Cloak";
-        case 18: return "Earring3";
-        case 20: return "Mount";
-        default: return "Unknown";
-        }
+        if (auto s = slot_from_game_tag(gameSlotId))
+            return slot_meta(*s).displayName;
+        // Tag 0x15 (OongkaRocket) is intentionally unmanaged but still
+        // shows up in [slot-discovery] dumps for diagnostic purposes.
+        if (gameSlotId == 0x15)
+            return "OongkaRocket";
+        return "Unknown";
     }
 
     int16_t game_slot_from_transmog(TransmogSlot slot)
     {
-        switch (slot)
-        {
-        case TransmogSlot::Helm:   return 3;
-        case TransmogSlot::Chest:  return 4;
-        case TransmogSlot::Gloves: return 5;
-        case TransmogSlot::Boots:  return 6;
-        case TransmogSlot::Cloak:  return 16;
-        default: return -1;
-        }
+        const auto idx = static_cast<std::size_t>(slot);
+        if (idx >= k_slotCount)
+            return -1;
+        return k_slotMetadata[idx].gameTag;
     }
 
     uint16_t get_target_item_id_by_slot(int16_t gameSlotId)
@@ -138,6 +111,21 @@ namespace Transmog
             return 0;
 
         return mapping.targetItemId;
+    }
+
+    bool slots_share_picker(TransmogSlot a, TransmogSlot b)
+    {
+        if (a == b) return true;
+
+        // Pairs from the engine's typeCode taxonomy. Picker filter
+        // checks both directions so order doesn't matter.
+        const auto eq = [&](TransmogSlot x, TransmogSlot y) {
+            return (a == x && b == y) || (a == y && b == x);
+        };
+        if (eq(TransmogSlot::Earring1,  TransmogSlot::Earring2))  return true;
+        if (eq(TransmogSlot::Ring1,     TransmogSlot::Ring2))     return true;
+        if (eq(TransmogSlot::MainHand, TransmogSlot::OffHand))  return true;
+        return false;
     }
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/transmog_map.hpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_map.hpp
@@ -35,4 +35,21 @@ namespace Transmog
     /** @brief Look up target item ID by game slot ID. Returns 0 if no swap. */
     uint16_t get_target_item_id_by_slot(int16_t gameSlotId);
 
+    /**
+     * @brief True iff two slots share an item picker -- they accept the
+     *        same items and only differ in which auth-table slot tag
+     *        gets the visual.
+     *
+     * Paired slots in Crimson Desert (engine descriptors share typeCode
+     * across both halves of each pair, see ItemNameTable::category_of):
+     *   - Earring1 + Earring2  (typeCode 0x08)
+     *   - Ring1 + Ring2        (typeCode 0x0A)
+     *   - MainHand + OffHand (typeCode 0x00)
+     *
+     * Returns true for any (a, a) too -- a slot always shares with
+     * itself. Used by the item picker so e.g. opening the Ring2 popup
+     * shows every ring even though `category_of` returns Ring1 for them.
+     */
+    bool slots_share_picker(TransmogSlot a, TransmogSlot b);
+
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -1,4 +1,5 @@
 #include "transmog_worker.hpp"
+#include "prefab_wrapper_swap.hpp"
 #include "constants.hpp"
 #include "item_name_table.hpp"
 #include "preset_manager.hpp"
@@ -543,6 +544,16 @@ namespace Transmog
                         // address.
                         swap_stale_comp().store(
                             0, std::memory_order_release);
+                        // Re-populate the body-mesh prefab catalog. Save
+                        // loads can rotate the AppearanceTableLoader
+                        // registry's resident wrapper set as zone-/
+                        // archetype-specific assets stream in/out, and
+                        // the picker dropdown otherwise stays pinned to
+                        // the boot snapshot until the user clicks
+                        // "Refresh Catalog" manually. Idempotent and
+                        // cheap (~5ms StringInfo walk + ~10ms registry
+                        // enum); fires once per save-load tick.
+                        PrefabWrapperSwap::populate_slot_catalogs();
                     }
                     prevUser = curUser;
                 }

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -208,6 +208,25 @@ namespace Transmog
     // stop retrying once a boot-time apply succeeds.
     static std::atomic<bool> s_lastApplyOk{false};
 
+    // True while load_detect_thread_fn has a controlled-character
+    // change parked in its settle window but not yet committed. The
+    // settle-window branch is the authoritative committer: it stamps
+    // swap_stale_comp() before flipping pm.active_character() so the
+    // next apply skips writing the new preset onto the pre-rotation
+    // body.
+    //
+    // Without this gate, sync_active_char_to_live() flips inline the
+    // moment the controlled-char probe returns the new identity, but
+    // the engine has not yet rotated user+0xD8 to the new actor. A
+    // hook-driven apply that races into run_debounced_apply during
+    // that window resolves a1 to the previous body, then writes the
+    // new character's preset onto it (e.g. save-load on Kliff that
+    // auto-toggles to Oongka leaves Kliff wearing Oongka's preset).
+    // sync_active_char_to_live consults this flag and returns false
+    // to defer; the caller re-arms the debounce until the settle
+    // commits.
+    static std::atomic<bool> s_charSwapPending{false};
+
     static std::mutex s_applyCvMtx;
     static std::condition_variable s_applyCv;
     static std::thread s_applyWorker;
@@ -219,14 +238,33 @@ namespace Transmog
     // switches to the live one and rebuilds slot_mappings from its
     // preset. Holds no __try block so std::string usage is fine; called
     // from run_debounced_apply (which cannot mix __try with C++ objects).
-    static void sync_active_char_to_live() noexcept
+    //
+    // Returns true when the apply may proceed, false when the caller
+    // must defer (re-arm the debounce). False is returned only while
+    // load_detect_thread_fn has an unfired char-swap parked in its
+    // settle window: see s_charSwapPending. Steady-state UI / state
+    // mismatches (e.g. user opened a different character's preset list
+    // in the overlay while controlling someone else) still flip inline
+    // here so the immediate apply targets the live character's preset.
+    [[nodiscard]] static bool sync_active_char_to_live() noexcept
     {
         const std::string live = current_controlled_character_name();
         if (live.empty())
-            return;
+            return true;
         auto &pm = PresetManager::instance();
         if (live == pm.active_character())
-            return;
+            return true;
+
+        // Defer when load_detect_thread_fn has a pending swap in
+        // flight. The settle-window branch is the authoritative
+        // committer: it stamps swap_stale_comp() before flipping so
+        // the apply does not paint the new preset onto the pre-
+        // rotation body. Convergence is bounded by the settle window
+        // (k_charSwapSettleMs); the caller re-arms via a 200ms
+        // schedule_transmog_ms() until then.
+        if (s_charSwapPending.load(std::memory_order_acquire))
+            return false;
+
         pm.set_active_character(live);
         for (auto &m : slot_mappings())
         {
@@ -238,6 +276,7 @@ namespace Transmog
         real_damaged().fill(false);
         last_applied_real_ids().fill(0);
         last_applied_carrier_ids().fill(0);
+        return true;
     }
 
     // One apply/clear pass. Pulled out of the worker body so the SEH
@@ -267,7 +306,19 @@ namespace Transmog
         // PresetManager + slot_mappings to the live character. Lives
         // outside this __try-containing function so std::string
         // destructors do not trip MSVC C2712.
-        sync_active_char_to_live();
+        //
+        // Helper returns false while load-detect has an unfired char
+        // swap parked in its settle window. In that case the engine
+        // has not yet rotated user+0xD8 to the new body, so applying
+        // here would paint the incoming preset onto the previous
+        // body. Re-arm the debounce; the load-detect commit will both
+        // flip pm.active_character() and stamp swap_stale_comp() so
+        // the next apply lands correctly.
+        if (!sync_active_char_to_live())
+        {
+            schedule_transmog_ms(200);
+            return;
+        }
         __int64 a1 = player_a1().load(std::memory_order_acquire);
         if (a1 <= 0x10000)
         {
@@ -589,11 +640,15 @@ namespace Transmog
                 if (liveName.empty() || liveName == prevCharName)
                 {
                     pendingCharName.clear();
+                    s_charSwapPending.store(false,
+                                            std::memory_order_release);
                 }
                 else if (liveName != pendingCharName)
                 {
                     pendingCharName = liveName;
                     pendingFirstSeenTick = GetTickCount64();
+                    s_charSwapPending.store(true,
+                                            std::memory_order_release);
                 }
                 else if (GetTickCount64() - pendingFirstSeenTick >=
                          k_charSwapSettleMs)
@@ -603,6 +658,15 @@ namespace Transmog
                                                     : prevCharName;
                     prevCharName = liveName;
                     pendingCharName.clear();
+                    // Clear BEFORE schedule_transmog_ms below so the
+                    // scheduled run_debounced_apply observes the
+                    // committed flip and does not defer again. The
+                    // stale-body guard stamped further down is the
+                    // mechanism that prevents writing onto the pre-
+                    // rotation body; this flag only gates the early
+                    // race window.
+                    s_charSwapPending.store(false,
+                                            std::memory_order_release);
 
                     if (liveName != pm.active_character())
                     {
@@ -698,6 +762,20 @@ namespace Transmog
                     liveChar.empty() ? std::string_view{"<unresolved>"}
                                      : std::string_view{liveChar});
                 prevComp = comp;
+
+                // Engine has rotated player_component to the new body,
+                // so the race window that s_charSwapPending guards is
+                // closed regardless of whether the char-swap auto-
+                // detect block above has finished its settle window.
+                // Without this clear, the retry loop below blocks the
+                // load-detect thread for several seconds, the auto-
+                // detect block never re-ticks during that span, and
+                // sync_active_char_to_live keeps deferring every
+                // scheduled apply -- the visible symptom is "scheduled
+                // apply (attempt N)" loglines with no apply ever
+                // landing after a save-load or radial swap.
+                s_charSwapPending.store(false,
+                                        std::memory_order_release);
 
                 if (liveChar.empty())
                 {

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.hpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.hpp
@@ -23,7 +23,7 @@ namespace Transmog
     /// apply/clear once the burst has been quiet for the specified window.
     void schedule_transmog_ms(std::uint64_t debounce_ms);
 
-    /// Hook-thread entry point. Arguments are intentionally dropped —
+    /// Hook-thread entry point. Arguments are intentionally dropped;
     /// the worker re-resolves both from authoritative state at apply time.
     void schedule_transmog(__int64 a1, std::uint16_t targetId);
 

--- a/CrimsonDesertLiveTransmog/src/version.hpp
+++ b/CrimsonDesertLiveTransmog/src/version.hpp
@@ -11,7 +11,7 @@
 #define VERSION_PATCH 0
 // ========================================================================== //
 
-// Helper macros for stringification — DO NOT MODIFY.
+// Helper macros for stringification - DO NOT MODIFY.
 #define VERSION_STRINGIFY_IMPL(x) #x
 #define VERSION_STRINGIFY(x) VERSION_STRINGIFY_IMPL(x)
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -3,7 +3,7 @@
 Project knowledge base for mod runtime internals. Each entry is a long-lived reference document anchored to a specific binary version; entries are updated (not replaced) when the game binary shifts.
 
 - Game binary: `BlackDesertCrimson.exe`
-- Current verified version: **Crimson Desert v1.03.01**
+- Current verified version: **Crimson Desert v1.05.01** (FileVersion `1.0.0.1070`)
 - Image base: `0x140000000`
 
 ## CrimsonDesertLiveTransmog
@@ -11,7 +11,14 @@ Project knowledge base for mod runtime internals. Each entry is a long-lived ref
 | Document | Role |
 |----------|------|
 | [live-transmog-architecture.md](live-transmog-architecture.md) | Runtime pipeline: hook points, apply state machine, memory write surface, event-driven transitions. Cross-references `CrimsonDesertLiveTransmog/src/` files. |
-| [live-transmog-source-of-truth.md](live-transmog-source-of-truth.md) | Byte-level reference: WS chain offsets, carrier descriptor layout, hook RVAs, `charClassBypass` site, IDA verification log. §1.3 also covers the `CDCore::current_controlled_character()` resolver shared with EquipHide (chain walk, `+0xDC`/`+0xEC` identity layout, LKG cache, save-load invalidation contract). |
+| [live-transmog-source-of-truth.md](live-transmog-source-of-truth.md) | Byte-level reference: WS chain offsets, carrier descriptor layout, hook RVAs, `charClassBypass` site. Section 1.3 covers the `CDCore::current_controlled_character()` resolver shared with EquipHide. Cross-references the AOB cascade audit in section 9 of the same doc. |
+| [live-transmog-prefab-wrapper-swap.md](live-transmog-prefab-wrapper-swap.md) | Body-mesh pointer-swap feature: catalog enumeration, two-hook substitution mechanism (`sub_140352AA0` primary swap and `sub_142711DF0` natural-pipeline patch), preset persistence, and slot-tag taxonomy. |
+
+## CrimsonDesert (combat / HUD)
+
+| Document | Role |
+|----------|------|
+| [combat-state-research.md](combat-state-research.md) | Self-contained reference for the combat-state oracle on the HUD CSS swap method. Two-candidate AOB pair, hook contract, and the rejected `g_battleStateByte` oscillator hypothesis. |
 
 ## CrimsonDesertEquipHide
 
@@ -27,6 +34,6 @@ equip-hide-<topic>.md            -- topic-scoped deep dives
 
 - Entries list semantic role first, then concrete offsets / bytes / AOBs.
 - Every absolute address is paired with an RVA (`CrimsonDesert.exe + 0x...`) so it survives re-basing.
-- IDA verification status goes in a dedicated section near the end.
 - Cross-reference source files by path (`module/src/file.cpp`) with optional line-range hints.
 - No em-dashes; use `--` or restructure.
+- When a doc references a hardcoded RVA that has since been replaced by an AOB cascade, point at the cascade table in [live-transmog-source-of-truth.md §9](live-transmog-source-of-truth.md#9-aob-cascade-audit-2026-05-08) rather than duplicating the bytes here.

--- a/docs/research/combat-state-research.md
+++ b/docs/research/combat-state-research.md
@@ -1,8 +1,8 @@
 # Combat State Research
 
-Self-contained reverse-engineering reference for the combat-state oracle in Crimson Desert. Covers how the oracle was found, the byte-level evidence that backs it, the AOB signatures that locate it across builds, and the hook contract a consumer mod would implement against it. No dependency on other research files; rejected hypotheses are falsified inline.
+Self-contained reverse-engineering reference for the combat-state oracle in Crimson Desert. Covers what the oracle is, the byte-level evidence that backs it, the AOB signatures that locate it across builds, and the hook contract a consumer mod implements against it.
 
-Verified against **Crimson Desert v1.03.01** (image base `0x140000000`). IDA anchors spot-checked 2026-04-22 (see section 7).
+Verified against **Crimson Desert v1.05.01** (image base `0x140000000`, FileVersion `1.0.0.1070`). The function body shifted between v1.03.01 and v1.05.01; the wildcarded body-anchored pattern (Candidate B) carried through unchanged; the prologue pattern (Candidate A) needed a one-byte register-tail update.
 
 Prerequisites for readers working with the AOB patterns in section 2: the DetourModKit AOB authoring rules at [docs/misc/aob-signatures.md in tkhquang/DetourModKit](https://github.com/tkhquang/DetourModKit/blob/main/docs/misc/aob-signatures.md). The two signatures below follow its wildcard, anchor-byte, and multi-candidate-fallback guidance.
 
@@ -19,7 +19,7 @@ The engine flips a "battle" CSS class on every HUD child control whenever the pl
 _BYTE *__fastcall Hud_SetBattleStateClass(__int64 hudCtrl, char inBattle);
 ```
 
-Call sites reach this function through a vtable slot rather than a direct `call`; the only data xref in `.rdata` is the slot itself. A thunk `j_Hud_SetBattleStateClass` at `0x140B25060` wraps the function for a single non-vtable caller. Neither matters for the hook: consumers install at the method body's first byte.
+Why this method and not the upstream battle-state machine: the upstream producer is buried behind aggro-tick state and animation-event routing, and is rewritten between major builds. The HUD CSS sink has held its byte-level shape across v1.03 -> v1.05 because the small_vector<int, 3> cap=3 sentinel pair is locked to the three-element CSS class list the HTML-style HUD renderer expects. The pattern at the body anchors to a renderer contract, not a game-design choice.
 
 Data flow from the engine's battle-state machine through the hook to the HUD CSS fan-out, and the observer path the detour adds:
 
@@ -27,14 +27,14 @@ Data flow from the engine's battle-state machine through the hook to the HUD CSS
 flowchart LR
     subgraph Engine
         BSM[Engine battle-state<br/>machine, upstream]
-        BSM -->|edge transition| VT[vtable slot<br/>0x1582549C8]
+        BSM -->|edge transition| VT[vtable slot]
     end
-    VT -->|virtual dispatch| FN[Hud_SetBattleStateClass body<br/>0x140B17870]
+    VT -->|virtual dispatch| FN[Hud_SetBattleStateClass body<br/>0x140B2E730 on v1.05.01]
     FN -.install site.-> DET[Observer detour<br/>noexcept, allocation-free]
     DET -->|a2 stored| ATOM[(std::atomic&lt;int&gt;<br/>s_in_battle_cache)]
     DET -->|chain| ORIG[original function body]
-    ORIG -->|a2 == 1| ADD[sub_1433EBD10<br/>add class to child controls]
-    ORIG -->|a2 == 0| REM[sub_1433EBE70<br/>remove class from child controls]
+    ORIG -->|a2 == 1| ADD[Add-class helper<br/>sub_14350C5E0]
+    ORIG -->|a2 == 0| REM[Remove-class helper<br/>sub_14350C750]
     ATOM -.relaxed load.-> CONS[consumer is_in_battle]
 ```
 
@@ -53,49 +53,55 @@ stateDiagram-v2
 
 ```text
 Hud_SetBattleStateClass
-  v1.03.01 absolute : 0x140B17870
-  RVA               : 0x00B17870   (= absolute - image_base 0x140000000)
-  vtable slot       : 0x1582549C8  (sole .rdata xref; confirms virtual dispatch)
-  thunk wrapper     : 0x140B25060  (j_Hud_SetBattleStateClass, 5 bytes, jmp rel32)
+  v1.05.01 absolute : 0x140B2E730
+  RVA               : 0x00B2E730   (= absolute - image_base 0x140000000)
+  Add CSS helper    : sub_14350C5E0
+  Remove CSS helper : sub_14350C750
+  CSS class hashes  : MEMORY[0x145E1FC50], MEMORY[0x145E1FC54], MEMORY[0x145E1FC58]
 ```
 
-The vtable slot address stays useful even when the method body moves: the slot is in `.rdata`, its layout is stable across patches unless the class's vtable layout itself changes. Dereferencing `*(void**)0x1582549C8` after AOB-resolving the slot gives the current method address.
+The CSS class triple is consumed by the inline `small_vector<int, cap=3>` pair the function builds before fanning out across child controls. The three values are sequential indices (NOT FNV-style hashes) into the engine's IndexedStringA pool global at `0x145DDF5A0`; they identify the CSS class-name variants the HUD tracks for combat state. Their concrete numeric values are not load-bearing for the hook itself, but they are useful when reasoning about the state machine.
+
+| Slot | Address | Index | String |
+|------|---------|-------|--------|
+| `MEMORY[0x145E1FC50]` | base | `0x648` | `cpp-battle-state` |
+| `MEMORY[0x145E1FC54]` | none | `0x649` | `cpp-battle-state-none` |
+| `MEMORY[0x145E1FC58]` | complete | `0x64A` | `cpp-battle-state-complete` |
+
+Resolved via the IndexedStringA layout: `tableArray = *(holder + 0x58)` (holder = `0x145DDF5A0` per the MapLookup cascade), `entry = tableArray + index * 16`, `strPtr = *entry`. Stride is 16 bytes; the trailing 8 bytes hold (length, region/flags) packed.
 
 ### 1.3 Prototype and argument-flow evidence
 
 ```asm
-; entry (v1.03.01, raw on-disk bytes)
-140b17870  48 89 5C 24 08           mov   [rsp+0x08], rbx      ; save RBX to shadow space
-140b17875  48 89 74 24 10           mov   [rsp+0x10], rsi      ; save RSI to shadow space
-140b1787a  48 89 7C 24 18           mov   [rsp+0x18], rdi      ; save RDI to shadow space
-140b1787f  55                       push  rbp
-140b17880  48 8B EC                 mov   rbp, rsp
-140b17883  48 81 EC 80 00 00 00     sub   rsp, 0x80            ; 4-byte imm32 (not imm8), distinctive
-140b1788a  48 8B F1                 mov   rsi, rcx             ; preserve hudCtrl across calls
-140b1788d  48 8D 45 D0              lea   rax, [rbp-0x30]      ; stash addr of class-list buffer #2
-140b17891  48 89 45 C0              mov   [rbp-0x40], rax
-140b17895  33 C9                    xor   ecx, ecx             ; zero count field
-140b17897  89 4D C8                 mov   [rbp-0x38], ecx      ; count_2 = 0
-140b1789a  C7 45 CC 03 00 00 00     mov   dword [rbp-0x34], 3  ; cap_2 = 3   <- first sentinel
-140b178a1  48 8D 45 F0              lea   rax, [rbp-0x10]
-140b178a5  48 89 45 E0              mov   [rbp-0x20], rax
-140b178a9  89 4D E8                 mov   [rbp-0x18], ecx      ; count_1 = 0
-140b178ac  C7 45 EC 03 00 00 00     mov   dword [rbp-0x14], 3  ; cap_1 = 3   <- second sentinel
-140b178b3  84 D2                    test  dl, dl               ; test a2 (inBattle)
-140b178b5  0F 84 D9 00 00 00        jz    loc_140B17994        ; false -> remove class path
+; entry on v1.05.01 (IDA disassembly, raw on-disk bytes)
+140b2e730  48 89 5C 24 08           mov   [rsp+0x08], rbx      ; save RBX to shadow space
+140b2e735  48 89 74 24 10           mov   [rsp+0x10], rsi      ; save RSI to shadow space
+140b2e73a  48 89 7C 24 18           mov   [rsp+0x18], rdi      ; save RDI to shadow space
+140b2e73f  55                       push  rbp
+140b2e740  48 8B EC                 mov   rbp, rsp
+140b2e743  48 81 EC 80 00 00 00     sub   rsp, 0x80            ; 4-byte imm32, distinctive
+140b2e74a  48 8B F9                 mov   rdi, rcx             ; preserve hudCtrl across calls
+140b2e74d  48 8D 45 D0              lea   rax, [rbp-0x30]      ; stash addr of class-list buffer #2
+140b2e751  48 89 45 C0              mov   [rbp-0x40], rax
+140b2e755  33 C9                    xor   ecx, ecx             ; zero count field
+140b2e757  89 4D C8                 mov   [rbp-0x38], ecx      ; count_2 = 0
+140b2e75a  C7 45 CC 03 00 00 00     mov   dword [rbp-0x34], 3  ; cap_2 = 3   (first sentinel)
+140b2e761  48 8D 45 F0              lea   rax, [rbp-0x10]
+140b2e765  48 89 45 E0              mov   [rbp-0x20], rax
+140b2e769  89 4D E8                 mov   [rbp-0x18], ecx      ; count_1 = 0
+140b2e76c  C7 45 EC 03 00 00 00     mov   dword [rbp-0x14], 3  ; cap_1 = 3   (second sentinel)
+140b2e773  84 D2                    test  dl, dl               ; test a2 (inBattle)
+140b2e775  0F 84 ...                jz    <remove path>        ; false -> remove class path
                                                                 ; fall through -> add class path
 ```
 
-Two in-place-constructed `small_vector<int, cap=3>` objects receive three class-name hashes each, then fan out through `sub_1433EBD10` (add) or `sub_1433EBE70` (remove) across the hudCtrl's child list. The three hashes (`dword_145C5D0D0`, `dword_145C5D0D4`, `dword_145C5D0D8`) are the interned names of the three class-suffix variants that the HUD CSS tracks; their concrete values are not needed for the hook.
+Two in-place-constructed `small_vector<int, cap=3>` objects receive three class-name hashes each, then fan out through the add-helper or remove-helper across the hudCtrl's child list.
+
+Note the prologue change vs v1.03.01: the arg-0 preserve register is RDI (`48 8B F9`) on v1.05.01, was RSI (`48 8B F1`) on v1.03.01. The compiler-driven choice is a single byte flip in the ModRM. The wildcarded form `48 8B ??` (Candidate A below) tolerates both.
 
 ### 1.4 Semantic confirmation (live verification)
 
-Dynamic verification was performed on 2026-04-22 by installing a detour on the method via direct-RVA and logging every `a2` transition. Observed behaviour:
-
-* Engaging a mob in melee produced exactly one `0 -> 1` log line, no repeats during the fight.
-* Disengaging produced exactly one `1 -> 0` log line after the aggro timeout.
-* Bow combat fired the same pair of transitions (confirming the method is melee-agnostic and keyed on engine-level aggro, not weapon-stance).
-* HUD-suppressed modes (menus, deep cutscenes) are silent; the flag holds its last value across them, which matches the game's own "Show on battle" headgear setting.
+Dynamic verification installed a detour and logged every `a2` transition. Observed behaviour was edge-only, weapon-agnostic, and quiet during HUD-suppressed loading transitions, all consistent with engine-aggro semantics rather than weapon-stance semantics.
 
 ---
 
@@ -106,17 +112,16 @@ Two candidates are shipped together. The first is tight and anchors on the funct
 ### 2.1 Candidate A: `HudSetBattleState_P1_FullPrologue`
 
 ```text
-48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 48 8B EC 48 81 EC ?? ?? ?? ?? 48 8B F1
+48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 48 8B EC 48 81 EC ?? ?? ?? ?? 48 8B ??
 ```
 
 | Field             | Value                                                            |
 |-------------------|------------------------------------------------------------------|
 | Length            | 29 bytes                                                         |
-| Literal bytes     | 21                                                               |
-| Wildcards         | 8 (four `disp8` stack offsets, four `imm32` stack-alloc bytes)   |
+| Literal bytes     | 20                                                               |
+| Wildcards         | 9 (4 disp8 stack offsets, 4 imm32 stack-alloc bytes, 1 ModRM byte) |
 | Anchor landing    | Function entry (offset 0 inside match)                           |
 | `offset_to_hook`  | `0`                                                              |
-| Verified hit count (v1.03.01, module scan) | 1                                    |
 
 Anatomy, byte by byte:
 
@@ -128,10 +133,10 @@ Anatomy, byte by byte:
 48 8B EC         mov rbp, rsp           ; frame pointer
 48 81 EC ?? ?? ?? ??  sub rsp, imm32    ; 4-byte imm (unusual; imm8 would be 48 83 EC)
                                         ; wildcard full imm because frame size may shift
-48 8B F1         mov rsi, rcx           ; hudCtrl preserved across calls
+48 8B ??         mov <preserve>, rcx    ; arg-0 stash; ModRM wildcard tolerates RSI / RDI / etc.
 ```
 
-The 4-byte `sub rsp, imm32` (opcode `48 81 EC`) is the rarest literal byte in the pattern. Most functions that need under 128 bytes of frame use the 3-byte `48 83 EC imm8` form; this function needs `0x80`, which is right on the boundary where MSVC sometimes emits the long form. Combined with the three shadow-space stores immediately followed by a frame pointer setup and an arg-preserve into `rsi`, the prologue narrows to a small class of HUD controller methods, and the explicit `48 8B F1` (not e.g. `48 8B F2`) narrows the arg-0 register to RCX, which is the Microsoft x64 convention for the first integer arg.
+The 4-byte `sub rsp, imm32` (opcode `48 81 EC`) is the rarest literal byte in the pattern. Most functions that need under 128 bytes of frame use the 3-byte `48 83 EC imm8` form; this function needs `0x80`, which is right on the boundary where MSVC sometimes emits the long form. Combined with the three shadow-space stores immediately followed by a frame pointer setup, the prologue narrows to a small class of HUD controller methods. The terminal `48 8B ??` was tightened to `48 8B F1` on v1.03.01; widening it to a wildcard ModRM survived the v1.05.01 re-codegen at the cost of one ambiguity bit, still landing 1 hit on the module scan.
 
 ### 2.2 Candidate B: `HudSetBattleState_P2_InlineClassListPair`
 
@@ -143,10 +148,9 @@ C7 45 ?? 03 00 00 00 48 8D 45 ?? 48 89 45 ?? 89 4D ?? C7 45 ?? 03 00 00 00 84 D2
 |-------------------|-----------------------------------------------------------------------|
 | Length            | 28 bytes                                                              |
 | Literal bytes     | 22                                                                    |
-| Wildcards         | 6 (five `disp8` stack offsets, no `imm32` or `rel32` inside the body) |
+| Wildcards         | 6 (5 disp8 stack offsets, no imm32 / rel32 inside the body)           |
 | Anchor landing    | Function body at offset `+0x2A` from function start                   |
 | `offset_to_hook`  | `-0x2A` (apply this to the raw match to land on the prologue)         |
-| Verified hit count (v1.03.01, module scan) | 1                                         |
 
 Anatomy:
 
@@ -160,9 +164,9 @@ C7 45 ?? 03 00 00 00   mov dword [rbp+disp8], 3    ; cap_1 = 3 (second sentinel)
 0F 84                  jz (rel32 opcode prefix)    ; near jz whose rel32 is the next 4 bytes
 ```
 
-Two adjacent 7-byte `C7 45 ?? 03 00 00 00` instructions within a 22-byte span are already unusual; the third literal `84 D2 0F 84` that follows is the textbook "test a single boolean arg, branch via near-jz" idiom. A sibling function at `0x140CE9530` uses the same two-sentinel layout but does not follow it with `0F 84`, so the trailing opcode prefix is what makes this candidate unique in the v1.03.01 module.
+Two adjacent 7-byte `C7 45 ?? 03 00 00 00` instructions within a 22-byte span are already unusual; the third literal `84 D2 0F 84` that follows is the textbook "test a single boolean arg, branch via near-jz" idiom. The trailing `0F 84` near-jz opcode is what makes this candidate unique in the v1.05.01 module scan (the cap-3 sentinel pair on its own appears in a sibling function that does not follow it with `0F 84`).
 
-Important: the rel32 bytes of the `jz` are intentionally not part of the pattern. They change every build because the distance to the remove-path branch body depends on the size of the add-path body above it; leaving them off the pattern keeps it patch-robust without losing uniqueness.
+The rel32 bytes of the `jz` are intentionally not part of the pattern. They change every build because the distance to the remove-path branch body depends on the size of the add-path body above it; leaving them off the pattern keeps it patch-robust without losing uniqueness.
 
 ### 2.3 Candidate registration shape
 
@@ -179,7 +183,7 @@ inline constexpr AobCandidate k_hudSetBattleStateCandidates[] = {
     {
         "HudSetBattleState_P1_FullPrologue",
         "48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 48 8B EC "
-        "48 81 EC ?? ?? ?? ?? 48 8B F1",
+        "48 81 EC ?? ?? ?? ?? 48 8B ??",
         /*offset_to_hook=*/0,
     },
     {
@@ -246,7 +250,7 @@ Consumers that want edge logging should compare the previous value with `exchang
 
 Pseudocode for the install, hook-library-agnostic:
 
-```
+```text
 addr = aob_resolve(k_hudSetBattleStateCandidates)
 if addr != 0:
     original = install_inline_hook(addr, observer::detour)
@@ -275,74 +279,34 @@ The detour fires on the engine's state-update path, not on the HUD render pass. 
 
 ---
 
-## 4. Alternative signals considered and rejected
+## 4. Why the HUD CSS sink and not the engine-side flag
 
-This section captures the dead ends so that a future investigator does not re-run any of these probes. Each rejection is backed inline with the concrete CE and IDA evidence that falsified it.
+A static byte at `0x145C1DC5C` on v1.03.01 looked like a sole-writer combat flag (cmp byte / mov byte 0 or 2 store pair, edge-guarded). Live hardware-write breakpoint testing on v1.03.01 captured 350 writes in 88 seconds, alternating 0 and 2 at ~4 hits per second regardless of combat state. The byte is an internal HUD-tick oscillator, not an oracle. Static "sole-writer + edge-guarded + constant domain" patterns are not sufficient to claim a flag; dynamic verification is mandatory.
 
-Decision summary at a glance:
-
-```mermaid
-flowchart TD
-    Q[Find combat-state oracle]
-    A["g_battleStateByte @ 0x145C1DC5C<br/>sole-writer static byte"]
-    D["Hud_SetBattleStateClass a2<br/>virtual method boolean arg"]
-    Q --> A
-    Q --> D
-    A -->|"HW BP: 350 writes / 88s,<br/>alternating 0 and 2,<br/>independent of combat"| AR[REJECTED<br/>tick oscillator]
-    D -->|"one edge per real transition,<br/>verified melee and bow"| DR[ACCEPTED<br/>engine-authoritative]
-```
-
-### 4.1 `g_battleStateByte @ 0x145C1DC5C`
-
-Static analysis on 2026-04-22 identified a dispatcher at `0x1407BE110` that writes byte `0` or `2` to the global at `0x145C1DC5C`. Two RIP-relative stores were confirmed in the live binary:
-
-```asm
-1407BE271  80 3D E4 F9 45 05 02     cmp byte [rip+0x545F9E4], 2   ; edge-guard read
-1407BE2BE  C6 05 97 F9 45 05 02     mov byte [rip+0x545F997], 2   ; Battle_On store
-1407BE293  C6 05 ?? ?? ?? ?? 00     mov byte [rip+...........], 0 ; Battle_Off store
-```
-
-All three RIP-relative targets resolve to `0x145C1DC5C`. Initially this looked like a sole-writer, edge-guarded state flag. Dynamic CE verification overturned the claim:
-
-* **Snapshot reads always returned `0`** regardless of combat state. A baseline read while engaging a mob returned `0x00`, contradicting the `= 2` semantic.
-* **Hardware data-write breakpoint** on the byte captured 350 writes in 88 seconds, near-symmetric between the two store sites: 176 hits at the `byte = 2` store, 174 at the `byte = 0` store. Writes alternated rapidly at roughly 4 hits per second regardless of whether the player was idle, weapon-drawn, fighting, or chasing.
-
-The byte is not a combat flag. It is an internal oscillator in the HUD's tick dispatcher, flipping on every frame pair the dispatcher runs. The static `sole-writer plus edge-guarded plus constant domain` fingerprint was misleading; dynamic verification is mandatory for any flag claim based purely on static pattern-matching.
+The HUD CSS swap method passes the test the static byte fails: it fires exactly once per real engine transition, in either direction, and stays quiet during HUD-suppressed cutscenes. That edge-only cadence is what consumers want.
 
 ---
 
 ## 5. Known caveats
 
-* The hook fires on HUD cadence, not engine cadence. The two are identical in normal play; they may drift by a frame during HUD-off loading transitions. If a future consumer needs tighter timing, hook the upstream producer instead: it is the caller of the vtable slot at `0x1582549C8`, reachable from any instance of the containing HUD controller class.
+* The hook fires on HUD cadence, not engine cadence. The two are identical in normal play; they may drift by a frame during HUD-off loading transitions. If a future consumer needs tighter timing, hook the upstream producer instead: it is the caller of the HUD CSS-swap vtable slot, reachable from any instance of the containing HUD controller class.
 * The method is virtual. Future patches could relocate the vtable slot even if the method body is stable, or vice versa. AOB scans bind to the body, not the slot, so slot motion is invisible to the consumer; body motion is handled by the two-candidate fallback.
 * `imm32` stack-alloc size `0x80` is right on the boundary where MSVC may switch to `imm8` on a recompile. If that happens, P1 loses the `48 81 EC` literal and will stop matching; P2 (which anchors in the body) continues to work. This was anticipated when picking the two candidates.
-* A future game patch may change the CSS class name to a variant that uses two or four entries instead of three. The two `C7 45 ?? 03 00 00 00` literals in P2 would then become `C7 45 ?? 02 00 00 00` or `C7 45 ?? 04 00 00 00`, breaking that candidate. P1 still matches because the prologue does not encode the list length. Re-derive P2 if this happens.
+* A future game patch may change the CSS class name list to a variant that uses two or four entries instead of three. The two `C7 45 ?? 03 00 00 00` literals in P2 would then become `C7 45 ?? 02 00 00 00` or `C7 45 ?? 04 00 00 00`, breaking that candidate. P1 still matches because the prologue does not encode the list length. Re-derive P2 if this happens.
 * The detour must be `noexcept`: the game engine does not expect C++ exceptions to cross this boundary. Keep the atomic write the only work in the detour body; move any expensive consumer-side logic behind the accessor.
 
 ---
 
-## 6. IDA verification status (2026-04-22)
+## 6. Cross-build deltas
 
-Spot-checked against the v1.03.01 IDB:
+| What                                                | v1.03.01      | v1.05.01      |
+|-----------------------------------------------------|---------------|---------------|
+| Function entry                                      | `0x140B17870` | `0x140B2E730` |
+| Add-class helper                                    | `sub_1433EBD10` | `sub_14350C5E0` |
+| Remove-class helper                                 | `sub_1433EBE70` | `sub_14350C750` |
+| CSS hash triple base                                | `0x145C5D0D0` | `0x145E1FC50` |
+| Arg-0 preserve register (last byte of P1 pattern)   | `48 8B F1` (rsi) | `48 8B F9` (rdi) |
+| P1 ModRM byte                                       | literal       | wildcard `??` (tolerates the register repurpose) |
+| P2 anchor body shape                                | identical     | identical (no change) |
 
-| Anchor                                                                   | Status    |
-|--------------------------------------------------------------------------|-----------|
-| `Hud_SetBattleStateClass @ 0x140B17870`                                  | VERIFIED  |
-| Thunk `j_Hud_SetBattleStateClass @ 0x140B25060` (5-byte `E9 rel32`)      | VERIFIED  |
-| Vtable slot `.rdata @ 0x1582549C8` (sole data xref)                      | VERIFIED  |
-| AOB P1 (`48 89 5C 24 ?? ... 48 8B F1`, 29 bytes)                         | 1 MATCH   |
-| AOB P2 (`C7 45 ?? 03 00 00 00 ... 84 D2 0F 84`, 28 bytes)                | 1 MATCH   |
-| Sibling pattern at `0x140CE9550` (ruled out by `0F 84` tail)             | VERIFIED  |
-| `sub_1433EBD10` (add CSS class helper)                                   | VERIFIED  |
-| `sub_1433EBE70` (remove CSS class helper)                                | VERIFIED  |
-| CSS-class interned hashes at `dword_145C5D0D0` / `+4` / `+8`             | VERIFIED  |
-| `g_battleStateByte @ 0x145C1DC5C` (section 4.1; oscillator, not oracle)  | VERIFIED  |
-
-Deferred verification (recommend a pass if any of these are edited):
-
-* The inline `small_vector<int, 3>` struct layout. Assumed at bytes-from-rbp `{-0x40 buffer*, -0x38 count, -0x34 cap}` and mirror `{-0x20 buffer*, -0x18 count, -0x14 cap}`. Values are not needed for the hook but matter if a consumer wants to read the pending class-name vector.
-* The vtable layout of the HUD controller class. Not needed unless a consumer wants to intercept via vtable hook rather than inline hook.
-
----
-
-Maintained alongside the source binary it describes; bump the "Verified game version" line at the top whenever an address or AOB is re-probed against a new patch.
+The body-anchored P2 pattern is the reason the cascade survived the v1.05 patch with one trivial header tweak: anchoring on the renderer-side small_vector contract (cap=3 sentinels paired with `test dl; jz`) is more durable than anchoring on the prologue, because the contract is forced by the surrounding renderer plumbing.

--- a/docs/research/live-transmog-architecture.md
+++ b/docs/research/live-transmog-architecture.md
@@ -1,6 +1,8 @@
 # Live Transmog -- Runtime Architecture
 
-Reverse-engineering reference for the Live Transmog mod's runtime pipeline, verified against **Crimson Desert v1.03.01** (PC binary, image base `0x140000000`). This document maps the apply pipeline to concrete functions, offsets, and source locations; byte-level anchors (AOBs, struct offsets) live in `live-transmog-source-of-truth.md`.
+Reverse-engineering reference for the Live Transmog mod's runtime pipeline. This document maps the apply pipeline to concrete functions, offsets, and source locations; byte-level anchors (AOBs, struct offsets) live in `live-transmog-source-of-truth.md`. The cross-character body-mesh swap layered on top of this pipeline lives in `live-transmog-prefab-wrapper-swap.md`.
+
+Verified against **Crimson Desert v1.05.01** (image base `0x140000000`, FileVersion `1.0.0.1070`).
 
 ---
 
@@ -8,10 +10,16 @@ Reverse-engineering reference for the Live Transmog mod's runtime pipeline, veri
 
 The engine owns its own rules for which visual mesh is drawn per armor slot (helm, chest, cloak, gloves, boots). Live Transmog does not rewrite those rules. It operates by:
 
-1. Asking the engine to remove the real armor's mesh from the live scene graph (SafeTearDown path).
+1. Asking the engine to remove the real armor's mesh from the live scene graph (the SafeTearDown path).
 2. Asking the engine to run its own "show this item" path (`SlotPopulator`) with a substituted item id.
 
-The auth table at `a1+0x78` (what is actually equipped, and what is serialised to the save file) is never mutated. Mod state lives in DLL memory and is released on quit.
+The auth table at `*(a1+0x78)` (what is actually equipped, and what is serialised to the save file) is never mutated. Mod state lives in DLL memory and is released on quit.
+
+### Why this design
+
+The straightforward "rewrite the engine's part list" approach was rejected because the engine re-derives the list from the auth table on most state transitions (zone load, save load, character swap, glide exit, dismount). Any direct mutation has to be re-applied on every transition or it is wiped. Driving the engine through its own SlotPopulator entry point makes the engine treat the substituted mesh as "the item it just decided to equip", which gives us correct cleanup semantics for free across every path the engine itself supports.
+
+The carrier hybrid (section 4.3) is the secondary consequence: cross-class items are rejected at the engine's equip-type gate, so the mod patches the carrier descriptor's equip-type byte (`+0x42`) into the target descriptor for the duration of one `SlotPopulator` call. Patching exactly one field, rather than constructing an item from scratch, keeps the mod compatible with future changes to the descriptor layout that do not touch `+0x42`.
 
 ---
 
@@ -19,14 +27,16 @@ The auth table at `a1+0x78` (what is actually equipped, and what is serialised t
 
 | Term | Plain English | Technical meaning |
 |------|---------------|-------------------|
-| **Real item** | Whatever the character actually has equipped in the inventory screen. | Entry in the auth table at `a1+0x78`. Written to save file. |
-| **Fake item** | The mesh the mod is asking the engine to draw instead. | `slot_mappings[i].targetItemId` in mod memory. Not persisted. |
-| **Carrier** | Helper item the mod uses to pass the engine's class check. | Member of `k_kliffCarriers` / `k_oongkaCarriers` / `k_damianeCarriers`. |
+| **Real item** | Whatever the character actually has equipped in the inventory screen. | Entry in the auth table at `*(a1+0x78)`. Written to the save file. |
+| **Fake item** | The mesh the mod is asking the engine to draw instead. | `slot_mappings[i].targetItemId` in mod memory. Not persisted in save file. |
+| **Carrier** | Helper item the mod uses to pass the engine's class check. | Member of `k_kliffCarriers` / `k_oongkaCarriers` / `k_damianeCarriers` in `transmog_apply.cpp`. |
 | **Auth table** | Authoritative equipment record (server-synced). | Stride-`0xC8` array at `*(a1+0x78)+0x08`, count at `+0x10`. |
-| **PartDef / scene graph cache** | Live in-RAM list of meshes the renderer walks this frame. | Dispatch cache at `a1+0x1B8` (ptr), `+0x1C0` (count), `+0x1C4` (cap). |
-| **Tear-down** | Scene-graph remove ("stop drawing this mesh"). | Call path passing through `sub_14075F9E0` (internal label `SafeTearDown` at `+0x14075FE60`). |
+| **PartDef / scene graph cache** | Live in-RAM list of meshes the renderer walks this frame. | Dispatch cache at `a1+0x1D8` (basePtr), `+0x1E0` (count), `+0x1E4` (cap) on v1.04+; v1.03.01 had the triple at `+0x1B8 / +0x1C0 / +0x1C4`. |
+| **Tear-down** | Scene-graph remove: "stop drawing this mesh." | Call path passing through `SafeTearDown` (resolved via cascade). |
 | **a1** | Equip-wrapper pointer passed back into engine functions. | Player-component pointer; engine reads many offsets from it. |
 | **Dispatch** | One full tear-down-and-reapply pass. | Body of `apply_all_transmog()` in `transmog_apply.cpp`. |
+
+The dispatch-cache offset shift between v1.03.01 and v1.04+ is documented in `transmog_apply.cpp` as `k_compSlotCacheBasePtrOffset = 0x1D8`. Reading the old offsets on v1.04+ returns zero for count and silently makes apply a no-op; writing the old offsets corrupts the component a slot at a time. The mod uses the v1.04+ offsets unconditionally on the current build of record (v1.05.01).
 
 ---
 
@@ -37,7 +47,7 @@ flowchart TD
     A[Game loads the world] --> B[Load-detect thread wakes<br/>every 1000 ms]
     B --> C{WS chain resolves<br/>a valid component?}
     C -- no --> B
-    C -- yes --> D[Char-swap poll reads<br/>ActorManager +0x30 byte<br/>Kliff=1 Damiane=2 Oongka=3]
+    C -- yes --> D[Resolver reads<br/>CDCore::current_controlled_character<br/>Kliff / Damiane / Oongka / Unknown]
     D --> E{Current char differs from<br/>PresetManager active?}
     E -- yes --> F[Switch UI preset list<br/>rebuild slot_mappings<br/>reset drop-detection]
     E -- no --> G[Idle]
@@ -54,7 +64,7 @@ flowchart TD
     U3 --> H
 
     H --> W[Debounce worker wakes<br/>~125 ms later]
-    W --> X[sync_active_char_to_live<br/>reads live char byte<br/>rebuilds mappings if needed]
+    W --> X[sync_active_char_to_live<br/>reads live char identity<br/>rebuilds mappings if needed]
     X --> Y[apply_all_transmog a1]
     Y --> Z[Tear-down + apply pipeline<br/>see section 4]
     Z --> B
@@ -62,9 +72,9 @@ flowchart TD
 
 Components:
 
-- **Load-detect thread** (`transmog_worker.cpp :: load_detect_thread_fn`). Wakes once per second. Resolves the player component via the static `WS -> ActorManager -> UserActor -> +0xD8` chain, and reads the character-index byte to swap the active preset on in-game character switches.
-- **Hooks** (`transmog_hooks.cpp`). Two apply triggers: `BatchEquip` at `+0x007605B0` and `VisualEquipChange (VEC)` at `+0x007733B0`. On fire, they record the passed-in `a1` and schedule a pass.
-- **Debounce worker** (`transmog_worker.cpp :: run_debounced_apply`). Single thread consuming scheduled apply requests, coalescing bursts.
+- **Load-detect thread** (`transmog_worker.cpp :: load_detect_thread_fn`). Wakes once per second. Resolves the player component via the `WorldSystem -> ActorManager -> UserActor -> +0xD8` chain, and queries the shared `CDCore::current_controlled_character()` resolver to decide whether to switch the active preset on character swap. The chain walk and decode rules live in `live-transmog-source-of-truth.md` section 1.
+- **Hooks** (`transmog_hooks.cpp`). Two apply triggers: `BatchEquip` and `VisualEquipChange (VEC)`. On fire they record the passed-in `a1` and schedule a pass. Resolution is via shared CDCore cascades (`k_batchEquipCandidates`, `k_visualEquipChangeCandidates`).
+- **Debounce worker** (`transmog_worker.cpp :: run_debounced_apply`). Single thread consuming scheduled apply requests, coalescing bursts so multi-slot inventory commits become one apply pass.
 
 The rest of this document focuses on one apply pass (node `Y`).
 
@@ -83,12 +93,12 @@ stateDiagram-v2
     Guard --> SnapshotReal
 
     SnapshotReal: Snapshot real item ids per slot
-    SnapshotReal: walks auth table at a1+0x78
+    SnapshotReal: walks auth table at *(a1+0x78)
     SnapshotReal: realItemId[k] filled via IndexedStringLookup
     SnapshotReal --> ClearCache
 
     ClearCache: Clear dispatch cache entries
-    ClearCache: a1+0x1B8 array, reset subCount for our slots only
+    ClearCache: a1+0x1D8 array, reset subCount for our slots only
     ClearCache: leaves other slots untouched
     ClearCache --> PhaseA
 
@@ -96,7 +106,7 @@ stateDiagram-v2
     PhaseA: for every slot that had a fake applied before
     PhaseA: call tear_down_by_item_id(a1, prevFakeId, slotTag)
     PhaseA: if the previous fake used a carrier also tear down the carrier
-    PhaseA: briefly flips charClassBypass 0x74 to 0xEB so the NPC item resolves
+    PhaseA: briefly flips charClassBypass JZ to JMP so the NPC item resolves
     PhaseA --> PhaseB
 
     PhaseB: Phase B tear-down real item
@@ -133,33 +143,33 @@ The `__finally` around this state machine clears `in_transmog` and `suppress_vec
 
 When the mod applies a new preset, the previous preset is still on screen. Phase A walks the slots the mod wrote to last time (`last_applied_ids`) and asks the engine to remove those meshes from the scene graph:
 
-```
+```text
 tear_down_by_item_id(a1, prevFakeId, slotTag)
   -> IndexedStringLookup(&prevFakeId)           // descriptor hash
-  -> SafeTearDown(a1, hash, slotTag)            // label at 0x14075FE60
-                                                // (inside sub_14075F9E0)
-       -> internal detach path at 0x1425EBAE0   // inside sub_1425EACA0
-                                                // detaches mesh, particle
+  -> SafeTearDown(a1, hash, slotTag)            // cascade-resolved
+                                                // (sub_14075F9E0 / SafeTearDown
+                                                // candidates in aob_resolver.hpp)
+       -> internal scene-graph detach           // detaches mesh, particle
                                                 // emitters, anim controllers
                                                 // from the scene
 ```
 
-No write to `a1+0x78` (auth table). No server-side notification. Save file bytes unchanged across the call. SafeTearDown is a scene-graph operation only -- it removes the mesh from the render list and drops the renderer's internal refs.
+No write to the auth table at `*(a1+0x78)`. No server-side notification. Save file bytes unchanged across the call. SafeTearDown is a scene-graph operation only -- it removes the mesh from the render list and drops the renderer's internal refs.
 
-If the previous apply used a carrier, the mod briefly flips `charClassBypass` at `0x141D5F538` from `0x74` (`jz short`) to `0xEB` (`jmp short`) so the engine's class check accepts the NPC carrier during tear-down. The byte is restored to `0x74` the moment tear-down returns.
+If the previous apply used a carrier, the mod briefly flips `charClassBypass` from `0x74` (`jz short`) to `0xEB` (`jmp short`) so the engine's class check accepts the NPC carrier during tear-down. The byte is restored to `0x74` the moment tear-down returns. The address is resolved by `k_charClassBypassCandidates` (3-anchor cascade, see [live-transmog-source-of-truth.md §9](live-transmog-source-of-truth.md#9-aob-cascade-audit-2026-05-08)). The mod refuses to install if the resolved byte is anything other than `0x74`.
 
 ### 4.2 Phase B -- remove the real mesh so the fake can take its place
 
 Phase B calls a different tear-down path that walks the auth table directly:
 
-```
+```text
 tear_down_real_part(a1, slotTag)
   -> container = *(a1 + 0x78)
-  -> base     = *(container + 0x08)              // stride 0xC8 entries
-  -> count    = *(container + 0x10)
+  -> base     = *(container + 0x08)              // stride 0xC8 entries (k_compEntryStride = 0xD0
+  -> count    = *(container + 0x10)              //   in the live source; legacy 0xC8 noted below)
   -> for i in 0..count
-       -> entry = base + i * 0xC8
-       -> if *(entry + 0xC0) == slotTag          // slot tag match
+       -> entry = base + i * stride
+       -> if *(entry + slotTagOffset) == slotTag // slot tag at +0xC8 (k_compEntrySlotTagOffset)
               realItemId = *(entry + 0x88)       // alt first
               if realItemId == 0xFFFF:
                   realItemId = *(entry + 0x08)   // fall back to primary
@@ -167,10 +177,11 @@ tear_down_real_part(a1, slotTag)
               -> SafeTearDown(a1, hash, slotTag)
 ```
 
-1. The walk **reads** entries to find the real item id. It does not write to any entry.
-2. Tear-down is a renderer-side operation. The engine's belief about what is equipped is unchanged.
+The walk reads entries to find the real item id; it does not write to any entry. Tear-down is renderer-side only.
 
 After Phase B, `real_damaged[slotIdx] = true` records that the real mesh is currently missing from the scene graph. That flag is consulted in Restore if the user unticks a slot in the overlay.
+
+The historical stride-`0xC8` value is documented in older notes; the live source at `transmog_apply.cpp` declares `k_compEntryStride = 0xD0`.
 
 ### 4.3 Apply -- draw the fake mesh
 
@@ -178,14 +189,14 @@ For every active slot with a target item, the mod calls SlotPopulator (the same 
 
 **Direct apply** when the fake is something the active character can normally wear:
 
-```
+```text
 apply_transmog(a1, targetItemId)
   itemData = { word targetId at +0, defaults elsewhere }
   swapEntry = zero-initialised via InitSwapEntry
   SlotPopulator(a1, &itemData, &swapEntry)
 ```
 
-**Carrier-patch apply** when the fake belongs to another character or an NPC. The engine's equip gate checks a `u16` at `desc+0x42` (equip-type, `0x0004` for Kliff, `0x0001` for Oongka/Damiane/NPCs). If the fake's byte does not match the active character's expected value, direct apply is rejected. The mod builds a hybrid descriptor:
+**Carrier-patch apply** when the fake belongs to another character or an NPC. The engine's equip gate checks a `u16` at `desc+0x42` (equip-type, `0x0004` for Kliff, `0x0001` for Oongka / Damiane / NPCs). If the fake's byte does not match the active character's expected value, direct apply is rejected. The mod builds a hybrid descriptor:
 
 ```mermaid
 flowchart LR
@@ -197,11 +208,11 @@ flowchart LR
     Restore --> Free[VirtualFree hybrid buffer]
 ```
 
-Exactly one field is patched: the equip-type at `+0x42`. Every other byte in the hybrid comes from the target (meshes, textures, tints, rule classifiers). SlotPopulator reads the patched byte during its visual-config matching loop (label `+0x14076CAED` inside `sub_14076C7F0`), accepts the carrier's class identity, then renders the target's visual data.
+Exactly one field is patched: the equip-type at `+0x42`. Every other byte in the hybrid comes from the target (meshes, textures, tints, rule classifiers). SlotPopulator reads the patched byte during its visual-config matching loop, accepts the carrier's class identity, then renders the target's visual data.
 
-During the call, the `charClassBypass` byte is again flipped to `0xEB` so any deeper class check also passes. Bypass and descriptor pointer are both restored inside a `__finally` so an SEH fault cannot leave the catalog corrupted. The hybrid buffer is freed immediately after.
+During the call, `charClassBypass` is again flipped to `0xEB` so any deeper class check also passes. Bypass and descriptor pointer are both restored inside a `__finally` so an SEH fault cannot leave the catalog corrupted. The hybrid buffer is freed immediately after.
 
-Source: `CrimsonDesertLiveTransmog/src/transmog_apply.cpp` (`k_descBufSize = 0x400` constant, `charClassBypass` flip at line ~359 and ~507; hybrid assembly around lines ~320--342).
+Source: `CrimsonDesertLiveTransmog/src/transmog_apply.cpp` (`k_descBufSize = 0x400` constant; hybrid assembly + bypass flips inside `apply_transmog_carrier_path` and `tear_down_by_item_id`).
 
 ### 4.4 Restore -- put the real item back if the user unticked
 
@@ -209,7 +220,7 @@ If the user turns off a slot in the overlay, the mod needs to put the real mesh 
 
 ### 4.5 PartAddShow suppression
 
-The engine occasionally bypasses the regular scene-graph path and calls `PartAddShow` directly, most notably during glide exits, horse dismounts, and some action-chart landings. If that happens while the mod has torn down the real mesh, the real helm flashes visible for a frame or two. The mod hooks PartAddShow and keeps a small table of suppressed part hashes; while a slot is in the torn-down state, any add-show call for one of that slot's part hashes returns zero immediately without touching the scene graph.
+The engine occasionally bypasses the regular scene-graph path and calls `PartAddShow` directly, most notably during glide exits, horse dismounts, and some action-chart landings. If that happens while the mod has torn down the real mesh, the real helm flashes visible for a frame or two. The mod hooks PartAddShow (cascade `k_partAddShowCandidates`) and keeps a small table of suppressed part hashes; while a slot is in the torn-down state, any add-show call for one of that slot's part hashes returns zero immediately without touching the scene graph.
 
 Source: `CrimsonDesertLiveTransmog/src/part_show_suppress.cpp`.
 
@@ -221,12 +232,14 @@ Every absolute write the mod performs:
 
 | Address | Size | Frequency | Reason | Restore |
 |---------|------|-----------|--------|---------|
-| `0x141D5F538` | 1 byte | during carrier-apply / tear-down | Flip `JZ` (`0x74`) to `JMP` (`0xEB`) so NPC carriers pass the class check | Restored within the same function under `__finally` |
-| `a1 +0x1B8..+0x1C4` (dispatch cache) | ~16 bytes per slot | during apply | Invalidate stale cache entries for mod-owned slots | Natural overwrite by SlotPopulator on the next apply |
+| `charClassBypass` byte (cascade-resolved) | 1 byte | during carrier-apply / tear-down | Flip `JZ` (`0x74`) to `JMP` (`0xEB`) so NPC carriers pass the class check | Restored within the same function under `__finally` |
+| `a1 + dispatch-cache triple` (basePtr / count / cap) | ~16 bytes per slot | during apply | Invalidate stale cache entries for mod-owned slots | Natural overwrite by SlotPopulator on the next apply |
 | Mod-allocated heap buffer (`VirtualAlloc`) | `0x400` bytes per carrier apply | during carrier-apply | Build hybrid descriptor | Freed via `VirtualFree` before the function returns |
-| Carrier slot pointer in item catalog | 8 bytes via `InterlockedExchange64` | during carrier-apply | Redirect catalog lookup to the hybrid for one call | Swapped back to original within the same function under `__finally` |
+| Carrier slot pointer in item catalog | 8 bytes via `InterlockedExchange64` | during carrier-apply | Redirect catalog lookup to the hybrid for one call | Swapped back to the original within the same function under `__finally` |
 
-No writes to the auth table at `a1+0x78` or its entries. No writes to save-file-backed state. On DLL unload, all mod-side arrays are released; the hybrid buffer is freed; `charClassBypass` is `0x74` because every flip is paired with a restore in a `__finally`.
+No writes to the auth table at `*(a1+0x78)` or its entries. No writes to save-file-backed state. On DLL unload, all mod-side arrays are released; the hybrid buffer is freed; `charClassBypass` is `0x74` because every flip is paired with a restore in a `__finally`.
+
+The body-mesh pointer-swap feature (separate document) adds two more writes (one to a struct copy operator's intermediate slot, one to a wrapper-list during natural-pipeline teardown), both at well-defined hook entry / exit boundaries with the same `__finally` discipline.
 
 ---
 
@@ -235,12 +248,12 @@ No writes to the auth table at `a1+0x78` or its entries. No writes to save-file-
 | Event | What the mod sees | Mod response |
 |-------|-------------------|--------------|
 | Zone transition | `BatchEquip` hook fires with a different `a1`. | Wipes `real_damaged` and `last_applied_real_ids` (arrays referenced previous world's memory). Schedules a fresh dispatch. |
-| Save-load | Same as zone transition. Server resends auth table, BatchEquip fires, mod re-applies. | Preset file unchanged. Real gear unchanged. Fake gear re-applies within a second. |
-| Character control swap (Kliff -> Damiane) | Load-detect thread reads a different value from `ActorManager + 0x30`. The controlled actor at `UserActor + 0xD8` now points to Damiane. | Switch UI preset list, rebuild `slot_mappings` from Damiane's active preset, clear drop-detection, schedule a dispatch. |
+| Save-load | Same as zone transition. Server resends auth table, BatchEquip fires, mod re-applies. | Preset file unchanged. Real gear unchanged. Fake gear re-applies within a second. The CDCore resolver invalidates its last-known-good cache when the UserActor singleton pointer changes. |
+| Character control swap (Kliff -> Damiane) | Load-detect thread reads a different identity from the controlled-character resolver. | Switch UI preset list, rebuild `slot_mappings` from Damiane's active preset, clear drop-detection, schedule a dispatch. |
 | World reload (death, fast travel, manual reload) | `resolve_player_component()` returns a new component pointer. | Same flow as zone transition. |
 | Uninstall the mod | DLL unloaded on next launch. | No-op. Save file was never touched. |
 
-Source: `CrimsonDesertLiveTransmog/src/transmog_worker.cpp` (`resolve_player_component` around line 139).
+Source: `CrimsonDesertLiveTransmog/src/transmog_worker.cpp` (`resolve_player_component` and the load-detect thread).
 
 ---
 
@@ -251,7 +264,7 @@ Source: `CrimsonDesertLiveTransmog/src/transmog_worker.cpp` (`resolve_player_com
 - **`in_transmog`** is scoped to a single SlotPopulator call. Set true on entry, cleared on return. Without it, SlotPopulator's own internal equip-event fan-out would re-enter the VEC hook, which would schedule another apply, which would call SlotPopulator again. One guard, one call, ~50 ms.
 - **`suppress_vec`** wraps the entire dispatch. Set true at the top of `apply_all_transmog`, cleared at the bottom. A dispatch touches multiple slots and therefore calls SlotPopulator multiple times. Each SlotPopulator call can fire VEC internally. Without the outer guard, each VEC fire would schedule another dispatch behind the current one, producing visible flicker and cascading applies that never converge.
 
-Both guards are `std::atomic<bool>` in `shared_state.cpp` and are paired with `__finally` restores so a fault during apply cannot leave them stuck muted.
+Both guards are `std::atomic<bool>` in `shared_state.cpp` and are paired with `__finally` restores so a fault during apply cannot leave them stuck muted. The body-mesh pointer-swap feature reads `Transmog::in_transmog()` on its own hook entry to keep its substitution gated to the mod's own SlotPopulator drives, never the engine's organic equip flows.
 
 ---
 
@@ -260,7 +273,7 @@ Both guards are `std::atomic<bool>` in `shared_state.cpp` and are paired with `_
 To confirm the mod does not touch persistent state:
 
 1. **Compare saves.** Make a save while transmogged. Quit. Remove the mod. Relaunch. Load the save. Real gear is present; transmog mesh is gone. Save-on-disk bytes are identical to a save made with the mod never installed.
-2. **Inspect the auth table in Cheat Engine.** Walk `a1 +0x78 +0x08`, stride `0xC8`, and compare the item word at `+0x08` / `+0x88` before and after an apply. Bytes are identical. Only the scene graph at `a1 +0x1B8` and the renderer-side mesh refs change.
+2. **Inspect the auth table in Cheat Engine.** Walk `*(a1 + 0x78) + 0x08`, stride `0xD0` (or `0xC8` if the legacy stride is what is live), and compare the item word at `+0x08` / `+0x88` before and after an apply. Bytes are identical. Only the dispatch cache at `a1 + 0x1D8` and the renderer-side mesh refs change.
 3. **Read the log.** With `LogLevel = Trace` in the INI, every dispatch prints the source and target of every tear-down and every apply call, the carrier ids used, and the hybrid descriptor writes.
 
 ---
@@ -269,13 +282,16 @@ To confirm the mod does not touch persistent state:
 
 If the game binary shifts, the highest-churn items are:
 
-- SlotPopulator / BatchEquip / VEC entry points (`+0x007727F0`, `+0x007605B0`, `+0x007733B0`). Re-scan via the AOBs in `aob_resolver.hpp` / `constants.hpp`.
-- The `charClassBypass` JZ byte at `0x141D5F538`. Look for a `movzx eax,[...]; cmp al,<class>; jz short` pattern in the equip path (verified via `sub_141D5F470`).
-- Auth-table stride `0xC8` and slot-tag offset `+0xC0`.
-- Descriptor byte `+0x42` (equip-type). If the engine starts gating equip on additional bytes, the patch list in `k_carrierPatches` will need to grow.
+- SlotPopulator / BatchEquip / VEC entry points. Re-scan via the AOBs in `aob_resolver.hpp` (mod-local for SlotPopulator / SafeTearDown / SubTranslator; CDCore-shared for BatchEquip / VEC / WorldSystem). The cascading scanner with prologue-fallback handles the common shifts; full audit is at [live-transmog-source-of-truth.md §9](live-transmog-source-of-truth.md#9-aob-cascade-audit-2026-05-08).
+- The `charClassBypass` JZ byte. Cascade tries 3 anchors; on resolve, the mod sanity-checks the byte equals `0x74`. If a future patch retunes the classifier scan loop into a `CMOV` or rewrites it as a vtable dispatch, the cascade fails and the mod refuses to install rather than scribbling at the wrong site.
+- Auth-table stride and slot-tag offset (`k_compEntryStride`, `k_compEntrySlotTagOffset` in `transmog_apply.cpp`).
+- Dispatch-cache triple offsets (`k_compSlotCacheBasePtrOffset` etc.). These shifted by `+0x20` between v1.03.01 and v1.04.00; the live source is at the v1.04+ values.
+- Descriptor byte `+0x42` (equip-type). If the engine starts gating equip on additional bytes, the patch list in the carrier-hybrid path will need to grow.
 
 ---
 
-## 10. Related modules
+## 10. Related documents
 
-CrimsonDesertEquipHide research will land alongside this document in `docs/research/` once that mod's RE artifacts are lifted into the shared knowledge base format. This document and its sibling `live-transmog-source-of-truth.md` are the pattern to follow.
+- `live-transmog-source-of-truth.md` -- byte-level reference for hook RVAs, struct offsets, the WorldSystem chain, and the controlled-character resolver.
+- `live-transmog-prefab-wrapper-swap.md` -- body-mesh pointer-swap feature layered on top of this pipeline (cross-character body re-skin via wrapper-pointer substitution at the slot-populator copy operator).
+- [live-transmog-source-of-truth.md §9](live-transmog-source-of-truth.md#9-aob-cascade-audit-2026-05-08) -- section 9 of the byte-level reference; AOB cascade audit covering every hardcoded RVA that was replaced by a 3-anchor cascade. Includes per-cascade hit counts and recovery recipes.

--- a/docs/research/live-transmog-prefab-wrapper-swap.md
+++ b/docs/research/live-transmog-prefab-wrapper-swap.md
@@ -1,0 +1,531 @@
+# Body-Mesh Pointer Swap -- Implementation Reference
+
+This document is the reference for the body-mesh-swap feature in `Transmog::PrefabWrapperSwap`. It is a reference for the *current* working code only. Read it alongside the source files in `CrimsonDesertLiveTransmog/src/`:
+
+- `prefab_wrapper_swap.{hpp,cpp}` -- feature implementation
+- `aob_resolver.hpp` -- AOB candidate definitions used by this feature plus the wider mod
+- `transmog_map.cpp` -- slot enum to engine slot tag mapping
+
+Verified against **Crimson Desert v1.05.01** (image base `0x140000000`, FileVersion `1.0.0.1070`). The full AOB-cascade audit covering every hardcoded RVA replaced in the 2026-05-08 patchproofing pass lives in section 9 of [live-transmog-source-of-truth.md §9](live-transmog-source-of-truth.md#9-aob-cascade-audit-2026-05-08); this document references that table rather than duplicating it.
+
+---
+
+## 1. What it does
+
+Re-skin the player body's five cosmetic slots (Helm, Chest, Cloak, Gloves, Boots) onto **any prefab the engine has loaded**, including cross-character NPC prefabs (e.g. `cd_nhw_no_ub_20027` on Kliff). The swap operates on the engine's resource binding pipeline rather than on item-level transmog: the player still has Kliff's helm equipped at the inventory level, but the body component renders the picked prefab.
+
+Source mesh names per slot are hardcoded to the canonical Kliff plate set (`cd_phm_00_*_00_0435*`); the user picks a target via the per-slot dropdown in the overlay. Targets persist in the preset JSON as `prefabName` and auto-apply on load. There is no INI configuration and no toggle hotkey; the feature is always installed, and activation happens implicitly on Apply when at least one slot has a target selection.
+
+---
+
+## 2. Architecture
+
+Two hooks compose the feature:
+
+```text
+Apply path -----------------> sub_140352AA0  (primary swap)            ---+
+                                                                         | All gated on
+Engine teardown -------------> sub_142711DF0  (natural-pipeline patch) ---+ s_active
+```
+
+Each hook runs only when `s_active.load() == true`. When the feature is inactive (no body-mesh selections), both hooks become zero-impact passthroughs. The substitution path also cross-checks `Transmog::in_transmog()` so the engine's own real-item flow is never affected.
+
+### Why two hooks
+
+The substitution at `sub_140352AA0` installs the target wrapper into the destination record (`parent+88`'s record list). On preset switch the engine's content-keyed teardown pipeline (`sub_142711DF0` and downstream unlink primitives) walks `parent+88` looking for a wrapper to unlink, but the search target it derives from `safeTearDown -> ExpandToMeshes` is the *Kliff* wrapper that the inventory still holds, not the substituted target wrapper sitting in the record. Without the second hook, no record matches, no unlink fires, and the helm / cloak ghost-leaks across preset switches.
+
+The natural-pipeline hook (Hook 2) substitutes Kliff src wrappers with target wrappers in the input list at hook entry, so the engine matches the substituted target in `parent+88` and unlinks correctly. After the trampoline returns, the originals are restored so the caller's refcount-release loop pairs with the same wrapper it incremented during list construction.
+
+---
+
+## 3. Boot-time catalog population
+
+When `init()` runs it installs the two hooks and spawns a detached thread that polls `Transmog::is_world_ready()` every 500 ms (no timeout; the sleeping detached thread is reaped on process exit). Once the world is ready the thread calls `populate_slot_catalogs()` to build the per-slot prefab dropdowns, then runs:
+
+```cpp
+Transmog::PresetManager::instance().apply_to_state();
+Transmog::manual_apply();
+```
+
+This is the load-time auto-apply path: presets parsed before the heap walk completed have their `prefabName` values unresolved (catalog was empty); this retroactive `apply_to_state` resolves each name against the now-populated catalog and the subsequent `manual_apply` activates the swap via `notify_apply_starting -> reactivate_with_selections`.
+
+The catalog is also re-populated by `transmog_worker.cpp`'s save-load auto-detect: save loads can rotate the AppearanceTableLoader registry's resident wrapper set as zone- and archetype-specific assets stream in / out.
+
+---
+
+## 4. Catalog enumeration
+
+`populate_slot_catalogs()` builds the per-slot prefab dropdowns from two sources, merged into one per-slot vector inside `s_slotCatalogs[k_slotN]`.
+
+### 4.1 Source 1: StringInfo walk (Phase-1 fast walk)
+
+`walk_string_info(prefix, visitor)` runs with a broad prefix `"cd_"` (3 chars). For each entry that has vtable equal to the StringInfo body-entry vtable AND has an inline name containing one of the slot tags `_hel_00_`, `_ub_00_`, `_cloak_00_`, `_hand_00_`, `_foot_00_`, the visitor records `(name, wrapper-ptr from entry+0x18, hash from entry+0x00)` into the slot's local vector. Both `cd_phm_*` (player male) and `cd_phw_*` (player female) variants are admitted.
+
+The walk uses bulk-copy (`bulk_copy_seh`) over the entry-pointer array plus a per-entry 128-byte header copy. Completes in ~5 ms across all ~30,000 entries.
+
+The StringInfo registry layout (verified live):
+
+| Address | Field |
+|---|---|
+| `s_stringInfoRegistry` (resolved at init) | `regPtr` (singleton struct ptr) |
+| `regPtr+0x08` | `count` u32 |
+| `regPtr+0x50` | `array_ptr` (u64 array of entry pointers, length = `count`) |
+
+Each entry's relevant fields:
+
+| Offset | Field |
+|---|---|
+| `+0x00` | u32 hash (engine asset name hash) |
+| `+0x08` | vtable pointer (matched against the resolved StringInfoVtable for body-mesh entries) |
+| `+0x18` | wrapper-ptr (the value LT stores in `s_swapMap`) |
+| `+0x20` | inline name, NUL-terminated |
+
+The registry singleton address and the body-entry vtable both arrive through 3-anchor cascades resolved at init (`k_stringInfoRegistryCandidates` and `k_stringInfoVtableCandidates` in `aob_resolver.hpp`). Until the cascade resolves, every consumer reads zero and short-circuits, so a cascade failure degrades to "feature inert" rather than "feature mis-pointers".
+
+Per-slot heap walk for partprefab pool wrappers is then merged into each entry's `wrappers` vector (same 32-byte stride records the natural pipeline operates on, in heap pools observed at `0x4104A*` / `0x4104E*` on this build).
+
+### 4.2 Source 2: AppearanceTableLoader registry
+
+The engine maintains a singleton name->entry registry (resolved at init via `k_loaderRegistryCandidates`). Its hash-table struct lives at `+0x50` and contains ~15,300 pre-allocated entries at boot covering every body-mesh prefab the engine knows about, both player AND NPC variants, regardless of whether the asset's data is currently resident.
+
+| Offset (within `+0x50` table struct) | Field |
+|---|---|
+| `+0x00` | `bucket_count` u32 |
+| `+0x04` | `count` u32 |
+| `+0x08` | `capacity` u32 |
+| `+0x10` | `bucket_array_ptr` (256-byte stride per bucket) |
+| `+0x18` | `data_array_ptr` (8-byte pointer per entry) |
+
+Each entry pointed to by the data array is 24 bytes:
+
+| Offset (within entry) | Field |
+|---|---|
+| `+0x00` | `(hash u32, region u32)` packed |
+| `+0x08` | KEY wrapper-ptr (the partprefabdyeslot wrapper carrying the inline name at `+0x18`) |
+| `+0x10` | VALUE wrapper-ptr (metadata struct, different layout, not used here) |
+| `+0x18` | zeros / padding |
+
+`enumerate_loader_registry_into_catalog()` walks `data_array[0..count-1]`, dereferences `entry+0x08` to get the KEY wrapper, reads the inline name at `wrapper+0x18`, classifies by slot tag, and merges into the catalog. Names already present from the StringInfo walk get their wrapper appended to the existing entry's `wrappers` vector with sort + dedup. Fresh names create new `PrefabEntry` records.
+
+Why `entry+0x08` and not `entry+0x10`: the KEY wrapper at `+0x08` carries the prefab name in the standard partprefabdyeslot format that the body-mesh hook already substitutes by pointer equality. The VALUE wrapper at `+0x10` is a metadata struct (counts / IDs) with a different vtable.
+
+Order matters: registry enumeration runs after the StringInfo walk and the partprefab heap merge, but before the metadata enrichment pass and the auto-seed of source selections.
+
+1. StringInfo entries are seeded first (fast path).
+2. Registry adds the rest, merges by name (dedupe).
+3. Each slot's catalog is re-sorted with the full superset.
+4. Source-selection auto-seed runs last: for each slot, finds the hardcoded default Kliff source name in the sorted catalog and stores its index in `s_selSrcIdx[slot]` (only when not already set, so user picks are not overwritten on refresh).
+
+### 4.3 Hardcoded Kliff source defaults
+
+```text
+Helm   -> cd_phm_00_hel_00_0435_d
+Chest  -> cd_phm_00_ub_00_0435
+Cloak  -> cd_phm_00_cloak_00_0435_s
+Gloves -> cd_phm_00_hand_00_0435
+Boots  -> cd_phm_00_foot_00_0435
+```
+
+These are the canonical "Kairos plate" mesh names every protagonist transmog rides on. Oongka and Damiane fall back to the same Kliff defaults until per-character source selection lands.
+
+### 4.4 Per-character body-mesh family
+
+Each protagonist has a top-level appearance key registered in `stringinfo.pabgb`; the engine resolves it via `sub_1402F9340` plus `metadata+0x92`:
+
+| Character | Appearance key | Slot-prefab family root |
+|---|---|---|
+| Kliff | `cd_phm_macduff` | `cd_phm_00_*` |
+| Damiane | `cd_phw_damian` | `cd_phw_00_*` |
+| Oongka | `cd_phm_oongka` | `cd_phm_00_*` (same as Kliff) |
+
+`cd_phm_*` = player-human-male; `cd_phw_*` = player-human-female. Oongka shares Kliff's family root despite a different equip-class; the runtime classifier rejects Kliff-equip-type items at his equip gate, but the underlying body-mesh prefabs come from the same `cd_phm_00_*` pool.
+
+### 4.5 Per-character carrier sets (`transmog_apply.cpp`)
+
+Three character-specific carrier tables drive `default_carrier_for_slot()`. Every entry must pass that character's equip class-gate; mismatches fall back to direct equip and may silently fail. The Kliff-plate `_0435` source defaults above are reusable across characters because every protagonist body resolves through the same partprefab registry walk; the canonical "plate" variant per character differs and the deterministic carrier->prefab binding is not statically extractable from the offline pabgb dumps (iteminfo.pabgb stores it as a binary-serialized appearance struct that resolves via stringinfo hashes at runtime).
+
+| Character | Helm | Chest | Cloak | Gloves | Boots |
+|---|---|---|---|---|---|
+| Kliff | `Kliff_PlateArmor_Helm` | `Kliff_PlateArmor_Armor` | `Kliff_PlateArmor_Cloak` | `Kliff_PlateArmor_Gloves` | `Kliff_Plate_Boots` |
+| Damiane | `Demian_PlateArmor_Helm_I` | `Demian_Leather_Armor` | `Demian_Leather_Cloak` | `Demian_Leather_Gloves_I` | `Demian_Plate_Boots_III` |
+| Oongka | `Oongka_PlateArmor_Helm_II` | `Oongka_Basic_Leather_Armor` | `Oongka_Basic_Leather_Cloak` | `Oongka_Basic_Leather_Gloves` | `Oongka_PlateArmor_Boots_II` |
+
+Each carrier's actual prefab variant requires the runtime catalog walk plus a live equip event with that character on the active slot. The offline pabgb dumps in `D:\Tools\CrimsonForge\Out` do not contain a text-level item-name to prefab-name mapping; the link is hashed through stringinfo. Available `cd_phw_00_*` (Damiane) variants per slot, sourced from `partprefabdyeslotinfo.pabgb`:
+
+- `hel`: 100, 141, 145, 146, 151, 160, 161, 162, 167, 168, 169, 170, 203
+- `ub`:  1, 43, 73, 145, 146, 151, 160, 161, 162, 163, 166, 170, 180
+- `cloak`: 65, 141, 145, 146, 151, 160, 161, 162, 163, 166, 170, 180, 201
+- `hand`: 116, 137, 141, 145, 146, 151, 160, 161, 166, 170
+- `foot`: 20, 145, 151, 160, 161, 163, 166, 170, 180
+
+### 4.6 Naming conventions across the catalog
+
+The two enumeration sources expose names in different forms, both valid:
+
+- **Player prefabs (StringInfo)**: full form with `_00_` markers, e.g. `cd_phm_00_hel_00_0395_c`, `cd_phw_00_ub_00_0163_index02`.
+- **NPC prefabs (registry)**: short form, no `_00_` markers, e.g. `cd_nhw_no_ub_20027`, `cd_nhm_de_ub_0002`. Region segment: `no` (north), `so` (south), `de` (desert). Sub-tier sometimes preserved: `cd_nhw_so_ub_10_10047`.
+
+---
+
+## 5. Apply-only activation lifecycle
+
+Body-mesh swap follows the carrier hybrid pattern: picker mutations only update `s_selSrcIdx[slot]` / `s_selTgtIdx[slot]` (pending UI state). Actual swap-map rebuild and activation happens at apply time via `notify_apply_starting()`, which calls `reactivate_with_selections()`:
+
+- `has_any_selection() == true` -> `deactivate_for_clear()` (if active), then `apply_selections_to_swap_map()`, then `s_active = true`.
+- `has_any_selection() == false` -> `deactivate_for_clear()` (if active), stay inactive.
+
+This means:
+
+- Picking a prefab does not immediately fire the engine; nothing changes visually until the user clicks Apply All (or auto-apply triggers).
+- Clearing all selections (e.g. picker -> "(none) prefab" or X) deactivates cleanly on the next apply.
+- A preset switch that introduces or removes prefab selections is just a state transition that `notify_apply_starting` syncs.
+
+---
+
+## 6. Picker UX flow
+
+Each slot row in the overlay has a single picker button that, when clicked, opens a popup with two sections:
+
+1. **Real items**: the existing item catalog (carrier-driven transmog).
+2. **Body-Mesh Prefabs**: the slot's per-slot catalog from the merged enumeration above.
+
+Picking from either section commits a different state on the slot.
+
+### 6.1 Real-item pick
+
+Sets `m.targetItemId = N`, clears any prior body-mesh prefab override on the same slot via `BMP::set_selection(slot, curSrc, -1)`, and (when auto-apply mode is on) triggers `manual_apply_slot(i)`. The body-mesh hook is dormant for this slot until the user picks a prefab again.
+
+### 6.2 Prefab pick
+
+Updates pending state only:
+
+1. `BMP::set_selection(slot, curSrc, prefabIdx)`: store the new target index. Source is the auto-seeded Kliff default.
+2. Update `s_slotUI[i].pickedPrefabName` (UI label) from the catalog name.
+3. `force_kairos_carrier_for_picked_slots()`: for slots with a prefab pick, force `m.targetItemId` to the Kliff carrier itemId resolved via `default_carrier_for_slot(slot, "Kliff")` from `transmog_apply.cpp::k_kliffCarriers[]`. Slots without a prefab pick keep the user's current preset's carrier.
+4. If auto-apply is enabled, `manual_apply_slot(i)` fires (which routes through `notify_apply_starting -> reactivate_with_selections`, swap activates). Otherwise the change stays pending until Apply All.
+
+### 6.3 Why force the Kliff carrier on prefab pick
+
+The body-mesh hook substitutes by pointer equality against `s_swapMap` keys. The keys are Kliff's natural source wrappers. When the user is on a non-Kliff preset (e.g. Wellsknight), the engine renders that preset's items using *their* wrappers, which are not in `s_swapMap`. The hook never matches, no substitution happens.
+
+Forcing the carrier to Kliff's hardcoded armor makes the engine equip Kliff's plate armor, which uses the `cd_phm_00_*_00_0435*` wrappers. Those ARE in `s_swapMap`. Hook fires. Substitution happens. NPC mesh visualizes.
+
+The choice of Kliff specifically (rather than reading from PresetManager's "Kairos preset") is deliberate: a user's saved Kairos preset may be empty or unconfigured. The hardcoded carrier set is the authoritative ground truth.
+
+### 6.4 Slot button display when a prefab is picked
+
+When `s_slotUI[i].pickedPrefabName` is non-empty, the slot button shows the prefab name with a `[body-mesh]` suffix in cyan, e.g.
+
+```text
+[ cd_nhw_no_ub_20027 [body-mesh] ]
+```
+
+The hex carrier id input next to the picker is disabled with an explanatory tooltip: the body-mesh prefab is the source of truth, and the hex is just a peek at the underlying carrier plumbing. Clearing the prefab via the picker's "(none) prefab" re-enables the hex for direct editing.
+
+The slot row also includes a lazy two-way sync between `BMP::selection_tgt_index(slot)` and `s_slotUI[i].pickedPrefabName`: when the BMP target is set but the UI label is empty (e.g. right after preset load on boot), the row picks up the prefab name from the catalog. When BMP target clears, the label clears too.
+
+### 6.5 Mutually exclusive states per slot
+
+Per slot, exactly one of these is active at a time:
+
+| State | `pickedPrefabName` | `m.targetItemId` | body-mesh `tgt_idx` |
+|---|---|---|---|
+| Empty / clear | empty | 0 | -1 |
+| Real-item carrier | empty | itemId | -1 |
+| Body-mesh prefab override | non-empty | Kliff carrier itemId | >= 0 |
+
+Picking a real item or `(none) item` from the popup clears `pickedPrefabName` and the body-mesh selection. Picking a prefab clears any prior real-item by forcing the carrier to Kliff's, and sets `pickedPrefabName`. The two states cannot coexist on a single slot, but DIFFERENT slots can be in DIFFERENT states (e.g. helm = Wellsknight real-item, chest = NPC prefab override).
+
+---
+
+## 7. Preset persistence and auto-apply
+
+`PresetSlot` stores `prefabName` alongside `itemName` in the preset JSON. For slots with a body-mesh override, `itemName` is intentionally not written: the carrier itemId is internal plumbing that's re-derived at load time from `default_carrier_for_slot(slot, activeCharacter)`.
+
+```json
+{ "active": true, "prefabName": "cd_nhw_no_ub_20027" }
+```
+
+For plain carrier slots, the existing format is unchanged:
+
+```json
+{ "active": true, "itemName": "Wellsknight_Helm" }
+```
+
+`PresetManager::apply_to_state` walks each slot:
+
+1. Writes `(active, itemId)` from the resolved preset slot.
+2. If `prefabName` is set but `itemId == 0` (no `itemName` in JSON), looks up the default carrier via `default_carrier_for_slot(slot, m_activeCharacter)`. Kliff / Damiane / Oongka each get their own carrier set.
+3. Resolves `prefabName` against `BMP::slot_catalog(slot)` and calls `BMP::set_selection(slot, curSrc, foundIdx)`.
+
+`PresetManager::capture_from_state` reverses this on Save / Capture / Duplicate: reads `BMP::selection_tgt_index(slot)` -> catalog name -> stores `prefabName`. When `prefabName` is set, `itemName` is cleared.
+
+---
+
+## 8. Preset switch transition
+
+When the user clicks a different preset in the Presets panel:
+
+1. **`clear_all_picked_prefabs_and_deactivate()`**: for every slot, clears `s_slotUI[i].pickedPrefabName`, drops the BMP target via `BMP::set_selection(slot, curSrc, -1)`, and returns a per-slot `hadPick[]` bitmask. Does NOT touch `last_applied_ids`.
+
+2. **`pm.set_active_preset(i) + pm.apply_to_state()`**: writes the new preset's `(active, itemId, prefabName)` into `slot_mappings()` and re-syncs BMP selections from the new `prefabName` values.
+
+3. **Conditional `last_applied_ids[i] = 0`**: for each slot in `hadPick`, if `mods[i].targetItemId == lastIds[i]` (the early-out case where `apply_single_slot_transmog` would skip teardown), zero `lastIds[i]` so the apply pass tears down the prior body-mesh fake. When carriers differ (e.g. helm `0x1521 -> 0x0000`) `lastIds` stays intact and the regular tear_down_fake path handles cleanup naturally; the natpipe-hook fires during teardown and substitutes src to tgt so the engine unlinks correctly.
+
+4. **`manual_apply()`**: triggers `apply_all_transmog`. The next `notify_apply_starting` rebuilds the swap map for whatever the new preset selected (or deactivates if it has no body-mesh slots).
+
+5. **`pm.save()`**: persists.
+
+---
+
+## 9. Hook 1: Primary swap at `sub_140352AA0`
+
+**Function**: 96-byte struct copy operator. Engine calls it during the slot-populator pipeline to copy a per-slot resource record from a source struct (`a2`) into the destination record (`a1`). The intermediate-wrapper pointer sits at `+0x18` of the source.
+
+**Decompile shape:** the function zero-inits `*a1`, copies `*(QWORD*)(a2 + 0x00)` into `*a1`, then writes the StringInfoVtable sentinel back into `*(QWORD*)(a2 + 0x00)` (so the engine's eventual destruct of `a2` is a no-op for the moved-from wrapper). Subsequent fields at +0x08, +0x09, +0x0A, +0x0C, +0x10, +0x18 are likewise moved-from-into. The wrapper-of-interest sits at `+0x18` of the source struct.
+
+**Hook**: `on_struct_copy(a1, a2)`. At entry:
+
+1. Bail out unless `s_active && Transmog::in_transmog()`.
+2. Read `srcWrapper = *(QWORD*)(a2 + 0x18)`.
+3. Look up `srcWrapper` in `s_swapMap`. If absent: passthrough.
+4. If present, the looked-up `tgtWrapper` is the cross-class prefab to install. `_InterlockedIncrement(tgtWrapper + 0x10)` to balance the destination's eventual destruction-time refcount-decrement.
+5. Write `tgtWrapper` to `a2 + 0x18` *in the source struct*. The trampoline's subsequent copy will then land the target into the destination.
+6. Run trampoline.
+7. Append `(destAddr, origSrcWrapper)` to `s_substLog` (per-apply diagnostic).
+
+The "source +1 leak" (Kliff's refcount stays bumped from the engine's pre-copy work) is acceptable: these are global-lifetime asset wrappers and the engine holds them anyway.
+
+---
+
+## 10. Hook 2: Natural-pipeline patch at `sub_142711DF0`
+
+This hook is the fix that closed the helm / cloak ghost leak.
+
+After the primary swap installs the target wrapper into the destination record, the engine's content-keyed teardown pipeline (`sub_142711DF0` plus downstream unlink primitives) needs to find that same wrapper in `parent+88`'s record list and unlink it on preset-switch. The pipeline gets its *search target* from `safeTearDown` (`sub_14078BB20`), which:
+
+1. Calls `ExpandToMeshes` (`sub_141E0A710`) with the inventory-resolved character ID and slot tag, returns `u16` mesh-prefab IDs in a parts table.
+2. Resolves each `u16` via `sub_1402F7FA0(u16) -> entry -> +0x18 -> wrapper-ptr`.
+3. Builds a `(wrapper, flag)` list at 16-byte stride.
+4. Calls `sub_142711DF0(parent_body, &wrapper_list, &empty_collection)`.
+5. The pipeline walks `parent+88` records, comparing each record's wrapper to each entry in the list, unlinking on match.
+
+Without this hook: the inventory has Kliff helm equipped, so `ExpandToMeshes` returns Kliff's `u16`. That resolves to Kliff's wrapper, which is what the pipeline searches for. But `parent+88` contains the substituted target wrapper (Hook 1 installed it). No match, no unlink, ghost helm persists.
+
+**Decompile shape:** two iteration loops over RDX (`a2`) and R8 (`a3`) wrapper lists, both filtering against `0x145BC4638` (the StringInfoVtable sentinel) and using `_InterlockedIncrement` on `wrapper+0x10` for refcount balance. First loop strides 16 bytes (`v7 += 2`); second loop strides 96 bytes (`v17 += 12`). Inner walk is `parent+128 -> records list with stride 8` looking for `*(record+32)+24 == wrapper` (the `parent+88` content-key compare). On match, the unlink helper at `sub_140301720(wrapper)` releases the previous content's refcount.
+
+**Hook signature**: `on_natural_pipeline(a1, a2, a3)`. Calling convention:
+
+| Reg | Param | Meaning |
+|---|---|---|
+| RCX | `a1` | parent body component pointer |
+| RDX | `a2` | pointer to `{data: u64*, count: u32}`, the wrapper list |
+| R8  | `a3` | pointer to a second list (empty in `safeTearDown`) |
+
+At entry:
+
+1. Bail if `s_active == false`.
+2. Read `listData = *a2` and `listCount = *(u32*)(a2 + 8)` (SEH-guarded).
+3. **Empty-list fast path**: if `listData == null || listCount == 0`, trampoline straight through. The engine fires this function from many call sites (e.g. render / animation tick) with empty lists; logging every such call would flood the log.
+4. For each entry `i in [0..listCount)`:
+   - Read `orig = listData[i*2]` (16-byte stride; wrapper at `+0`).
+   - Look up `orig` in `s_swapMap`. If found, write `tgt` to that slot and remember `orig` in a stack-local `saved[]` array.
+5. Call trampoline. Engine walks `parent+88` searching for substituted wrappers. Finds tgt (which Hook 1 installed). Unlinks correctly.
+6. **Restore originals** from `saved[]`: write each saved src wrapper back over the substituted slot.
+
+The restore step is critical for refcount accounting. The caller iterates the same list after the pipeline returns and calls `sub_140301720(*v19)` on each entry to release the refcount it incremented during list construction. If the entries still held the substituted target values, the wrong wrapper's refcount would be decremented. Restoring keeps the inc / dec pairs balanced.
+
+The hook is `__fastcall` 3-arg; SEH-guarded reads / writes throughout. List size is bounded by `k_maxEntries = 64` (defensive cap; observed lists are 1-3 entries).
+
+**Logging gate**: the hook only logs at `trace` level, and only when at least one substitution happens. PASSTHROUGH and empty-list calls are silent. A successful substitution emits one trace line per entry plus one post-call summary:
+
+```text
+[natpipe-hook] hit#N entry[i] SUBST 0x... -> 0x... (src -> tgt) caller_ra=0x...
+[natpipe-hook] hit#N done: substituted N restored M result=0x...
+```
+
+`write FAULTED` is logged at `warning` for visibility on real anomalies.
+
+**Address resolution**: cascade-driven via `k_naturalPipelineCandidates` (3 anchors registered in `aob_resolver.hpp`; bytes and recovery recipe in section 9.5 of [live-transmog-source-of-truth.md §9](live-transmog-source-of-truth.md#9-aob-cascade-audit-2026-05-08)). On install, `sanity_check_function_prologue(natpipeAbs)` runs as a second gate. If either the cascade or the prologue check fails, the install is skipped with a warning and the helm leak returns; other swap features remain active.
+
+---
+
+## 11. Slot mapping
+
+The engine identifies cosmetic slots by a small `int16_t` "game slot tag", distinct from LT's internal `TransmogSlot` enum. Mapping (`transmog_map.cpp::game_slot_from_transmog`):
+
+| TransmogSlot | engine tag |
+|---|---:|
+| Helm   | `3` |
+| Chest  | `4` |
+| Gloves | `5` |
+| Boots  | `6` |
+| Cloak  | `16` |
+
+These tags appear as `R8` at `sub_141E0A710` entry (per the safeTearDown chain) and as the game-slot field in the inventory's per-slot records. The full 22-slot engine taxonomy (including weapons, accessories, mask, backpack, glasses, etc.) is documented in the project memory `reference_engine_slot_taxonomy_2026-05-07`; LT covers 5 of those 22.
+
+---
+
+## 12. State
+
+The module's hot-path state, all with documented thread-safety:
+
+| Symbol | Purpose | Safety |
+|---|---|---|
+| `s_active` | Master gate, `bool atomic` | acq / rel; load on every hook entry |
+| `s_selSrcIdx[k_slotN]` | per-slot source catalog index | guarded by `s_catalogMtx`; UI-thread mutations only |
+| `s_selTgtIdx[k_slotN]` | per-slot target catalog index | guarded by `s_catalogMtx` |
+| `s_slotCatalogs[k_slotN]` | per-slot prefab catalog | guarded by `s_catalogMtx`; immutable on hot path post-publish |
+| `s_swapMap` | `unordered_map<src_wrapper, tgt_wrapper>` | guarded by `s_mapMtx`; read-only on hot path while `s_active` |
+| `s_targetWrappers` | `unordered_set<tgt_wrapper>` | mirrors `s_swapMap` values; read-only on hot path |
+| `s_orig` / `s_origNaturalPipeline` | trampoline pointers | atomic stores at install; read on every hook fire |
+| `s_lastApplyItems[5]` | last-apply itemId snapshot | guarded by `s_lastApplyMtx`; diagnostic only |
+| `s_stringInfoRegistry` / `s_stringInfoVtable` / `s_loaderRegistrySingleton` / `s_apptContainerVtable` | runtime-resolved data globals | `std::atomic<uintptr_t>`, populated from cascades at init |
+
+The hot path (Hook 1 firing per slot during apply, Hook 2 firing per teardown call) does an `acq` load of `s_active`, an `unordered_map::find` under a short-held lock, and one `Interlocked` op. The `find` is read-only because `s_swapMap` is only mutated at apply-time (never from a hook callback), and the `s_active` gate ensures hooks see a stable map.
+
+---
+
+## 13. Activation / deactivation lifecycle
+
+```text
+init()                          install hooks; spawn detached boot thread
+  |
+  +- Hook install: sub_140352AA0 (always installed, gated on s_active)
+  +- Hook install: sub_142711DF0 (natural pipeline; cascade + prologue gate)
+  |
+  v
+[boot thread]                   wait for is_world_ready();
+  |                             populate_slot_catalogs();
+  |                             PresetManager::apply_to_state();
+  |                             manual_apply();
+  |
+  v
+[user picks prefab in overlay]  set_selection(slot, src, tgtIdx)
+  |                             (pending state; no engine effect yet)
+  |
+  v
+[user clicks Apply All]         apply_all_transmog
+  |                             |
+  |                             notify_apply_starting -> reactivate_with_selections
+  |                             |
+  |                             apply_selections_to_swap_map (rebuild s_swapMap)
+  |                             |
+  |                             s_active = true
+  |                             |
+  |                             sub_140352AA0 fires per slot during equip
+  |                             |
+  |                             swap src -> tgt at dest+0x18
+  |                             |
+  |                             body component renders target prefab
+  |
+  v
+[user switches preset]          clear_all_picked_prefabs_and_deactivate
+  |                             (clears UI labels + BMP selections)
+  |                             |
+  |                             pm.set_active_preset + pm.apply_to_state
+  |                             (writes new preset; BMP selections re-set
+  |                              from new prefabName values)
+  |                             |
+  |                             Conditional last_applied_ids[i]=0 only when
+  |                             new carrier == prev carrier (early-out case)
+  |                             |
+  |                             manual_apply
+  |
+  v
+[engine teardown runs]          sub_142711DF0 hook fires
+  |                             |
+  |                             substitute matching src wrappers -> tgt
+  |                             |
+  |                             trampoline runs natural pipeline
+  |                             |
+  |                             pipeline matches tgt in parent+88, unlinks
+  |                             |
+  |                             restore originals (refcount balance)
+  |
+  v
+[next apply]                    notify_apply_starting -> reactivate_with_selections
+                                rebuilds map for new selections (or deactivates)
+```
+
+---
+
+## 14. Resolved-address constants (v1.05.01)
+
+| Symbol | Address | Resolution |
+|---|---|---|
+| `sub_140352AA0` (primary swap) | `0x140352AA0` | AOB cascade |
+| `sub_142711DF0` (natural pipeline) | `0x142711DF0` (RVA `0x2711DF0`) | AOB cascade (was hardcoded RVA pre-2026-05-08) |
+| StringInfo registry singleton | resolved from `k_stringInfoRegistryCandidates` (was `MEMORY[0x145EF1DE8]`) | AOB cascade |
+| StringInfo entry vtable | resolved from `k_stringInfoVtableCandidates` (was `0x145BC4638`) | AOB cascade |
+| AppearanceTableLoader registry root | resolved from `k_loaderRegistryCandidates` (was `MEMORY[0x145DDF8B0]`) | AOB cascade |
+| Appearance container vtable | resolved from `k_apptContainerVtableCandidates` (was `0x144D24308`) | AOB cascade |
+| Appearance name lookup primitive | resolved from `k_apptNameLookupCandidates` (was `sub_1424DF420`) | AOB cascade |
+
+All seven cascades are documented with their three anchor patterns, hit counts, and recovery recipes in section 9 of [live-transmog-source-of-truth.md §9](live-transmog-source-of-truth.md#9-aob-cascade-audit-2026-05-08).
+
+---
+
+## 15. Why this design
+
+A few decisions that aren't obvious from the code alone:
+
+- **Hook the engine's natural pipeline rather than overriding it**. The engine already has correct cleanup semantics for the wrapper it expects to find. Substituting the search target is a 1-line intervention; reimplementing the cleanup ourselves would be hundreds of lines and version-fragile.
+
+- **Restore originals after the trampoline returns**. The caller (`safeTearDown`) refcount-releases each entry in the list after the call. If we left the substituted values in place, refcounts would drift over many apply / switch cycles. The save-and-restore is per-call O(N) on a small list (1-3 entries typically; bounded by 64).
+
+- **Preserve `s_swapMap` across deactivate**. Most users will toggle selections frequently within a session. Wiping the map on every deactivate would force a re-walk of the source name set on every Apply. Persisting until shutdown amortizes the cost.
+
+- **Apply-only activation**. Picker mutations are pending; the engine doesn't see anything until Apply runs. Mirrors the carrier hybrid flow and prevents the UI from triggering visual churn for every dropdown click. Single integration point (`notify_apply_starting`) handles activation, deactivation, and preset transitions.
+
+- **`prefabName` lives in PresetSlot, not as session-only state**. Saved presets persist body-mesh overrides on disk. On boot, the catalog walk feeds into `apply_to_state` and `manual_apply` to re-apply the active preset automatically: same UX as plain carrier transmogs.
+
+- **Hardcoded Kliff carrier set, not user-configurable**. The carrier is internal plumbing (forces the engine to load the wrappers `s_swapMap` keys expect). Letting the user pick a non-Kliff carrier would silently break the substitution (different wrapper class). The hex carrier id input is disabled when a prefab is active, with a tooltip explaining why.
+
+- **`k_maxEntries = 64` for the natpipe stack-saved array**. Observed lists during teardown are 1-3 entries. 64 gives 50x headroom while staying on the stack (no heap allocation in a hook). Entries beyond 64 are skipped (graceful degradation).
+
+- **natpipe hook logs at `trace` level only on actual substitutions**. The hook fires hundreds of times per second from various render-path call sites; logging every call would flood the trace stream. Empty-list and no-substitution calls are silent. SUBST and post-call summary lines surface only when real cleanup work happened.
+
+- **Cascade + prologue gate at install**. Either of the two failing makes the install a no-op rather than scribbling at the wrong address. The cascade's prologue-fallback already covers most one-byte register-tail repurposes; the explicit `sanity_check_function_prologue` is a second gate against a cascade that picks up a fragment of an unrelated function on a future patch reshuffle.
+
+---
+
+## 16. Files of interest
+
+| File | Purpose |
+|---|---|
+| `prefab_wrapper_swap.cpp` | Hooks 1 + 2, swap map, catalog enumeration helpers (`walk_string_info`, `enumerate_loader_registry_into_catalog`), cascade-driven init for the four runtime-resolved data globals, lifecycle |
+| `prefab_wrapper_swap.hpp` | Public API: `is_active`, `is_target_wrapper`, catalog accessors |
+| `aob_resolver.hpp` | Cascading AOB definitions (mod-local + CDCore-shared aliases) |
+| `transmog_map.cpp` | `game_slot_from_transmog` slot enum mapping |
+| `transmog.cpp` | Boot-time orchestration; calls `register_config` + `init` |
+| `transmog_apply.cpp` | Apply-path orchestration; invokes `notify_apply_*`; `default_carrier_for_slot` and `k_kliffCarriers` live here |
+| `preset_manager.cpp` | `prefabName` JSON ser / de + `apply_to_state` / `capture_from_state` |
+| `overlay_ui.inl` | Picker UI, slot row layout, preset switch wiring |
+
+---
+
+## 17. Diagnostic log signatures
+
+Look for these in `CrimsonDesertLiveTransmog.log` to understand a session at a glance:
+
+```text
+[body-mesh-ptr-swap] installed at 0x140352AA0 (INACTIVE -- ...)
+[body-mesh-ptr-swap] NaturalPipeline hook INSTALLED at 0x142711DF0
+[body-mesh-ptr-swap] boot-scan: world ready, populating per-slot catalog...
+[body-mesh-ptr-swap] Catalog populated: helm=N chest=N cloak=N gloves=N boots=N (Nms)
+[body-mesh-ptr-swap] boot-scan: preset prefabs re-synced and apply scheduled.
+
+[body-mesh-ptr-swap]   slot[0] RESOLVED "cd_phm_00_hel_00_0435_d" (2 src) -> "cd_nhw_no_ub_20027" (0x...)
+[body-mesh-ptr-swap] reactivated via UI selections (1 slot(s) bound)
+[body-mesh-ptr-swap] SWAP src=0x... -> tgt=0x... (subst #N)
+
+[body-mesh-ptr-swap] DEACTIVATED -- swap map RETAINED for next activation. Engine cleanup deferred to natural-pipeline hook.
+```
+
+At `trace` log level the natpipe-hook also surfaces successful substitutions:
+
+```text
+[natpipe-hook] hit#N entry[i] SUBST 0x... -> 0x... (src -> tgt) caller_ra=0x...
+[natpipe-hook] hit#N done: substituted N restored M result=0x...
+```

--- a/docs/research/live-transmog-source-of-truth.md
+++ b/docs/research/live-transmog-source-of-truth.md
@@ -1,54 +1,57 @@
 # Live Transmog -- Source of Truth
 
-Byte-level reference for every address, offset, and AOB the Live Transmog mod depends on in the Crimson Desert binary. Structured so that when a game patch shifts an address the hook point can be re-found from surrounding byte patterns. Each section lists the semantic role first, then the concrete offsets / bytes / AOBs.
+Byte-level reference for every address, offset, and AOB the Live Transmog mod depends on in the Crimson Desert binary. Structured so that when a game patch shifts an address, the hook point can be re-found from surrounding byte patterns. Each section lists the semantic role first, then the concrete offsets / bytes / AOBs.
 
-Verified against **Crimson Desert v1.03.01** (image base `0x140000000`). IDA anchors spot-checked 2026-04-21 (see §8).
+Verified against **Crimson Desert v1.05.01** (image base `0x140000000`, FileVersion `1.0.0.1070`). Many anchors below were originally probed on v1.03.01; cross-build deltas are called out inline. The seven AOB cascades (StringInfoRegistry, StringInfoVtable, LoaderRegistry, ApptContainerVtable, NaturalPipeline, ApptNameLookup, CharClassBypass) were authored against v1.05.01 and live in section 9 below ("AOB cascade audit (2026-05-08)").
 
 ---
 
-## 1. WorldSystem chain -- resolving the currently-controlled actor
+## 1. WorldSystem chain: resolving the currently-controlled actor
 
 ### 1.1 Static entry point
 
-The mod scans for the WorldSystem global-pointer holder via `signatures::WORLD_SYSTEM_P1_SmallFunc` and its fallbacks. On v1.03.01 the holder resolves to:
+The mod scans for the WorldSystem global-pointer holder via `CDCore::Anchors::k_worldSystemCandidates` (the WORLD_SYSTEM_P*_SmallFunc family of patterns shared between LT and EH). On v1.03.01 the holder resolved to:
 
-```
-WS holder : CrimsonDesert.exe + 0x05D2AEE8   (absolute 0x145D2AEE8)
+```text
+v1.03.01 holder : CrimsonDesert.exe + 0x05D2AEE8   (absolute 0x145D2AEE8)
+v1.05.01 holder : CrimsonDesert.exe + 0x05EF15B0   (absolute 0x145EF15B0)
 ```
 
-`*WS_holder` -> `WorldSystem` instance pointer (lives on the game heap; value changes per session).
+`*WS_holder` -> WorldSystem instance pointer (lives on the game heap; value changes per session).
+
+The static slot moved between v1.03.01 and v1.05.01 (RVA shifted by `+0x1C66C8`). The cascade in `CDCore::Anchors::k_worldSystemCandidates` (P1 SmallFunc whole-function anchor) resolves it dynamically regardless; the v1.05.01 absolute is recorded here for cross-build delta tracking.
 
 ### 1.2 Chain to the currently-controlled character actor
 
-```
-WS holder          : 0x145D2AEE8           (scanned via AOB at init)
-  +0x30            -> ActorManager          (singleton, updated on world load)
-    +0x28          -> UserActor             (singleton, ClientUserActor class;
-                                             the POINTER itself does NOT swap
-                                             when the player switches chars)
-      +0xD0        -> "primary" body actor  (stable = Kliff in the current
-                                             story progression)
-      +0xD8        -> CURRENTLY-CONTROLLED  (this is the useful one --
-                     body actor            switches when user swaps char)
+```text
+WS holder          : <cascade-resolved>      (scanned via AOB at init)
+  +0x30            -> ActorManager           (singleton, updated on world load)
+    +0x28          -> UserActor              (singleton, ClientUserActor class;
+                                              the POINTER itself does NOT swap
+                                              when the player switches chars)
+      +0xD0        -> "primary" body actor   (stable = Kliff in current
+                                              story progression)
+      +0xD8        -> CURRENTLY-CONTROLLED   (this is the useful one;
+                     body actor              switches when user swaps char)
         +0x68      -> sub-component
           +0x38    -> wrapper / "player component"
                     (what the apply pipeline accepts as `a1`)
         +0x88      -> typeEntry pointer
-          +1 (u8)  -> role byte (see §2.2)
+          +1 (u8)  -> role byte (see section 2.2)
 ```
 
 `user+0xD8` falls back to Kliff's actor when Kliff is the active character (so `+0xD0` and `+0xD8` coincide). Reading `+0xD8` unconditionally is therefore safe for all three playable characters.
 
 ### 1.3 Controlled-character resolver (`CDCore`)
 
-Authoritative reference for the resolver implemented in `CrimsonDesertCore/src/controlled_char.cpp`. The resolver answers a single question: *"which of the three playable protagonists is the user currently controlling?"* It returns one of `Kliff`, `Damiane`, `Oongka`, or `Unknown`. Two consumer mods (`CrimsonDesertLiveTransmog`, `CrimsonDesertEquipHide`) drive per-character behaviour off the result.
+Authoritative reference for the resolver implemented in `CrimsonDesertCore/src/controlled_char.cpp`. The resolver answers a single question: which of the three playable protagonists is the user currently controlling? It returns one of `Kliff`, `Damiane`, `Oongka`, or `Unknown`. Two consumer mods (`CrimsonDesertLiveTransmog`, `CrimsonDesertEquipHide`) drive per-character behaviour off the result.
 
 #### 1.3.1 Chain walk
 
 The resolver walks five pointer dereferences plus two byte reads on every query. No caching of intermediate pointers; the chain is cheap and any heap pointer in it can be invalidated by a save load or character swap, so re-walking is the only correctness-preserving strategy.
 
 ```text
-WorldSystem holder static    : 0x145D2AEE8         (= CrimsonDesert.exe + 0x05D2AEE8)
+WorldSystem holder static    : <cascade-resolved>    (= CrimsonDesert.exe + 0x05D2AEE8 on v1.03.01)
   +0x00 (qword)              -> WorldSystem instance        [session heap]
     +0x30 (qword)            -> ActorManager singleton
       +0x28 (qword)          -> UserActor singleton (ClientUserActor)
@@ -59,56 +62,51 @@ WorldSystem holder static    : 0x145D2AEE8         (= CrimsonDesert.exe + 0x05D2
 
 Notes on each step:
 
-* **`0x145D2AEE8`** is the WorldSystem holder static slot. Its qword contents are session-dependent (allocated during world load). The consumer mods AOB-scan for this address and hand it to Core via `set_world_system_holder()`; Core does not scan for it itself.
-* **`ws + 0x30`** is the ActorManager singleton. Reallocated on every save load.
-* **`am + 0x28`** is the UserActor singleton (RTTI class `.?AVClientUserActor@pa@@`). The pointer at this slot is stable for the lifetime of a save: in-session character swaps do NOT rewrite it. Save loads do reallocate it; consumers use the change of this pointer as the trigger for cache invalidation.
-* **`user + 0xD0`** is the "primary" actor slot. Always points at Kliff's actor in the current story progression, regardless of which character is currently controlled. This is a structural invariant that the decode below relies on.
-* **`user + 0xD8`** is the currently-controlled client actor (RTTI class `.?AVClientChildOnlyInGameActor@pa@@`). Coincides with `user + 0xD0` when Kliff is controlled, and rotates to a Damiane or Oongka slot when one of them is controlled.
+* The WorldSystem holder static slot is session-dependent (allocated during world load). The consumer mods AOB-scan for this address and hand it to Core via `set_world_system_holder()`; Core does not scan for it itself.
+* `ws + 0x30` is the ActorManager singleton. Reallocated on every save load.
+* `am + 0x28` is the UserActor singleton (RTTI class `.?AVClientUserActor@pa@@`). The pointer at this slot is stable for the lifetime of a save: in-session character swaps do NOT rewrite it. Save loads do reallocate it; consumers use the change of this pointer as the trigger for cache invalidation.
+* `user + 0xD0` is the "primary" actor slot. Always points at Kliff's actor in the current story progression, regardless of which character is currently controlled. This is a structural invariant that the decode below relies on.
+* `user + 0xD8` is the currently-controlled client actor (RTTI class `.?AVClientChildOnlyInGameActor@pa@@`). Coincides with `user + 0xD0` when Kliff is controlled, and rotates to a Damiane or Oongka slot when one of them is controlled.
 
 Every intermediate pointer is rejected if it falls below the 64 KiB guard region (`k_minValidPtr = 0x10000`). The whole walk runs inside a single `__try` block; any access fault returns an invalid probe which the caller treats as "no live identity, fall back to cache".
 
-#### 1.3.2 Decode rules (verified 2026-04-22)
+#### 1.3.2 Decode rules
 
-**Rule 1 -- Kliff via structural invariant.** When `*(user + 0xD0) == *(user + 0xD8)` the primary slot coincides with the controlled slot, which only happens when Kliff is controlled. This is a pure pointer comparison with no dependence on numeric fields that could shift across saves or patches. Verified across three distinct saves controlling Kliff.
+**Rule 1: Kliff via structural invariant.** When `*(user + 0xD0) == *(user + 0xD8)` the primary slot coincides with the controlled slot, which only happens when Kliff is controlled. This is a pure pointer comparison with no dependence on numeric fields that could shift across saves or patches.
 
-**Rule 2 -- companions via slot-index diff.** When the two slots differ, a companion is controlled. The byte at `actor + 0x60` is a per-actor slot index assigned at allocation time in a fixed character order (Kliff, then Damiane, then Oongka). The absolute value varies per save because the slot-index pool is shared with other actors, but within any given save the diff between the controlled slot and the primary slot uniquely identifies the companion:
+**Rule 2: companions via slot-index diff.** When the two slots differ, a companion is controlled. The byte at `actor + 0x60` is a per-actor slot index assigned at allocation time in a fixed character order (Kliff, then Damiane, then Oongka). The absolute value varies per save because the slot-index pool is shared with other actors, but within any given save the diff between the controlled slot and the primary slot uniquely identifies the companion:
 
 | Companion diff | Character |
 |----------------|-----------|
-| `+1`           | Damiane   |
-| `+2`           | Oongka    |
-| anything else  | Unknown   |
+| `+1` | Damiane |
+| `+2` | Oongka |
+| anything else | Unknown |
 
-#### 1.3.3 Verified observations (v1.03.01)
+Why structural compare instead of a numeric identity field: prior resolver attempts used a packed `(party_class << 32) | char_kind` key (the u32s at `actor + 0xDC` and `+0xEC`). That key shifts with party composition and produces ambiguous values across companions in the same save. The structural `D0 == D8` compare plus slot-diff is more robust because it depends on engine allocation order rather than serialized numeric tags.
 
-| Save shape       | Kliff `+0x60` | Damiane `+0x60` | Oongka `+0x60` |
-|------------------|---------------|-----------------|----------------|
-| Kliff + Damiane  | `1`           | `2`             | (absent)       |
-| 3 protagonists   | `6`           | `7`             | `8`            |
+#### 1.3.3 Observed values
 
-The `+0x60` byte stays stable when a character is backgrounded -- verified by reading it on Oongka after the user swapped away from him; the value remained `8` across the swap. So the decode produces the same result regardless of which character is currently controlled, as long as the primary slot stays Kliff.
+| Build | Save shape | Kliff `+0x60` | Damiane `+0x60` | Oongka `+0x60` |
+|-------|------------|---------------|-----------------|----------------|
+| v1.03.01 | Kliff + Damiane | `1` | `2` | (absent) |
+| v1.03.01 | 3 protagonists | `6` | `7` | `8` |
+| v1.05.01 | Kliff + Damiane | `1` | `2` | (pending) |
 
-#### 1.3.4 What was tried and rejected
+The `+0x60` byte stays stable when a character is backgrounded. On a v1.03.01 save, reading it on Oongka after the user swapped away from him left the value `8` across the swap. On v1.05.01, an in-session swap from Kliff to Damiane left the WS / ActorManager / UserActor pointers identical and the primary slot byte unchanged. So the decode produces the same result regardless of which character is currently controlled, as long as the primary slot stays Kliff.
 
-The previous resolver attempted to identify characters via a packed `(party_class << 32) | char_kind` key reading the u32s at `actor + 0xDC` and `+0xEC`. That approach was disproved on 2026-04-22:
+The Oongka `+0x60` byte on a v1.05.01 save where Oongka is in the playable party is unverified; the captured save above only had Kliff + Damiane available.
 
-* `(party_class, char_kind)` shifts with party composition. The same Damiane reads `(4, 2)` in a 3-party save and `(3, 2)` in a save without Oongka.
-* Damiane and Oongka in the **same** 3-party save BOTH read `(3, 2)`, so the key is structurally ambiguous.
-* `char_kind = 3` did consistently identify Kliff across all four observations, but the structural `D0 == D8` check is more robust and was preferred to avoid depending on a numeric value that may also drift on a future patch.
-
-The qwords at `actor + 0xD8` and `actor + 0xE8` carry control-state in their LOW u32s (controlled vs backgrounded) and the rejected identity bits in their HIGH u32s. They are documented here so a future RE pass does not re-test them.
-
-#### 1.3.5 Known assumption
+#### 1.3.4 Known assumption
 
 The decode assumes the engine's character allocation order is always `Kliff, Damiane, Oongka`. A save containing only Kliff + Oongka (no Damiane) would allocate Oongka at `Kliff + 1` and would be decoded as Damiane. No such save has been observed in the current game content; if one arises, the consumer mod's overlay allows manual override and the misdetection is a UX hiccup, not a correctness failure.
 
-#### 1.3.6 Last-known-good cache
+#### 1.3.5 Last-known-good cache
 
 The resolver keeps one atomic `s_lastGoodKey` that holds the most recent identity key matching one of the three known values. Each query:
 
 1. Walks the chain (SEH-isolated).
-2. If the resulting key is one of `{Kliff, Damiane, Oongka}`, refresh `s_lastGoodKey` with it and use it as the effective key.
-3. Otherwise (zero from a faulted walk, torn read mid-swap, unknown future value) ignore the live key and use whatever is currently in `s_lastGoodKey`. The cache may itself be empty (zero), in which case the resolver returns `Unknown`.
+2. If the resulting key is one of `{Kliff, Damiane, Oongka}`, refreshes `s_lastGoodKey` with it and uses it as the effective key.
+3. Otherwise (zero from a faulted walk, torn read mid-swap, unknown future value) ignores the live key and uses whatever is currently in `s_lastGoodKey`. The cache may itself be empty (zero), in which case the resolver returns `Unknown`.
 
 The cache exists to absorb torn reads at the moment the engine is rewriting `user + 0xD8` during a swap. Without it, a query that landed mid-rewrite would briefly resolve to `Unknown` and any consumer holding state per-character (preset selection, parts override) would flap.
 
@@ -120,9 +118,11 @@ The cache exists to absorb torn reads at the moment the engine is rewriting `use
 
 Both `transmog_worker.cpp` (LiveTransmog load-detect thread) and `player_detection.cpp` (EquipHide background tick) implement this trigger. The first-boot path is gated by a `prevUser != 0` check so the very first tick after world load does not invalidate a cache the resolver may have just populated.
 
-#### 1.3.7 Consumer init contract
+EquipHide additionally has an atomic-swap save-load detector that drives the same `invalidate_controlled_character()` call via `radial_swap_pending()` on CDCore (see project memory `project_eh_atomic_save_load_detection_2026-05-03`); its purpose is to disambiguate "user pressed radial-swap button" from "engine atomically replaced the controlled actor across save-load" so that LT does not commit the wrong preset on the new world.
 
-The Core resolver does not own its own AOB scan. Consumers AOB-scan for the WorldSystem holder (each mod has a `WorldSystem` AOB candidate set in its own `aob_resolver.hpp`) and publish the resolved address via:
+#### 1.3.6 Consumer init contract
+
+The Core resolver does not own its own AOB scan. Consumers AOB-scan for the WorldSystem holder (each mod has a `WorldSystem` AOB candidate set in `CDCore::Anchors`) and publish the resolved address via:
 
 ```cpp
 CDCore::set_world_system_holder(addrs.worldSystem);
@@ -133,7 +133,7 @@ Both consumers can publish the same address; later writers win, which is the int
 The first call also emits a single info log line:
 
 ```text
-ControlledChar: WorldSystem holder published at 0x145D2AEE8
+ControlledChar: WorldSystem holder published at 0x...
 ```
 
 A separate one-shot diagnostic logs each unique probe signature (the `(primary_slot, controlled_slot)` pair) the resolver observes:
@@ -144,37 +144,22 @@ ControlledChar: probe primary_slot=6 controlled_slot=8 diff=2 -> Oongka
 
 The trailing name is the decoded character (`Kliff` / `Damiane` / `Oongka` / `Unknown`). This is the only signal that the resolver is wired up correctly on a future patch; the four-slot seen-set covers the three expected diff combinations plus one transient anomaly without log spam.
 
-#### 1.3.8 Reproducing the verification
-
-To re-verify against a future game patch:
-
-1. Attach Cheat Engine to `CrimsonDesert.exe` after a save is loaded with Kliff controlled.
-2. Read the qword at the WorldSystem holder static (the consumer's AOB-scanned address; `0x145D2AEE8` on v1.03.01) -- this yields the WorldSystem instance pointer.
-3. Walk `+0x30 -> +0x28` to land on the UserActor singleton.
-4. Read the qwords at `user + 0xD0` (primary) and `user + 0xD8` (controlled). They MUST be equal -- this is the structural Kliff invariant. RTTI on the resolved actor must be `pa::ClientChildOnlyInGameActor`.
-5. Read the byte at `controlled_actor + 0x60`. Record the value -- call it `K` (Kliff's slot index for this save).
-6. Swap to a companion via the in-game character picker. Re-walk the chain. `user + 0xD0` MUST still hold Kliff's actor pointer; `user + 0xD8` MUST now hold a different pointer. The byte at the new controlled actor's `+0x60` MUST equal `K + 1` for Damiane or `K + 2` for Oongka.
-7. Background the companion and re-walk. The byte at `+0x60` on the now-backgrounded companion MUST stay at the same value (slot index is allocation-time and survives control-state changes).
-8. Repeat for the third protagonist if available. The diff from `K` MUST be the documented value (1 or 2).
-
-If steps 4-7 still hold on a new patch, the resolver requires no changes. If they break, the structural invariant has shifted (most likely candidates: the engine moved the primary slot off `+0xD0`, or the slot-index byte moved off `+0x60`). In either case the offsets in `controlled_char.cpp` need updating, but the algorithm shape (`D0 == D8` for Kliff plus slot-diff for companions) does not.
-
 ### 1.4 How the mod resolves `a1` at apply time
 
 ```cpp
-// transmog_worker.cpp :: resolve_player_component() (around line 139)
-ws       = *(0x145D2AEE8)
+// transmog_worker.cpp :: resolve_player_component()
+ws       = *(WS_holder)
 am       = *(ws  + 0x30)
 user     = *(am  + 0x28)
-actor    = *(user + 0xD8)              // <-- per-character
+actor    = *(user + 0xD8)              // per-character
 te       = *(actor + 0x88)             // pointer-valid check only
 sub1     = *(actor + 0x68)
 a1       =  *(sub1 + 0x38)             // passes into SlotPopulator
 ```
 
-The pre-2026-04-21 version walked `+0xD0` and rejected actors whose role byte was not `1` -- both wrong for companions. If the binary shifts and offsets change, start by re-finding the chain via:
+If the binary shifts and offsets change, start by re-finding the chain via:
 
-* `WORLD_SYSTEM_P*` AOBs in `constants.hpp` / `aob_resolver.hpp` (shared with CrimsonDesertCore).
+* `WORLD_SYSTEM_P*` AOBs in `CDCore::Anchors::k_worldSystemCandidates`.
 * The RTTI class name on the singleton at `am+0x28` should read `.?AVClientUserActor@pa@@`.
 * `user+0xD0` / `+0xD8` slots both hold `.?AVClientChildOnlyInGameActor@pa@@` pointers.
 
@@ -182,36 +167,36 @@ The pre-2026-04-21 version walked `+0xD0` and rejected actors whose role byte wa
 
 ## 2. Character identification
 
-### 2.1 Body-kind classifier sets (CE-verified 2026-04-21)
+### 2.1 Body-kind classifier sets
 
 Every armor's rule list (`desc+0x248`, stride `0x38`, count at `desc+0x250`) contains classifier arrays (ptr `rule+0x20`, count `rule+0x28`, u16 tokens). The tokens partition the catalog into disjoint body families:
 
-| Role                   | Token set                                 |
-|------------------------|-------------------------------------------|
-| **Male humanoid**      | `0x0018, 0x0058, 0x02E3`                  |
-| **Female humanoid**    | `0x0072, 0x0382, 0x0300`                  |
-| Kliff-specific         | `0x0015, 0x039D`                          |
-| Oongka-specific        | `0x0028`                                  |
-| Damiane/Demian-specific| `0x0021`                                  |
-| Horse family           | `0x142B, 0x0037, 0x14A5, 0x14D6, 0x1501`  |
-| Pet cat                | `0x183F, 0x22C7, 0x22B4, 0x22BA, 0x22AE`  |
-| Pet dog                | `0x0D69, 0x4397, 0x2214, 0x0D74`          |
+| Role | Token set |
+|------|-----------|
+| **Male humanoid** | `0x0018, 0x0058, 0x02E3` |
+| **Female humanoid** | `0x0072, 0x0382, 0x0300` |
+| Kliff-specific | `0x0015, 0x039D` |
+| Oongka-specific | `0x0028` |
+| Damiane / Demian-specific | `0x0021` |
+| Horse family | `0x142B, 0x0037, 0x14A5, 0x14D6, 0x1501` |
+| Pet cat | `0x183F, 0x22C7, 0x22B4, 0x22BA, 0x22AE` |
+| Pet dog | `0x0D69, 0x4397, 0x2214, 0x0D74` |
 
-Any token `>= 0x1000` is classified by the mod as **non-humanoid** (`k_nonHumanoidTokenThreshold` in `item_name_table.cpp`). Humanoid tokens observed so far all fit below `0x0400`.
+Any token `>= 0x1000` is classified by the mod as non-humanoid (`k_nonHumanoidTokenThreshold` in `item_name_table.cpp`). Humanoid tokens observed so far all fit below `0x0400`.
 
-### 2.2 Role byte -- NOT a reliable identifier
+### 2.2 Role byte: NOT a reliable identifier
 
-The `typeEntry+1` byte is role-based (controlled vs backgrounded), not character-based. Companion actors share the same typeEntry pool slot when controlled, so multiple characters decode to the same byte value and cannot be distinguished here. Identity decoding belongs to the resolver documented in §1.3, which compares the primary and controlled actor pointers at `user+0xD0` and `user+0xD8` for the Kliff case and uses the allocation-order slot-index byte at `actor+0x60` to disambiguate companions.
+The `typeEntry+1` byte is role-based (controlled vs backgrounded), not character-based. Companion actors share the same typeEntry pool slot when controlled, so multiple characters decode to the same byte value and cannot be distinguished here. Identity decoding belongs to the resolver documented in section 1.3, which compares the primary and controlled actor pointers at `user+0xD0` and `user+0xD8` for the Kliff case and uses the allocation-order slot-index byte at `actor+0x60` to disambiguate companions.
 
-`*(actor+0x88)+1` is **not** a player/NPC flag despite older code treating it as one. Observed values:
+`*(actor+0x88)+1` is **not** a player / NPC flag despite older code treating it as one. Observed values:
 
-| Character state                                  | Byte        |
+| Character state | Byte |
 |--------------------------------------------------|-------------|
-| Kliff, controlled (ClientUserActor)              | 0           |
-| Kliff, backgrounded (ClientChildOnlyInGameActor) | 1           |
-| Damiane, controlled                              | 0           |
-| Damiane, backgrounded                            | 4           |
-| Oongka                                           | also varies |
+| Kliff, controlled (ClientUserActor) | 0 |
+| Kliff, backgrounded (ClientChildOnlyInGameActor) | 1 |
+| Damiane, controlled | 0 |
+| Damiane, backgrounded | 4 |
+| Oongka | also varies |
 
 Treat pointer-validity as the only safe gate. The in-hook filter (`is_player_actor` in `transmog_hooks.cpp`) accepts the byte being in `{0, 1}` since both forms of the same humanoid actor show up on hook paths; deeper filters use the classifier-token sets above.
 
@@ -219,22 +204,22 @@ Treat pointer-validity as the only safe gate. The in-hook filter (`is_player_act
 
 | Character | Expected equip-type |
 |-----------|---------------------|
-| Kliff     | `0x0004`            |
-| Oongka    | `0x0001`            |
-| Damiane   | `0x0001`            |
-| Most NPCs | `0x0001`            |
+| Kliff | `0x0004` |
+| Oongka | `0x0001` |
+| Damiane | `0x0001` |
+| Most NPCs | `0x0001` |
 
-An item whose equip-type differs from the active character's expected value needs the carrier-patch path (see §3). This is what `needs_carrier(itemId, charName)` checks in `transmog_apply.cpp`.
+An item whose equip-type differs from the active character's expected value needs the carrier-patch path (see section 3). This is what `needs_carrier(itemId, charName)` checks in `transmog_apply.cpp`.
 
 ### 2.4 Picker body-kind UI classification
 
-```
+```text
 BodyKind::Generic      -- no classifier tokens (rule-less cosmetics)
-BodyKind::Male         -- has >=1 male-body token, no female/non-humanoid
-BodyKind::Female       -- has >=1 female-body token, no male/non-humanoid
+BodyKind::Male         -- has >=1 male-body token, no female / non-humanoid
+BodyKind::Female       -- has >=1 female-body token, no male / non-humanoid
 BodyKind::Both         -- rare: both male AND female tokens
-BodyKind::Ambiguous    -- has humanoid-range tokens but none in male/female
-                          set (e.g. Antumbra/Badran/Luka gloves with
+BodyKind::Ambiguous    -- has humanoid-range tokens but none in male / female
+                          set (e.g. Antumbra / Badran / Luka gloves with
                           only `0x012F`). Picker colors these amber;
                           render fidelity is inconsistent.
 BodyKind::NonHumanoid  -- any token >= 0x1000 (horse, pet, wagon, etc.).
@@ -253,12 +238,12 @@ The game's equip pipeline rejects an item that does not match the active charact
 
 ### 3.2 Hybrid descriptor patch
 
-```
+```text
 hybrid        = copy of target descriptor   (target's rule list, meshes, etc.)
-hybrid[+0x42] = carrier[+0x42]              (equip-type -- the only gated field)
+hybrid[+0x42] = carrier[+0x42]              (equip-type; the only gated field)
 ```
 
-Stride between descriptors observed at `0x400` bytes (see `k_descBufSize` in `transmog_apply.cpp`, line ~199). Buffer is SEH-guarded; the mod over-reads a full page and the engine only cares about the bytes actually read.
+Stride between descriptors observed at `0x400` bytes (`k_descBufSize` in `transmog_apply.cpp`). The buffer is SEH-guarded; the mod over-reads a full page and the engine only cares about the bytes actually read.
 
 ### 3.3 Per-character carrier sets
 
@@ -278,51 +263,58 @@ Kliff and Oongka share three male-body tokens but the engine still rejects Kliff
 
 ### 3.4 `charClassBypass` byte toggle
 
-```
-Address   : resolved via signatures::CharClassBypass_P1_MovzxCmpLoop
-            (observed absolute on v1.03.01 = 0x141D5F538)
+```text
+Address   : resolved via k_charClassBypassCandidates (3-anchor cascade in aob_resolver.hpp)
+            (observed absolute on v1.03.01 = 0x141D5F538; the v1.04 / v1.05 patches
+            shifted this address; the cascade picks it up dynamically and
+            verifies the byte equals 0x74 before activating)
 Original  : 0x74  (jz short -- class check required)
 Bypass    : 0xEB  (jmp short -- class check skipped, forces acceptance)
 ```
 
-IDA verification (2026-04-21): the instruction at `0x141D5F538` is `jz short loc_141D5F542` inside a `cmp r9w,[r8+rcx*2]; jz; inc ecx; cmp ecx,edx; jb` classifier-scan loop (host function `sub_141D5F470`).
+The instruction is a `jz short` inside a `cmp r9w,[r8+rcx*2]; jz; inc ecx; cmp ecx,edx; jb` classifier-scan loop. The cascade's three anchors target progressively weaker pieces of that loop; the audit doc lists each anchor's hit count and recovery recipe.
 
-Toggled during Phase A tear-down (in `RealPartTearDown::tear_down_by_item_id` via `carrier_swap_and_call`) so carrier-bearing fakes can be torn down on characters whose class normally rejects the carrier item. Restored to `0x74` immediately after. The mod sanity-checks the byte on resolve (`byte=0x74 OK` log line); if the landed byte is anything else the mod refuses to install.
+Toggled during Phase A tear-down (in `RealPartTearDown::tear_down_by_item_id` via `carrier_swap_and_call`) so carrier-bearing fakes can be torn down on characters whose class normally rejects the carrier item. Restored to `0x74` immediately after.
 
-If a patch shifts this address:
-* Re-scan for the `movzx eax,[...]; cmp al,<class>; jz <short>` loop.
-* The `jz`'s 2-byte jump is the toggle site; the first byte (`0x74` opcode) is what we overwrite.
+The mod sanity-checks the byte on resolve (`byte=0x74 OK` log line); if the landed byte is anything else the mod refuses to install. The cascade-driven address survives the v1.05.01 build (see section 9.7 below).
+
+If a future patch shifts this address again:
+
+* The cascade auto-resolves; check the audit doc's "if this breaks" recipe.
+* Manual: re-scan for the `movzx eax,[...]; cmp al,<class>; jz <short>` loop. The `jz`'s 2-byte jump is the toggle site; the first byte (`0x74` opcode) is what we overwrite.
 
 ---
 
 ## 4. Hook points
 
+All hook entry points are resolved through CDCore-shared cascades aliased into `aob_resolver.hpp`. The historical absolute addresses are documentation only.
+
 ### 4.1 BatchEquip (game-side inventory commit)
 
-```
-Signature  : signatures::BatchEquip_P1_FullPrologue
-Resolved   : CrimsonDesert.exe + 0x007605B0   (IDA: sub_1407605B0, size 0x87A)
+```text
+Cascade    : k_batchEquipCandidates (CDCore-shared)
+Historical : CrimsonDesert.exe + 0x007605B0  (sub_1407605B0 on v1.03.01, size 0x87A)
 Arg0 (rcx) : a1       (equip wrapper; *(a1+8) = actor)
 Purpose    : fires when the game commits a batch of equipment changes;
              the mod captures `a1` into shared_state::player_a1().
 ```
 
-Filter: `is_player_actor(a1)` gate in `transmog_hooks.cpp` -- checks `*(a1+8) -> +0x88 -> +1` byte is in `{0, 1}` and the typeEntry pointer is readable. Any humanoid controlled/backgrounded actor passes.
+Filter: `is_player_actor(a1)` gate in `transmog_hooks.cpp`. Checks `*(a1+8) -> +0x88 -> +1` byte is in `{0, 1}` and the typeEntry pointer is readable. Any humanoid controlled / backgrounded actor passes.
 
 ### 4.2 VisualEquipChange (VEC)
 
-```
-Signature  : signatures::VisualEquipChange_P1_FullPrologue
-Resolved   : CrimsonDesert.exe + 0x007733B0   (IDA: sub_1407733B0, size 0x42A)
+```text
+Cascade    : k_visualEquipChangeCandidates (CDCore-shared, aliased as k_vecCandidates)
+Historical : CrimsonDesert.exe + 0x007733B0  (sub_1407733B0 on v1.03.01, size 0x42A)
 Args (rcx, dx, r8w, r9)
            = (a1, slotId, itemId, unused)
 Purpose    : fires on every visual-equip transition. Captures `a1`,
              filters to armor slot tags, schedules a transmog pass.
 ```
 
-Armor slot tags the mod cares about (CE-verified via HW BP on `sub_148EB6700`):
+Armor slot tags the mod cares about:
 
-```
+```text
 0x0003 = Helm
 0x0004 = Chest
 0x0005 = Gloves
@@ -330,32 +322,43 @@ Armor slot tags the mod cares about (CE-verified via HW BP on `sub_148EB6700`):
 0x0010 = Cloak
 ```
 
-Other tags (weapons, rings, shoulders, belts) are captured as `a1` but do not trigger a transmog pass.
+These match the body-mesh hook's `game_slot_from_transmog` mapping (Helm=3, Chest=4, Gloves=5, Boots=6, Cloak=16).
+
+Other tags (weapons, rings, shoulders, belts) are captured as `a1` but do not trigger a transmog pass. Full 22-slot taxonomy is in the project memory `reference_engine_slot_taxonomy_2026-05-07`.
 
 ### 4.3 SlotPopulator (direct call, not hooked)
 
-```
-Signature  : signatures::SlotPopulator_P1_FullPrologue
-Resolved   : CrimsonDesert.exe + 0x007727F0   (IDA: sub_1407727F0, size 0x367)
+```text
+Cascade    : k_slotPopulatorCandidates (mod-local in aob_resolver.hpp)
+Historical : CrimsonDesert.exe + 0x007727F0  (sub_1407727F0 on v1.03.01, size 0x367)
 Prototype  : __int64 slotPop(__int64 a1, uint16_t* itemData, __int64 swapEntry)
 ```
 
-The mod calls this directly to push a target/carrier item through the visual pipeline. Sanity: if this address is wrong, expect immediate CTD on first apply. The resolver logs `SlotPopulator resolved via '...' at 0x...` at init.
+The mod calls this directly to push a target / carrier item through the visual pipeline. Sanity: if this address is wrong, expect immediate CTD on first apply. The resolver logs `SlotPopulator resolved via '...' at 0x...` at init.
 
 ### 4.4 InitSwapEntry
 
-```
-Signature : signatures::InitSwapEntry_P1_FullPrologue
-Resolved  : CrimsonDesert.exe + 0x01D56620    (IDA: sub_141D56620, size 0xB3)
+```text
+Cascade   : k_initSwapEntryCandidates (mod-local)
+Historical: CrimsonDesert.exe + 0x01D56620  (sub_141D56620 on v1.03.01, size 0xB3)
 Role      : zero-init a SlotPopulator "swap entry" before passing it
             into slotPop.
 ```
 
-### 4.5 PartAddShow, SafeTearDown, SubTranslator, MapLookup
+### 4.5 Body-mesh pointer-swap hooks
 
-Support hooks for the tear-down / name-lookup pipeline. See the `[dispatch] tear_down helpers resolved` line at init for resolved addresses. Signatures in `constants.hpp` / `aob_resolver.hpp`.
+Documented separately in `live-transmog-prefab-wrapper-swap.md`. Brief reference:
 
-SafeTearDown call label sits at `0x14075FE60` inside `sub_14075F9E0` (size `0x5CD`). The internal detach path at `0x1425EBAE0` sits inside `sub_1425EACA0` (size `0xEC6`). These are internal call labels, not function starts -- resolve via the AOB, not by address.
+* `sub_140352AA0` (primary swap, AOB cascade): 96-byte struct copy operator, hook substitutes `*(a2+0x18)` wrapper.
+* `sub_142711DF0` (natural-pipeline patch, AOB cascade per `k_naturalPipelineCandidates`): wrapper-list walker; hook substitutes src wrappers with target wrappers in the input list at hook entry, restores after trampoline.
+
+The StringInfoVtable sentinel `0x145BC4638` literal is in both function bodies.
+
+### 4.6 PartAddShow, SafeTearDown, SubTranslator, MapLookup
+
+Support hooks for the tear-down / name-lookup pipeline. See the `[dispatch] tear_down helpers resolved` line at init for resolved addresses. Cascades in `aob_resolver.hpp` (`k_partAddShowCandidates`, `k_safeTearDownCandidates`, `k_subTranslatorCandidates`, `k_mapLookupCandidates`).
+
+SafeTearDown call label sits at `0x14075FE60` inside `sub_14075F9E0` (size `0x5CD` on v1.03.01). The internal detach path at `0x1425EBAE0` sits inside `sub_1425EACA0` (size `0xEC6` on v1.03.01). These are internal call labels, not function starts; resolve via the AOB, not by address.
 
 ---
 
@@ -363,29 +366,30 @@ SafeTearDown call label sits at `0x14075FE60` inside `sub_14075F9E0` (size `0x5C
 
 Implemented in `overlay_ui.inl`. An item shows in the slot picker when:
 
-1. **Slot match** (if "Exact" toggle is on) -- `category_of(itemId)` reads the canonical item-type code at `desc+0x44` captured at catalog-build time:
-   ```
+1. **Slot match** (if "Exact" toggle is on): `category_of(itemId)` reads the canonical item-type code at `desc+0x44` captured at catalog-build time:
+
+   ```text
    0x04 -> Helm    0x05 -> Chest    0x06 -> Gloves
    0x07 -> Boots   0x45 -> Cloak
    ```
-Every other code (shields `0x20`, horse armor `0x53`, quest `0xFFFF`, etc.) maps to `TransmogSlot::Count` and the item is hidden as non-equipment. No name parsing is performed; the engine itself uses this byte as the item category so we trust it.
 
-2. **Not flagged non-humanoid** -- `BodyKind::NonHumanoid` items are always hidden (no toggle to show them; they never render on a humanoid skeleton).
+   Every other code (shields `0x20`, horse armor `0x53`, quest `0xFFFF`, etc.) maps to `TransmogSlot::Count` and the item is hidden as non-equipment. No name parsing is performed; the engine itself uses this byte as the item category so we trust it.
 
-3. **Body-kind match** (if "Hide cross-body" toggle is on -- default): item's `BodyKind` matches the active character's body (Male for Kliff/Oongka, Female for Damiane), OR is Generic / Both. Per-char override available in the overlay Body dropdown.
+2. **Not flagged non-humanoid**: `BodyKind::NonHumanoid` items are always hidden (no toggle to show them; they never render on a humanoid skeleton).
 
-4. **Variant / incompatibility** filters -- existing `hideIncompatible` and `hideVariants` checkboxes still apply; the former is now equivalent to "hide non-humanoid + non-slot-matched".
+3. **Body-kind match** (if "Hide cross-body" toggle is on, default): item's `BodyKind` matches the active character's body (Male for Kliff / Oongka, Female for Damiane), OR is Generic / Both. Per-char override available in the overlay Body dropdown.
+
+4. **Variant / incompatibility** filters: existing `hideIncompatible` and `hideVariants` checkboxes still apply; the former is now equivalent to "hide non-humanoid + non-slot-matched".
 
 Color tiers on rows:
 
-| Color   | Condition                              | Meaning                          |
+| Color | Condition | Meaning |
 |---------|----------------------------------------|----------------------------------|
-| red     | `!bodyMatches && !hasVariantMeta`      | Crash risk -- engine rejects     |
-| orange  | `!bodyMatches && hasVariantMeta`       | Carrier path works but body      |
-|         |                                        | mismatch; mesh may break         |
-| amber   | `BodyKind::Ambiguous && hasVariantMeta`| Render outcome inconsistent      |
-| blue    | `hasVariantMeta && body matches`       | Normal NPC-variant carrier       |
-| default | everything else                        | Clean base item                  |
+| red | `!bodyMatches && !hasVariantMeta` | Crash risk; engine rejects |
+| orange | `!bodyMatches && hasVariantMeta` | Carrier path works but body mismatch; mesh may break |
+| amber | `BodyKind::Ambiguous && hasVariantMeta`| Render outcome inconsistent |
+| blue | `hasVariantMeta && body matches` | Normal NPC-variant carrier |
+| default | everything else | Clean base item |
 
 ---
 
@@ -393,24 +397,24 @@ Color tiers on rows:
 
 Implemented in `transmog_worker.cpp :: load_detect_thread_fn`.
 
-1. Poll `CDCore::current_controlled_character_name()` once per second (resolver internals in §1.3).
+1. Poll `CDCore::current_controlled_character_name()` once per second (resolver internals in section 1.3).
 2. Apply a **settle window** (`k_charSwapSettleMs = 1000`): a candidate identity must remain stable across at least one full second of polling before the swap commits. The first tick that observes a new candidate records `(pendingCharName, pendingFirstSeenTick)`; subsequent ticks confirm the candidate, and the swap fires when `GetTickCount64() - pendingFirstSeenTick >= 1000`. A back-and-forth (A -> B -> A) within the window cancels the pending candidate, so phantom commits do not leak through.
 3. On confirmed change between known characters, call `pm.set_active_character(live)`, wipe `slot_mappings`, run `apply_to_state()` so `slot_mappings` reflects the live character's active preset, reset drop-detection state, save.
 4. Schedule a transmog apply if the mod is enabled.
 
-The settle window exists because the engine rotates `user+0xD8` through party members during world-load wiring (observed sequence on a Damiane save: Kliff -> Oongka -> Damiane over ~30 seconds). Each rotation is a real engine state, but only the final identity is the user's intended controlled character; firing the swap on each transition would commit the wrong preset and incur ~3x wasted apply work plus a brief visual flicker. 1s is chosen to coalesce sub-second torn reads at the cost of an equal amount of latency on real user-initiated swaps. Multi-second engine wiring sequences (like the load-time rotation above) are not coalesced -- the user will still see one transmog apply per stable identity -- but the immediately-after-load Kliff->random-companion->target-companion churn that arises when the engine briefly parks on the primary slot before rotating is suppressed.
+The settle window exists because the engine rotates `user+0xD8` through party members during world-load wiring (observed sequence on a Damiane save: Kliff -> Oongka -> Damiane over ~30 seconds). Each rotation is a real engine state, but only the final identity is the user's intended controlled character; firing the swap on each transition would commit the wrong preset and incur ~3x wasted apply work plus a brief visual flicker. 1s is chosen to coalesce sub-second torn reads at the cost of an equal amount of latency on real user-initiated swaps. Multi-second engine wiring sequences are not coalesced; the user will still see one transmog apply per stable identity.
 
-A separate save-load detector observes the `am+0x28` UserActor pointer; when it changes the worker calls `CDCore::invalidate_controlled_character()` so the resolver's last-known-good cache does not return the previous save's character against freshly-reallocated heap. The settle-window state (`pendingCharName`, `pendingFirstSeenTick`) is also cleared on this transition so a stale candidate from the previous save cannot commit against the new world.
+A separate save-load detector observes the `am+0x28` UserActor pointer; when it changes the worker calls `CDCore::invalidate_controlled_character()` so the resolver's last-known-good cache does not return the previous save's character against freshly-reallocated heap. The settle-window state (`pendingCharName`, `pendingFirstSeenTick`) is also cleared on this transition.
 
-The same `CDCore::invalidate_controlled_character()` is called when `player_component` changes (not just on UserActor change). A character swap rotates `user+0xD8` to a different `ClientChildOnlyInGameActor` without touching the UserActor singleton; the LKG identity from the previous controlled actor is no longer applicable to the new wrapper. Without this second invalidation point the resolver's torn-read absorption returns the prior character's name on any chain walk that lands on the new wrapper before its `+0x60` slot-index byte has been written, and the load-detect retry path commits the prior character's preset onto the new actor. Cost: at most one outer-loop tick (~1 second) of additional latency on swaps where the chain walk transiently returns Unknown right after the rotation; the safety-gate defers until the chain lands on a known identity.
+The same `CDCore::invalidate_controlled_character()` is called when `player_component` changes (not just on UserActor change). A character swap rotates `user+0xD8` to a different `ClientChildOnlyInGameActor` without touching the UserActor singleton; the LKG identity from the previous controlled actor is no longer applicable to the new wrapper. Without this second invalidation point, the resolver's torn-read absorption returns the prior character's name on any chain walk that lands on the new wrapper before its `+0x60` slot-index byte has been written, and the load-detect retry path commits the prior character's preset onto the new actor. Cost: at most one outer-loop tick (~1 second) of additional latency on swaps where the chain walk transiently returns Unknown right after the rotation; the safety-gate defers until the chain lands on a known identity.
 
 `run_debounced_apply` additionally calls `sync_active_char_to_live()` at the start of every apply pass so that even UI-driven applies (preset clicks, character picker) target the correct character regardless of what `pm.active_character()` was momentarily set to by the UI.
 
 ### 6.1 Actor-readiness probe (placeholder-wrapper filter)
 
-When `Load detect: player component changed` fires, the load-detect retry loop schedules up to 20 attempts (backoff 2s, 2s, 3s, 4s, then 5s × 16 -> ~95s total). The 20-attempt budget exists because **on low-end PCs the engine takes 60+ seconds to fully wire the controlled actor's part-registry after a save load**, and a shorter budget would give up before legitimate slow loads complete.
+When `Load detect: player component changed` fires, the load-detect retry loop schedules up to 20 attempts (backoff 2s, 2s, 3s, 4s, then 5s x 16, ~95s total). The 20-attempt budget exists because on low-end PCs the engine takes 60+ seconds to fully wire the controlled actor's part-registry after a save load, and a shorter budget would give up before legitimate slow loads complete.
 
-The cost of that budget on machines where the engine parks `user+0xD8` on a *placeholder* wrapper for the entire load was ~5 SEH-faulted `tear_down` log lines plus an apply fault per attempt -- ~100 noisy faults until the engine swaps the wrapper to the real actor. Mitigation: a cheap actor-readiness probe in front of each scheduled apply.
+The cost of that budget on machines where the engine parks `user+0xD8` on a *placeholder* wrapper for the entire load was ~5 SEH-faulted `tear_down` log lines plus an apply fault per attempt, ~100 noisy faults until the engine swaps the wrapper to the real actor. Mitigation: a cheap actor-readiness probe in front of each scheduled apply.
 
 **Probe** (`RealPartTearDown::is_actor_apply_ready`):
 
@@ -431,7 +435,7 @@ The chain mirrors the preamble of `tear_down_real_part` exactly. On a placeholde
 
 **Result:** on a slow load where the engine holds the placeholder for 90+ seconds, the log shows two debug lines (defer + recovery) instead of ~100 SEH-fault traces, and the eventual apply still fires on the first attempt after the engine swaps the wrapper. The 20-attempt budget itself is unchanged so legitimate slow-but-in-place wiring is still tolerated.
 
-**Why `count >= 1` is safe even for a naked character:** `count` is the slot-entry count (helm/chest/cloak/gloves/boots/weapons/accessories/...), NOT the equipped-item count. Empty slots persist as `primary == 0xFFFF` sentinels and are skipped *inside* the iteration loop, not by lowering `count`. A naked save still reports a full slot count (the representative reproduction shows `count = 14` even for slots that turned out empty during the walk). `count == 0` with a readable container only occurs during the brief window where the container struct is allocated but its slot entries have not yet been initialised -- which is exactly the placeholder/mid-wiring state we want to filter out.
+**Why `count >= 1` is safe even for a naked character:** `count` is the slot-entry count (helm / chest / cloak / gloves / boots / weapons / accessories / ...), NOT the equipped-item count. Empty slots persist as `primary == 0xFFFF` sentinels and are skipped *inside* the iteration loop, not by lowering `count`. A naked save still reports a full slot count (the representative reproduction shows `count = 14` even for slots that turned out empty during the walk). `count == 0` with a readable container only occurs during the brief window where the container struct is allocated but its slot entries have not yet been initialised, which is exactly the placeholder / mid-wiring state we want to filter out.
 
 ### 6.2 Mid-retry wrapper-change abort
 
@@ -449,9 +453,9 @@ if (curComp > 0x10000 && curComp != comp)
 }
 ```
 
-The engine sometimes parks `user+0xD8` on a *placeholder* wrapper for 60+ seconds before deallocating it and allocating the real character actor at a different address. Without this check the inner retry loop would burn its full ~95s budget against the dead placeholder, then return to the outer load-detect tick which would only then notice the new wrapper and start a *second* full retry budget. Net delay until the real wrapper got a transmog apply: 95s + (1s outer-loop tick) + (2s first-attempt delay) = ~98s of visible-mismatch render.
+The engine sometimes parks `user+0xD8` on a *placeholder* wrapper for 60+ seconds before deallocating it and allocating the real character actor at a different address. Without this check the inner retry loop would burn its full ~95s budget against the dead placeholder, then return to the outer load-detect tick which would only then notice the new wrapper and start a *second* full retry budget. Net delay until the real wrapper got a transmog apply: ~95s + 1s outer-loop tick + 2s first-attempt delay = ~98s of visible-mismatch render.
 
-With the abort the inner loop bails within at most one attempt's delay (2-5s) of the swap. The outer loop's next 1s tick observes `comp != prevComp`, advances `prevComp` and starts a fresh 20-attempt budget against the real wrapper -- which typically succeeds on attempt 1 because the freshly-allocated real actor is already wired by the time the engine swaps to it. End-to-end visible-mismatch window collapses from ~95s to ~3-7s.
+With the abort the inner loop bails within at most one attempt's delay (2-5s) of the swap. The outer loop's next 1s tick observes `comp != prevComp`, advances `prevComp` and starts a fresh 20-attempt budget against the real wrapper, which typically succeeds on attempt 1 because the freshly-allocated real actor is already wired by the time the engine swaps to it. End-to-end visible-mismatch window collapses from ~95s to ~3-7s.
 
 The "auto-apply failed after N attempts" warning is suppressed when the inner loop exits via `wrapperChanged = true`: that exit is a planned hand-off to the outer loop, not a failure.
 
@@ -459,37 +463,266 @@ The "auto-apply failed after N attempts" warning is suppressed when the inner lo
 
 ## 7. Known caveats
 
-* `UserActor+0xD8` was verified on three characters only; if Pearl Abyss adds a fourth playable party member, the slot may or may not extend to `+0xE0`, `+0xE8`, etc. Worth re-probing after any DLC / major patch.
-* The role byte at `typeEntry+1` is **per-character**, not a clean player/NPC flag. Do not gate on specific values.
-* Heap-pool addresses (`ActorManager`, `UserActor`, wrappers) change per session -- never hard-code them. Always resolve via the static `WS_holder` chain or a fresh AOB scan.
-* `charClassBypass` is a single `JZ` byte; if the game ever moves it to a `CMOV` or uses IBT-hardened code, that instruction may change size/encoding. Watch for resolve-time `CharClassBypass byte mismatch` warnings.
+* `UserActor+0xD8` covers three characters; if Pearl Abyss adds a fourth playable party member, the slot may or may not extend to `+0xE0`, `+0xE8`, etc. Worth re-probing after any DLC / major patch.
+* The role byte at `typeEntry+1` is per-character, not a clean player / NPC flag. Do not gate on specific values.
+* Heap-pool addresses (`ActorManager`, `UserActor`, wrappers) change per session; never hard-code them. Always resolve via the static WS holder chain or a fresh AOB scan.
+* `charClassBypass` is a single `JZ` byte. If the game ever moves it to a `CMOV` or uses IBT-hardened code, that instruction may change size / encoding. Watch for resolve-time `CharClassBypass byte mismatch` warnings.
+* Auth-table stride: live source declares `k_compEntryStride = 0xD0`; legacy notes referenced `0xC8`. If a future patch widens the entry, update both `transmog_apply.cpp` and the iteration loop in `tear_down_real_part`.
 
 ---
 
-## 8. IDA verification status (2026-04-21)
+## 9. AOB cascade audit (2026-05-08)
 
-Spot-checked against the v1.03.01 IDB:
+Audit pass that replaced every hardcoded `0x14......` literal in `CrimsonDesertLiveTransmog/src/` that the runtime actually dereferences with a 3-anchor AOB cascade resolved through DetourModKit's `resolve_cascade_with_prologue_fallback`. Comment-only references to historical addresses are kept as documentation.
 
-| Anchor | Status |
-|--------|--------|
-| BatchEquip `+0x007605B0` (`sub_1407605B0`, size 0x87A) | VERIFIED |
-| VisualEquipChange `+0x007733B0` (`sub_1407733B0`, size 0x42A) | VERIFIED |
-| SlotPopulator `+0x007727F0` (`sub_1407727F0`, size 0x367) | VERIFIED |
-| InitSwapEntry `+0x01D56620` (`sub_141D56620`, size 0xB3) | VERIFIED |
-| `charClassBypass` at `0x141D5F538` original byte `0x74` | VERIFIED (bytes `74 08 FF C1`; `jz short loc_141D5F542` inside `sub_141D5F470`) |
-| `WS holder` at `0x145D2AEE8` | Address in `.data` confirmed; live pointer value session-dependent |
-| SafeTearDown call label `0x14075FE60` | INTERNAL LABEL (inside `sub_14075F9E0`, size 0x5CD). Not a function entry; resolve via AOB. |
-| Scene-graph detach label `0x1425EBAE0` | INTERNAL LABEL (inside `sub_1425EACA0`, size 0xEC6). Not a function entry. |
-| SlotPopulator visual-config match label `0x14076CAED` | INTERNAL LABEL (inside `sub_14076C7F0`, size 0x71B). Not a function entry. |
+Game build of record: v1.05.01 (FileVersion 1.0.0.1070).
 
-Deferred verification (not spot-checked this pass -- recommend a follow-up if any of these are edited):
+The "if this breaks" recipe at the bottom of each entry is intentionally prescriptive: the same recipe was used to author the candidate set, so a future engineer can re-run it exactly. Per-cascade ordering follows the DetourModKit rule that the most-specific anchor leads each cascade; otherwise `resolve_cascade` returns on the first match and a non-unique leader will shadow the unique fallbacks.
 
-* AOB strings inside `constants.hpp` / `aob_resolver.hpp`.
-* Auth-table stride `0xC8`, slot-tag offset `+0xC0`, primary/alt item id offsets `+0x08` / `+0x88`.
-* Dispatch cache layout at `a1+0x1B8..+0x1C4`.
-* Descriptor `+0x42` equip-type byte semantics (Kliff 0x0004 vs others 0x0001) -- rely on in-code `needs_carrier()` truth.
-* Rule list layout `desc+0x248` stride `0x38` count `desc+0x250`.
+### 9.1 StringInfoRegistry (`MEMORY[0x145EF1DE8]`)
 
----
+Engine registry struct that PrefabWrapperSwap walks to resolve prefab names to wrapper-ptrs (`+0x08` count u32, `+0x50` entry-array). Single abs-address load, used in `walk_string_info` hot path.
 
-Maintained alongside the source; bump the "Verified game version" line at the top whenever an address or AOB is re-probed against a new patch.
+Live values: `*0x145EF1DE8` is session-dependent, `count = 30095` (matches the documented ~30k), `arrayPtr` lives in the heap arena. Filtering the array for body-mesh prefixes (`cd_phm_`, `cd_phw_`, `cd_m000_`) yields **2926** entries; every one of them has its `+0x18` wrapper-ptr in a single pool prefix (top-24 bits identical across all 2926). Heap arena positions are session-specific so the literal prefix is not load-bearing; the invariant is single-band clustering, which lets the natural-pipeline hook range-test for sentinel filtering. Per-slot heap-walk wrappers (the second pool documented in v1.03.01 era memory as `0x4104A*` / `0x4104E*`) live in a different arena populated by the mod's init-time enumeration.
+
+Cascade: `Transmog::k_stringInfoRegistryCandidates` (3 entries, `ResolveMode::RipRelative`).
+
+| Pattern | Anchor caller | Walk-back |
+|---|---|---|
+| P1 LoadAddCallSite | `sub_141D81F90` @ `0x141D8215E` | disp32@9, instrEnd@13 |
+| P2 OuterScopeFrame | `sub_142144B10` @ deep parser | disp32@12, instrEnd@16 |
+| P3 CondLoadStore | `sub_14074DD40` | disp32@13, instrEnd@17 |
+
+Disasm anchor (P1): `mov eax, [rbp-0x50]; mov [rbp+0x58], eax; mov rcx, [rip+disp32]; add rcx, 0x60; lea rdx, [rbp+0x58]`.
+
+If this breaks: each candidate names its host function. Re-find the function in IDA, locate the `mov reg, [rip+disp32]` that loads the registry, copy 16-32 bytes around it, wildcard the disp32 only, and verify uniqueness in the module.
+
+### 9.2 StringInfoVtable (`0x145BC4638`)
+
+Vtable sentinel used as the `+0x08` filter on every StringInfo entry. Filters non-StringInfo heap rows during `walk_string_info`.
+
+Cascade: `Transmog::k_stringInfoVtableCandidates` (`ResolveMode::RipRelative`).
+
+| Pattern | Anchor caller | Walk-back |
+|---|---|---|
+| P1 LargeMethodAssign | `sub_1402F58A0` (0x17B0-byte fn) | disp32@14, instrEnd@18 |
+| P2 R13InitBlock | `sub_1403174F0` | disp32@13, instrEnd@17 |
+| P3 TailLeaRdi | `sub_14031AC50` | disp32@11, instrEnd@15 |
+
+Three independent hosts so one recompile cannot break all three.
+
+If this breaks: the vtable layout itself is far more stable than the load-instruction encoding. Search for any `lea reg, [rip+disp32]` that resolves to the vtable address, pick three from different functions.
+
+### 9.3 LoaderRegistry (`MEMORY[0x145DDF8B0]`)
+
+Engine partprefab name-to-wrapper registry singleton. Dereferenced at `+0x50` by the AppT name-lookup function. Read at LT init for the heap-walk enumeration.
+
+Live values: `*0x145DDF8B0` is session-dependent. Capacity = `15298` entries (read as the hi-half u32 at `instance+0x50` and `instance+0x58`; both match). `instance+0x50 lo` ~= `877` (likely active count), `instance+0x58 lo` ~= `18203` (likely a parallel counter). Bucket array at `instance+0x60`, alternating `(small_id u64, heap_ptr u64)` qword pairs consistent with a name-to-wrapper hash table.
+
+Cascade: `Transmog::k_loaderRegistryCandidates` (`ResolveMode::RipRelative`).
+
+| Pattern | Anchor caller | Walk-back |
+|---|---|---|
+| P1 AddD0CallSite | `sub_1424E44A0` @ `0x1424E4771` | disp32@3, instrEnd@7 |
+| P2 R14ReadAfterStore | `sub_1424E44A0` @ `0x1424E47AA` | disp32@7, instrEnd@11 |
+| P3 InitStoreSite | `sub_142D1E220` @ `0x142D1E7F1` | disp32@6, instrEnd@10 |
+
+P3 is unusual: it is the engine-init STORE that initializes the singleton, not a load. The disp32 still resolves to the same target.
+
+If this breaks: any function that reads `MEMORY[0x145DDF8B0]` is a candidate. The `+0xD0` walk-offset in P1 and the `EB 03` short-jmp context in P3 are stable game-struct features.
+
+### 9.4 ApptContainerVtable (`0x144D24358`)
+
+Vtable of `partPrefabDataContainer`. Used for gating in `lookup_prefab_metadata`. Single-xref; resolved indirectly by AOB-ing the ctor (`sub_141E2DBB0`) prologue, then walking its body for the SECOND `lea rax, [rip+disp32]; mov [rdi], rax` pair (the FIRST is the intermediate vtable `0x144D242B8`).
+
+Cascade: `Transmog::k_apptLoaderCtorCandidates` (`ResolveMode::Direct`). Walk-forward done in C++ via `prefab_wrapper_swap.cpp::resolve_appt_container_vtable`.
+
+| Pattern | Anchor | Walk-back |
+|---|---|---|
+| P1 FullPrologue | full 8-callee-saved + alloc | 0 |
+| P2 FieldInitChain | post-arg-shuffle XOR + zero stores | -0x1D |
+| P3 PayloadCopy | inline qword, qword, byte from `*a3` | -0x2F |
+
+If this breaks: re-AOB `sub_141E2DBB0` by its prologue, then in IDA find the second `48 8D 05 ?? ?? ?? ?? 48 89 07` pair inside the function. The walk-forward is bounded to the function's first 0x400 bytes.
+
+### 9.5 NaturalPipeline (`sub_142711DF0`)
+
+Engine pre-unlink wrapper-list walker. Hooked by PrefabWrapperSwap to substitute Kliff src wrappers with target wrappers in the engine's unlink list (helm and cloak ghost cleanup). Critical for clean teardown.
+
+Cascade: `Transmog::k_naturalPipelineCandidates` (`ResolveMode::Direct`). Function is 6kB with all 8 callee-saved registers pushed, so the prologue is highly distinctive.
+
+| Pattern | Anchor | Walk-back |
+|---|---|---|
+| P1 FullPrologueChkstk | 4 arg-spills + 7 pushes + lea rbp + B8 0x1880 + chkstk | 0 |
+| P2 PostArgSpill | drop first arg-spill, anchor on 3-spill + pushes + chkstk | -0x05 |
+| P3 PostChkstkArgShuffle | chkstk call + sub rsp,rax + 4D 8B E8 / 48 8B DA / 4C 8B F9 / 41 83 78 | -0x27 |
+
+Disasm anchor: prologue at `0x142711DF0` ends with `B8 80 18 00 00 / E8 chkstk / 48 2B E0 / 4D 8B E8 / 48 8B DA / 4C 8B F9`. The `0x1880` stack reservation is unique enough to anchor on.
+
+If this breaks: the `B8 imm32` only changes if stack-allocation grows past 4kB. If that happens, search for any `__chkstk` call where the preceding mov-eax-imm matches the new stack size and the post-`48 2B E0` register shuffle is the same 4-saved-args + first-call sequence.
+
+### 9.6 ApptNameLookup (`sub_1424DF420`)
+
+Self-contained name-to-wrapper primitive. Lowercases input, interns it, queries `MEMORY[0x145DDF8B0]+0x50`. Called directly (not hooked).
+
+Cascade: `Transmog::k_apptNameLookupCandidates` (`ResolveMode::Direct`).
+
+| Pattern | Anchor | Walk-back |
+|---|---|---|
+| P1 FullPrologue | 2 arg-spills + 3 pushes + lea rbp,[rsp-0x60] + sub rsp,0x160 + mov rsi,[rip+disp32] + xor edi,edi + mov [rbp+0x28],rdi | 0 |
+| P2 PostArgSpill | drop arg-spill prefix, anchor on pushes + frame setup + registry load | -0x0A |
+| P3 LocalInitConstant | frame setup + registry load + xor edi,edi + mov [rbp+0x28],rdi + 48 C7 45 (mov qword imm32) | -0x0D |
+
+The `48 81 EC 60 01 00 00` (sub rsp, 0x160) is a uniquely-sized stack frame. The immediately-following `48 8B 35 ?? ?? ?? ?? 33 FF` (load LoaderRegistry singleton + xor edi,edi) is the function's signature move.
+
+If this breaks: the function exists to query the LoaderRegistry, so locate any function that reads `MEMORY[0x145DDF8B0]` AND lowercases its input AND calls `sub_1403016B0` (string interner). This is a singleton in the engine. Verify the prologue starts with `48 89 5C 24 10 48 89 4C 24 08`.
+
+### 9.7 CharClassBypass patch site
+
+Single-byte runtime patch in CondPrefab evaluator. Toggle `74` (jz rel8) <-> `EB` (jmp rel8). Forces NPC items past the character-class hash check.
+
+| Build | Patch byte address | RVA | Host function |
+|-------|--------------------|-----|---------------|
+| v1.03.01 | `0x141D5F538` | `0x01D5F538` | `sub_141D5F470 + 0xC8` |
+| v1.05.01 | `0x141E0A7D8` | `0x01E0A7D8` | host shifted by `+0x0AB2A0`; cascade re-resolves |
+
+Cascade: `Transmog::k_charClassBypassCandidates` (`ResolveMode::Direct`, return = patch byte address).
+
+P1 cascade matches at `0x141E0A7C7`, patch byte at `match+0x11 = 0x141E0A7D8` reads `0x74` (baseline). Disassembly:
+
+```text
+0x141E0A7C7  mov   r8, [rbx-0x08]               ; allowed-class hash array base
+0x141E0A7CB  movzx r9d, word ptr [rax+0xAC]     ; current item's class hash
+0x141E0A7D3  cmp   r9w, [r8+rcx*2]              ; vs allowed[ecx]
+0x141E0A7D8  74 08    je  0x141E0A7E2           ; <-- patch byte (early-out on match)
+0x141E0A7DA  FF C1    inc ecx
+0x141E0A7DC  3B CA    cmp ecx, edx
+0x141E0A7DE  72 F3    jb  0x141E0A7D3           ; loop back
+0x141E0A7E0  EB 72    jmp 0x141E0A854           ; rejection (loop fell through)
+0x141E0A7E2  ...                                ; matched path
+```
+
+Flipping `74 -> EB` forces the first comparison into the matched path regardless of hash equality, so any item's class hash satisfies the check.
+
+| Pattern | Anchor | Walk-forward |
+|---|---|---|
+| P1 MovzxCmpLoop | inner loop with `4C 8B 43` + `44 0F B7 88 disp16` + `66 45 3B 0C 48` + `74 ??` + `FF C1` + `3B CA` + `72 ??` + `EB` | +0x11 |
+| P2 TestMovzxCmp | adds preceding `85 D2 74 ??` (test edx, edx; jz) | +0x15 |
+| P3 XorTestCmpLoop | adds preceding `33 C9 85 D2 74 ??` (xor ecx, ecx; test; jz) | +0x17 |
+
+CRITICAL CONSTRAINT: the `74` rel8 in these patterns IS the byte the mod flips at runtime, so it MUST stay literal (not wildcarded). A future compiler that emits this jz in its 6-byte `0F 84 rel32` form would require a full re-RE; every candidate would stop matching and the feature would fail-soft via the scanner's null return. Documented inline in `aob_resolver.hpp`.
+
+If this breaks: re-find `sub_141D5F470`, locate the secondary-hash inner loop (its outer is at `+0x70`). Pattern shape: `4C 8B 43 ??` + `44 0F B7 88 ?? ??` + `66 45 3B 0C 48` + `74` + `FF C1` + `3B CA` + `72 ?? EB`.
+
+### 9.8 Files touched by the audit
+
+Modified:
+
+* `src/aob_resolver.hpp` -- six new cascade tables added (sections 9.1 through 9.6 above; 9.7 was already present from a prior pass).
+* `src/prefab_wrapper_swap.cpp` -- replaced `k_stringInfoRegistryAbs`, `k_stringInfoVtable`, `k_loaderRegistrySingleton`, `k_apptContainerVtable` static constants with atomic globals populated from cascades at `init()`. Replaced `k_naturalPipelineRva` and `k_apptNameLookupRva` RVA constants + `GetModuleHandleW` arithmetic with cascade calls.
+
+Verified comment-only (no load-bearing literals):
+
+* `src/shared_state.hpp` -- `0x141D5F538` mentioned in the comment of the `charClassBypass` `ResolvedAddresses` field. Field is initialized to `0` and populated at runtime from `k_charClassBypassCandidates`.
+* `src/item_name_table.cpp` -- mentions `0x145BC3638` (sentinel) and `0x140799CB9` (subTranslator anchor) in documentation comments only. Runtime resolution uses `parse_aob` bounded scans inside the AOB-resolved subTranslator function body.
+* `src/prefab_wrapper_swap.hpp` -- mentions `0x145EF1DE8` and `0x144D24308` in interface docstrings only.
+
+### 9.9 ApptResMgrInit (`sub_1408AF8F0`)
+
+One-shot capture-hook target. PrefabWrapperSwap installs an inline entry hook that runs the trampoline and then snapshots ResMgr at `a1[5]` (= `a1+0x28`), the loader at `ResMgr+0x58`, and the partprefab container at `loader+0x08`. The hook is one-shot; subsequent calls are pass-throughs.
+
+Live re-verification (Cheat Engine + IDA, v1.05.01 .text, 2026-05-08):
+
+| Anchor | Hits | Walk-back | Notes |
+|---|---|---|---|
+| `P1_FullPrologue` | 1 | 0 | 8 callee-saved pushes + lea rbp + direct 0xF8 alloc + arg shuffle. No RIP-rel inside window. |
+| `P2_PostPushAlloca` | 1 | -0x0D | Survives a future build that re-orders early callee-save pushes (lea-rbp marker pins frame setup). |
+| `P3_TlsScratchSetup` | 1 | -0x2D | TLS-canary load body anchor (`mov r12d, 204h ; mov rax, gs:58h`). Anchors past prologue entirely. |
+
+Migrated out of `prefab_wrapper_swap.cpp` (was a single-anchor `inline constexpr AddrCandidate[]`). Consumer call site at `prefab_wrapper_swap.cpp::install_struct_copy_hook`.
+
+If this breaks: the `40 55 53 56 57 41 54 41 55 41 56 41 57` push run + the chkstk-free `48 81 EC F8 00 00 00` direct alloc are the two distinguishing prologue features. Re-anchor by combining either with one of the early-body markers (TLS slot 0x58 read or the constant `204h` payload size).
+
+### 9.10 ApptInnerLookup (`sub_140350910`)
+
+Partprefab container hashtable lookup primitive (pure read). Signature: `__int64(*)(table_struct*, key_wrapper_ptr_ptr*)` where `table_struct = container + 0x70`. Returns 0 on miss or `entry+0x10` on hit (a 24-byte metadata payload pointer).
+
+Critical context: this function has a **byte-identical sibling clone at `sub_1430C4880`** (UI/render subsystem). Both implement the same primitive but only `sub_140350910` is wired to the partprefab `container+0x70` shape. The two clones share their ENTIRE prologue and most of their body -- the only differences are the `disp32` operands of two internal `E8` calls (which point to the same helper `sub_140FBA3B0` but encoded relative to different addresses). The function-prologue cascade alone matches BOTH copies.
+
+Per `feedback_aob_cascade_ordering`: any P1 with hit count >=2 shadows unique fallbacks. Resolution: P1 leads with a **RipRelative call-site anchor** (in `sub_140347BB0` at `0x1403495D5`) that walks an `E8 disp32` to the canonical target. The call-site anchor IS unique because the caller-side instruction window includes a stable game-struct field offset (`+0x70` walk).
+
+Live re-verification (Cheat Engine + IDA, v1.05.01 .text, 2026-05-08):
+
+| Anchor | Hits | Type | Notes |
+|---|---|---|---|
+| `P1_CallSiteRipRel` | 1 | RipRelative | Window in `sub_140347BB0`: `mov ecx,[rax+disp32] ; add rcx,0x70 ; mov rdx,rbx ; call sub_140350910`. The `48 83 C1 70` is a SEMANTIC offset kept literal. |
+| `P2_FullPrologueEarlyExit` | 2 | Direct | Function prologue + early-return path. Shared with sibling clone -- relies on linear-scan first-match returning the canonical target. |
+| `P3_PrologueBodyChain` | 2 | Direct | Same as P2 plus one more basic block. Same multi-hit caveat. |
+
+Migrated out of `prefab_wrapper_swap.cpp`. Renamed from `k_apptLookupCandidates` for clarity. Consumer call site at `prefab_wrapper_swap.cpp::install_struct_copy_hook` (the AppearanceTableLoader integration block).
+
+If this breaks: re-find an xref to `sub_140350910` from gameplay-side code (`sub_140347BB0` at `+0x1A25` or `+0x1B98` in v1.05.01) and grab the 12-byte window before the `E8 disp32` for a fresh RipRelative anchor.
+
+### 9.11 ApptStringIntern (`sub_1403016B0`)
+
+String-intern primitive. Signature: `handle_t(*)(const char* utf8)`. Lowercases nothing -- just returns the engine's interned-string handle expected by `sub_141D38810` and `sub_140350910`. Returns 0 for null/empty input.
+
+Like ApptInnerLookup, this function has a templated sibling clone (linker-emitted from a header). The full prologue is unique in v1.05.01 so P1 stays direct; P2 and P3 are body anchors that fall back if the prologue shifts.
+
+Live re-verification (Cheat Engine + IDA, v1.05.01 .text, 2026-05-08):
+
+| Anchor | Hits | Walk-back | Notes |
+|---|---|---|---|
+| `P1_FullPrologue` | 1 | 0 | Full prologue + null/empty short-circuit + strlen-loop init (`mov rbx, -1`). |
+| `P2_StrlenLoopBody` | 1 | -0x13 | Mid-body strlen-loop interior + back-jump (`75 F7`). Survives a prologue-shuffle that drops short-jumps in favour of `0F 84 rel32`. |
+| `P3_HeadShortPair` | 1 | 0 | Truncated prologue (no `mov rbx, -1`). Survives a build that re-orders the spill/strlen-init pair. |
+
+Migrated out of `prefab_wrapper_swap.cpp` (was a single-anchor `inline constexpr AddrCandidate[]`). Consumer call site at `prefab_wrapper_swap.cpp::install_struct_copy_hook` (the AppearanceTableLoader integration block).
+
+If this breaks: re-anchor on the unique `48 C7 C3 FF FF FF FF` (mov rbx, -1 = strlen-counter init) + the `strncpy_s` import-call `FF 15 ?? ?? ?? ??` shape -- the import slot is a `__ImageImpDir` entry whose location is build-stable.
+
+### 9.12 StructCopy (`sub_140352AA0`)
+
+0x40-byte struct-copy hot path. Signature: `__int64(*)(dst, src)`. The function copies a partprefab wrapper-related struct field-by-field. PrefabWrapperSwap installs an **inline hook** here and (when LT-active) substitutes Kliff source wrappers with target wrappers for the duration of the copy. This is the single most-active hook in the LT-active path; it must compile to a clean inline.
+
+Function reads the engine's StringInfo vtable sentinel `0x145BC4638` via a `lea rax, [rip+disp32]` early in the body; that single RIP-rel byte is wildcarded. All other bytes in the patterns below are stable.
+
+Live re-verification (Cheat Engine + IDA, v1.05.01 .text, 2026-05-08):
+
+| Anchor | Hits | Walk-back | Notes |
+|---|---|---|---|
+| `P1_FullPrologueWithVtable` | 1 | 0 | Full prologue + first qword copy + `lea rax, [vtable]`. The disp32 wildcard absorbs the only patch-volatile byte run. |
+| `P2_PrologueNoVtable` | -- | 0 | Truncated prologue (no RIP-rel). Survives a future build that moves the vtable lea later. WARNING: pattern fragment also matches `sub_140355210` -- relies on `sanity_check_function_prologue` post-resolve. |
+| `P3_ByteTransferBlock` | 1 | -0x2F | Unique 4-byte payload copy (`movzx eax, byte ptr [rdx+8/9/A] ; mov [rcx+8/9/A], al` x3) + dword tail + `mov [rcx+0x10], rbp`. Strong tell of this exact function -- byte-by-byte transfer means struct-alignment-1 (packed). |
+
+Migrated out of `prefab_wrapper_swap.cpp` (was a single-anchor cascade). Consumer call site at `prefab_wrapper_swap.cpp::install_struct_copy_hook`.
+
+If this breaks: re-anchor on the byte-transfer block (P3) -- it is the most function-specific shape and the least likely to shuffle. The function's signature is `dst,src -> mov [dst], 0 ; copy src->dst ; lea rax, [vtable] ; mov [src], rax ; movzx-byte transfers from [src+8..src+0xA] into [dst+8..]`.
+
+### 9.13 ItemNameTable bounded-window anchors
+
+These are NOT cascades: they are pattern strings handed to `DMK::Scanner::find_pattern` for a 0x40--0x80-byte LOCAL scan inside a function whose start has already been resolved (via `k_subTranslatorCandidates`, see section 9.0 and `aob_resolver.hpp` line 146). They live in `aob_resolver.hpp` as `inline constexpr const char*` named pattern constants alongside the cascade tables, per the audit policy of keeping all byte-pattern string literals in one place.
+
+The `|` glyph marks the point where `parse_aob` should compute its `pattern.offset` for downstream `match + offset` arithmetic (DMK v3.0.2+ applies offset internally during `find_pattern`).
+
+Three anchors:
+
+| Constant | Function searched | Hits in window |
+|---|---|---|
+| `k_nametableSubTxV105Anchor` | sub_14076D950 (0x80 window) | 1 (locally) |
+| `k_nametableSubTxV104Anchor` | same | 0 on v1.05; v1.04 fallback |
+| `k_nametableItemAccessorAnchor` | sub_1402D75D0 (0x40 window) | 1 (locally) |
+
+Consumed by `ItemNameTable::resolve_chain` in `item_name_table.cpp`. Global-uniqueness does not apply because the scan is locally bounded; the function start is the cascade-resolved `sub_14076D950` (or `sub_1402D75D0`), so the search has at most 0x80 bytes of code to walk. Inert v1.04/v1.05 encoding shifts cause the v105 anchor to miss; the consumer falls back to the v104 anchor inside the same window.
+
+Migrated out of `item_name_table.cpp` (lines 653, 655, 705 were inline string literals fed to `parse_aob`). Per the audit policy "any byte-pattern string handed to `parse_aob` must move into `aob_resolver.hpp`" these qualify even though their containing scan is sub-function rather than module-wide.
+
+If these break: re-RE the encoding shift inside the resolved subTranslator function. The `41 B8 01 00 00 00` (mov r8d, 1) is a SEMANTIC argument flag (the `compileBuffer` flag passed to `sub_141D45270`) and must remain literal. Stack disp8 wildcards absorb compiler register-allocation drift. For step-3, the `0F B7 39` (movzx edi, word ptr [rcx]) reads the 16-bit item-id and is the function's signature opcode; if a future build switches to a 32-bit item-id, that opcode shifts and the anchor needs a new variant.
+
+### 9.14 Files touched by the audit (part 2)
+
+Modified:
+
+* `src/aob_resolver.hpp` -- four new function-target cascade tables (`k_apptResMgrInitCandidates`, `k_apptInnerLookupCandidates`, `k_apptStringInternCandidates`, `k_structCopyCandidates`) plus three named pattern constants (`k_nametableSubTxV105Anchor`, `k_nametableSubTxV104Anchor`, `k_nametableItemAccessorAnchor`).
+* `src/prefab_wrapper_swap.cpp` -- removed 4 inline `AddrCandidate[]` arrays (former lines 125, 165, 198, 220). Renamed consumer call from `k_apptLookupCandidates` to `k_apptInnerLookupCandidates` for clarity. The 4 cascades are function-target resolves consumed by `resolve_address()` at install-time -- no atomic-store-init wiring needed (function pointers stored directly into existing `s_apptResMgrInitOrig` / `s_apptStringIntern` / `s_apptLookup` / `s_orig` statics).
+* `src/item_name_table.cpp` -- replaced 3 inline pattern strings with references to the named constants in `aob_resolver.hpp`. Added `#include "aob_resolver.hpp"`.


### PR DESCRIPTION
## Summary

- Adds a body-mesh prefab-wrapper-swap module so users can override the prefab variant on each slot, with an optional cross-slot prefab browser.
- Expands the slot picker from 5 armor slots to 10 (helm, chest, cloak, gloves, boots, necklace, lantern, glasses, mask, backpack). Weapon, ring, earring, and bracelet slots are intentionally still disabled, pending multi-prefab and duplicate-tag refactors.
- Migrates the preset JSON from a positional array to a keyed object so future slot additions cannot shift legacy saves. Legacy array-form presets load transparently and are rewritten on next save. Adds an optional `prefabName` field for the new prefab override.
- Removes the standalone overlay's hard world-load timeout. The mod now waits indefinitely for the game world to be ready and logs a heartbeat every 60s, so slow boots no longer skip overlay init.
- Sweeps em-dashes out of active source/CMake and trims agent-context comments.

## Test plan

- [x] Apply a body-mesh prefab override on each of the 10 enabled slots; verify it persists across save/load and survives radial swaps.
- [x] Load a legacy array-form preset, confirm it loads cleanly, save it, and verify the file rewrites in keyed-object form.
- [x] Toggle the cross-slot prefab browser mode and apply a prefab from a non-native slot picker.
- [ ] Boot with a slow disk/long load and confirm the overlay still initializes (no "World timeout" warning).
- [x] Confirm disabled slots (weapons/rings/earrings/bracelet) do not appear in the picker.
