### PR TITLE
fix(live-transmog): standalone overlay UI sizing and click input

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,3 +1,6 @@
 ## Dye picker
 
 - New per-slot dye picker recolors transmog armor in real time, independent of the dye on your real items.
+- Fixed mouse clicks being ignored in the standalone overlay on some setups (hover already worked; clicks now follow it).
+- Standalone overlay UI tightened up: bigger color swatches, button labels no longer get clipped, and the dye popup laid out so nothing runs off the edge.
+- Fresh slots now highlight the "Default" material and show 100% repair, matching the engine's natural state.

--- a/CrimsonDesertLiveTransmog/src/dx_overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/dx_overlay.cpp
@@ -408,6 +408,42 @@ namespace Transmog
             vp.MaxDepth = 1.0f;
             s_context->RSSetViewports(1, &vp);
 
+            // Bridge mouse-button state via polling.
+            //
+            // The game uses SetCapture / RawInput so WM_LBUTTONDOWN
+            // and WM_LBUTTONUP route to the game window even when the
+            // cursor is over our overlay. ImGui_ImplWin32 polls cursor
+            // position via GetCursorPos as a fallback (so hover and
+            // tooltips keep working without the messages), but it does
+            // NOT poll button state -- buttons rely on the wndproc
+            // messages we never see. Without this bridge, io.MouseDown
+            // is stuck at false and every click is ignored.
+            //
+            // We only report "down" while the cursor is over the
+            // overlay window rect; outside the rect we report "up" so
+            // a click on the game itself never fires a spurious widget
+            // event on whatever widget happened to be under the
+            // ImGui-tracked cursor coordinate.
+            {
+                ImGuiIO &io = ImGui::GetIO();
+                POINT pt;
+                GetCursorPos(&pt);
+                RECT wr;
+                GetWindowRect(s_overlayHwnd, &wr);
+                const bool overOverlay =
+                    pt.x >= wr.left && pt.x < wr.right &&
+                    pt.y >= wr.top  && pt.y < wr.bottom;
+                const bool lDown = overOverlay &&
+                    (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+                const bool rDown = overOverlay &&
+                    (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
+                const bool mDown = overOverlay &&
+                    (GetAsyncKeyState(VK_MBUTTON) & 0x8000) != 0;
+                io.AddMouseButtonEvent(0, lDown);
+                io.AddMouseButtonEvent(1, rDown);
+                io.AddMouseButtonEvent(2, mDown);
+            }
+
             ImGui_ImplDX11_NewFrame();
             ImGui_ImplWin32_NewFrame();
             ImGui::NewFrame();

--- a/CrimsonDesertLiveTransmog/src/dye_record_inject.hpp
+++ b/CrimsonDesertLiveTransmog/src/dye_record_inject.hpp
@@ -47,7 +47,10 @@ namespace Transmog::DyeRecordInject
     ///   +8       g
     ///   +9       b
     ///   +10      0xFF
-    ///   +11      repair_byte     (0xFF=pristine, 0x7F=max wear)
+    ///   +11      repair_byte     (0=pristine, 0x7F=max wear; the
+    ///                            engine still accepts 0xFF as a
+    ///                            legacy "no override" sentinel and
+    ///                            renders it as pristine)
     ///   +13      0x04 for indices 0 and 3 (mirrors natural records)
     struct ChannelState
     {
@@ -82,14 +85,4 @@ namespace Transmog::DyeRecordInject
     /// Clear the published state. Call after the apply path
     /// completes so subsequent natural equip events go un-modified.
     void clear_slot_dye_state() noexcept;
-
-    /// Convert repair percent (0..100) to the engine's wear byte
-    /// (0..127). Calibration verified 2026-04-30: forward-truncated
-    /// linear map; 100% maps to 0x00 (sentinel "no wear override").
-    constexpr std::uint8_t pct_to_repair_byte(int pct) noexcept
-    {
-        if (pct >= 100) return 0;
-        if (pct <= 0)   return 127;
-        return static_cast<std::uint8_t>(((100 - pct) * 127) / 100);
-    }
 }

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -2085,13 +2085,12 @@ static void draw_overlay_content()
                         }
                 }
 
