### PR TITLE
chore(live-transmog): remove leftover scaffolding and fix shadow warning

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Title for next release]
+## Code cleanup pass
 
-- New feature
-- Bug fix
-- Improvement
+- Removed leftover scaffolding and inert markers from prior body-mesh experiments so the source tree only carries code that actually ships.
+- Tightened comments throughout the mod: kept the technical "why" notes that help future readers, dropped narrative filler that was only meaningful during investigation.
+- No behavior change for existing users; presets, hotkeys, and supported slots are unchanged.

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -789,19 +789,19 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
             // and only Selectable() the visible window. Net cost per
             // frame: O(visible_rows) instead of O(totalShown). For the
             // observed lag this drops from ~5000 emits to ~30.
-            const float rowH = ImGui::GetTextLineHeightWithSpacing();
+            const float prefabRowH = ImGui::GetTextLineHeightWithSpacing();
             const float scrollY = ImGui::GetScrollY();
             const float winH = ImGui::GetWindowHeight();
             const int total = static_cast<int>(totalShown);
-            int firstVis = static_cast<int>(scrollY / rowH) - 1;
+            int firstVis = static_cast<int>(scrollY / prefabRowH) - 1;
             int lastVis = static_cast<int>(
-                (scrollY + winH) / rowH) + 2;
+                (scrollY + winH) / prefabRowH) + 2;
             if (firstVis < 0) firstVis = 0;
             if (lastVis > total) lastVis = total;
             if (firstVis > total) firstVis = total;
 
             if (firstVis > 0)
-                ImGui::Dummy(ImVec2(0.0f, firstVis * rowH));
+                ImGui::Dummy(ImVec2(0.0f, firstVis * prefabRowH));
             {
                 for (int row = firstVis; row < lastVis; ++row)
                 {
@@ -871,7 +871,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
                 }
             }
             if (lastVis < total)
