### PR TITLE
feat(live-transmog): cross-character preset editing with Unpin

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Title for next release]
+## Cross-character preset editing
 
-- New feature
-- Bug fix
-- Improvement
+- You can now pick a different character in the Character dropdown to edit (and wear) their preset on whoever you are currently controlling, with an Unpin button to snap back to following the controlled character.

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -434,8 +434,13 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
     BK charBody;
     {
         const auto &pm = Transmog::PresetManager::instance();
+        // The picker filter follows the editing character: the user
+        // is populating that character's preset and wants to see
+        // items from that body's catalog. Falls back to the
+        // controlled character automatically when editing is
+        // unpinned because the two axes are identical in that state.
         const std::string ov =
-            pm.body_kind_of(pm.active_character());
+            pm.body_kind_of(pm.editing_character());
         if (ov == "Male")
             charBody = BK::Male;
         else if (ov == "Female")
@@ -445,7 +450,7 @@ static bool name_contains_ci(const std::string &hay, const char *needle) noexcep
         else // "Auto" or unrecognised
             charBody =
                 Transmog::ItemNameTable::body_kind_for_character(
-                    pm.active_character());
+                    pm.editing_character());
     }
 
     // Two-pass filter+draw. Pass 1 collects matching catalog indices;
@@ -1264,30 +1269,28 @@ static void draw_overlay_content()
             for (std::size_t i = 0; i < n; ++i)
             {
                 cstrs[i] = names[i].c_str();
-                if (names[i] == pm.active_character())
+                if (names[i] == pm.editing_character())
                     selectedIdx = static_cast<int>(i);
             }
 
-            // Character picker is READ-ONLY for now. Load-detect writes
-            // active_character on every char-swap (ActorManager+0x30
-            // byte) so manual picks get snapped back instantly. The
-            // fix is to split active_character into controlled (game-
-            // driven) and editing (UI-driven) states plus per-char
-            // actor enumeration from user+0xD0..+0x108 -- see memory
-            // note `project_per_companion_edit_deferred`. Until then
-            // the combo just shows which character load-detect
-            // currently thinks is controlled.
+            // Dropdown writes the editing character only. The pin
+            // engages automatically when editing differs from
+            // controlled; picking the controlled character clears
+            // the pin. Apply is cross-body when pinned: the
+            // controlled body wears the editing character's preset
+            // items via PWS / carrier substitution. Gendered or
+            // character-specific items may not have a renderable
+            // variant on the controlled body and silently no-op.
             ImGui::SetNextItemWidth(200.0f);