-                // Dye button: always plain "Dye" with fixed width
-                // and no background color override -- keeps text
-                // legible and rows aligned regardless of dye state.
-                // Active state is signalled by a small color-swatch
-                // chip rendered next to the button.
-                const bool dyeBtn = ImGui::Button(
-                    "Dye##dyeBtn", ImVec2(40.0f, 0.0f));
+                // Dye button: always plain "Dye" with no background
+                // color override -- keeps text legible regardless of
+                // dye state. Active state is signalled by a small
+                // color-swatch chip rendered next to the button.
+                // Auto-sized so the label fits at any font scale.
+                const bool dyeBtn = ImGui::Button("Dye##dyeBtn");
 
                 if (firstActiveCh)
                 {
@@ -2102,8 +2101,11 @@ static void draw_overlay_content()
                     ImGui::PushStyleColor(ImGuiCol_Button, sw);
                     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, sw);
                     ImGui::PushStyleColor(ImGuiCol_ButtonActive, sw);
+                    // Match the Dye button's height so the chip sits
+                    // on the row baseline at any font scale.
+                    const float chip_size = ImGui::GetFrameHeight();
                     if (ImGui::Button("##dyeSw",
-                                      ImVec2(20.0f, 20.0f)))
+                                      ImVec2(chip_size, chip_size)))
                     {
                         ImGui::OpenPopup("##dye_picker");
                     }
@@ -2234,7 +2236,7 @@ static void draw_overlay_content()
                         std::snprintf(gid, sizeof(gid),
                                       "##g%zu", g);
                         if (ImGui::Button(gid,
-                                          ImVec2(28.0f, 22.0f)))
+                                          ImVec2(32.0f, 28.0f)))
                         {
                             // string_key is the source-of-truth; hash
                             // is derived. If the group is missing
@@ -2280,7 +2282,7 @@ static void draw_overlay_content()
                                 std::snprintf(nlabel, sizeof(nlabel),
                                               "##n%u", s);
                                 if (ImGui::Button(nlabel,
-                                                  ImVec2(20.0f, 20.0f)))
+                                                  ImVec2(28.0f, 28.0f)))
                                 {
                                     ch.r = (bgra >> 16) & 0xFF;
                                     ch.g = (bgra >> 8) & 0xFF;
@@ -2322,7 +2324,7 @@ static void draw_overlay_content()
                                 std::snprintf(slabel, sizeof(slabel),
                                               "##s%u", s);
                                 if (ImGui::Button(slabel,
-                                                  ImVec2(20.0f, 20.0f)))
+                                                  ImVec2(28.0f, 28.0f)))
                                 {
                                     ch.r = (bgra >> 16) & 0xFF;
                                     ch.g = (bgra >> 8) & 0xFF;
@@ -2351,14 +2353,18 @@ static void draw_overlay_content()
                         ui_text_disabled("(pick a group above)");
                     }
 
-                    // Repair-level slider (offset +11 of dye record).
-                    int repairPct = 100 - (ch.repair_byte == 0xFF
-                        ? 0
-                        : ((ch.repair_byte * 100 + 63) / 127));
-                    if (ch.repair_byte == 0xFF) repairPct = 100;
+                    // Repair slider (offset +11 of dye record).
+                    // The engine stores wear as a 0..127 byte; 0 means
+                    // pristine, 127 means max wear. We surface the
+                    // inverse as "Repair %" so 100 = pristine and 0 =
+                    // max wear, matching the conventional reading.
+                    // 0xFF is the legacy "no override" sentinel and is
+                    // treated as 100% on read for old presets.
+                    int repairPct = (ch.repair_byte == 0xFF)
+                        ? 100
+                        : 100 - ((ch.repair_byte * 100 + 63) / 127);
                     ImGui::SetNextItemWidth(200.0f);