-                ImGui::Dummy(ImVec2(0.0f, (total - lastVis) * rowH));
+                ImGui::Dummy(ImVec2(0.0f, (total - lastVis) * prefabRowH));
             if (catalogedTotal == 0)
             {
                 ui_text_disabled(
@@ -886,12 +886,12 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         else
         {
             // Prefab catalog rendering is gated to prefabMode=true
-            // (the cross-slot browser block above). The user said the
-            // per-slot prefab list bloats the items dropdown, so when
-            // prefabMode is OFF we don't render rows at all -- only
-            // expose the clear-override option when an active prefab
-            // selection exists, so the user can always undo without
-            // having to flip the prefabMode toggle on first.
+            // (the cross-slot browser block above). The per-slot prefab
+            // list otherwise bloats the items dropdown, so when
+            // prefabMode is OFF we render no prefab rows; only the
+            // clear-override option appears when an active prefab
+            // selection exists, so it can be undone without flipping
+            // the prefabMode toggle on first.
             const int curTgt = PWS::selection_tgt_index(slotCategory);
             if (curTgt >= 0)
             {
@@ -1049,50 +1049,6 @@ static int s_renameIndex = -1;
     return false;
 }
 
-// Identify the "Kairos" character -- the default-carrier preset whose
-// chest item resolves to `cd_phm_00_ub_00_0435` wrappers (Kliff's
-// canonical body-mesh source). The body-mesh hook's swap-map source
-// only matches when this character's gear is loaded, so picking a
-// body-mesh prefab while another character (e.g. Wellsknight) is
-// active must temporarily borrow Kairos's slot itemIds.
-//
-// Resolution policy (in order):
-//   1. Exact name match "Kliff" -- the canonical default carrier.
-//   2. First character returned by character_names().
-//
-// Documented this way so adding a new "Kairos"-equivalent character
-// later is a one-line change. Returns empty string only if the
-// PresetManager has no characters at all (impossible at runtime).
-[[nodiscard]] static std::string kairos_character_name()
-{
-    const auto &pm = Transmog::PresetManager::instance();
-    const auto names = pm.character_names();
-    for (const auto &n : names)
-    {
-        if (n == "Kliff")
-            return n;
-    }
-    return names.empty() ? std::string{} : names.front();
-}
-
-// Borrow the Kairos preset's slot itemIds into the live slot_mappings.
-// Body-mesh swap matches by SOURCE wrapper (e.g. `0435`), which is
-// only resident when the matching carrier item is loaded. When the
-// user picks a body-mesh prefab while controlling another character,
-// the engine has Wellsknight wrappers loaded and the hook never fires.
-// Forcing Kairos's itemIds into slot_mappings makes the engine load
-// Kairos's gear, which loads the source wrappers, which the hook
-// then substitutes with the chosen prefab.
-//
-// Side-effect contract (intentional):
-//   - mutates slot_mappings()[*].targetItemId / .active for slots
-//     where the user has an active body-mesh prefab pick.
-//   - DOES NOT mutate PresetManager state (no set_active_character,
-//     no save). The user's saved preset is untouched.
-//
-// Slots WITHOUT a pickedPrefabName are left alone so the user can
-// stack a body-mesh override on chest while keeping Wellsknight's
-// helm/gloves visible.
 // Clear all picked-prefab UI state and deactivate the body-mesh hook.
 // Called BEFORE preset switches so the prefab swap is torn down before
 // the new preset's items are equipped -- otherwise the hook would still
@@ -1135,9 +1091,9 @@ static void force_active_character_carrier_for_picked_slots()
     // default_carrier_for_slot). The PWS swap is keyed by the source
     // wrapper that THAT character's body emits, so we need the
     // matching carrier to make the source wrapper resident at apply
-    // time. Previously hardcoded to "Kliff" -- which forced Kliff's
-    // plate item onto Damiane / Oongka when they had any prefab
-    // selection active, breaking their carrier-equip path.
+    // time. Hardcoding "Kliff" here would force Kliff's plate item
+    // onto Damiane / Oongka whenever they had a prefab selection
+    // active, breaking their carrier-equip path.
     auto &mappings = Transmog::slot_mappings();
     const auto &activeChar =
         Transmog::PresetManager::instance().active_character();

--- a/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
+++ b/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
@@ -46,78 +46,26 @@ namespace Transmog::PrefabWrapperSwap
     constexpr std::uint32_t  k_minPlausibleCount     = 100;
     constexpr std::uint32_t  k_maxPlausibleCount     = 200000;
 
-    // --- Runtime-resolved data globals (audit 2026-05-08) ---
+    // --- Runtime-resolved data globals ---
     //
-    // Hardcoded RVAs and absolute addresses were replaced with AOB
-    // cascades (see aob_resolver.hpp::k_stringInfoRegistryCandidates et
-    // al). The cascade resolves at init(); these atomics carry the
-    // resolved address into the hot path. Zero indicates "not yet
-    // resolved" -- every consumer must check for non-zero before
-    // dereferencing.
-    //
-    // Atomics are used because init() runs on the main thread but the
-    // hot path (walk_string_info, enumerate_loader_registry_into_catalog)
-    // can run on the background population thread. x64 qword stores are
-    // naturally atomic on aligned data; the explicit atomic gives the
-    // compiler the memory fence it needs.
+    // Resolved by AOB cascades at init() (see aob_resolver.hpp::
+    // k_stringInfoRegistryCandidates et al). Atomic because init runs on
+    // the main thread while the hot path (walk_string_info,
+    // enumerate_loader_registry_into_catalog) can run on the background
+    // population thread. Zero means "not resolved yet"; every consumer
+    // must check for non-zero before dereferencing.
     static std::atomic<std::uintptr_t> s_stringInfoRegistry{0};
     static std::atomic<std::uintptr_t> s_stringInfoVtable{0};
     static std::atomic<std::uintptr_t> s_loaderRegistrySingleton{0};
     static std::atomic<std::uintptr_t> s_apptContainerVtable{0};
 
-    // (Removed 2026-05-07: k_maxPairs / k_pathBufSize. Both backed
-    // the deleted INI Pair config -- no callers remain.)
-
-    // --- AOB for sub_14270B030 (resource binder) ---
-    //
-    // sub_14270B030 is called by sub_14270AD50 to bind resolved
-    // resources into a record's slots:
-    //   sub_14270B030(charState, entry+16, charState, entry, &v14)  // PRIMARY
-    //   sub_14270B030(charState, entry+24, charState, entry, &v13)  // SECONDARY
-    //
-    // The PRIMARY bind installs the full-string-lookup result (e.g.
-    // target prefab `_0395_c`). The SECONDARY bind installs the
-    // suffix-variant-lookup result (extracted suffix `_c`). When our
-    // pointer-swap changes a wrapper from `_d` (Kliff helm) to `_c`
-    // (target prefab), the secondary bind creates a NEW scene-graph
-    // node keyed on the `_c` suffix in a DIFFERENT class table that
-    // LT's tear_down doesn't traverse -- causing the helm to leak when
-    // the user clears or switches presets.
-    //
-    // Fix: hook this function and SKIP the secondary bind for any
-    // record whose wrapper matches one of our active target wrappers.
-    // The primary bind still happens (target prefab visible). The
-    // secondary suffix-variant bind is skipped (no leak).
-    //
-    // Detection: sub_14270B030 is variadic; va arg is at [rbp+0x60].
-    // Distinguishing primary-vs-secondary at the hook: a2 == entry+24
-    // means secondary (where entry == a4).
-    //
-    // First 50 bytes are a unique prologue + frame setup + first arg
-    // load (`mov rdi, [r12]; test rdi, rdi`); rel32 jcc disp32 after
-    // that varies, so we anchor on the prologue alone.
-    // (Removed 2026-05-07: AOB tables for sub_14275AC00 ResourceBinder,
-    // sub_14271A720 EngineUnlink, sub_1402F94B0 SmartPtrRelease, and
-    // sub_1427127D0 Factory. These supported the legacy helm-leak fix
-    // path -- ResourceBinder gating, factory orphan tracking, and
-    // do_reverse_write force-destroy cleanup. The natural-pipeline
-    // hook on sub_142711DF0 now handles cleanup at the unlink layer
-    // by substituting Kliff src wrappers with target wrappers in the
-    // engine's unlink list, so none of those primitives are referenced
-    // anymore. Verified live 2026-05-05: clear-all + save-reload runs
-    // clean without them. See diff snapshots in
-    // docs/research/ghost-helm-snapshots/diff-2026-05-05-cold/.)
-
-    // 4 inline AOB cascades migrated to aob_resolver.hpp on 2026-05-08
-    // (audit pass 2):
+    // The four cascades consumed below are defined in aob_resolver.hpp:
     //   k_apptResMgrInitCandidates    -- sub_1408AF8F0 capture hook
     //   k_apptInnerLookupCandidates   -- sub_140350910 lookup primitive
-    //                                    (renamed from k_apptLookupCandidates)
     //   k_apptStringInternCandidates  -- sub_1403016B0 string intern
     //   k_structCopyCandidates        -- sub_140352AA0 struct copy hot path
-    //
-    // Each is now a 3-anchor cascade per aob-signatures.md ordering rules.
-    // See aob_resolver.hpp for the cascade definitions and per-anchor docs.
+    // Each is a 3-anchor cascade per the AOB ordering rules in
+    // docs/aob-signatures.md (most-specific candidate first).
 
     // Offset within container where the boot-loaded hash table struct
     // begins. The boot loader (sub_1424E15F0) populates `container +
@@ -125,12 +73,9 @@ namespace Transmog::PrefabWrapperSwap
     // sub_140350910 takes the SAME table-struct pointer.
     static constexpr std::size_t k_apptHashTableOff = 0x70;
 
-    // (Removed 2026-05-07: legacy INI Pair config. The Pair struct,
-    // s_pairs[k_maxPairs] static array, s_enabled gate flag, and the
-    // s_bindings input-binding guard vector all supported the old
-    // [Research]-section INI keys (PrefabWrapperSwap_Pair{1..8} +
-    // ToggleHotkey). All gone -- selection is overlay-driven, no
-    // INI keys remain.)
+    // Module is "active" when at least one slot has a resolved swap
+    // pair installed in s_swapMap. Selection is overlay-driven; there
+    // are no INI keys for this feature.
     static std::atomic<bool> s_active{false};
 
     // Resolved wrapper address map: source_wrapper_ptr → target_wrapper_ptr.
@@ -167,50 +112,30 @@ namespace Transmog::PrefabWrapperSwap
     static std::vector<SubstRecord> s_substLog;
     static constexpr std::size_t  k_maxSubstLog = 256;
 
-    // (Removed 2026-05-07: ResourceBinderFn / s_origBinder /
-    // s_secondarySkipCount + FactoryFn / s_origFactory + LeakedStruct
-    // tracking (s_leakedMtx, s_leakedStructs, k_maxLeakedStructs,
-    // s_factoryHitCount, s_factoryTrackCount). All of these supported
-    // the legacy helm-leak fix path that the natpipe hook on
-    // sub_142711DF0 has obsoleted.)
-
-    // (Removed 2026-05-07: EngineUnlinkFn / s_engineUnlink and
-    // SmartPtrReleaseFn / s_smartPtrRelease typedefs + statics.
-    // Their consumers -- release_orphan_via_smartptr +
-    // do_reverse_write -- were removed in the same pass; the natpipe
-    // hook on sub_142711DF0 handles cleanup without these primitives.)
-
-    // Natural-pipeline unlink (sub_142711DF0) -- RVA 0x2711DF0. Called by
-    // safeTearDown (sub_14078BB20) and other unmount paths with a list
-    // of asset wrappers to unlink from parent+88 records. The function
-    // is content-keyed: it walks parent+88 looking for records whose
+    // Natural-pipeline unlink (sub_142711DF0). Called by safeTearDown
+    // (sub_14078BB20) and other unmount paths with a list of asset
+    // wrappers to unlink from parent+88 records. The function is
+    // content-keyed: it walks parent+88 looking for records whose
     // wrapper field == one of the wrappers in the input list.
     //
-    // ROOT CAUSE OF HELM GHOST (verified live 2026-05-05):
-    //   ExpandToMeshes returns u16=0x4213 (Kliff helm name).
-    //   safeTearDown resolves 0x4213 -> wrapper 0x4104E394BE0 (engine's
-    //   StringInfo entry's +0x18 = the SECOND src instance LT tracks).
-    //   But LT's pointer-swap (sub_140352AA0) installed target wrapper
-    //   0x4104A4B7C80 in parent+88's record. Engine searches for Kliff
-    //   src, doesn't find it, no unlink, helm renderable persists.
+    // Why we hook here: when LT's struct-copy hook substitutes a Kliff
+    // source wrapper with a target wrapper in parent+88, the engine's
+    // tear-down still looks up the original Kliff wrapper at unmount
+    // time, fails to find it, and leaves the substituted record alive
+    // (visible as a ghosted helm/cloak). At natural-pipeline entry we
+    // walk the unlink list and replace each Kliff src with the
+    // corresponding target so the engine's content-keyed search hits.
+    // Originals are restored on the way out so the caller's
+    // refcount-release loop decrements the same wrappers it
+    // incremented.
     //
-    // FIX: hook this function entry, walk RDX's wrapper list, and for
-    // each entry that matches a Kliff src in s_swapMap, replace with
-    // the corresponding target. Engine then matches the target in
-    // parent+88, unlinks correctly, helm cleans up.
-    //
-    // After the call returns we RESTORE the original wrappers so the
-    // caller's refcount-release loop on the list decrements the same
-    // wrapper it incremented (no refcount imbalance).
+    // Resolved via k_naturalPipelineCandidates in aob_resolver.hpp.
     using NaturalPipelineFn = std::int64_t(__fastcall *)(
         std::int64_t a1, std::uint64_t *a2, std::uint64_t *a3);
     static NaturalPipelineFn s_origNaturalPipeline = nullptr;
     static std::atomic<std::uint64_t> s_natpipeHitCount{0};
     static std::atomic<std::uint64_t> s_natpipeSubstCount{0};
     static std::atomic<std::uint64_t> s_natpipeListEntries{0};
-    // sub_142711DF0 -- engine unlink fn. Resolved through
-    // k_naturalPipelineCandidates cascade in aob_resolver.hpp at install
-    // time (audit 2026-05-08); RVA literal removed.
 
     // sub_1424DF420 -- name-based prefab lookup primitive.
     // Signature: `__int64 fn(__int64 unused_a1, const char* name)`.
@@ -275,10 +200,7 @@ namespace Transmog::PrefabWrapperSwap
 
     static std::atomic<std::uintptr_t> s_apptContainer{0};
     static std::atomic<bool>           s_apptCaptureDone{false};
-    // s_apptResMgr / s_apptLoader / s_apptForceLoadEnabled removed
-    // 2026-05-07: only the container snapshot is consumed by
-    // lookup_prefab_metadata; ResMgr/Loader were write-only state and
-    // ForceLoad was a stub-only INI flag.
+    // Only the container snapshot is consumed by lookup_prefab_metadata.
 
     // Lookup primitives, resolved by AOB at init. Both must be
     // non-null for lookup_prefab_metadata to succeed; they are
@@ -487,13 +409,6 @@ namespace Transmog::PrefabWrapperSwap
         return rv;
     }
 
-    // (Removed 2026-05-07: aob_scan_for_container fallback +
-    // try_capture_container_via_aob wrapper. Both were a dormant
-    // fallback path for the case where the chain-based ResMgrInit
-    // hook missed; in practice the hook fires reliably and the
-    // fallback was never triggered. The full-memory writable-heap
-    // vtable scan was overkill for a path with no callers.)
-
     // --- AppearanceTableLoader public API ---
 
     bool is_loader_ready() noexcept
@@ -527,12 +442,6 @@ namespace Transmog::PrefabWrapperSwap
         }();
         return result;
     }