-            ImGui::BeginDisabled(true);
             if (ImGui::Combo("Character##char_picker",
                              &selectedIdx,
                              cstrs,
                              static_cast<int>(n)))
             {
                 const auto &pick = names[static_cast<std::size_t>(selectedIdx)];
-                if (pick != pm.active_character())
+                if (pick != pm.editing_character())
                 {
-                    pm.set_active_character(pick);
+                    pm.set_editing_character(pick);
                     for (auto &m : slot_mappings())
                     {
                         m.active = false;
@@ -1302,12 +1305,45 @@ static void draw_overlay_content()
                     pm.save();
                 }
             }
-            ImGui::EndDisabled();
             if (ImGui::IsItemHovered())
-                ui_tooltip("Read-only for now -- follows the character you "
-                           "control in-game. Editing another character's "
-                           "preset while controlling someone else is "
-                           "planned (see per-companion-edit memory note).");
+            {
+                if (pm.editing_pinned())
+                    ui_tooltip("Editing pinned: this character's preset is "
+                               "loaded into the slot rows, but the body on "
+                               "screen is whoever you control in-game. "
+                               "Cross-body apply -- some items (gender-"
+                               "specific, weapons) may not render. Pick "
+                               "the controlled character to unpin.");
+                else
+                    ui_tooltip("Pick a different character to edit their "
+                               "preset while controlling someone else. "
+                               "The controlled body will wear the picked "
+                               "character's preset items (cross-body "
+                               "apply -- partial coverage expected).");
+            }
+            if (pm.editing_pinned())
+            {
+                ImGui::SameLine();
+                if (ImGui::SmallButton("Unpin##char_unpin"))
+                {
+                    pm.clear_editing_pin();
+                    for (auto &m : slot_mappings())
+                    {
+                        m.active = false;
+                        m.targetItemId = 0;
+                    }
+                    pm.apply_to_state();
+                    last_applied_ids().fill(0);
+                    real_damaged().fill(false);
+                    last_applied_real_ids().fill(0);
+                    last_applied_carrier_ids().fill(0);
+                    manual_apply();
+                    pm.save();
+                }
+                if (ImGui::IsItemHovered())
+                    ui_tooltip("Drop the editing pin and follow the "
+                               "controlled character again.");
+            }
 
             // Body-kind override. Lets body-swap mod users mark e.g.
             // Kliff as Female so the picker shows the female-body-
@@ -1323,7 +1359,7 @@ static void draw_overlay_content()
                 static_cast<int>(sizeof(k_bodyItems) / sizeof(k_bodyItems[0]));
 
             const std::string currentBody =
-                pm.body_kind_of(pm.active_character());
+                pm.body_kind_of(pm.editing_character());
             int bodyIdx = 0;
             for (int i = 0; i < k_bodyCount; ++i)
             {
@@ -1340,7 +1376,7 @@ static void draw_overlay_content()
                              k_bodyItems,
                              k_bodyCount))
             {
-                pm.set_body_kind_of(pm.active_character(),
+                pm.set_body_kind_of(pm.editing_character(),
                                     k_bodyItems[bodyIdx]);
             }
             if (ImGui::IsItemHovered())

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -303,11 +303,12 @@ namespace Transmog
         {
             json root = json::parse(file);
 
-            // `activeCharacter` JSON field is no longer used -- the
-            // runtime active character is driven by the live WS
-            // chain via the char-swap detector. Kept here only to
-            // silently tolerate old presets.json files that still
-            // carry it; the value is discarded.
+            // `activeCharacter` was a legacy JSON field; the
+            // controlled character is now driven entirely by the
+            // live WS chain via the char-swap detector and the
+            // editing character is session-only. Old presets.json
+            // files may still carry the field, so it is read and
+            // discarded here to avoid a "missing key" parse error.
             (void)root.value("activeCharacter", std::string{});
 
             if (root.contains("characters") && root["characters"].is_object())
@@ -361,9 +362,10 @@ namespace Transmog
         // Schema v3: slots carry only itemName (stable identifier).
         // itemId is resolved at runtime from the item catalog.
         root["version"] = 3;
-        // `activeCharacter` is intentionally NOT written -- the live
-        // controlled character drives apply at runtime, so the field
-        // would just be a stale last-viewed-UI hint.
+        // Neither the controlled character nor the editing character
+        // are serialised. Controlled is driven by the live WS chain
+        // at runtime; editing is a session-only UI affordance that
+        // resets to controlled on load.
 
         json chars = json::object();
         for (auto &[name, cp] : m_characters)
@@ -400,13 +402,83 @@ namespace Transmog
 
     const std::string &PresetManager::active_character() const
     {
-        return m_activeCharacter;
+        return m_controlledCharacter;
     }
 
     void PresetManager::set_active_character(const std::string &name)
     {
-        m_activeCharacter = name;
+        m_controlledCharacter = name;
         ensure_character(name);
+        if (!m_editingPinned)
+        {
+            // Editing follows controlled whenever the user has not
+            // explicitly pinned a different editing target. The dye
+            // snapshot is rotated here so unsaved dye edits on the
+            // outgoing character do not bleed into the incoming
+            // character's preset.
+            if (name != m_editingCharacter)
+            {
+                revert_active_dye_to_snapshot();
+                m_editingCharacter = name;
+                capture_dye_snapshot();
+            }
+        }
+        else if (name == m_editingCharacter)
+        {
+            // The player is now controlling the very character the
+            // user had pinned for editing. The pin no longer
+            // represents anything distinct, so it auto-clears.
+            m_editingPinned = false;
+        }
+    }
+
+    const std::string &PresetManager::editing_character() const
+    {
+        return m_editingCharacter;
+    }
+
+    void PresetManager::set_editing_character(const std::string &name)
+    {
+        if (name == m_editingCharacter)
+        {
+            // No-op switch: keep the pin state consistent against
+            // controlled and return without touching the snapshot.
+            m_editingPinned = (name != m_controlledCharacter);
+            ensure_character(name);
+            return;
+        }
+
+        // Switching the editing character is a larger context shift
+        // than cycling presets: drop any unsaved dye edits on the
+        // outgoing preset and capture a fresh baseline snapshot for
+        // the incoming preset. Mirrors set_active_preset().
+        revert_active_dye_to_snapshot();
+        m_editingCharacter = name;
+        ensure_character(name);
+        // Pin engages when the user picked anyone other than the
+        // controlled character; picking the controlled character is
+        // the unpin gesture from the dropdown.
+        m_editingPinned = (name != m_controlledCharacter);
+        capture_dye_snapshot();
+    }
+
+    bool PresetManager::editing_pinned() const noexcept
+    {
+        return m_editingPinned;
+    }
+
+    void PresetManager::clear_editing_pin()
+    {
+        if (m_editingCharacter != m_controlledCharacter)
+        {
+            // Drop unsaved dye edits on the outgoing preset and
+            // capture a fresh baseline for the controlled character's
+            // active preset.
+            revert_active_dye_to_snapshot();
+            m_editingCharacter = m_controlledCharacter;
+            capture_dye_snapshot();
+        }
+        m_editingPinned = false;
     }
 
     std::string PresetManager::body_kind_of(const std::string &charName) const
@@ -441,7 +513,7 @@ namespace Transmog
 
     int PresetManager::active_preset_index() const
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end())
             return 0;
         return it->second.activePreset;
@@ -449,7 +521,7 @@ namespace Transmog
 
     int PresetManager::preset_count() const
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end())
             return 0;
         return static_cast<int>(it->second.presets.size());