-                    if (ImGui::SliderInt("Repair %", &repairPct,
-                                         0, 100))
+                    if (ImGui::SliderInt("Repair %", &repairPct, 0, 100))
                     {
                         if (repairPct >= 100) ch.repair_byte = 0;
                         else if (repairPct <= 0) ch.repair_byte = 127;
@@ -2381,6 +2387,13 @@ static void draw_overlay_content()
                     namespace MPT =
                         Transmog::MaterialPaletteTable;
                     ui_text("Material template:");
+                    // Width sized to the widest two-digit label so the
+                    // "10" button is not cut off; all rows align at the
+                    // same width regardless of single- vs two-digit.
+                    const float mat_btn_w =
+                        ImGui::CalcTextSize("10").x
+                        + ImGui::GetStyle().FramePadding.x * 2.0f
+                        + 8.0f;
                     for (std::uint16_t v = 1; v <= 10; ++v)
                     {
                         if (v != 1) ImGui::SameLine();
@@ -2393,7 +2406,7 @@ static void draw_overlay_content()
                         std::snprintf(mlabel, sizeof(mlabel),
                                       "%u##m%u", v, v);
                         if (ImGui::Button(mlabel,
-                                          ImVec2(28.0f, 0.0f)))
+                                          ImVec2(mat_btn_w, 0.0f)))
                         {
                             ch.material_id = v;
                             reapply_now();
@@ -2450,8 +2463,10 @@ static void draw_overlay_content()
                         if (selected)
                             ImGui::PushStyleColor(ImGuiCol_Button,
                                 ImVec4(0.3f, 0.6f, 0.9f, 1.0f));
-                        if (ImGui::Button("Default##mFFFF",
-                                          ImVec2(56.0f, 0.0f)))
+                        // Auto-sized so the label always fits regardless
+                        // of overlay font scale; prior fixed widths
+                        // truncated the text on chunky bitmap fonts.
+                        if (ImGui::Button("Default##mFFFF"))
                         {
                             ch.material_id = 0xFFFF;
                             reapply_now();
@@ -2463,9 +2478,14 @@ static void draw_overlay_content()
                                 "0xFFFF -- engine picks the "
                                 "natural variant for this channel.");
                     }
+                    // Render the label on the left so the trailing
+                    // ImGui auto-label does not clip on the popup's
+                    // right edge in the standalone overlay.
                     int rawMat = static_cast<int>(ch.material_id);
-                    ImGui::SetNextItemWidth(160.0f);
-                    if (ImGui::InputInt("raw u16##matRaw",
+                    ui_text("Raw u16:");
+                    ImGui::SameLine();
+                    ImGui::SetNextItemWidth(140.0f);
+                    if (ImGui::InputInt("##matRaw",
                                         &rawMat, 1, 16,
                                         ImGuiInputTextFlags_CharsHexadecimal
                                         | ImGuiInputTextFlags_EnterReturnsTrue))
@@ -2523,7 +2543,11 @@ static void draw_overlay_content()
                             ImGui::PushID(static_cast<int>(k) + 5000);
 
                             // Header: chevron + "Mod K" + swatch +
-                            // summary.
+                            // summary. Width is computed from the
+                            // widest label ("v Mod 15") so all rows
+                            // align in a column regardless of font
+                            // scale; auto-size would let single-digit
+                            // rows shrink and break the column.
                             const bool expanded =
                                 s_expandedMod[i] ==
                                 static_cast<int>(k);
@@ -2531,15 +2555,25 @@ static void draw_overlay_content()
                             std::snprintf(hdr, sizeof(hdr),
                                           "%s Mod %2zu",
                                           expanded ? "v" : ">", k);
+                            const float row_btn_w =
+                                ImGui::CalcTextSize("v Mod 15").x
+                                + ImGui::GetStyle().FramePadding.x * 2.0f
+                                + 8.0f;
                             if (ImGui::Button(hdr,
-                                              ImVec2(110.0f, 0.0f)))
+                                              ImVec2(row_btn_w, 0.0f)))
                             {
                                 s_expandedMod[i] = expanded
                                     ? -1
                                     : static_cast<int>(k);
                             }
 
-                            // Color swatch (small).
+                            // Color swatch. Sized to the row button's
+                            // height so the two widgets sit on the
+                            // same baseline regardless of font scale,
+                            // and made clickable so the swatch acts
+                            // as a second hit target for expanding
+                            // the row (small fixed sizes were hard to
+                            // hit in the standalone overlay).
                             ImGui::SameLine();
                             ImVec4 sw = ch.active()
                                 ? ImVec4(ch.r / 255.0f,
@@ -2549,7 +2583,16 @@ static void draw_overlay_content()
                             ImGui::PushStyleColor(ImGuiCol_Button, sw);
                             ImGui::PushStyleColor(
                                 ImGuiCol_ButtonHovered, sw);
-                            ImGui::Button("##sw", ImVec2(20.0f, 20.0f));
+                            const float sw_size =
+                                ImGui::GetFrameHeight();
+                            if (ImGui::Button(
+                                    "##sw",
+                                    ImVec2(sw_size, sw_size)))
+                            {
+                                s_expandedMod[i] = expanded
+                                    ? -1
+                                    : static_cast<int>(k);
+                            }
                             ImGui::PopStyleColor(2);
 
                             // Summary text.

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -75,9 +75,9 @@ namespace Transmog
                     {"g",          ch.g},
                     {"b",          ch.b},
                 };