-
-    // (Removed 2026-05-07: force_load_prefab documented stub.
-    // The orchestration call to sub_141E237C0 was out-of-scope research
-    // work that never landed; the public-API stub returned false in all
-    // builds. Removed alongside the s_apptForceLoadEnabled INI flag and
-    // the PrefabWrapperSwap_AttemptForceLoad INI key.)
 
     // --- Per-slot catalog state (Goal B) ---
     //
@@ -573,10 +482,11 @@ namespace Transmog::PrefabWrapperSwap
         = k_initialSelectionIndices;
     static std::atomic<bool>                                   s_catalogPopulated{false};
 
-    // Slot prefix tables. The engine uses `cd_phm_*` for male body
-    // prefabs and `cd_phw_*` for female; both variants live in the
-    // same StringInfo registry and can be transmogged interchangeably.
-    // We carry parallel tables so classification matches either.
+    // Slot prefix tables come from slot_metadata.hpp's SlotMetadata
+    // table (slot_meta(slot).prefabPrefixMale / .prefabPrefixFemale).
+    // The engine uses `cd_phm_*` for male body prefabs and `cd_phw_*`
+    // for female; both variants live in the same StringInfo registry
+    // and can be transmogged interchangeably.
     //
     //   Helm   -> "cd_ph[mw]_00_hel_00_"
     //   Chest  -> "cd_ph[mw]_00_ub_00_"
