### PR TITLE
docs(live-transmog): credit SoraSkySun for item data dump

### DIFF
--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -236,6 +236,7 @@ Press **Numpad 0** in-game to trigger a reload after rebuilding.
 - [Brodie Thiesfield](https://github.com/brofield) - for SimpleIni
 - [Omar Cornut](https://github.com/ocornut) - for Dear ImGui
 - [Frans 'Otis_Inf' Bouma](https://github.com/FransBouma) - for v1.05.00 AOB shift diagnosis
+- [SoraSkySun](https://www.nexusmods.com/profile/SoraSkySun) - for the [Crimson Desert save editor and game file parser / item data dump](https://github.com/NattKh/CRIMSON-DESERT-SAVE-EDITOR-AND-GAME-MODS)
 - Pearl Abyss - for Crimson Desert
 
 ## Changelog

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -244,6 +244,7 @@ Built with [url=https://github.com/tkhquang/DetourModKit]DetourModKit[/url] for 
 [*][url=https://github.com/microsoft/DirectXMath]DirectXMath[/url] by Microsoft -math primitives
 [*][url=https://reshade.me/]ReShade[/url] by crosire -optional addon host
 [*][url=https://github.com/FransBouma]Frans 'Otis_Inf' Bouma[/url] -v1.05.00 AOB shift diagnosis
+[*][url=https://www.nexusmods.com/profile/SoraSkySun]SoraSkySun[/url] -[url=https://github.com/NattKh/CRIMSON-DESERT-SAVE-EDITOR-AND-GAME-MODS]Crimson Desert save editor + game file parser / item data dump[/url]
 [*]Pearl Abyss -Crimson Desert
 [/list]
 


### PR DESCRIPTION
## Summary
- Add SoraSkySun to Live Transmog credits in README and Nexus BBCode
- Links Nexus profile and the CRIMSON-DESERT-SAVE-EDITOR-AND-GAME-MODS repo (game file parser / item data dump)

## Test plan
- [x] README renders the new credit line correctly
- [x] BBCode entry placed alongside other contributor credits