-                if (ch.material_id != 0x0001)
+                if (ch.material_id != 0xFFFF)
                     m["material"] = ch.material_id;
-                if (ch.repair_byte != 0xFF)
+                if (ch.repair_byte != 0)
                     m["repair"] = ch.repair_byte;
                 mods.push_back(std::move(m));
             }
@@ -108,8 +108,8 @@ namespace Transmog
                 ch.g = m.value("g", std::uint8_t{0});
                 ch.b = m.value("b", std::uint8_t{0});
                 ch.material_id =
-                    m.value("material", std::uint16_t{0x0001});
-                ch.repair_byte = m.value("repair", std::uint8_t{0xFF});
+                    m.value("material", std::uint16_t{0xFFFF});
+                ch.repair_byte = m.value("repair", std::uint8_t{0});
                 resolve_dye_group(ch); // populates ch.group_hash
             }
         }

--- a/CrimsonDesertLiveTransmog/src/preset_manager.hpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.hpp
@@ -16,15 +16,21 @@ namespace Transmog
     /// to the user; channels above the item's natural count are no-ops.
     inline constexpr std::size_t k_dyeChannelCount = 16;
 
-    /// Per-channel dye override (cracked 2026-05-10 PM):
+    /// Per-channel dye override:
     ///   group_hash = 0  -> no override for this channel
     ///   else            -> inject ARMOR_MOD record with R/G/B at +7/+8/+9
-    /// `repair_byte = 0xFF` is the no-override sentinel.
     /// `material_id` is the dye-template index (1..10) written at
-    /// +4..+5 of the dye record. 0xFFFF = engine default. The engine
-    /// resolves (item, channel) -> cat_code, then looks up the
+    /// +4..+5 of the dye record. 0xFFFF = engine default (the engine
+    /// picks the natural variant for the item/channel combo). The
+    /// engine resolves (item, channel) -> cat_code, then looks up the
     /// template's variant for that cat_code (per
     /// partprefabdyetexturepalleteinfo.pabgb).
+    /// `repair_byte` follows the engine's wear formula
+    /// (`byte = ((100-pct)*127)/100`); 0 = pristine, 127 = max wear.
+    /// The engine still treats the legacy 0xFF as pristine, so old
+    /// presets that recorded 0xFF round-trip cleanly: the slider
+    /// reads 0xFF as 100% repair on load, and a fresh slot saves the
+    /// new 0 default instead.
     /// `group_name` is the data-file `_stringKey` that maps to
     /// `group_hash` (e.g. "Her_Color_Group_I"). Persisted alongside
     /// the hash so we can recover the right group across game updates
@@ -35,8 +41,8 @@ namespace Transmog
         std::uint8_t  r = 0;
         std::uint8_t  g = 0;
         std::uint8_t  b = 0;
-        std::uint16_t material_id = 0x0001;
-        std::uint8_t  repair_byte = 0xFF;
+        std::uint16_t material_id = 0xFFFF;
+        std::uint8_t  repair_byte = 0;
         std::string   group_name; // empty = no fallback anchor
 
         bool active() const noexcept { return group_hash != 0; }


### PR DESCRIPTION
## Summary

- Fixes mouse clicks being ignored in the standalone overlay on setups where the game's `SetCapture` / RawInput routes `WM_LBUTTONDOWN` to the game window. Polls `GetAsyncKeyState` each frame, gated on cursor-over-overlay, and pushes via `io.AddMouseButtonEvent`.
- Resizes overlay widgets to be font-aware so the standalone overlay's chunky bitmap font no longer clips labels: material "Default" / "10" buttons, mod-row headers, the "Dye" button, and the raw u16 input all use `CalcTextSize` or auto-size.
- Bigger, click-aligned swatches: row preview chips and the slot-list "Dye" chip now use `ImGui::GetFrameHeight()`; group buttons 32x28, hue/neutral grid 28x28.
- Rotates `ChannelDye` defaults so a fresh slot reads as "engine default" everywhere: `material_id` 0x0001 -> 0xFFFF, `repair_byte` 0xFF -> 0. JSON read/write defaults updated; legacy 0xFF presets still round-trip cleanly.