@@ -584,24 +494,12 @@ namespace Transmog::PrefabWrapperSwap
     //   Gloves -> "cd_ph[mw]_00_hand_00_"
     //   Boots  -> "cd_ph[mw]_00_foot_00_"
     //
-    // `slot_prefix_str` returns the male variant (used by the UI for
-    // default name-stripping); the UI also strips the female variant
-    // when present, so cd_phw_* entries display compactly too.
-    // Body-mesh prefab prefixes per TransmogSlot. The body-mesh-swap
-    // module is armor-family ONLY; accessory/utility slots (Earring*,
-    // Necklace, Ring*, Lantern, Glasses, Mask, Backpack, Bracelet) do
-    // not live under cd_phm_*/cd_phw_* prefab families and are excluded
-    // by giving them an empty prefix. Callers (slot_prefix_str /
-    // populate_slot_catalogs / resolve_pairs_into_map) treat an empty
-    // string as "this slot is not body-mesh-swappable" -- the picker
-    // dropdown for that slot stays empty and the user routes through
-    // the normal carrier-based transmog path instead.
-    // (Removed 2026-05-07: k_slotPrefixes / k_slotPrefixesFemale.
-    // Per-slot prefab prefixes now live on slot_metadata.hpp's single
-    // SlotMetadata table -- access via slot_meta(slot).prefabPrefixMale
-    // and slot_meta(slot).prefabPrefixFemale. Same content; one source
-    // of truth for both genders alongside displayName, gameTag, and
-    // partShowHashKey.)
+    // The body-mesh-swap module is armor-family ONLY; accessory slots
+    // (Earring*, Necklace, Ring*, Lantern, Glasses, Mask, Backpack,
+    // Bracelet) do not live under cd_phm_*/cd_phw_* and are excluded
+    // by giving them an empty prefix. An empty prefix means "this slot
+    // is not body-mesh-swappable" -- the picker dropdown stays empty
+    // and the slot routes through the carrier-based transmog path.
 
     // --- Shared StringInfo walker (Phase 1 fast path) ---
     //