@@ -457,7 +529,7 @@ namespace Transmog
 
     const Preset *PresetManager::active_preset() const
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end() || it->second.presets.empty())
             return nullptr;
 
@@ -469,12 +541,12 @@ namespace Transmog
     const Preset *PresetManager::active_preset_of(
         const std::string &charName) const
     {
-        // Read-only sibling of active_preset() that targets an arbitrary
-        // character. Used by the body-mesh prefab picker to borrow the
-        // Kairos (default-carrier) preset's itemIds while leaving the
-        // manager's active_character untouched -- mutating active_character
-        // here would side-trigger load-detect / radial-swap state and
-        // cascade into a save.
+        // Read-only sibling of active_preset() that targets an
+        // arbitrary character. Used by the body-mesh prefab picker
+        // to borrow the Kairos (default-carrier) preset's itemIds
+        // without disturbing the controlled or editing axes -- any
+        // mutation of either field would cascade into a save and
+        // could race with the load-detect commit branch.
         auto it = m_characters.find(charName);
         if (it == m_characters.end() || it->second.presets.empty())
             return nullptr;
@@ -486,7 +558,7 @@ namespace Transmog
 
     Preset *PresetManager::active_preset_mut()
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end() || it->second.presets.empty())
             return nullptr;
 
@@ -498,7 +570,7 @@ namespace Transmog
     const std::vector<Preset> &PresetManager::presets() const
     {
         static const std::vector<Preset> s_empty;
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end())
             return s_empty;
         return it->second.presets;
@@ -506,7 +578,7 @@ namespace Transmog
 
     void PresetManager::append_from_state()
     {
-        auto &cp = ensure_character(m_activeCharacter);
+        auto &cp = ensure_character(m_editingCharacter);
         int idx = static_cast<int>(cp.presets.size());
         std::string name = "Preset " + std::to_string(idx);
         Preset blank;
@@ -530,7 +602,7 @@ namespace Transmog
 
     void PresetManager::duplicate_current()
     {
-        auto &cp = ensure_character(m_activeCharacter);
+        auto &cp = ensure_character(m_editingCharacter);
         int idx = static_cast<int>(cp.presets.size());
         std::string name = "Preset " + std::to_string(idx);
         auto captured = capture_from_state(name);
@@ -571,7 +643,7 @@ namespace Transmog
         auto *p = active_preset_mut();
         if (!p)
         {
-            auto &cp = ensure_character(m_activeCharacter);
+            auto &cp = ensure_character(m_editingCharacter);
             int idx = static_cast<int>(cp.presets.size());
             std::string name = "Preset " + std::to_string(idx);
             cp.presets.push_back(capture_from_state(name));
@@ -606,7 +678,7 @@ namespace Transmog
 
     void PresetManager::remove_current()
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end() || it->second.presets.empty())
             return;
 
@@ -629,7 +701,7 @@ namespace Transmog
 
     void PresetManager::next_preset()
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end() || it->second.presets.empty())
             return;
 
@@ -656,7 +728,7 @@ namespace Transmog
 
     void PresetManager::prev_preset()
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end() || it->second.presets.empty())
             return;
 