@@ -864,17 +762,6 @@ namespace Transmog::PrefabWrapperSwap
             if (regionSize == 0) break;
         }
     }
-
-    // (Removed 2026-05-07: resolve_pairs_into_map. The StringInfo-based
-    // resolver was the engine for the legacy [Research] INI Pair config
-    // (PrefabWrapperSwap_Pair{1..8}_Source/_Target). With INI gone,
-    // its only caller -- on_hotkey -- removed too, the function is
-    // dead. apply_selections_to_swap_map() drives swap-map construction
-    // from the picker UI now and reads pre-cached PrefabEntry::wrappers
-    // from the catalog -- no walk, no INI lookup. Body deleted; the
-    // matching helpers it inlined (decode_name, try_parse_hex_addr,
-    // longest-common-prefix probe, partprefabdyeslot heap walk) all
-    // went with it.)
 
     // --- Per-slot catalog API (Goal B) ---
 
@@ -1383,23 +1270,21 @@ namespace Transmog::PrefabWrapperSwap
                 if (s_selTgtIdx[i] >= sz) s_selTgtIdx[i] = -1;
             }
 
-            // Auto-seed of src selections from INI pairs has been
-            // MOVED below to run AFTER enumerate_loader_registry_into_
-            // catalog(). That call adds thousands of entries and re-
-            // sorts each slot's vector, which would invalidate any
-            // index seeded here.
+            // Auto-seed of source selections runs below, AFTER
+            // enumerate_loader_registry_into_catalog(). That call adds
+            // thousands of entries and re-sorts each slot's vector,
+            // which would invalidate any index seeded here.
         }
 
         // --- Heap-walk merge: cache parallel-pool wrappers per name ---
         //
         // The StringInfo walk above seeded each PrefabEntry with the
-        // entry+0x18 wrapper (pool 0x4104E*). The engine ALSO sources
+        // entry+0x18 wrapper (pool 0x4104E*). The engine also sources
         // wrappers from a parallel partprefabdyeslot pool (e.g.
-        // 0x4104A*) which is NOT in StringInfo. Previously each picker
-        // pick re-walked all writable heap regions to find these (~7s
-        // per pick). Walk ONCE here at boot for ALL cataloged names --
-        // single pass cost is the same for N names as for 1 because
-        // the dominant cost is the heap traversal itself.
+        // 0x4104A*) which is NOT in StringInfo. We walk ONCE here at
+        // boot for ALL cataloged names; the dominant cost is the heap
+        // traversal itself, so the single-pass cost for N names is
+        // close to the cost for 1.
         //
         // Pass empty tgtNames so only the src side runs; we want all
         // wrappers per name regardless of src/tgt classification (the
@@ -1523,19 +1408,12 @@ namespace Transmog::PrefabWrapperSwap
             }
         }
 
-        // (Removed 2026-05-07: INI-pair src auto-seed block. Read
-        // s_pairs[k_maxPairs] (always empty since INI keys are gone)
-        // and seeded s_selSrcIdx for matching slots. The hardcoded
-        // k_defaultSrcByEnumSlot defaults below now own the seeding.)
-
         // --- AppearanceTableLoader metadata enrichment ---
         //
         // Cross-references each catalog entry against the engine's