@@ -714,7 +786,7 @@ namespace Transmog
 
     void PresetManager::set_active_preset(int index)
     {
-        auto it = m_characters.find(m_activeCharacter);
+        auto it = m_characters.find(m_editingCharacter);
         if (it == m_characters.end() || it->second.presets.empty())
             return;
 
@@ -787,15 +859,17 @@ namespace Transmog
             mappings[i].targetItemId = p->slots[i].itemId;
 
             // Body-mesh slots only persist `prefabName`; the carrier
-            // itemId is derived here from the active character's
-            // default Kliff/Damiane/Oongka plate set. This keeps the
-            // user-facing JSON clean (no spurious "Kliff_PlateArmor_*"
-            // names cluttering body-mesh-only preset entries).
+            // itemId is derived here from the controlled character's
+            // default plate set. The carrier MUST come from the live
+            // body because PWS pointer-equality matches against the
+            // wrapper that body actually emits; using the editing
+            // character's carrier here would silently no-op the swap
+            // whenever editing is pinned to a different character.
             if (mappings[i].targetItemId == 0 &&
                 !p->slots[i].prefabName.empty())
             {
                 const auto carrier = Transmog::default_carrier_for_slot(
-                    static_cast<TransmogSlot>(i), m_activeCharacter);
+                    static_cast<TransmogSlot>(i), m_controlledCharacter);
                 if (carrier != 0)
                 {
                     mappings[i].targetItemId = carrier;

--- a/CrimsonDesertLiveTransmog/src/preset_manager.hpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.hpp
@@ -140,10 +140,63 @@ namespace Transmog
         bool save(const std::string &path) const;
 
         // --- Character management ---
+        //
+        // The manager tracks two distinct character identities:
+        //
+        //   controlled = the in-game character the player is currently
+        //                controlling. Drives carrier defaults, body-
+        //                mesh wrapper source resolution, and the stale-
+        //                body guard. Owned by the load-detect thread
+        //                via set_active_character().
+        //
+        //   editing    = the character whose preset list the overlay
+        //                is showing and the user is mutating. By
+        //                default it tracks `controlled`. When the user
+        //                picks a different character in the overlay
+        //                dropdown, `editing` becomes "pinned" and
+        //                stops following `controlled` until the user
+        //                unpins (manually, or by re-selecting the
+        //                controlled character). With editing pinned,
+        //                the apply pipeline reads target itemIds from
+        //                the editing character's preset while carriers
+        //                and the source body still come from the
+        //                controlled character; this is the cross-body
+        //                "wear another character's preset" path.
+        //
+        // active_character() / set_active_character() always refer to
+        // the *controlled* axis. editing_character() and friends are
+        // the UI-side API.
+        //
+        // Thread safety: both axes are written on different threads
+        // (load-detect writes controlled; the overlay render thread
+        // writes editing). PresetManager has no internal locking;
+        // callers rely on the fact that std::string assignment of a
+        // small known-size value is atomic enough in practice for the
+        // single-string read on the apply path, and that pin/unpin
+        // transitions are immediately followed by a slot_mappings
+        // reset + apply, which serialises any half-observed state.
 
         std::vector<std::string> character_names() const;
+
+        /// Returns the controlled character.
         const std::string &active_character() const;
+        /// Sets the controlled character. If editing is unpinned,
+        /// editing follows. If editing was pinned and the user has
+        /// switched to controlling the very character they had pinned
+        /// for editing, the pin auto-clears (the pin no longer
+        /// represents anything distinct).
         void set_active_character(const std::string &name);
+
+        /// Returns the character whose preset list the overlay is
+        /// editing.
+        const std::string &editing_character() const;
+        /// Sets the editing character. The pin engages whenever the
+        /// new editing character differs from controlled; selecting
+        /// the controlled character clears the pin.
+        void set_editing_character(const std::string &name);
+        bool editing_pinned() const noexcept;
+        /// Drop the pin and snap editing back to controlled.
+        void clear_editing_pin();
 
         /// Get/set the per-character body-kind override. Empty or
         /// "Auto" falls back to the hardcoded default in
@@ -243,7 +296,10 @@ namespace Transmog
         void revert_active_dye_to_snapshot() noexcept;
 
         std::map<std::string, CharacterPresets> m_characters;
-        std::string m_activeCharacter = "Kliff";
+        // See class-level comment for the controlled / editing split.
+        std::string m_controlledCharacter = "Kliff";
+        std::string m_editingCharacter    = "Kliff";
+        bool        m_editingPinned       = false;
         std::string m_filePath;
     };
 

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -234,18 +234,21 @@ namespace Transmog
 
     // Apply ALWAYS targets the currently-controlled character. This
     // helper re-reads the live character via the Core resolver and,
-    // when PresetManager has a different active character cached,
-    // switches to the live one and rebuilds slot_mappings from its
-    // preset. Holds no __try block so std::string usage is fine; called
-    // from run_debounced_apply (which cannot mix __try with C++ objects).
+    // when PresetManager has a different controlled character
+    // cached, switches to the live one and rebuilds slot_mappings
+    // from its preset. Holds no __try block so std::string usage is
+    // fine; called from run_debounced_apply (which cannot mix __try
+    // with C++ objects).
+    //
+    // The editing axis is left untouched here: if the user has the
+    // overlay dropdown pinned to a different character, that pin
+    // persists across in-game character swaps and the cross-body
+    // apply remains in effect.
     //
     // Returns true when the apply may proceed, false when the caller
     // must defer (re-arm the debounce). False is returned only while
     // load_detect_thread_fn has an unfired char-swap parked in its
-    // settle window: see s_charSwapPending. Steady-state UI / state
-    // mismatches (e.g. user opened a different character's preset list
-    // in the overlay while controlling someone else) still flip inline
-    // here so the immediate apply targets the live character's preset.
+    // settle window: see s_charSwapPending.
     [[nodiscard]] static bool sync_active_char_to_live() noexcept
     {
         const std::string live = current_controlled_character_name();
@@ -298,22 +301,23 @@ namespace Transmog
         // SEH-guarded actor deref below catches a stale wrapper after
         // world reload by dropping the apply.
         //
-        // Apply ALWAYS targets the currently-controlled character.
-        // The UI's "active character" is just a view into the JSON
-        // preset list -- a user can pick Oongka in the overlay while
-        // controlling Damiane, but we still want Damiane to end up
-        // wearing Damiane's preset. The helper below syncs
-        // PresetManager + slot_mappings to the live character. Lives
-        // outside this __try-containing function so std::string
-        // destructors do not trip MSVC C2712.
+        // Apply ALWAYS targets the controlled character's body.
+        // The helper below syncs PresetManager's controlled axis +
+        // slot_mappings to the live character. It lives outside this
+        // __try-containing function so std::string destructors do
+        // not trip MSVC C2712. When the user has the overlay
+        // dropdown pinned to a different editing character, the
+        // controlled body still drives carriers and the live source
+        // wrappers; the editing character only supplies preset
+        // itemIds (cross-body apply).
         //
-        // Helper returns false while load-detect has an unfired char
-        // swap parked in its settle window. In that case the engine
-        // has not yet rotated user+0xD8 to the new body, so applying
-        // here would paint the incoming preset onto the previous
-        // body. Re-arm the debounce; the load-detect commit will both
-        // flip pm.active_character() and stamp swap_stale_comp() so
-        // the next apply lands correctly.
+        // The helper returns false while load-detect has an unfired
+        // char swap parked in its settle window. In that case the
+        // engine has not yet rotated user+0xD8 to the new body, so
+        // applying here would paint the incoming preset onto the
+        // previous body. Re-arm the debounce; the load-detect
+        // commit will both flip the controlled axis and stamp
+        // swap_stale_comp() so the next apply lands correctly.
         if (!sync_active_char_to_live())
         {
             schedule_transmog_ms(200);


### PR DESCRIPTION
## Summary
- Adds a Character dropdown so you can pick any character's preset to edit and wear on whoever you're currently controlling.
- Adds an Unpin button to snap the editor back to following the controlled character.