-        // name->wrapper registry at MEMORY[0x145DDF8B0]+0x50 via
-        // sub_1424DF420 (RVA-resolved). Cheap: no full-heap AOB scan
-        // anymore, just one direct call per name. The legacy AOB
-        // fallback for the AppearanceTableLoader container is now
-        // dormant -- the new primitive is self-contained.
+        // name->wrapper registry at MEMORY[0x145DDF8B0]+0x50 via the
+        // RVA-resolved primitive sub_1424DF420. One direct call per
+        // name; no heap scan.
 
         // For every catalog entry seeded above (StringInfo-resident),
         // ask the loader whether it knows about the same name. We
@@ -1836,9 +1714,9 @@ namespace Transmog::PrefabWrapperSwap
 
     // Reactivate using the current per-slot dropdown selections. This
     // is the auto-apply path triggered when the slot-row body combos
-    // change in the overlay -- it reproduces the F10 toggle's
-    // deactivate-then-activate cycle so the new selection becomes
-    // visible without requiring a hotkey press.
+    // change in the overlay; it runs a deactivate-then-activate cycle
+    // so the new selection becomes visible without requiring a hotkey
+    // press.
     std::size_t reactivate_with_selections() noexcept
     {
         auto &logger = DMK::Logger::get_instance();
@@ -1874,15 +1752,6 @@ namespace Transmog::PrefabWrapperSwap
             resolved);
         return resolved;
     }
-
-    // (Removed 2026-05-07: on_resource_binder + on_factory. These
-    // were the legacy helm-leak fix path -- ResourceBinder gating to
-    // skip suffix-variant secondary binds, and the factory hook to
-    // capture (struct, kliff_source) for `do_reverse_write` to undo on
-    // deactivate. The natural-pipeline hook on sub_142711DF0
-    // substitutes wrappers in the engine's unlink list at the right
-    // moment without needing either of these. Verified live
-    // 2026-05-05.)
 
     // --- Hook callback ---
 
@@ -2103,18 +1972,11 @@ namespace Transmog::PrefabWrapperSwap
 
     // --- Init / shutdown ---
 
-    // (Removed 2026-05-07: copy_to_buf utility + on_hotkey toggle
-    // path. The legacy F10 toggle was retired when activation became
-    // driven by the overlay's per-slot picker. copy_to_buf was a
-    // helper for the old INI pair-string buffers, which no longer
-    // exist.)
-
     void register_config()
     {
         // Body-mesh swap has no INI keys. The hook installs at boot;
         // source defaults are hardcoded per-character (k_kliffCarriers
-        // etc.); target selection is user-driven via the overlay
-        // picker.
+        // etc.); target selection is overlay-driven.
     }
 
     bool init()
@@ -2275,31 +2137,6 @@ namespace Transmog::PrefabWrapperSwap
             "Hook gates on Transmog::in_transmog() so real-item flow is "
             "untouched.",
             addr);
-
-        // ResourceBinder + Factory hooks REMOVED 2026-05-05.
-        //
-        // Both were part of the *old* helm-leak fix attempt:
-        //   - ResourceBinder gate skipped suffix-mismatched secondary
-        //     binds (`_d -> _c`) to prevent duplicate scene-graph entries.
-        //   - Factory hook tracked the resulting orphans so
-        //     `do_reverse_write` could force-destroy them on deactivate.
-        //
-        // The natural-pipeline hook on sub_142711DF0 (installed below)
-        // now handles the leak at the unlink layer by substituting
-        // Kliff src wrappers with target wrappers in the engine's
-        // unlink list. The engine's content-keyed search then matches
-        // and unlinks correctly via its own natural pipeline. No
-        // secondary-bind gating or orphan tracking required.
-        //
-        // Verified live 2026-05-05: clear-all + save-reload cycles run
-        // clean with these hooks disabled. See diff snapshots in
-        // docs/research/ghost-helm-snapshots/diff-2026-05-05-cold/.
-
-        // (Removed 2026-05-07: EngineUnlink + SmartPtrRelease address
-        // resolution. Both feed dead-code paths -- their consumers
-        // release_orphan_via_smartptr / do_reverse_write were removed
-        // in the same pass, and the natpipe hook on sub_142711DF0
-        // handles cleanup without them.)
 
         // Natural-pipeline unlink hook (sub_142711DF0). Substitutes
         // Kliff src wrappers with target wrappers in the input
@@ -2559,16 +2396,6 @@ namespace Transmog::PrefabWrapperSwap
         return s_targetWrappers.size();
     }
 
-    // (Removed 2026-05-07: heap_scan_for_qword + same_heap_region +
-    // release_orphan_via_smartptr + do_reverse_write. The whole
-    // dead-code chain supported the legacy helm-leak fix path
-    // (force-destroy of orphan body-mesh structs on deactivate). Once
-    // the natural-pipeline hook on sub_142711DF0 took over scene-graph
-    // cleanup, do_reverse_write was hard-coded to a tracking-list
-    // clear (k_skipReverseWrite=true) and never actually called from
-    // anywhere. Removed alongside their s_engineUnlink /
-    // s_smartPtrRelease consumers.)
-
     void notify_apply_starting(const std::uint16_t (&itemIds)[5])
     {
         // Apply-only activation lifecycle. Mirrors the carrier hybrid
@@ -2602,10 +2429,6 @@ namespace Transmog::PrefabWrapperSwap
         s_lastApplyValid = true;
     }
 
-    // (Removed 2026-05-07: reverse_write_tracked no-op stub. Was
-    // empty since 2026-05-05; call site in transmog_apply.cpp also
-    // removed.)
-
     void deactivate_for_clear()
     {
         if (!s_active.load(std::memory_order_acquire))
@@ -2613,13 +2436,13 @@ namespace Transmog::PrefabWrapperSwap
         s_active.store(false, std::memory_order_release);
 
         // Swap map and target-wrapper set are PRESERVED across
-        // deactivate cycles -- F10 re-activate is instant (no heap
+        // deactivate cycles so re-activation is instant (no heap
         // walk). Clear only on shutdown or explicit re-resolve. The
         // active flag alone gates substitution; preserved map is fine.
         //
-        // Engine cleanup is now driven by the natural-pipeline hook on
-        // sub_142711DF0, which substitutes src -> tgt
-        // wrappers in the engine's unlink list at hook entry. No
+        // Engine cleanup is driven by the natural-pipeline hook on
+        // sub_142711DF0, which substitutes src -> tgt wrappers in the
+        // engine's unlink list at hook entry. No
         // explicit reverse-write, force-destroy, or smart-ptr-release
         // is performed here.
         DMK::Logger::get_instance().info(

--- a/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.hpp
+++ b/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.hpp
@@ -55,10 +55,6 @@ namespace Transmog::PrefabWrapperSwap
     /// carrier's mesh). Idempotent.
     void deactivate_for_clear();
 
-    // (Removed 2026-05-07: reverse_write_tracked declaration. The
-    // function was a no-op stub since 2026-05-05 because the
-    // natural-pipeline hook on sub_142711DF0 handles cleanup.)
-
     /// Notify the module of an upcoming apply's slot itemIds. If swap
     /// is active AND the previous apply's recorded itemIds differ from
     /// these, treat this as a preset-switch and `deactivate_for_clear`
@@ -146,11 +142,6 @@ namespace Transmog::PrefabWrapperSwap
     /// snapshots of partPrefabContainer.
     [[nodiscard]] bool is_loader_ready() noexcept;
 
-    // (Removed 2026-05-07: force_load_prefab declaration. Was a
-    // documented stub gated on PrefabWrapperSwap_AttemptForceLoad
-    // INI; the orchestration call is out-of-scope and the stub
-    // always returned false.)
-
     /// Idempotent. Walks StringInfo with prefix "cd_phm_00_" once and
     /// classifies entries into per-slot vectors (sorted by name).
     /// Returns total entries cataloged. Does NOT mutate s_swapMap or
@@ -199,10 +190,9 @@ namespace Transmog::PrefabWrapperSwap
         Transmog::TransmogSlot fromSlot,
         int fromIdx) noexcept;
 
-    /// Rebuilds s_swapMap from current per-slot selections. Replaces
-    /// the legacy pair-config-driven resolve when called. Reads ALL
-    /// pre-cached wrapper instances per name from the catalog (the
-    /// boot-time heap walk merges parallel pool allocations into
+    /// Rebuilds s_swapMap from the current per-slot selections. Reads
+    /// every pre-cached wrapper instance per name from the catalog
+    /// (the boot-time heap walk merges parallel pool allocations into
     /// PrefabEntry::wrappers); no I/O or heap walk on this hot path.
     /// Returns the count of slot pairs successfully bound. Safe to
     /// call when inactive -- this only resolves; it does NOT toggle
@@ -210,8 +200,6 @@ namespace Transmog::PrefabWrapperSwap
     std::size_t apply_selections_to_swap_map() noexcept;
 
     /// True if at least one slot has BOTH a src AND tgt selection set.
-    /// Activation handlers should prefer apply_selections_to_swap_map
-    /// over resolve_pairs_into_map when this is true.
     [[nodiscard]] bool has_any_selection() noexcept;
 
     /// Reactivate using the current per-slot dropdown selections. If

--- a/CrimsonDesertLiveTransmog/src/slot_metadata.hpp
+++ b/CrimsonDesertLiveTransmog/src/slot_metadata.hpp
@@ -89,16 +89,16 @@ namespace Transmog
         { TransmogSlot::Mask,          0x12, "Mask",          "cd_phm_00_mask_00_",     "cd_phw_00_mask_00_",    nullptr        , true  },
         { TransmogSlot::Backpack,      0x13, "Backpack",      "cd_phm_00_bag_0",        "cd_phw_00_bag_0",       nullptr        , true  },
         // Bracelet uses cd_phw_*_rinkband_ on BOTH genders (phw natively,
-        // even for male characters -- engine quirk verified live).
-        // DISABLED: multi-prefab non-armor slot.
+        // even for male characters -- engine quirk verified live). Marked
+        // disabled (`enabled=false`) because it is a multi-prefab,
+        // non-armor slot the current pipeline does not handle.
         { TransmogSlot::Bracelet,      0x14, "Bracelet",      "cd_phw_00_rinkband_",    "cd_phw_00_rinkband_",   nullptr        , false },
-        // -- DISABLED (weapon family): every weapon slot below emits
-        //    multiple prefabs per item (mesh + scabbard + FX + binds),
-        //    and MainHand/OffHand additionally share tag space when
-        //    dual-wielding. Need a separate cd_phw_* weapon pipeline
-        //    + sub-index disambiguation in SlotPopulator before re-
-        //    enabling. Tracked in memory file `engine_slot_taxonomy_
-        //    2026-05-07` Tier 3.
+        // Weapon family slots below are marked disabled (`enabled=false`):
+        // every weapon slot emits multiple prefabs per item (mesh +
+        // scabbard + FX + binds), and MainHand/OffHand share tag space
+        // when dual-wielding. A separate cd_phw_* weapon pipeline plus
+        // sub-index disambiguation in SlotPopulator is required before
+        // re-enabling them.
         { TransmogSlot::MainHand,     0x00, "MainHand",     "cd_phm_01_",             "cd_phw_01_",            nullptr        , false },
         { TransmogSlot::OffHand,      0x01, "OffHand",      "cd_phm_01_",             "cd_phw_01_",            nullptr        , false },
         { TransmogSlot::Ranged,        0x02, "Ranged",        "cd_phm_04_",             "cd_phw_04_",            nullptr        , false },

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -480,10 +480,6 @@ namespace Transmog
     //     apply_transmog_with_carrier.
     //   - State: only updates lastIds, carrier, suppress for this slot.
 
-    // (Removed 2026-05-07: k_gameSlotTags array. Use
-    // slot_meta(slot).gameTag from slot_metadata.hpp instead -- single
-    // source of truth for per-slot gameTag mappings.)
-
     void apply_single_slot_transmog(__int64 a1, std::size_t slotIdx)
     {
         if (slotIdx >= k_slotCount)
@@ -782,13 +778,6 @@ namespace Transmog
 
         logger.trace("[dispatch] apply_all_transmog entry a1={:#018x}",
                      static_cast<uint64_t>(a1));
-
-        // (Removed 2026-05-07: legacy PrefabWrapperSwap::
-        // reverse_write_tracked() call. The function was a no-op
-        // since 2026-05-05 because the natural-pipeline hook on
-        // sub_142711DF0 handles cleanup by substituting wrapper
-        // pointers in the engine's unlink list -- no staging revert
-        // is needed.)
 
         // Body has rotated past the stale one (or no swap was in
         // flight) -- this apply will run against the live body, so

--- a/CrimsonDesertLiveTransmog/src/transmog_hooks.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_hooks.cpp
@@ -17,23 +17,22 @@ namespace Transmog
 
     bool is_player_actor(__int64 a1) noexcept
     {
-        // Originally this checked `*(typeEntry+1) == 1` (role byte).
-        // CE probing on 1.03.01 showed the byte is character-specific
-        // (Kliff=1, Damiane=4, Oongka=?), not a clean player/NPC flag,
-        // so the equality check silently rejected every companion.
+        // The role byte at typeEntry+1 is character-specific
+        // (Kliff=1, Damiane=4, Oongka unique), not a clean player/NPC
+        // flag, so an equality check would silently reject companions.
         //
-        // New filter: pointer chain is readable AND typeEntry+8 is a
-        // non-null pointer. For every party member we sampled, this
+        // Filter used here: pointer chain is readable AND typeEntry+8
+        // is a non-null pointer. For every party member sampled, this
         // value is the same ActorManager pointer; for unrelated NPCs
         // the pointer differs or the chain faults. Good enough for
-        // the transmog hooks -- misclassification just produces a
-        // harmless no-op apply (no presets exist for unknown chars).
+        // the transmog hooks -- misclassification produces a harmless
+        // no-op apply (no presets exist for unknown chars).
         //
         // DMK::Memory::read_ptr_unsafe is SEH-protected on MSVC and
         // VirtualQuery-guarded on MinGW; on fault it returns 0, which
         // the < 0x10000 guard rejects. This avoids the SEH-vs-C++-
-        // destructors restriction that previously forced this whole
-        // chain into a single __try frame.
+        // destructors restriction that would otherwise require this
+        // whole chain to live inside a single __try frame.
         if (a1 < 0x10000)
             return false;
 


### PR DESCRIPTION
## Summary

- Removes inert markers, dated removal-comments, and dead-code residue left over from the body-mesh investigation cycle. Only the shipped `sub_142711DF0` natural-pipeline hook remains as the body-mesh cleanup path.
- Tightens comment hygiene across the mod: keeps technical "why" notes that aid future readers, drops narrative filler that was only meaningful during investigation.
- Renames the inner prefab-list virtualization variable to `prefabRowH` to eliminate the C4456 shadow warning at `overlay_ui.inl:792`. Build is now warning-free.
- Updates `docs/NEXT_CHANGELOG.md` with a user-facing cleanup entry.
