### PR TITLE
feat(core): rewrite controlled-character resolver

### DIFF
--- a/CrimsonDesertCore/include/cdcore/anchors.hpp
+++ b/CrimsonDesertCore/include/cdcore/anchors.hpp
@@ -13,9 +13,9 @@
 //     AnchorDescriptor = what the candidate anchors on
 //                        (FullPrologue, PostAlloca, BodyAnchor, ...)
 //
-// Every candidate here has been verified to return exactly one match in the
-// live v1.03.01 .text section via `mcp__cheatengine__aob_scan` (see the
-// uniqueness audit in the session log).
+// Each candidate is uniqueness-verified against the live .text section at
+// authoring time; cascades exist so partial recompilations or sibling-DLL
+// hook patches that invalidate the tightest signature still resolve.
 //
 // Authoring rules (from external/DetourModKit/docs/misc/aob-signatures.md):
 //   - Sign CODE, not DATA. Anchor on instruction semantics, not on linker
@@ -296,103 +296,6 @@ namespace CDCore::Anchors
     };
 
     // -----------------------------------------------------------------------
-    // Player -- static pointer for the server-side party-state root global.
-    //
-    // Resolves to qword_145F0D580 in the v1.04.00 .text. The dereference of
-    // that qword is a heap-allocated root object (no specific RTTI) whose
-    // chain is:
-    //
-    //   *(player_static)        -> root container
-    //   *(root  + 0x18)         -> pa::NwVirtualAsyncSession
-    //   *(nwSes + 0xA0)         -> pa::ServerUserActor
-    //   *(srvUA + 0xD0)         -> pa::ServerChildOnlyInGameActor
-    //                              (the party container)
-    //
-    // Inside the party container the three protagonist slots are inline
-    // structs at fixed offsets with stride 0x100:
-    //
-    //   party + 0x68            = Kliff slot
-    //   party + 0x168           = Damiane slot
-    //   party + 0x268           = Oongka slot
-    //
-    // Per slot the active-flag byte is at slot+0x2C (1 = currently
-    // controlled, 0 = passive). The character is identified by which slot
-    // offset, NEVER by a stored character ID. The +0x40 dword is an
-    // observability handle and is volatile; it is logged for diagnostics
-    // but not used for identity.
-    //
-    // The CE-validated state-transition table (5 transitions across radial
-    // swaps and a save-load) confirmed the invariant that exactly one slot
-    // has +0x2C == 1 while the player is in-world; zero slots are active
-    // during cutscenes / loading screens. The top three pointers in the
-    // chain (root, NwVirtualAsyncSession, ServerUserActor) stay identical
-    // across save-load; only the final party container reallocates.
-    //
-    // Why this static and not the older WorldSystem holder at +0x5F0D210:
-    // the WorldSystem chain reaches a CLIENT-side ChildOnlyInGameActor pool
-    // whose per-actor +0x50 byte was the prior identity discriminator. On
-    // v1.04.00 that byte ceased to discriminate (every protagonist reads
-    // 0x08), and actor-pool reuse made the field unstable across radial
-    // swaps. The Player static reaches the SERVER-side party state, which
-    // identifies the controlled character by slot offset (a structural
-    // invariant) instead of by a value the engine can repurpose.
-    //
-    // 3-tier cascade. Stable read sites verified unique on v1.04.00 via
-    // mcp__cheatengine__aob_scan (each returns exactly 1 hit).
-    // -----------------------------------------------------------------------
-    inline constexpr AddrCandidate k_playerStaticCandidates[] = {
-        // P1 -- the unique writer site at sub_1420D0470.
-        //   4C 89 3D <disp32>          mov [rip+disp32], r15
-        //   48 8B 8F F8 00 00 00       mov rcx, [rdi+0xF8]
-        //   41 BC 04 02 00 00          mov r12d, 0x204
-        //   48 85 C9 ??                test rcx, rcx ; jcc rel8
-        //
-        // Writer encodings on globals are typically rare (one or two per
-        // module) and the immediately-following load from [rdi+0xF8] +
-        // mov-r12d-0x204 sequence is semantically distinctive. The 0x204
-        // is a SEMANTIC constant (an initialisation tag) and is kept
-        // literal per the §2 exception; the rel8 of the trailing jcc is
-        // wildcarded because branch distance can shift.
-        {"PlayerStatic_P1_WriterSite",
-         "4C 89 3D ?? ?? ?? ?? 48 8B 8F F8 00 00 00 "
-         "41 BC 04 02 00 00 48 85 C9 ??",
-         ResolveMode::RipRelative, 3, 7},
-
-        // P2 -- read-into-r12 at sub_1420D3700+0x39.
-        //   4C 8B 25 <disp32>          mov r12, [rip+disp32]
-        //   8B D5                      mov edx, ebp
-        //   4C 8B F0                   mov r14, rax
-        //   E8 <disp32>                call <subroutine>
-        //   48 8B D8                   mov rbx, rax
-        //   48 85 C0 ??                test rax, rax ; jcc rel8
-        //
-        // The 4C 8B 25 prefix (load into r12) is uncommon; combined with
-        // the immediate mov-edx-ebp / mov-r14-rax / call / mov-rbx-rax /
-        // test-rax-rax tail it pins this single read site. Both rel32
-        // displacements are wildcarded (linker-owned).
-        {"PlayerStatic_P2_ReadIntoR12",
-         "4C 8B 25 ?? ?? ?? ?? 8B D5 4C 8B F0 "
-         "E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 ??",
-         ResolveMode::RipRelative, 3, 7},
-
-        // P3 -- read-into-rcx + stack-slot test at sub_140819600+0x14F.
-        //   48 8B 0D <disp32>          mov rcx, [rip+disp32]
-        //   E8 <disp32>                call <subroutine>
-        //   83 7C 24 ?? 00             cmp dword [rsp+disp8], 0
-        //   74 ??                      jz rel8
-        //   48 8B 8E E0 00 00 00       mov rcx, [rsi+0xE0]
-        //
-        // The 48 8B 0D / E8 mov-then-call shape is common, but the tail
-        // (cmp dword [rsp+disp8], 0; jz rel8; mov rcx, [rsi+0xE0]) pins
-        // this site. 0xE0 is a game-struct ABI offset, kept literal. The
-        // stack disp8 in the cmp and the rel8 jz target are wildcarded.
-        {"PlayerStatic_P3_ReadStackTest",
-         "48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? "
-         "83 7C 24 ?? 00 74 ?? 48 8B 8E E0 00 00 00",
-         ResolveMode::RipRelative, 3, 7},
-    };
-
-    // -----------------------------------------------------------------------
     // RadialSwapKey: function-entry anchor for the radial-UI character swap
     // handler `sub_141B04040`. The target binary is Crimson Desert v1.06.00.
     //
@@ -419,9 +322,10 @@ namespace CDCore::Anchors
     //   +0x282         FF 90 80 01 00 00   call [rax+0x180]
     //
     // RDX (a2) at function entry holds the new active character's outer-slot
-    // pointer: party_base + 0x000 (Kliff), 0x100 (Damiane), 0x200 (Oongka).
-    // The MidHook in controlled_char.cpp reads ctx.rdx and decodes the
-    // offset against the live party container resolved via walk_chain_seh.
+    // pointer. CDCore's radial-swap MidHook does not read any of the args:
+    // its sole side effect is a single atomic-store of GetTickCount64() that
+    // powers `radial_swap_pending()` (used by EH and LT to disambiguate a
+    // user-initiated swap from a save-load arena rotation).
     //
     // Resolution strategy. Each candidate resolves directly to the entry
     // address sub_141B04040 (Direct mode, dispOffset = anchor_offset_from_
@@ -442,6 +346,129 @@ namespace CDCore::Anchors
     // 6-byte vtable call, giving an instruction-stream landmark that no
     // other function in the .text section reproduces.
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // FocusActorInit -- bridge-function family that interns per-protagonist
+    // focus-actor name strings into engine-owned u32 hash globals at static
+    // init. Each bridge body is identical apart from the two RIP-relative
+    // LEA targets:
+    //
+    //     41 B9 FF FF 02 00          mov  r9d, 0x2FFFF        ; table cap
+    //     48 8D 15 ?? ?? ?? ??       lea  rdx, "focus-actor-<name>"
+    //     41 B8 01 00 00 00          mov  r8d, 1              ; insert flag
+    //     48 8D 0D ?? ?? ?? ??       lea  rcx, &dword_<global>
+    //     E9 ?? ?? ?? ??             jmp  <sequential-allocator>
+    //
+    // The trailing allocator does NOT hash the string; it consults an
+    // internal table, returns the existing slot if the name was seen, or
+    // assigns the next free counter value. The published u32s are therefore
+    // session-deterministic but shift whenever a patch adds or reorders a
+    // focus-actor registration. Hash values must be AOB-discovered every
+    // session and read from RAM at query time; never bake them into code.
+    //
+    // The two `mov` immediates (0x2FFFF, 0x01) are NOT linker-owned -- they
+    // are engine-API call arguments shared by every bridge in this family.
+    // Wildcarding them would inflate matches to thousands of unrelated
+    // `mov r9d, imm; lea rdx, str` callers, swamping the disambiguator. The
+    // pattern therefore intentionally pins both literals, accepting that it
+    // matches hundreds of sibling tag-registration bridges; the per-hit
+    // string deref selects the three player-protagonist bridges by name.
+    //
+    // Resolution flow (caller-side):
+    //   1. Scan .text for `k_focusActorInitPattern` (hundreds of hits).
+    //   2. For each hit, RIP-resolve the string LEA at +9 -> bridge name.
+    //   3. Filter for "focus-actor-kliff/oongka/damian"; for those three,
+    //      RIP-resolve the dword LEA at +22 -> per-character hash global.
+    //   4. Publish the three addresses; Tier-0 character resolution reads
+    //      the dwords on every query.
+    //
+    // A single pattern + manual multi-hit walk is required because the
+    // bridge prologues are byte-for-byte identical and the standard
+    // `resolve_cascade_*` flow returns only the first hit.
+    // -----------------------------------------------------------------------
+    inline constexpr std::string_view k_focusActorInitPattern =
+        "41 B9 FF FF 02 00 48 8D 15 ?? ?? ?? ?? "
+        "41 B8 01 00 00 00 48 8D 0D ?? ?? ?? ?? E9";
+
+    // disp32 location and post-instruction RIP for the two RIP-relative
+    // LEAs inside `k_focusActorInitPattern`. Absolute address is computed
+    // as `(match + instr_end) + sign_extend_32(disp32)`.
+    inline constexpr std::ptrdiff_t k_focusActorInitStringDispOffset     = 9;
+    inline constexpr std::ptrdiff_t k_focusActorInitStringInstrEndOffset = 13;
+    inline constexpr std::ptrdiff_t k_focusActorInitDwordDispOffset      = 22;
+    inline constexpr std::ptrdiff_t k_focusActorInitDwordInstrEndOffset  = 26;
+
+    // -----------------------------------------------------------------------
+    // FocusBroadcast -- entry of the engine's per-subscriber focus-actor
+    // list mutator (`sub_14353BA60` on v1.06.00). The engine fires this
+    // function once per subscriber whenever a focus-actor hash is added to
+    // or removed from a subscriber list. Argument map at entry:
+    //
+    //     rcx = manager
+    //     rdx = remove-list
+    //     r8  = add-list
+    //     r9  = new focus-actor hash (player-character on the player
+    //           broadcast path; arbitrary NPC hash on NPC focus events)
+    //
+    // The Tier-0 character resolver hooks this site because the player
+    // broadcast fires during world-spawn -- before any mod query can run --
+    // and the hash arriving in R9 is the engine's own identity primitive,
+    // so once `k_focusActorInitPattern` has resolved the three hash globals
+    // no further chain walking is required. NPC focus events vastly
+    // outnumber player broadcasts (only ~0.2% of fires carry a player
+    // hash); the hook callback filters by hash-equality against the
+    // published globals.
+    //
+    // 2-tier cascade ordered for patch + sibling-DLL coexistence:
+    //   P1 covers a virgin-load scan when no DLL has yet patched the entry.
+    //   P2 anchors past SafetyHook's 5-byte JMP window so a sibling mod
+    //   that installed a MidHook on the entry does not prevent re-resolution
+    //   on subsequent loads.
+    // -----------------------------------------------------------------------
+    inline constexpr AddrCandidate k_focusBroadcastCandidates[] = {
+        // P1 -- function entry through the first four body instructions:
+        //
+        //     4C 89 44 24 18             mov [rsp+0x18], r8
+        //     48 89 54 24 10             mov [rsp+0x10], rdx
+        //     41 55                      push r13
+        //     48 83 EC ??                sub rsp, <frame-size>
+        //     48 8B 81 A8 00 00 00       mov rax, [rcx+0xA8]
+        //     4C 8B E9                   mov r13, rcx
+        //
+        // The two home-space stores (+0x10/+0x18 are Windows x64 ABI shadow
+        // slots for the RDX/R8 args -- canonical, not compiler-volatile),
+        // the lone `push r13` callee-save, the `mov rax, [rcx+0xA8]`
+        // indirect through a struct-stable game ABI offset (0xA8), and the
+        // `mov r13, rcx` arg stash together pin this function's prologue
+        // uniquely in the v1.06.00 .text. The `sub rsp` immediate is
+        // wildcarded because stack-frame size is one of the operands the
+        // compiler is most likely to perturb across patches.
+        {"FocusBroadcast_P1_EntryPrologue",
+         "4C 89 44 24 18 48 89 54 24 10 41 55 48 83 EC ?? "
+         "48 8B 81 A8 00 00 00 4C 8B E9",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- post-prologue anchor at entry + 0x10:
+        //
+        //     48 8B 81 A8 00 00 00       mov rax, [rcx+0xA8]
+        //     4C 8B E9                   mov r13, rcx
+        //     48 85 C0                   test rax, rax
+        //     ?? ??                      <2-byte branch>
+        //     48 83 78 08 00             cmp qword [rax+8], 0
+        //
+        // The 2-byte branch slot is wildcarded rather than hard-coded as
+        // `74 rel8` (per aob-signatures.md the compiler may flip between
+        // `74 xx` and the 6-byte `0F 84 rel32` form across patches); the
+        // four-byte wildcard tolerates either form while preserving the
+        // surrounding 18 fixed bytes for uniqueness. dispOffset = -0x10
+        // walks back to the function entry so consumers receive the same
+        // address P1 would produce.
+        {"FocusBroadcast_P2_PostPrologueBody",
+         "48 8B 81 A8 00 00 00 4C 8B E9 48 85 C0 ?? ?? "
+         "48 83 78 08 00",
+         ResolveMode::Direct, -0x10, 0},
+    };
+
     inline constexpr AddrCandidate k_radialSwapKeyCandidates[] = {
         // P1: function-entry mid-prologue. Anchors on the unique stack
         // layout (`lea rbp, [rsp-0x37]; sub rsp, 0xB0`) and the

--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -6,59 +6,39 @@
 #include <string_view>
 
 // ---------------------------------------------------------------------------
-// Controlled-character resolver.
+// Controlled-character resolver -- focus-broadcast architecture.
 //
-// Walks the live server-side party-state chain on every query and identifies
-// the currently-controlled protagonist by which fixed-offset slot inside the
-// party container has its active-flag byte set.
+// Identity is decoded from the engine's own focus-actor broadcast event.
+// The engine assigns each protagonist a stable u32 hash handle at static
+// init (via "focus-actor-kliff/oongka/damian" string registration) and
+// fires `sub_14353BA60` on every focus mutation -- cold-load,
+// save-load reattach, radial swap. R9 at function entry carries the
+// new focus handle; the CDCore MidHook compares against the three
+// AOB-resolved hash globals and stamps a process-wide cache.
 //
-//   *(player_static)        -> root container
-//   *(root  + 0x18)         -> pa::NwVirtualAsyncSession
-//   *(nwSes + 0xA0)         -> pa::ServerUserActor
-//   *(srvUA + 0xD0)         -> pa::ServerChildOnlyInGameActor
-//                              (the party container)
+// Init flow (consumer is LiveTransmog or EquipHide):
+//   1. resolve_and_publish_focus_actor_globals()  -> publishes the 3
+//      hash global addresses via set_focus_actor_hash_globals().
+//   2. install_focus_broadcast_hook(addr)         -> hooks
+//      sub_14353BA60 entry. Callback writes the resolved character
+//      into the Tier-0 cache.
+//   3. install_radial_swap_hook(addr)             -> hooks
+//      sub_141B04040 entry. Callback timestamps a flag consumed
+//      by `radial_swap_pending()` (used by EquipHide to
+//      disambiguate radial swap from save-load arena rotation).
 //
-// Inside the party container the three protagonist slots are inline structs
-// at fixed offsets with stride 0x100:
-//
-//   party + 0x68            = Kliff slot
-//   party + 0x168           = Damiane slot
-//   party + 0x268           = Oongka slot
-//
-// Per slot the active-flag byte at slot+0x2C is the discriminator: exactly
-// one slot reads 1 while the player is in-world (cutscenes / loading screens
-// produce zero hot slots, which the resolver reports as Unknown). The +0x40
-// dword is an observability handle that is volatile across sessions and
-// asset rebuilds; it is logged for diagnostic correlation only and never
-// participates in identity decoding.
-//
-// Why identity is decoded by SLOT OFFSET and not by a stored character ID:
-// inside the party container the slot for a given protagonist is at a fixed
-// compile-time-known offset, which is a structural invariant of the engine
-// layout and cannot drift across actor-pool reuse, save-load reallocation,
-// or radial-menu swaps. Earlier resolver iterations decoded a per-actor
-// byte field that the engine repurposed across versions; the slot-offset
-// approach is immune to that class of regression because there is no engine
-// field whose meaning the resolver depends on.
-//
-// To absorb transient torn reads (the active-flag byte can momentarily
-// disagree across the three slots during a swap event when the engine is
-// still flipping bytes) the resolver keeps a last-known-good cache: any
-// query that returns no single-1-bit-hot slot reuses the cached value
-// instead, and the cache refreshes whenever a fresh single-bit-hot decode
-// succeeds.
-//
-// The resolver requires the consumer to publish the player static address
-// once (typically right after that mod's own AOB scan resolves it). Until
-// set_player_static_holder() has been called, every query returns Unknown.
-// This avoids duplicating the AOB scan across every consumer.
+// Body cache. As a side effect of every successful
+// current_controlled_character() resolve, the resolver stamps
+// (user+0xD8 -> character) into a learning cache consumed by
+// resolve_character_idx_for_body() and snapshot_body_cache(). The
+// cache reaches user+0xD8 via the WorldSystem chain published by
+// set_world_system_holder().
 //
 // Thread safety:
-//   - set_player_static_holder() and set_world_system_holder() are safe from
-//     any thread; later writers win, which is the intended behaviour if a
-//     consumer re-resolves on reload.
-//   - current_controlled_character() is non-blocking and SEH-guarded; safe
-//     to call from any thread including the rendering thread.
+//   - All setters (set_world_system_holder, set_focus_actor_hash_
+//     globals) are safe from any thread; later writers win.
+//   - current_controlled_character() is non-blocking and SEH-
+//     guarded; safe from any thread including the rendering thread.
 // ---------------------------------------------------------------------------
 
 namespace CDCore
@@ -66,12 +46,11 @@ namespace CDCore
     /**
      * @brief Identifies one of the three controlled playable characters.
      * @details The Unknown sentinel is returned before
-     *          set_player_static_holder() has been called, before the chain
-     *          walk yields a known identity (very early in the loading
-     *          screen, or while a cutscene zeroes every slot's active flag),
-     *          and after invalidate_controlled_character() until the next
-     *          chain walk observes one of the three known keys and refreshes
-     *          the cache.
+     *          set_focus_actor_hash_globals() has been called, before the
+     *          engine has fired its first focus-actor broadcast for the
+     *          session, and after invalidate_controlled_character() until
+     *          the next broadcast or structural Kliff body anchor
+     *          repopulates the cache.
      */
     enum class ControlledCharacter : std::uint8_t
     {
@@ -82,59 +61,37 @@ namespace CDCore
     };
 
     /**
+     * @brief Resolve the currently-controlled character.
+     * @details Reads the Tier-0 focus-broadcast cache; falls back to
+     *          the LKG cache when the broadcast has not yet fired
+     *          this session. Side-effect: stamps (user+0xD8 ->
+     *          character) into the body learning cache on every
+     *          successful resolve.
+     * @return The identified character, or
+     *         ControlledCharacter::Unknown when neither Tier-0 nor
+     *         the LKG cache holds a known value (the engine has not
+     *         yet broadcast a focus-actor change this session, or
+     *         caches were just invalidated).
+     */
+    [[nodiscard]] ControlledCharacter current_controlled_character() noexcept;
+
+    /**
+     * @brief Short display name for a controlled character.
+     */
+    [[nodiscard]] std::string_view controlled_character_name(
+        ControlledCharacter ch) noexcept;
+
+    /**
      * @brief Publish the WorldSystem holder static address to Core.
-     * @details Retained for callers that need the WorldSystem reach
-     *          (UserActor, body-pool walks, mesh-bound state). The
-     *          controlled-character resolver no longer consumes this
-     *          pointer; identification is handled via
-     *          set_player_static_holder() instead.
+     * @details Used by walk_to_controlled_body_seh() to reach the
+     *          rotating user+0xD8 client body pointer that the body
+     *          learning cache keys on.
      * @param holderAddr Absolute address of the WorldSystem holder slot
      *                   (the static qword whose dereference yields the
      *                   live WorldSystem instance pointer). Pass 0 to
      *                   clear.
      */
     void set_world_system_holder(std::uintptr_t holderAddr) noexcept;
-
-    /**
-     * @brief Publish the server-side player static address to the
-     *        controlled-character resolver.
-     * @details Both consumer mods (CrimsonDesertEquipHide and
-     *          CrimsonDesertLiveTransmog) AOB-scan for the player static
-     *          during their own init. Whichever resolves first should hand
-     *          the address to Core via this call so the resolver does not
-     *          need its own AOB scan. Subsequent calls overwrite the
-     *          previous value.
-     * @param holderAddr Absolute address of the player static slot (the
-     *                   static qword whose dereference yields the root
-     *                   container described in the file-level comment).
-     *                   Pass 0 to disable the resolver.
-     */
-    void set_player_static_holder(std::uintptr_t holderAddr) noexcept;
-
-    /**
-     * @brief Resolve the currently-controlled character.
-     * @details Walks the server-side party-state chain and reads the
-     *          active-flag byte at slot+0x2C for each of the three fixed
-     *          protagonist offsets (Kliff=0x68, Damiane=0x168,
-     *          Oongka=0x268). Returns the slot whose flag reads 1. When no
-     *          slot is hot (cutscene, loading screen) or more than one is
-     *          hot (transient torn read mid-swap), the resolver returns the
-     *          previously-cached identity instead, so transient drift does
-     *          not flap the controlled character.
-     * @return The identified character, or ControlledCharacter::Unknown
-     *         when the player static has not been published yet, when the
-     *         chain walk faults, or when neither the live decode nor the
-     *         last-known-good cache yields a known value.
-     */
-    [[nodiscard]] ControlledCharacter current_controlled_character() noexcept;
-
-    /**
-     * @brief Short display name for a controlled character.
-     * @return A static string view ("Kliff" / "Damiane" / "Oongka") or
-     *         an empty view for Unknown.
-     */
-    [[nodiscard]] std::string_view controlled_character_name(
-        ControlledCharacter ch) noexcept;
 
     /**
      * @brief Convenience wrapper that returns the live name.
@@ -157,30 +114,19 @@ namespace CDCore
      * @details Looks up @p body in the learning cache populated by
      *          current_controlled_character() each time the resolver
      *          observes a known controlled identity. Returns 0 when
-     *          the body has not yet been seen as controlled (the user
-     *          has never been that character in this session) --
-     *          callers should treat 0 as "unknown" and fall back to
-     *          the active character's mask, which is the safe
-     *          degradation.
-     *
-     *          Why a learning cache instead of a structural decode:
-     *          the v1.04.00 client body has no reachable back-reference
-     *          to its protagonist slot in the party container, and the
-     *          per-actor +0x50 byte that earlier builds used as a slot
-     *          index ceased to discriminate on this build. Observing
-     *          the controlled-body / known-character pairing each
-     *          resolver tick is the only stable mapping available from
-     *          the public game-state surface.
+     *          the body has not yet been seen as controlled this
+     *          session -- callers should treat 0 as "unknown" and
+     *          fall back to the active character's mask.
      *
      *          Cache scope: per-DLL (CDCore is statically linked into
      *          each consumer Logic DLL). Each consumer learns
      *          independently. Cleared by
-     *          invalidate_controlled_character() on save-load so dead
-     *          body pointers cannot mis-attribute a future protagonist.
-     *          Preserved across in-session radial swaps (callers should
-     *          use invalidate_swap_caches() on those transitions) since
-     *          the engine rotates user+0xD8 between existing body
-     *          pointers in the pool without reallocating bodies.
+     *          invalidate_controlled_character() on save-load.
+     *          Preserved across in-session radial swaps (callers
+     *          should use invalidate_swap_caches() on those
+     *          transitions) since the engine rotates user+0xD8
+     *          between existing body pointers in the pool without
+     *          reallocating bodies.
      *
      * @param body Pointer to a ClientChildOnlyInGameActor instance.
      * @return 1 for Kliff, 2 for Damiane, 3 for Oongka, or 0 for
@@ -227,152 +173,201 @@ namespace CDCore
         std::size_t cap) noexcept;
 
     /**
-     * @brief Install the radial-swap-key capture mid-hook at the
-     *        resolved address.
-     * @details The hook target must be the instruction immediately
-     *          following the EAX-load from the radial-UI input pointer
-     *          (the `mov [rbp+0x78], eax` at sub_1422019A0+e9 in
-     *          v1.04.00). At hook entry the low 32 bits of RAX hold the
-     *          requested characterinfo key (1 = Kliff, 4 = Damiane,
-     *          6 = Oongka). The hook stamps a short-lived process-wide
-     *          pending-key record so the next chain-walk that observes
-     *          a non-Kliff identity can attribute the user-actor pointer
-     *          to the captured key, building an actor->character cache
-     *          that the resolver consults before falling back to the
-     *          slot-offset decode.
+     * @brief Publish the three engine focus-actor hash globals to CDCore.
+     * @details The engine assigns each protagonist (Kliff/Damiane/Oongka)
+     *          a per-process u32 handle at static init. The three globals
+     *          live at fixed addresses inside the binary's writable data
+     *          section; consumers AOB-resolve those addresses (see
+     *          `CDCore::resolve_and_publish_focus_actor_globals()`) and
+     *          publish them here. The values themselves -- which differ
+     *          per game version -- are read from these addresses every
+     *          query in the focus-broadcast MidHook callback, so we
+     *          never hardcode the numeric handles.
      *
-     *          Single-owner semantics within a DLL:
-     *          - First call with a non-zero @p hookAddr: builds the
-     *            SafetyHook MidHook against that address.
-     *          - Subsequent calls with the SAME @p hookAddr: idempotent
-     *            no-op (the hook is already live at the requested site).
-     *          - Subsequent calls with a DIFFERENT non-zero @p hookAddr:
-     *            destroy the existing MidHook and rebuild against the
-     *            new address (used if an AOB re-resolution shifts the
-     *            target mid-session).
-     *          - Call with @p hookAddr == 0: tear down the MidHook so
-     *            the patched bytes return to the original instruction
-     *            sequence. Safe to call when no hook is installed.
+     *          When all three addresses are non-zero the new Tier-0
+     *          decoder in `current_controlled_character()` activates and
+     *          returns whichever character last fired the focus-actor
+     *          broadcast. Pass any address as zero to disable the layer
+     *          (the resolver falls through to the existing slot-offset
+     *          decode and the LKG cache).
      *
-     *          Cross-DLL coordination: CrimsonDesertCore is linked as a
-     *          STATIC library, so each consumer Logic DLL (LiveTransmog,
-     *          EquipHide) carries its own copy of CDCore state and its
-     *          own SafetyHook MidHook against the shared process address.
-     *          When both consumers call this function against the same
-     *          target site, SafetyHook's internal chaining lets the two
-     *          MidHooks coexist transparently -- each consumer's
-     *          trampoline runs independently on every radial swap. The
-     *          AOB cascade in cdcore/anchors.hpp k_radialSwapKeyCandidates
-     *          is ordered so the post-patch-tolerant patterns resolve
-     *          first, ensuring the second consumer to scan still finds
-     *          the same hook target the first consumer already patched.
+     *          Per-DLL state (CDCore is statically linked into each
+     *          consumer): each consumer publishes independently. A
+     *          consumer that fails to AOB-resolve still receives the
+     *          slot-offset / LKG behaviour as before.
      *
-     *          Failure modes (returns false): SafetyHook allocation
-     *          failure (ENOMEM-shaped, rare), trampoline placement
-     *          failure (target page already heavily hooked), or address
-     *          below the 64 KiB guard region. On any failure the
-     *          resolver continues to function via the slot-offset decode
-     *          and the LKG cache; only the deterministic
-     *          radial-attribution layer is missing for this consumer.
+     *          Safe to call from any thread; later writers win.
      *
-     * @param hookAddr Absolute address of the `mov [rbp+0x78], eax`
-     *                 instruction inside sub_1422019A0. The AOB cascade
-     *                 in cdcore/anchors.hpp k_radialSwapKeyCandidates
+     * @param kliffAddr Absolute address of the Kliff hash u32 global.
+     * @param oongkaAddr Absolute address of the Oongka hash u32 global.
+     * @param damianAddr Absolute address of the Damian hash u32 global.
+     */
+    void set_focus_actor_hash_globals(std::uintptr_t kliffAddr,
+                                      std::uintptr_t oongkaAddr,
+                                      std::uintptr_t damianAddr) noexcept;
+
+    /**
+     * @brief One-shot helper that AOB-resolves the three focus-actor
+     *        hash globals and publishes them via
+     *        `set_focus_actor_hash_globals()`.
+     * @details Scans .text for the three identical bridge functions
+     *          described in `CDCore::Anchors::k_focusActorInitPattern`,
+     *          dereferences each match's RIP-relative string and dword
+     *          LEAs, identifies which protagonist each bridge serves
+     *          by matching the string against
+     *          "focus-actor-kliff/oongka/damian", then publishes the
+     *          three resolved dword addresses to CDCore. Returns true
+     *          on full success (all three protagonists resolved). On
+     *          any failure (pattern mismatch, fewer than 3 hits, name
+     *          dispatch ambiguity) returns false WITHOUT calling the
+     *          setter, leaving the Tier-0 layer disabled.
+     *
+     *          Idempotent: safe to call multiple times. Each successful
+     *          call overwrites the previously published addresses (no-op
+     *          if the addresses are unchanged across calls).
+     *
+     *          Logs a single Info line on success and a Warning on
+     *          failure.
+     */
+    [[nodiscard]] bool resolve_and_publish_focus_actor_globals() noexcept;
+
+    /**
+     * @brief Install the focus-actor broadcast capture mid-hook at the
+     *        resolved address (sub_14353BA60 entry).
+     * @details The hook fires on every focus-actor list mutation
+     *          (subscription event), reads `ctx.r9` as the new focus
+     *          handle, and -- when r9 matches one of the three globals
+     *          published via `set_focus_actor_hash_globals()` --
+     *          stamps the resolved character into a process-wide cache
+     *          consumed by `current_controlled_character()`'s Tier-0
+     *          layer.
+     *
+     *          The hook is the canonical signal for cold-load and
+     *          save-load reattach because the engine fires the
+     *          broadcast during world-spawn before the player can
+     *          interact, populating the cache before any mod query
+     *          occurs. Radial swaps trigger it the same way.
+     *
+     *          ~99.8% of the broadcast firings carry NPC focus handles
+     *          in r9 (filtered out by the equality check against the
+     *          three published character globals), so the per-call
+     *          overhead is three relaxed atomic loads and three
+     *          dword compares.
+     *
+     *          Single-owner-per-DLL semantics mirror
+     *          `install_radial_swap_hook()`. Pass `hookAddr == 0` to
+     *          tear down. Failure modes match the radial-swap path.
+     *
+     * @param hookAddr Absolute address of `sub_14353BA60` entry.
+     *                 The AOB cascade in
+     *                 `cdcore/anchors.hpp::k_focusBroadcastCandidates`
      *                 resolves to this address. Pass 0 to tear down.
+     * @return true on successful install / idempotent no-op / teardown,
+     *         false on SafetyHook error.
+     */
+    bool install_focus_broadcast_hook(std::uintptr_t hookAddr) noexcept;
+
+    /**
+     * @brief Tear down the focus-broadcast mid-hook owned by this DLL.
+     * @details Equivalent to `install_focus_broadcast_hook(0)`. Safe
+     *          when no hook is installed; safe in shutdown paths.
+     *          Idempotent. Each consumer DLL owns its own MidHook;
+     *          calling this in one DLL does not affect any other
+     *          DLL's MidHook against the same process address.
+     */
+    void uninstall_focus_broadcast_hook() noexcept;
+
+    /**
+     * @brief Install the radial-swap-input mid-hook at the resolved
+     *        address (sub_141B04040 entry).
+     * @details Post-Tier-0 refactor the hook callback is a single
+     *          atomic store: it stamps a monotonic timestamp consumed
+     *          by `radial_swap_pending()`. EquipHide reads that flag
+     *          to disambiguate a user radial swap from a save-load
+     *          arena rotation (both rotate user+0xD8 between bodies
+     *          in different ways). The character identity itself
+     *          comes from the focus-broadcast hook, not this one.
+     *
+     *          Single-owner-per-DLL semantics, cross-DLL chaining,
+     *          and tear-down semantics mirror
+     *          `install_focus_broadcast_hook()`. Pass `hookAddr == 0`
+     *          to tear down. Failure modes: SafetyHook allocation /
+     *          trampoline placement failure, or address below the
+     *          64 KiB guard region. On any failure
+     *          `radial_swap_pending()` always returns false (no
+     *          stamping occurs) and EquipHide falls back to the
+     *          conservative save-load path -- still correct, slightly
+     *          more aggressive on body-cache wipes.
+     *
+     * @param hookAddr Absolute address of `sub_141B04040` entry
+     *                 (the AOB cascade in
+     *                 `cdcore/anchors.hpp::k_radialSwapKeyCandidates`
+     *                 resolves to this address). Pass 0 to tear down.
      * @return true on successful install / idempotent no-op / teardown,
      *         false on SafetyHook error.
      */
     bool install_radial_swap_hook(std::uintptr_t hookAddr) noexcept;
 
     /**
-     * @brief Tear down the radial-swap-key mid-hook owned by this DLL.
-     * @details Equivalent to install_radial_swap_hook(0). Safe to call
-     *          when no hook is installed; safe to call from shutdown
-     *          paths. Idempotent. Each consumer DLL owns its own
-     *          MidHook; calling this in one DLL does not affect any
-     *          other DLL's MidHook against the same process address.
+     * @brief Tear down the radial-swap mid-hook owned by this DLL.
+     * @details Equivalent to install_radial_swap_hook(0). Idempotent
+     *          and shutdown-safe.
      */
     void uninstall_radial_swap_hook() noexcept;
 
     /**
-     * @brief Whether a radial-swap key was stamped within the
-     *        pending-key window and has not yet been consumed by a
-     *        resolver chain walk.
-     * @details Returns true when the user has just initiated a radial
-     *          swap and the resolver has not yet caught up to publish
-     *          the new identity. Lets consumers disambiguate an
-     *          in-session protagonist swap from a save-load when both
-     *          appear as a controlled-actor pointer rotation: a swap
-     *          fired by user input has a fresh pending key; a save-load
-     *          does not.
-     *
-     *          Window matches the pending-key TTL (2 s in the current
-     *          build). Returns false outside the window, after the
-     *          resolver consumed the key, or when no key has ever been
-     *          stamped this session.
+     * @brief Whether a radial-swap input was observed within the
+     *        pending-key window.
+     * @details Returns true when the radial-swap mid-hook has fired
+     *          within the pending window (currently 2 s). Lets
+     *          consumers disambiguate an in-session protagonist swap
+     *          from a save-load when both appear as a controlled-
+     *          actor pointer rotation: a swap fired by user input
+     *          has a fresh timestamp, a save-load does not.
      *
      *          Per-DLL state (CDCore is statically linked into each
-     *          consumer): observes the pending key written by THIS
-     *          DLL's radial-swap safetyhook callback. Sibling DLLs
-     *          maintain their own copy.
+     *          consumer): observes the timestamp written by THIS
+     *          DLL's radial-swap callback.
      *
-     *          Safe to call from any thread; non-blocking (two relaxed
-     *          atomic loads + a tick comparison).
+     *          Safe to call from any thread; non-blocking (one
+     *          relaxed atomic load + a tick comparison).
      */
     [[nodiscard]] bool radial_swap_pending() noexcept;
 
     /**
-     * @brief Full world-reload invalidation. Clears the last-known-good
-     *        identity cache, the actor->character cache, the pending
-     *        radial-swap-key record, AND the body->character learning
-     *        cache.
+     * @brief Full world-reload invalidation. Clears Tier-0, LKG,
+     *        radial-swap timestamp, AND the body learning cache.
      * @details Call on world-reload transitions (save load, return to
      *          title) so the resolver does not keep returning the
      *          previous save's character while the new save is still
      *          populating the engine state. After invalidation the
-     *          resolver returns Unknown until the next chain walk observes
-     *          one of the three known keys and refreshes the cache.
+     *          resolver returns Unknown until the next focus-actor
+     *          broadcast fires.
      *
-     *          Why the body cache is flushed here: save-load reallocates
-     *          the body pool, so any cached body pointer becomes a
-     *          dangling key the engine may reuse for a different
-     *          protagonist. Mis-attribution after reload is prevented by
-     *          dropping the entire body map.
+     *          The body cache is flushed because save-load
+     *          reallocates the body pool; cached body pointers may be
+     *          reused for a different protagonist.
      *
-     *          For in-session protagonist swaps (radial menu rotation,
-     *          scripted Kliff returns) use invalidate_swap_caches()
-     *          instead -- it preserves the body cache because radial
-     *          swaps only rotate user+0xD8 between EXISTING body
-     *          pointers in the pool, leaving previously-learned
-     *          bodies still valid.
+     *          For in-session protagonist swaps (radial menu) use
+     *          invalidate_swap_caches() instead -- preserves the body
+     *          cache because radial swaps only rotate user+0xD8
+     *          between EXISTING body pointers in the pool.
      *
      *          Safe to call from any thread; non-blocking.
      */
     void invalidate_controlled_character() noexcept;
 
     /**
-     * @brief Clear the LKG identity cache, the actor->character cache,
-     *        and the pending radial-swap-key record, but preserve the
-     *        body->character learning cache.
-     * @details Use this on in-session protagonist swaps (radial menu
-     *          rotation, scripted Kliff returns). The controlled actor
-     *          pointer at user+0xD8 rotates between existing body
-     *          pointers in the pool; the body pointers themselves stay
-     *          valid for the lifetime of the session, so previously-
-     *          learned body identities remain correct after the swap.
-     *
-     *          What this clears:
-     *            - last-known-good cached identity (s_lastGoodChar)
-     *            - actor (userActor parent) -> character cache
-     *            - pending radial-swap-key record
-     *
-     *          What this preserves:
-     *            - body (user+0xD8 pointer) -> character cache
+     * @brief Clear Tier-0 cache, LKG, and the radial-swap timestamp;
+     *        preserve the body learning cache.
+     * @details Use this on in-session protagonist swaps. The
+     *          controlled actor pointer at user+0xD8 rotates between
+     *          existing body pointers in the pool; the body pointers
+     *          themselves stay valid for the lifetime of the session.
      *
      *          For full world-reload semantics use
-     *          invalidate_controlled_character() instead, which also
-     *          flushes the body cache because save-load may reuse old
-     *          body pointers for different characters.
+     *          invalidate_controlled_character() which also flushes
+     *          the body cache.
      *
      *          Safe to call from any thread; non-blocking.
      */

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -1,626 +1,220 @@
+#include <cdcore/anchors.hpp>
 #include <cdcore/controlled_char.hpp>
 
 #include <DetourModKit.hpp>
+#include <DetourModKit/scanner.hpp>
 
 #include <safetyhook/context.hpp>
 #include <safetyhook/mid_hook.hpp>
 
 #include <Windows.h>
+#include <Psapi.h>
 
-#include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <mutex>
 #include <shared_mutex>
+#include <string_view>
 #include <unordered_map>
+
+// ---------------------------------------------------------------------------
+// Controlled-character resolver (v1.06.01 verified).
+//
+// Identity is decoded from the engine's own focus-actor broadcast event
+// (`sub_14353BA60` -- the per-subscriber focus-actor list mutator). R9
+// at function entry carries the new focus-actor's u32 hash handle; the
+// MidHook compares against the three AOB-resolved player hash globals
+// (Kliff/Oongka/Damiane) and stamps a process-wide cache.
+//
+// Resolver layers (top wins) used by `current_controlled_character()`:
+//
+//   1. Structural Kliff anchor -- `body+0x80 == 0x30` reached through
+//      the WorldSystem chain. Positive Kliff signal that does not need
+//      a broadcast (covers cold-load to Kliff).
+//   2. Tier-0 focus-broadcast cache, but only if non-Kliff. Skips a
+//      stale Kliff intermediate fired by the engine during a same-
+//      non-Kliff save reload.
+//   3. `s_lastKnownNonKliff` fallback. Preserved across
+//      `invalidate_controlled_character()` so a same-non-Kliff save
+//      reload (engine never re-broadcasts the actual non-Kliff)
+//      still recovers the correct identity.
+//   4. Tier-0 even if Kliff (engine's authoritative signal).
+//   5. LKG cache (final fallback for torn reads / pre-broadcast).
+//
+// Body learning cache. Each successful resolve stamps
+// (user+0xD8 -> character) into a learning map consumed by
+// `resolve_character_idx_for_body()` and `snapshot_body_cache()`. The
+// cache reaches `user+0xD8` via the WorldSystem chain published by
+// `set_world_system_holder()`.
+//
+// Radial-swap timestamp. The radial-swap MidHook callback is a single
+// atomic store of `GetTickCount64()`; `radial_swap_pending()` reports
+// true for the next 2 s. Consumers (EquipHide, LiveTransmog) use that
+// flag to disambiguate a user-initiated swap from a save-load arena
+// rotation when both surface as a `user+0xD8` pointer change.
+//
+// Thread safety:
+//   - All setters (`set_world_system_holder`, `set_focus_actor_hash_
+//     globals`) are safe from any thread; later writers win.
+//   - `current_controlled_character()` is non-blocking and SEH-
+//     guarded; safe from any thread including the rendering thread.
+// ---------------------------------------------------------------------------
 
 namespace CDCore
 {
     namespace
     {
-        // Server-side player-state holder static. Published by a consumer's
-        // init code via set_player_static_holder(). While zero every
-        // resolver query short-circuits to Unknown so the mod degrades
-        // gracefully when the consumer has not yet completed its own AOB
-        // scan (or that scan fails on a future patch).
-        std::atomic<std::uintptr_t> s_playerStaticHolder{0};
-
-        // WorldSystem holder retained for callers that walk the client-side
-        // chain (UserActor body pool, mesh state). Identity decoding does
-        // not consume this pointer; it is stored only because the public
-        // set_world_system_holder() API still exists for source-level
-        // compatibility with consumers that publish both addresses.
+        // WorldSystem holder. Published by set_world_system_holder(). The
+        // chain walk in walk_to_controlled_body_seh() reaches the rotating
+        // user+0xD8 client body pointer via this chain; the body cache
+        // keys on those body pointers.
         std::atomic<std::uintptr_t> s_wsHolder{0};
 
-        // Cache of the most recent known identity. The chain walk can land
-        // mid-swap when the engine is rewriting active-flag bytes on the
-        // three slots and produce a transient state with zero or two hot
-        // slots; the cache absorbs those torn reads so the resolver does
-        // not flap between Unknown and a known character within a single
-        // swap. Stored as the underlying enum value to keep the atomic
-        // lock-free on x64.
+        // Tier-0 focus-broadcast cache. Stamped by the focus-broadcast
+        // MidHook every time the engine fires a focus event whose R9
+        // matches one of the three published character hash globals.
+        // Stored as the underlying enum value to keep the atomic lock-
+        // free on x64.
+        std::atomic<std::uint8_t> s_focusBroadcastChar{
+            static_cast<std::uint8_t>(ControlledCharacter::Unknown)};
+
+        // Last-known-good identity. Used as the final fallback when a
+        // chain walk transiently faults or the focus-broadcast cache
+        // has not been stamped yet.
         std::atomic<std::uint8_t> s_lastGoodChar{
             static_cast<std::uint8_t>(ControlledCharacter::Unknown)};
 
-        // Walk offsets from the player static down to the party container.
-        // See controlled_char.hpp for the full chain narrative.
-        //
-        //   *(holder)            -> root container (no specific RTTI)
-        //   *(root  + 0x18)      -> pa::NwVirtualAsyncSession
-        //   *(nwSes + 0xA0)      -> pa::ServerUserActor
-        //   *(srvUA + 0xD0)      -> pa::ServerChildOnlyInGameActor
-        //                           (the party container)
-        constexpr std::ptrdiff_t k_rootToNwSessionOffset    = 0x18;
-        constexpr std::ptrdiff_t k_nwSessionToUserOffset    = 0xA0;
-        constexpr std::ptrdiff_t k_userToPartyOffset        = 0xD0;
+        // Last broadcasted NON-Kliff identity (Damiane or Oongka).
+        // Updated only when the focus-broadcast hook captures a non-
+        // Kliff hash; Kliff captures do NOT touch this. Preserved
+        // across invalidate_controlled_character() so the resolver
+        // can recover the user's last Damiane/Oongka selection when
+        // the engine wires Kliff intermediate during a same-non-
+        // Kliff save reload (engine fires Kliff broadcast for the
+        // intermediate, then transitions to the actual non-Kliff
+        // body without firing a follow-up broadcast -- the
+        // structural body marker tells us "not Kliff" but cannot
+        // discriminate Damiane vs Oongka, so we fall back to this
+        // cache).
+        std::atomic<std::uint8_t> s_lastKnownNonKliff{
+            static_cast<std::uint8_t>(ControlledCharacter::Unknown)};
 
-        // Per-protagonist slot offsets inside the party container. Stride
-        // is 0x100 between consecutive slots; the absolute offsets are
-        // baked into the engine layout and serve as the identity
-        // discriminator. Adding a fourth protagonist would extend this
-        // table at +0x368.
-        constexpr std::ptrdiff_t k_kliffSlotOffset   = 0x68;
-        constexpr std::ptrdiff_t k_damianeSlotOffset = 0x168;
-        constexpr std::ptrdiff_t k_oongkaSlotOffset  = 0x268;
-
-        // Per-slot fields:
-        //   slot + 0x2C   u8   active flag (1 = controlled, 0 = passive)
-        //   slot + 0x40   u32  observability handle (volatile; log-only)
-        constexpr std::ptrdiff_t k_slotActiveFlagOffset       = 0x2C;
-        constexpr std::ptrdiff_t k_slotObservabilityOffset    = 0x40;
-
-        // Lower bound for "looks like a heap pointer". Any value below the
-        // 64 KiB Windows guard region is treated as null/invalid; this
-        // catches both real null pointers and the small enum-shaped values
-        // an uninitialised slot may carry before the singleton is wired up.
+        // Lower bound for "looks like a heap pointer". Any value below
+        // the 64 KiB Windows guard region is treated as null/invalid;
+        // this catches both real null pointers and small enum-shaped
+        // values an uninitialised slot may carry before the engine
+        // singleton is wired up.
         constexpr std::uintptr_t k_minValidPtr = 0x10000;
 
-        // One chain walk yields the three slot bytes plus their
-        // observability handles. Populated fully only when the walk
-        // completes without faulting; on any fault `valid` stays false and
-        // the numeric fields carry zero.
-        struct ChainProbe
-        {
-            std::uintptr_t partyContainer;
-            std::uint8_t   kliffActive;
-            std::uint8_t   damianeActive;
-            std::uint8_t   oongkaActive;
-            std::uint32_t  kliffObservability;
-            std::uint32_t  damianeObservability;
-            std::uint32_t  oongkaObservability;
-            bool           valid;
-        };
+        // -------------------------------------------------------------------
+        // Focus-broadcast (Tier-0) state.
+        //
+        // Three engine globals hold per-protagonist u32 hash handles
+        // assigned at static init by the bridge functions described in
+        // cdcore/anchors.hpp::k_focusActorInitPattern. Consumers AOB the
+        // bridges (one-shot, on init) and publish the resolved global
+        // addresses here via set_focus_actor_hash_globals(). The values
+        // themselves are read on every focus-broadcast hook tick (cheap
+        // relaxed loads) and compared against ctx.r9.
+        // -------------------------------------------------------------------
+        std::atomic<std::uintptr_t> s_kliffHashGlobalAddr{0};
+        std::atomic<std::uintptr_t> s_oongkaHashGlobalAddr{0};
+        std::atomic<std::uintptr_t> s_damianHashGlobalAddr{0};
 
-        // SEH-isolated chain walk. Lives in its own function because MSVC
-        // rejects the combination of __try and any C++ object with a
-        // non-trivial destructor in the same scope (C2712). Each
-        // intermediate pointer is rejected if it falls below the guard
-        // region so a half-torn chain cannot reach the slot reads with
-        // garbage state.
-        ChainProbe walk_chain_seh(std::uintptr_t holder) noexcept
-        {
-            ChainProbe out{};
-            if (holder < k_minValidPtr)
-            {
-                return out;
-            }
-            __try
-            {
-                const auto root =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(holder);
-                if (root < k_minValidPtr)
-                {
-                    return out;
-                }
-                const auto nwSession =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(
-                        root + k_rootToNwSessionOffset);
-                if (nwSession < k_minValidPtr)
-                {
-                    return out;
-                }
-                const auto userActor =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(
-                        nwSession + k_nwSessionToUserOffset);
-                if (userActor < k_minValidPtr)
-                {
-                    return out;
-                }
-                const auto party =
-                    *reinterpret_cast<const volatile std::uintptr_t *>(
-                        userActor + k_userToPartyOffset);
-                if (party < k_minValidPtr)
-                {
-                    return out;
-                }
-                // Three slot reads, each one byte for the active flag and
-                // one dword for the observability handle. The slot bytes
-                // are nominally pinned at compile-time-stable offsets so
-                // a fault here would indicate a torn party container that
-                // the SEH guard correctly rejects.
-                const auto kliffSlot   = party + k_kliffSlotOffset;
-                const auto damianeSlot = party + k_damianeSlotOffset;
-                const auto oongkaSlot  = party + k_oongkaSlotOffset;
-                const auto kliffActive =
-                    *reinterpret_cast<const volatile std::uint8_t *>(
-                        kliffSlot + k_slotActiveFlagOffset);
-                const auto damianeActive =
-                    *reinterpret_cast<const volatile std::uint8_t *>(
-                        damianeSlot + k_slotActiveFlagOffset);
-                const auto oongkaActive =
-                    *reinterpret_cast<const volatile std::uint8_t *>(
-                        oongkaSlot + k_slotActiveFlagOffset);
-                const auto kliffObs =
-                    *reinterpret_cast<const volatile std::uint32_t *>(
-                        kliffSlot + k_slotObservabilityOffset);
-                const auto damianeObs =
-                    *reinterpret_cast<const volatile std::uint32_t *>(
-                        damianeSlot + k_slotObservabilityOffset);
-                const auto oongkaObs =
-                    *reinterpret_cast<const volatile std::uint32_t *>(
-                        oongkaSlot + k_slotObservabilityOffset);
-                out.partyContainer       = party;
-                out.kliffActive          = kliffActive;
-                out.damianeActive        = damianeActive;
-                out.oongkaActive         = oongkaActive;
-                out.kliffObservability   = kliffObs;
-                out.damianeObservability = damianeObs;
-                out.oongkaObservability  = oongkaObs;
-                out.valid                = true;
-                return out;
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return out;
-            }
-        }
-
-        // Decode identity from a completed chain probe. Returns Unknown
-        // when the probe is invalid, when no slot is hot (cutscene /
-        // loading screen), or when more than one slot is hot (a transient
-        // engine state mid-swap that the cache layer is responsible for
-        // smoothing over).
-        ControlledCharacter decode_probe(const ChainProbe &probe) noexcept
-        {
-            if (!probe.valid)
-            {
-                return ControlledCharacter::Unknown;
-            }
-            const int hotCount = (probe.kliffActive   == 1 ? 1 : 0) +
-                                 (probe.damianeActive == 1 ? 1 : 0) +
-                                 (probe.oongkaActive  == 1 ? 1 : 0);
-            if (hotCount != 1)
-            {
-                return ControlledCharacter::Unknown;
-            }
-            if (probe.kliffActive == 1)
-            {
-                return ControlledCharacter::Kliff;
-            }
-            if (probe.damianeActive == 1)
-            {
-                return ControlledCharacter::Damiane;
-            }
-            return ControlledCharacter::Oongka;
-        }
-
-        // Diagnostic: log each unique active-flag triplet observed from a
-        // valid probe, at most once per process. Eight slots covers the
-        // four expected states (none-hot, Kliff-hot, Damiane-hot,
-        // Oongka-hot) with headroom for transient torn-read patterns. The
-        // observability dwords are logged alongside the active flags so
-        // session-to-session correlation is possible without re-running
-        // the resolver in a debugger.
-        std::array<std::atomic<std::uint32_t>, 8> s_seenProbes{};
-
-        constexpr std::uint32_t k_probeSentinel = 0xFFFFFFFFu;
-
-        // Pack the three active-flag bytes (each clamped to {0, 1}) into a
-        // 24-bit signature. Guaranteed distinct from k_probeSentinel
-        // because the high byte is always zero.
-        std::uint32_t pack_probe_signature(const ChainProbe &probe) noexcept
-        {
-            const std::uint32_t k = (probe.kliffActive == 1) ? 1u : 0u;
-            const std::uint32_t d = (probe.damianeActive == 1) ? 1u : 0u;
-            const std::uint32_t o = (probe.oongkaActive == 1) ? 1u : 0u;
-            return k | (d << 8) | (o << 16);
-        }
-
-        void log_first_seen_probe(const ChainProbe &probe,
-                                  ControlledCharacter decoded) noexcept
-        {
-            const auto sig = pack_probe_signature(probe);
-            for (auto &slot : s_seenProbes)
-            {
-                auto prev = slot.load(std::memory_order_relaxed);
-                if (prev != 0 && (prev ^ k_probeSentinel) == sig)
-                {
-                    return;
-                }
-                if (prev == 0)
-                {
-                    const auto stamp = sig ^ k_probeSentinel;
-                    if (slot.compare_exchange_strong(
-                            prev, stamp,
-                            std::memory_order_relaxed,
-                            std::memory_order_relaxed))
-                    {
-                        // Prefer the short character name when the decode
-                        // matched one of the three known identities.
-                        // Unknown falls back to a literal "Unknown" label
-                        // because controlled_character_name() returns an
-                        // empty view for that case and we want a
-                        // self-describing log line even for anomalies.
-                        const auto name = controlled_character_name(decoded);
-                        DMK::Logger::get_instance().info(
-                            "ControlledChar: probe kliff_active={} "
-                            "damiane_active={} oongka_active={} "
-                            "kliff_obs=0x{:X} damiane_obs=0x{:X} "
-                            "oongka_obs=0x{:X} -> {}",
-                            static_cast<unsigned>(probe.kliffActive),
-                            static_cast<unsigned>(probe.damianeActive),
-                            static_cast<unsigned>(probe.oongkaActive),
-                            probe.kliffObservability,
-                            probe.damianeObservability,
-                            probe.oongkaObservability,
-                            name.empty() ? std::string_view{"Unknown"}
-                                         : name);
-                        return;
-                    }
-                    if ((prev ^ k_probeSentinel) == sig)
-                    {
-                        return;
-                    }
-                }
-            }
-            // Seen-set exhausted. The resolver stays functional; only the
-            // diagnostic log is silently dropped for additional unknown
-            // probe signatures.
-        }
+        std::mutex s_focusHookMutex;
+        safetyhook::MidHook s_focusBroadcastHook;
+        std::atomic<std::uintptr_t> s_focusBroadcastHookAddr{0};
 
         // -------------------------------------------------------------------
-        // Radial-swap-key capture: actor pointer -> character cache.
+        // Radial-swap timestamp (powers `radial_swap_pending()`).
         //
-        // The mid-hook installed by install_radial_swap_hook() fires inside
-        // the radial UI's swap handler at the moment EAX has just been
-        // loaded with the requested characterinfo key (1 = Kliff,
-        // 4 = Damiane, 6 = Oongka). At that point User+0xD8 still holds
-        // the OLD actor pointer; the new actor commit happens later in
-        // the same handler when sub_141B0C2B0 writes the resolved actor.
+        // EquipHide consumes this signal to disambiguate two events that
+        // both rotate user+0xD8: (a) the user pressing radial-swap keys
+        // and (b) save-load reattach. When the controlled-actor pointer
+        // shifts and the new pointer is absent from the body cache,
+        // EquipHide checks `radial_swap_pending()`; true -> "first-time
+        // radial swap to this protagonist" (preserve cache), false ->
+        // "save-load arena rotation" (full reload wipe).
         //
-        // Correlation strategy (chosen for cleaner concurrency vs. a
-        // second hook on the call return):
-        //
-        //   1. Hook stamps a short-lived process-wide pending record
-        //      with (key, deadline_tick). Single record because a radial
-        //      swap is a synchronous user event with no nested handlers.
-        //
-        //   2. The next chain-walk in current_controlled_character() that
-        //      observes a valid userActor and a non-Kliff slot+0x2C
-        //      decode commits (actor_ptr -> key) into the actor cache,
-        //      then clears the pending record. The deadline (currently
-        //      2000 ms) bounds the window so a stale record from a
-        //      cancelled radial cannot pollute future commits.
-        //
-        //   3. The resolver consults the cache before falling back to
-        //      the slot-offset decode when the +0x2C decode itself
-        //      yielded Unknown but the chain walk reached a valid
-        //      userActor. Cache hits are deterministic per-actor;
-        //      cache misses fall through to the slot decode.
-        //
-        // Concurrency model: shared_mutex on the cache because the hook
-        // (game thread) and resolver (worker threads + main render) hit
-        // the cache asymmetrically -- many readers, occasional writer.
-        // The pending record itself is two atomics (key + deadline);
-        // races on the pending-record path collapse to a benign no-op
-        // because either the hook overwrites a stale pending value or
-        // the resolver clears one we are about to commit. In both cases
-        // the next radial swap rebuilds the record correctly.
-        //
-        // Why a per-actor cache instead of a single "latest key" atomic:
-        // the LiveTransmog preset routing must distinguish between
-        // saved-out and reloaded actor pointers (actor pool reuses old
-        // addresses across save loads). A per-actor map naturally goes
-        // stale at save-load -- pre-existing entries reference dead
-        // pointers the engine will not reuse for the same character --
-        // and invalidate_controlled_character() clears the cache to
-        // bound stale-entry growth.
+        // The mid-hook callback is a single atomic store -- no character
+        // decode, no chain walk. The character identity itself comes
+        // from the focus-broadcast hook (Tier 0) which fires for the
+        // same swap event.
         // -------------------------------------------------------------------
+        constexpr std::uint64_t k_radialSwapPendingWindowMs = 2000u;
+        std::atomic<std::uint64_t> s_radialSwapTimestampMs{0};
 
-        // 2-second window: typical radial swap commits within tens of
-        // milliseconds, but post-swap the resolver only refreshes when
-        // a consumer queries it; 2 s tolerates one full
-        // load_detect_thread tick before declaring the pending record
-        // stale. Bounded above by the next radial swap clobbering it.
-        constexpr std::uint64_t k_pendingKeyWindowMs = 2000u;
-
-        // Engine characterinfo keys, verified live (CE 2026-05-02 across
-        // four protagonist transitions including a save B follow-up):
-        //   key 1 -> Kliff
-        //   key 4 -> Damiane
-        //   key 6 -> Oongka
-        // Other key values land outside the protagonist set and are
-        // stored as Unknown so the cache never falsely attributes an
-        // NPC body to one of the three.
-        constexpr std::uint32_t k_keyKliff   = 1u;
-        constexpr std::uint32_t k_keyDamiane = 4u;
-        constexpr std::uint32_t k_keyOongka  = 6u;
-
-        ControlledCharacter character_from_key(std::uint32_t key) noexcept
-        {
-            switch (key)
-            {
-                case k_keyKliff:   return ControlledCharacter::Kliff;
-                case k_keyDamiane: return ControlledCharacter::Damiane;
-                case k_keyOongka:  return ControlledCharacter::Oongka;
-                default:           return ControlledCharacter::Unknown;
-            }
-        }
-
-        // Pending-record fields. s_pendingKey is read in the resolver
-        // hot path so it is a plain atomic instead of a struct under a
-        // lock; the deadline atomic provides freshness gating without
-        // taking a mutex on every query. A non-zero pendingKey with
-        // deadline >= now is "live"; everything else is "expired".
-        std::atomic<std::uint32_t> s_pendingKey{0};
-        std::atomic<std::uint64_t> s_pendingDeadlineMs{0};
-
-        // Per-actor identity cache populated by the resolver when a
-        // pending record commits, and consulted by the resolver as a
-        // Stage 3 layer when the chain walk reaches a valid userActor
-        // but the slot decode returns Unknown (or for cross-validation
-        // when both Damiane and Oongka are radial-controllable but
-        // neither holds a hot +0x2C flag in the formal party). Ranged
-        // small (the engine has at most three live protagonist actor
-        // pointers per session); the unordered_map is sized for that.
-        std::shared_mutex s_actorCacheMutex;
-        std::unordered_map<std::uintptr_t, ControlledCharacter>
-            s_actorKeyCache;
-
-        // Learning cache: body pointer (user+0xD8 at the moment of an
-        // identified-controlled snapshot) -> character. Populated as a
-        // side effect of every successful current_controlled_character()
-        // call that sees a non-Unknown identity AND can reach user+0xD8
-        // via the WS chain. Each protagonist's body is added to the
-        // cache the first time the user controls that character; from
-        // then on resolve_character_idx_for_body() can attribute roster
-        // bodies to their identities even while a different protagonist
-        // is currently controlled.
-        //
-        // Lifetime: cleared together with s_actorKeyCache in
-        // invalidate_controlled_character() because save-load
-        // reallocates the body pool; pre-existing entries reference
-        // dead pointers the engine may reuse for a different character.
-        //
-        // Why a learning cache instead of a structural decode: the
-        // v1.04.00 client body has no reachable back-reference to its
-        // protagonist slot in the party container, and the per-actor
-        // +0x50 byte that earlier builds used as a slot index ceased
-        // to discriminate on this build. Observing the controlled-body
-        // / known-character pairing each resolver tick is the only
-        // stable mapping available from the public game-state surface.
-        std::shared_mutex s_bodyCacheMutex;
-        std::unordered_map<std::uintptr_t, ControlledCharacter>
-            s_bodyKeyCache;
-
-        // SafetyHook owner. Held in a dedicated mutex because the
-        // install/uninstall paths must serialise against each other,
-        // and a second mutex separate from s_actorCacheMutex prevents
-        // any caller of the public install/uninstall API from blocking
-        // a resolver query already inside the cache critical section.
-        //
-        // Single-owner-per-DLL semantics: CrimsonDesertCore is linked
-        // as a STATIC library, so this state is private to whichever
-        // Logic DLL (LiveTransmog or EquipHide) owns this translation
-        // unit's instance. When both consumers AOB-resolve the same
-        // radial-swap site and call install_radial_swap_hook(addr),
-        // each DLL builds its own MidHook independently. SafetyHook's
-        // internal chaining at the JMP-target site lets the two
-        // MidHooks coexist -- each consumer's callback fires on every
-        // radial swap. The AOB cascade in cdcore/anchors.hpp is
-        // ordered so the post-patch-tolerant patterns match first,
-        // letting the second consumer resolve the same target after
-        // the first has already patched the prelude bytes.
         std::mutex s_hookMutex;
         safetyhook::MidHook s_radialSwapHook;
         std::atomic<std::uintptr_t> s_radialSwapHookAddr{0};
 
-        // Outer-slot offsets used by the swap handler sub_141B04040.
-        // The MidHook decodes (ctx.rdx - party_base) against this table
-        // to recover the requested character. Distinct from the inner
-        // slot offsets used by walk_chain_seh (0x68 / 0x168 / 0x268):
-        // those reach the per-protagonist record whose +0x2C byte is
-        // the active flag, while the swap handler views each slot as a
-        // 0x100-stride aggregate with the active byte at +0x94 from the
-        // slot start (party + 0x000 + 0x94 == party + 0x68 + 0x2C,
-        // i.e. the two views address the same byte through different
-        // intermediates).
-        constexpr std::ptrdiff_t k_swapKliffOuterOffset   = 0x000;
-        constexpr std::ptrdiff_t k_swapDamianeOuterOffset = 0x100;
-        constexpr std::ptrdiff_t k_swapOongkaOuterOffset  = 0x200;
-
-        // SafetyHook MidHook destination. Lives at file scope because a
-        // function pointer cannot be a lambda capture target.
+        // -------------------------------------------------------------------
+        // Body learning cache (body_ptr -> character).
         //
-        // Hook target: function entry of sub_141B04040, the radial-UI
-        // character-swap handler with signature
-        //   __fastcall(container *a1, slot *a2, int a3)
-        // RDX (a2) at function entry holds the requested new active
-        // slot pointer; the function subsequently clears the previous
-        // slot's +0x94 active byte and sets the new slot's +0x94 to 1.
-        // Decoding (a2 - party_base) against k_swap*OuterOffset gives
-        // the protagonist identity without involving the engine's u32
-        // characterinfo-key lookup table.
+        // Populated as a side effect of every successful current_
+        // controlled_character() call: when the resolver confirms an
+        // identity it stamps the user+0xD8 body pointer into the cache.
+        // Consumed by resolve_character_idx_for_body() so EquipHide's
+        // roster walker can attribute non-controlled bodies (party
+        // members visible in the world).
         //
-        // Must not block, allocate, or call into anything that can
-        // re-enter SafetyHook. The body performs an SEH-isolated chain
-        // probe to resolve the live party container, a fixed-cost
-        // offset switch, and an atomic store pair to stamp the pending
-        // record consumed by the resolver hot path.
-        void radial_swap_midhook(safetyhook::Context &ctx) noexcept
+        // Cleared on full world-reload via invalidate_controlled_
+        // character() because save-load reallocates the body pool;
+        // pre-existing entries reference dead pointers the engine may
+        // reuse for a different protagonist.
+        // -------------------------------------------------------------------
+        std::shared_mutex s_bodyCacheMutex;
+        std::unordered_map<std::uintptr_t, ControlledCharacter>
+            s_bodyKeyCache;
+
+        // SEH-isolated read of one of the three published hash globals.
+        // Returns 0 when the address is unpublished or the load faults.
+        std::uint32_t safe_read_hash_global(std::uintptr_t addr) noexcept
         {
-            const auto new_slot_ptr =
-                static_cast<std::uintptr_t>(ctx.rdx);
-            if (new_slot_ptr < k_minValidPtr)
-            {
-                return;
-            }
-
-            const auto holder =
-                s_playerStaticHolder.load(std::memory_order_acquire);
-            if (holder < k_minValidPtr)
-            {
-                return;
-            }
-
-            const auto probe = walk_chain_seh(holder);
-            if (!probe.valid || probe.partyContainer < k_minValidPtr)
-            {
-                return;
-            }
-
-            const auto offset =
-                static_cast<std::ptrdiff_t>(
-                    new_slot_ptr - probe.partyContainer);
-            std::uint32_t key = 0;
-            switch (offset)
-            {
-                case k_swapKliffOuterOffset:
-                    key = k_keyKliff;
-                    break;
-                case k_swapDamianeOuterOffset:
-                    key = k_keyDamiane;
-                    break;
-                case k_swapOongkaOuterOffset:
-                    key = k_keyOongka;
-                    break;
-                default:
-                    // RDX did not land on a known protagonist slot
-                    // (e.g. a NPC body swap or a future protagonist
-                    // not in this table). Silently no-op so the cache
-                    // does not pollute with an out-of-range identity.
-                    return;
-            }
-
-            const auto now = GetTickCount64();
-            // Stamp the deadline before the key so the resolver never
-            // observes a fresh key paired with a stale deadline. The
-            // acquire loads on the resolver side pair with these
-            // releases.
-            s_pendingDeadlineMs.store(now + k_pendingKeyWindowMs,
-                                      std::memory_order_release);
-            s_pendingKey.store(key, std::memory_order_release);
-        }
-
-        // Try to commit the pending key against the supplied actor
-        // pointer. Called from the resolver hot path on every query
-        // that sees a valid userActor. Cheap on the no-pending fast
-        // path (one relaxed atomic load + branch). On commit, takes
-        // the cache mutex exclusive briefly; commit failures (expired
-        // record, unknown key) silently drop the pending record so a
-        // late retry does not double-commit.
-        void try_commit_pending(std::uintptr_t userActor) noexcept
-        {
-            if (userActor < k_minValidPtr)
-            {
-                return;
-            }
-            const auto key = s_pendingKey.load(std::memory_order_acquire);
-            if (key == 0)
-            {
-                return;
-            }
-            const auto deadline =
-                s_pendingDeadlineMs.load(std::memory_order_acquire);
-            const auto now = GetTickCount64();
-            if (now > deadline)
-            {
-                // Stale; clear so we do not consume it on a later
-                // unrelated query.
-                s_pendingKey.store(0, std::memory_order_release);
-                s_pendingDeadlineMs.store(0, std::memory_order_release);
-                return;
-            }
-            const auto ch = character_from_key(key);
-            if (ch == ControlledCharacter::Unknown)
-            {
-                // Out-of-range key (engine repurposed the slot for an
-                // NPC body or a future protagonist not in our table);
-                // clear and do not pollute the cache.
-                s_pendingKey.store(0, std::memory_order_release);
-                s_pendingDeadlineMs.store(0, std::memory_order_release);
-                return;
-            }
-            {
-                std::unique_lock<std::shared_mutex> lk(s_actorCacheMutex);
-                s_actorKeyCache[userActor] = ch;
-            }
-            s_pendingKey.store(0, std::memory_order_release);
-            s_pendingDeadlineMs.store(0, std::memory_order_release);
-
-            DMK::Logger::get_instance().info(
-                "ControlledChar: radial-swap cache bind userActor=0x{:X} "
-                "-> {} (key={})",
-                static_cast<std::uint64_t>(userActor),
-                controlled_character_name(ch),
-                key);
-        }
-
-        ControlledCharacter lookup_actor_cache(
-            std::uintptr_t userActor) noexcept
-        {
-            if (userActor < k_minValidPtr)
-            {
-                return ControlledCharacter::Unknown;
-            }
-            std::shared_lock<std::shared_mutex> lk(s_actorCacheMutex);
-            const auto it = s_actorKeyCache.find(userActor);
-            if (it == s_actorKeyCache.end())
-            {
-                return ControlledCharacter::Unknown;
-            }
-            return it->second;
-        }
-
-        // SEH-isolated reach to the userActor pointer alone. The full
-        // walk_chain_seh() above stops at the party container; the
-        // cache layer keys on the userActor (party container's parent
-        // in the chain) because the actor pointer is what the engine
-        // commits per radial swap and what the radial-swap-key hook's
-        // pending record is meant to attribute to.
-        std::uintptr_t walk_to_user_actor_seh(std::uintptr_t holder) noexcept
-        {
-            if (holder < k_minValidPtr)
-            {
+            if (addr < k_minValidPtr)
                 return 0;
-            }
             __try
             {
-                const auto root = *reinterpret_cast<
-                    const volatile std::uintptr_t *>(holder);
-                if (root < k_minValidPtr)
-                {
-                    return 0;
-                }
-                const auto nwSession = *reinterpret_cast<
-                    const volatile std::uintptr_t *>(
-                    root + k_rootToNwSessionOffset);
-                if (nwSession < k_minValidPtr)
-                {
-                    return 0;
-                }
-                const auto userActor = *reinterpret_cast<
-                    const volatile std::uintptr_t *>(
-                    nwSession + k_nwSessionToUserOffset);
-                if (userActor < k_minValidPtr)
-                {
-                    return 0;
-                }
-                return userActor;
+                return *reinterpret_cast<const volatile std::uint32_t *>(addr);
             }
             __except (EXCEPTION_EXECUTE_HANDLER)
             {
                 return 0;
+            }
+        }
+
+        // SEH-isolated read of an asciiz at @p addr into @p outBuf.
+        // Caller-owned storage avoids RAII inside the SEH scope (MSVC
+        // C2712). Writes the byte count (excluding NUL) into @p outLen.
+        bool seh_read_cstring(std::uintptr_t addr,
+                              char         *outBuf,
+                              std::size_t   capacity,
+                              std::size_t  &outLen) noexcept
+        {
+            outLen = 0;
+            if (addr < k_minValidPtr || outBuf == nullptr || capacity == 0)
+                return false;
+            __try
+            {
+                const auto *cstr =
+                    reinterpret_cast<const char *>(addr);
+                std::size_t i = 0;
+                while (i < capacity - 1 && cstr[i] != '\0')
+                {
+                    outBuf[i] = cstr[i];
+                    ++i;
+                }
+                outBuf[i] = '\0';
+                outLen = i;
+                return true;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                outBuf[0] = '\0';
+                outLen = 0;
+                return false;
             }
         }
 
@@ -628,57 +222,32 @@ namespace CDCore
         // CLIENT body pointer used as the body-cache key. Walks the WS
         // chain (s_wsHolder -> ws -> ws+0x30 (ActorManager) -> am+0x28
         // (ClientUserActor) -> +0xD8). The PLAYER-STATIC chain reaches
-        // a distinct server-side ServerUserActor whose +0xD8 is not
-        // the client body and would mis-key the cache (EquipHide's
-        // body_to_vis_ctrl walker and char-swap detector both consume
-        // the client body, so the cache must be keyed on it).
-        //
-        // Returns 0 when the WS holder has not been published yet,
-        // when any intermediate pointer is below the guard region, or
-        // when the load faults. Callers treat 0 as "no stamp this
-        // tick" and leave the cache unchanged.
+        // a distinct server-side ServerUserActor whose +0xD8 is not the
+        // client body and would mis-key the cache.
         std::uintptr_t walk_to_controlled_body_seh() noexcept
         {
             const auto wsHolder =
                 s_wsHolder.load(std::memory_order_acquire);
             if (wsHolder < k_minValidPtr)
-            {
                 return 0;
-            }
             __try
             {
                 const auto ws = *reinterpret_cast<
                     const volatile std::uintptr_t *>(wsHolder);
                 if (ws < k_minValidPtr)
-                {
                     return 0;
-                }
-                // ws + 0x30 -> ActorManager. Same offset as walks
-                // elsewhere in the codebase (EH player_detection, LT
-                // transmog_worker).
                 const auto am = *reinterpret_cast<
                     const volatile std::uintptr_t *>(ws + 0x30);
                 if (am < k_minValidPtr)
-                {
                     return 0;
-                }
-                // am + 0x28 -> ClientUserActor.
                 const auto userActor = *reinterpret_cast<
                     const volatile std::uintptr_t *>(am + 0x28);
                 if (userActor < k_minValidPtr)
-                {
                     return 0;
-                }
-                // user + 0xD8 -> controlled CLIENT body. The userActor
-                // singleton stays constant across radial swaps; only
-                // this field rotates per swap, so it is the correct
-                // key for body-identity attribution.
                 const auto controlledBody = *reinterpret_cast<
                     const volatile std::uintptr_t *>(userActor + 0xD8);
                 if (controlledBody < k_minValidPtr)
-                {
                     return 0;
-                }
                 return controlledBody;
             }
             __except (EXCEPTION_EXECUTE_HANDLER)
@@ -687,13 +256,38 @@ namespace CDCore
             }
         }
 
-        // Stamp (body -> character) into the learning cache. Called from
-        // current_controlled_character() at every success exit. The
-        // shared_mutex pattern matches s_actorKeyCache: many readers
-        // (resolve_character_idx_for_body) and an occasional writer
-        // (this stamp). Skips when @p body is below the guard region or
-        // when @p ch is Unknown -- callers should only stamp on a
-        // confirmed identity.
+        // SEH-isolated structural read: is the given body Kliff?
+        // Body+0x80 dword is 0x30 for Kliff bodies and 0x1D (or
+        // similar non-0x30 sentinel) for Damiane/Oongka bodies, per
+        // live captures 2026-05-14. This is a binary "is-Kliff"
+        // signal: returns true ONLY when the marker explicitly says
+        // Kliff. Returns false for non-Kliff AND for any fault /
+        // unmapped read (so the caller falls back to Tier-0 / last-
+        // known-non-Kliff cache, never up-casting an unknown to
+        // Kliff). Cannot discriminate Damiane from Oongka -- both
+        // share the non-Kliff marker.
+        constexpr std::uint32_t k_bodyKliffMarker = 0x30;
+        constexpr std::ptrdiff_t k_bodyMarkerOffset = 0x80;
+
+        bool body_is_structurally_kliff(std::uintptr_t body) noexcept
+        {
+            if (body < k_minValidPtr)
+                return false;
+            __try
+            {
+                const auto marker =
+                    *reinterpret_cast<const volatile std::uint32_t *>(
+                        body + k_bodyMarkerOffset);
+                return marker == k_bodyKliffMarker;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return false;
+            }
+        }
+
+        // Stamp (body -> character) into the learning cache. Skips when
+        // @p body is below the guard region or @p ch is Unknown.
         void stamp_body_cache(std::uintptr_t body,
                               ControlledCharacter ch) noexcept
         {
@@ -704,6 +298,113 @@ namespace CDCore
             }
             std::unique_lock<std::shared_mutex> lk(s_bodyCacheMutex);
             s_bodyKeyCache[body] = ch;
+        }
+
+        // SafetyHook MidHook destination for sub_14353BA60 (the engine's
+        // per-subscriber focus-actor list mutator). ctx.r9 carries the
+        // new focus-actor hash handle; we compare against the three
+        // published player-character globals and, on match, stamp the
+        // resolved character into s_focusBroadcastChar.
+        //
+        // The vast majority of fires (~99.8% on captured sessions) carry
+        // NPC focus handles and are filtered out by the equality checks.
+        // Must not block, allocate, or call into anything that can
+        // re-enter SafetyHook.
+        void focus_broadcast_midhook(safetyhook::Context &ctx) noexcept
+        {
+            const auto incoming = static_cast<std::uint32_t>(ctx.r9);
+            if (incoming == 0)
+                return;
+
+            const auto kliff =
+                safe_read_hash_global(s_kliffHashGlobalAddr.load(
+                    std::memory_order_acquire));
+            const auto oongka =
+                safe_read_hash_global(s_oongkaHashGlobalAddr.load(
+                    std::memory_order_acquire));
+            const auto damian =
+                safe_read_hash_global(s_damianHashGlobalAddr.load(
+                    std::memory_order_acquire));
+
+            ControlledCharacter resolved = ControlledCharacter::Unknown;
+            if (kliff != 0 && incoming == kliff)
+                resolved = ControlledCharacter::Kliff;
+            else if (oongka != 0 && incoming == oongka)
+                resolved = ControlledCharacter::Oongka;
+            else if (damian != 0 && incoming == damian)
+                resolved = ControlledCharacter::Damiane;
+            else
+                return; // Not a player-character broadcast.
+
+            const auto prior = s_focusBroadcastChar.exchange(
+                static_cast<std::uint8_t>(resolved),
+                std::memory_order_acq_rel);
+            s_lastGoodChar.store(
+                static_cast<std::uint8_t>(resolved),
+                std::memory_order_release);
+
+            // Update s_lastKnownNonKliff ONLY for Damiane/Oongka
+            // captures. This cache is the resolver's fallback when
+            // the structural body marker says "not Kliff" but the
+            // engine has not fired a Damiane/Oongka broadcast for
+            // the actual current character (the same-non-Kliff
+            // save reload edge case). Kliff captures must NOT
+            // overwrite this cache, otherwise an intermediate Kliff
+            // broadcast during world load would erase the user's
+            // last Damiane/Oongka selection.
+            if (resolved == ControlledCharacter::Damiane ||
+                resolved == ControlledCharacter::Oongka)
+            {
+                s_lastKnownNonKliff.store(
+                    static_cast<std::uint8_t>(resolved),
+                    std::memory_order_release);
+            }
+
+            // Always emit at INFO on a change, TRACE otherwise. The
+            // broadcast is event-rate (rare), not tick-rate, so log
+            // volume is irrelevant; dedupe was suppressing the first
+            // post-hot-reload capture when CDCore static state
+            // retained the pre-reload value, making it look like the
+            // hook had not fired.
+            const bool changed =
+                (prior != static_cast<std::uint8_t>(resolved));
+            auto &logger = DMK::Logger::get_instance();
+            if (changed)
+            {
+                logger.info(
+                    "ControlledChar: focus-broadcast captured "
+                    "hash=0x{:X} -> {} (changed={})",
+                    incoming,
+                    controlled_character_name(resolved),
+                    changed);
+            }
+            else
+            {
+                logger.trace(
+                    "ControlledChar: focus-broadcast captured "
+                    "hash=0x{:X} -> {} (changed={})",
+                    incoming,
+                    controlled_character_name(resolved),
+                    changed);
+            }
+        }
+
+        // SafetyHook MidHook destination for the radial-swap handler
+        // (sub_141B04040). Stamps a single monotonic timestamp consumed
+        // by `radial_swap_pending()`. Consumers use that flag to
+        // distinguish a user radial swap from a save-load arena
+        // rotation; the character identity itself comes from the
+        // focus-broadcast hook.
+        void radial_swap_midhook(safetyhook::Context & /*ctx*/) noexcept
+        {
+            const auto now = GetTickCount64();
+            s_radialSwapTimestampMs.store(now, std::memory_order_release);
+
+            // User-input rate (sub-Hz) -- trace log overhead is
+            // irrelevant. Surfacing every fire lets consumers tell a
+            // radial swap (fires) from a save-load reattach (does not).
+            DMK::Logger::get_instance().trace(
+                "ControlledChar: radial-swap input fired (ts={})", now);
         }
 
     } // anonymous namespace
@@ -720,100 +421,284 @@ namespace CDCore
         }
     }
 
-    void set_player_static_holder(std::uintptr_t holderAddr) noexcept
+    void set_focus_actor_hash_globals(std::uintptr_t kliffAddr,
+                                      std::uintptr_t oongkaAddr,
+                                      std::uintptr_t damianAddr) noexcept
     {
-        s_playerStaticHolder.store(holderAddr, std::memory_order_release);
+        s_kliffHashGlobalAddr.store(kliffAddr,  std::memory_order_release);
+        s_oongkaHashGlobalAddr.store(oongkaAddr, std::memory_order_release);
+        s_damianHashGlobalAddr.store(damianAddr, std::memory_order_release);
 
-        if (holderAddr != 0)
+        if (kliffAddr || oongkaAddr || damianAddr)
         {
+            // Note: hash values may be 0 at this moment if the engine's
+            // static init has not yet populated them; the addresses
+            // themselves are correct and the hook callback re-reads on
+            // every fire.
             DMK::Logger::get_instance().info(
-                "ControlledChar: Player static holder published at 0x{:X}",
-                static_cast<std::uint64_t>(holderAddr));
+                "ControlledChar: focus-actor hash global addresses "
+                "published (kliff=0x{:X}, oongka=0x{:X}, damian=0x{:X})",
+                static_cast<std::uint64_t>(kliffAddr),
+                static_cast<std::uint64_t>(oongkaAddr),
+                static_cast<std::uint64_t>(damianAddr));
         }
+    }
+
+    bool resolve_and_publish_focus_actor_globals() noexcept
+    {
+        constexpr std::string_view k_kliffName  = "focus-actor-kliff";
+        constexpr std::string_view k_oongkaName = "focus-actor-oongka";
+        constexpr std::string_view k_damianName = "focus-actor-damian";
+
+        auto compiled = DetourModKit::Scanner::parse_aob(
+            CDCore::Anchors::k_focusActorInitPattern);
+        if (!compiled)
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: focus-actor init pattern failed to "
+                "compile -- Tier-0 disabled");
+            return false;
+        }
+
+        // Resolve the main module's base + size so we can scan the
+        // whole image (including the `.tls` section). The bridge
+        // functions live in `.tls` on this binary; that section is
+        // mapped without PAGE_EXECUTE so scan_executable_regions
+        // skips it. Module-bounded find_pattern covers any section
+        // regardless of execute permission.
+        const auto mainModule = ::GetModuleHandleW(nullptr);
+        if (mainModule == nullptr)
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: GetModuleHandle(nullptr) returned NULL "
+                "-- focus-actor AOB scan aborted");
+            return false;
+        }
+        MODULEINFO modInfo{};
+        if (!::GetModuleInformation(::GetCurrentProcess(),
+                                    mainModule,
+                                    &modInfo,
+                                    sizeof(modInfo)))
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: GetModuleInformation failed (gle={}) "
+                "-- focus-actor AOB scan aborted",
+                ::GetLastError());
+            return false;
+        }
+        const auto *moduleBase =
+            reinterpret_cast<const std::byte *>(modInfo.lpBaseOfDll);
+        const auto moduleSize =
+            static_cast<std::size_t>(modInfo.SizeOfImage);
+
+        std::uintptr_t kliffGlobal  = 0;
+        std::uintptr_t oongkaGlobal = 0;
+        std::uintptr_t damianGlobal = 0;
+
+        // The pattern matches the generic "register tag via
+        // sub_140F46680" bridge shape used by HUNDREDS of engine
+        // strings (focus-actor-*, layer tags, query keys, etc.), not
+        // just the three protagonists. Walk the entire image with an
+        // advancing start pointer so the total cost stays O(image)
+        // rather than O(N * image), and dispatch each hit by its
+        // string content. The loop exits early once all three
+        // protagonists are bound.
+        const std::byte *cursor      = moduleBase;
+        const auto      *moduleEnd   = moduleBase + moduleSize;
+        constexpr std::size_t k_maxScannedHits = 4096;
+        std::size_t hitsScanned = 0;
+        while (cursor < moduleEnd && hitsScanned < k_maxScannedHits)
+        {
+            const auto remaining =
+                static_cast<std::size_t>(moduleEnd - cursor);
+            const auto *match =
+                DetourModKit::Scanner::find_pattern(
+                    cursor, remaining, *compiled);
+            if (match == nullptr)
+                break;
+            ++hitsScanned;
+            cursor = match + 1;
+
+            const auto matchAddr =
+                reinterpret_cast<std::uintptr_t>(match);
+
+            // Resolve the string LEA: disp32 at +9, RIP after instr at +13.
+            const auto strDispAddr =
+                matchAddr + CDCore::Anchors::k_focusActorInitStringDispOffset;
+            std::int32_t strDisp = 0;
+            std::memcpy(&strDisp,
+                        reinterpret_cast<const void *>(strDispAddr),
+                        sizeof(strDisp));
+            const auto strAddr =
+                matchAddr +
+                CDCore::Anchors::k_focusActorInitStringInstrEndOffset +
+                static_cast<std::ptrdiff_t>(strDisp);
+
+            char        nameBuf[32];
+            std::size_t nameLen = 0;
+            if (!seh_read_cstring(strAddr, nameBuf, sizeof(nameBuf), nameLen))
+                continue;
+            std::string_view name{nameBuf, nameLen};
+
+            // Resolve the dword LEA: disp32 at +22, RIP after instr at +26.
+            const auto dwordDispAddr =
+                matchAddr + CDCore::Anchors::k_focusActorInitDwordDispOffset;
+            std::int32_t dwordDisp = 0;
+            std::memcpy(&dwordDisp,
+                        reinterpret_cast<const void *>(dwordDispAddr),
+                        sizeof(dwordDisp));
+            const auto dwordAddr =
+                matchAddr +
+                CDCore::Anchors::k_focusActorInitDwordInstrEndOffset +
+                static_cast<std::ptrdiff_t>(dwordDisp);
+
+            if (name == k_kliffName)
+                kliffGlobal = dwordAddr;
+            else if (name == k_oongkaName)
+                oongkaGlobal = dwordAddr;
+            else if (name == k_damianName)
+                damianGlobal = dwordAddr;
+
+            if (kliffGlobal && oongkaGlobal && damianGlobal)
+                break;
+        }
+
+        if (!kliffGlobal || !oongkaGlobal || !damianGlobal)
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: focus-actor AOB resolved {} of 3 "
+                "globals (kliff=0x{:X} oongka=0x{:X} damian=0x{:X}) "
+                "-- Tier-0 disabled",
+                (kliffGlobal ? 1 : 0) +
+                    (oongkaGlobal ? 1 : 0) +
+                    (damianGlobal ? 1 : 0),
+                static_cast<std::uint64_t>(kliffGlobal),
+                static_cast<std::uint64_t>(oongkaGlobal),
+                static_cast<std::uint64_t>(damianGlobal));
+            return false;
+        }
+
+        set_focus_actor_hash_globals(kliffGlobal, oongkaGlobal, damianGlobal);
+        return true;
     }
 
     ControlledCharacter current_controlled_character() noexcept
     {
-        const auto holder =
-            s_playerStaticHolder.load(std::memory_order_acquire);
-        if (holder == 0)
+        // Five-layer resolve. See the file-level header for the why
+        // behind each ordering choice (in particular: why Layer 2
+        // gates on non-Kliff, and why Layer 3 must outlive
+        // invalidate_controlled_character()).
+        const auto controlledBody = walk_to_controlled_body_seh();
+
+        // Layer 1: structural Kliff anchor.
+        if (body_is_structurally_kliff(controlledBody))
         {
-            return ControlledCharacter::Unknown;
+            s_lastGoodChar.store(
+                static_cast<std::uint8_t>(ControlledCharacter::Kliff),
+                std::memory_order_release);
+            stamp_body_cache(controlledBody,
+                             ControlledCharacter::Kliff);
+            return ControlledCharacter::Kliff;
         }
 
-        const auto probe   = walk_chain_seh(holder);
-        const auto decoded = decode_probe(probe);
-
-        if (probe.valid)
+        // Layer 2: Tier-0 if non-Kliff (bypasses stale Kliff
+        // intermediate broadcast).
+        const auto focusCh = static_cast<ControlledCharacter>(
+            s_focusBroadcastChar.load(std::memory_order_acquire));
+        if (focusCh == ControlledCharacter::Damiane ||
+            focusCh == ControlledCharacter::Oongka)
         {
-            log_first_seen_probe(probe, decoded);
+            stamp_body_cache(controlledBody, focusCh);
+            return focusCh;
         }
 
-        // Resolver layering, top-to-bottom:
-        //
-        //   1. Slot-offset decode (above): returns the character whose
-        //      +0x2C flag is uniquely hot. Wins outright for all in-
-        //      world states where the engine maintains the formal
-        //      party invariant.
-        //
-        //   2. Pending-key commit + actor cache lookup (this block):
-        //      walks the chain to the userActor and consults the
-        //      radial-swap cache built by the mid-hook. Resolves the
-        //      ghost-roster case where the formal party shows zero or
-        //      multiple hot slots but the radial UI deterministically
-        //      picked a specific character moments earlier.
-        //
-        //   3. Last-known-good cache (below): preserves the previously
-        //      decoded identity when both prior layers return Unknown.
-        //      Bridges transient torn reads mid-swap and any decode
-        //      path that has never seen a known identity yet.
-        const auto userActor = walk_to_user_actor_seh(holder);
-        try_commit_pending(userActor);
-
-        // A known slot-offset decode wins. Refresh the LKG cache so a
-        // subsequent torn-read query can fall back to it.
-        if (decoded != ControlledCharacter::Unknown)
+        // Layer 3: last-known non-Kliff cache (saves the same-non-
+        // Kliff save-reload case).
+        const auto lastNonKliff = static_cast<ControlledCharacter>(
+            s_lastKnownNonKliff.load(std::memory_order_acquire));
+        if (lastNonKliff != ControlledCharacter::Unknown)
         {
-            s_lastGoodChar.store(static_cast<std::uint8_t>(decoded),
-                                 std::memory_order_release);
-            // Body-cache stamp: the chain walk just confirmed `decoded`
-            // is the controlled identity, so user+0xD8 right now points
-            // to that character's body. Reading it here lets
-            // resolve_character_idx_for_body() attribute the body for
-            // EquipHide's UA stride walk on later ticks even when a
-            // different protagonist is being controlled.
-            const auto controlledBody = walk_to_controlled_body_seh();
-            stamp_body_cache(controlledBody, decoded);
-            return decoded;
+            stamp_body_cache(controlledBody, lastNonKliff);
+            return lastNonKliff;
         }
 
-        // Slot decode unknown -- consult the actor cache. A hit here is
-        // the deterministic answer for ghost-roster scenes where the
-        // formal +0x2C invariant does not apply but the radial UI's
-        // captured key is still authoritative for the live actor. Also
-        // refreshes the LKG cache on hit so a later query that the
-        // userActor walk happens to fault on still resolves correctly.
-        const auto cached = lookup_actor_cache(userActor);
-        if (cached != ControlledCharacter::Unknown)
+        // Layer 4: Tier-0 even if Kliff.
+        if (focusCh != ControlledCharacter::Unknown)
         {
-            s_lastGoodChar.store(static_cast<std::uint8_t>(cached),
-                                 std::memory_order_release);
-            // Body-cache stamp: the actor cache resolved an identity
-            // for the live userActor, so user+0xD8 currently holds the
-            // body for `cached`. Same rationale as the slot-decode
-            // branch above -- learn the body here so later body-keyed
-            // queries resolve without re-running this chain walk.
-            const auto controlledBody = walk_to_controlled_body_seh();
-            stamp_body_cache(controlledBody, cached);
-            return cached;
+            stamp_body_cache(controlledBody, focusCh);
+            return focusCh;
         }
 
-        // Neither the slot decode nor the actor cache yielded a known
-        // identity; fall back to the last-known-good. Empty pre-world
-        // and post-invalidation, in which case the final return is
-        // Unknown.
+        // Layer 5: LKG.
         return static_cast<ControlledCharacter>(
             s_lastGoodChar.load(std::memory_order_acquire));
+    }
+
+    bool install_focus_broadcast_hook(std::uintptr_t hookAddr) noexcept
+    {
+        std::lock_guard<std::mutex> lk(s_focusHookMutex);
+
+        const auto current =
+            s_focusBroadcastHookAddr.load(std::memory_order_acquire);
+
+        if (hookAddr == 0)
+        {
+            if (current == 0)
+                return true;
+            s_focusBroadcastHook = safetyhook::MidHook{};
+            s_focusBroadcastHookAddr.store(0, std::memory_order_release);
+            DMK::Logger::get_instance().info(
+                "ControlledChar: focus-broadcast hook uninstalled");
+            return true;
+        }
+
+        if (hookAddr < k_minValidPtr)
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: focus-broadcast hook rejected -- "
+                "address 0x{:X} below guard region",
+                static_cast<std::uint64_t>(hookAddr));
+            return false;
+        }
+
+        if (current == hookAddr)
+            return true;
+
+        if (current != 0)
+        {
+            DMK::Logger::get_instance().info(
+                "ControlledChar: focus-broadcast hook target shifted "
+                "0x{:X} -> 0x{:X}, rebuilding",
+                static_cast<std::uint64_t>(current),
+                static_cast<std::uint64_t>(hookAddr));
+            s_focusBroadcastHook = safetyhook::MidHook{};
+            s_focusBroadcastHookAddr.store(0, std::memory_order_release);
+        }
+
+        auto built = safetyhook::MidHook::create(
+            reinterpret_cast<void *>(hookAddr),
+            focus_broadcast_midhook);
+        if (!built)
+        {
+            DMK::Logger::get_instance().warning(
+                "ControlledChar: focus-broadcast hook creation failed "
+                "at 0x{:X}",
+                static_cast<std::uint64_t>(hookAddr));
+            return false;
+        }
+
+        s_focusBroadcastHook = std::move(*built);
+        s_focusBroadcastHookAddr.store(hookAddr, std::memory_order_release);
+
+        DMK::Logger::get_instance().info(
+            "ControlledChar: focus-broadcast hook installed at 0x{:X}",
+            static_cast<std::uint64_t>(hookAddr));
+        return true;
+    }
+
+    void uninstall_focus_broadcast_hook() noexcept
+    {
+        (void)install_focus_broadcast_hook(0);
     }
 
     bool install_radial_swap_hook(std::uintptr_t hookAddr) noexcept
@@ -825,22 +710,10 @@ namespace CDCore
 
         if (hookAddr == 0)
         {
-            // Teardown path. Idempotent: when nothing is installed the
-            // moved-from MidHook destructor below is a no-op.
             if (current == 0)
-            {
                 return true;
-            }
-            // Destroy the MidHook so the patched bytes return to their
-            // original instruction sequence. safetyhook::MidHook's
-            // destructor handles unhook plus trampoline-page free under
-            // SafetyHook's own internal synchronization. When two
-            // consumer DLLs both have a MidHook here, each tears down
-            // its own copy independently -- SafetyHook's chaining
-            // unwinds the JMP target back through the remaining hooks.
             s_radialSwapHook = safetyhook::MidHook{};
             s_radialSwapHookAddr.store(0, std::memory_order_release);
-
             DMK::Logger::get_instance().info(
                 "ControlledChar: radial-swap hook uninstalled");
             return true;
@@ -856,16 +729,10 @@ namespace CDCore
         }
 
         if (current == hookAddr)
-        {
-            // Already installed at this exact address. Idempotent.
             return true;
-        }
 
         if (current != 0)
         {
-            // Address shifted (AOB re-resolution mid-session). Tear
-            // down the existing MidHook before rebuilding so we never
-            // hold two MidHooks owned by the same DLL slot.
             DMK::Logger::get_instance().info(
                 "ControlledChar: radial-swap hook target shifted "
                 "0x{:X} -> 0x{:X}, rebuilding",
@@ -875,10 +742,6 @@ namespace CDCore
             s_radialSwapHookAddr.store(0, std::memory_order_release);
         }
 
-        // Build the SafetyHook MidHook. SafetyHook's internal chaining
-        // tolerates a sibling DLL having already patched this site
-        // with its own MidHook; the JMP at the hook target is rewritten
-        // to chain through both callbacks transparently.
         auto built = safetyhook::MidHook::create(
             reinterpret_cast<void *>(hookAddr),
             radial_swap_midhook);
@@ -912,7 +775,7 @@ namespace CDCore
         {
             case ControlledCharacter::Kliff:   return "Kliff";
             case ControlledCharacter::Damiane: return "Damiane";
-            case ControlledCharacter::Oongka: return "Oongka";
+            case ControlledCharacter::Oongka:  return "Oongka";
             case ControlledCharacter::Unknown: return {};
         }
         return {};
@@ -929,7 +792,7 @@ namespace CDCore
         {
             case ControlledCharacter::Kliff:   return 1;
             case ControlledCharacter::Damiane: return 2;
-            case ControlledCharacter::Oongka: return 3;
+            case ControlledCharacter::Oongka:  return 3;
             case ControlledCharacter::Unknown: return 0;
         }
         return 0;
@@ -938,30 +801,12 @@ namespace CDCore
     std::uint32_t resolve_character_idx_for_body(
         std::uintptr_t body) noexcept
     {
-        // Learning-cache lookup. The cache is populated as a side
-        // effect of every successful current_controlled_character()
-        // call -- the resolver stamps (user+0xD8 -> identity) once it
-        // confirms the controlled character, and after the user has
-        // cycled through each protagonist at least once every
-        // protagonist's body pointer is cache-resident. Roster bodies
-        // (party members visible in the world but not currently
-        // controlled) resolve here without requiring a structural
-        // decode the v1.04.00 layout does not expose.
-        //
-        // Zero return on miss is the safe degradation: callers in
-        // EquipHide treat zero as "unknown body" and fall back to the
-        // active character's hide mask, which matches single-character
-        // semantics until the cache warms.
         if (body < k_minValidPtr)
-        {
             return 0;
-        }
         std::shared_lock<std::shared_mutex> lk(s_bodyCacheMutex);
         const auto it = s_bodyKeyCache.find(body);
         if (it == s_bodyKeyCache.end())
-        {
             return 0;
-        }
         switch (it->second)
         {
             case ControlledCharacter::Kliff:   return 1;
@@ -975,17 +820,13 @@ namespace CDCore
     std::size_t snapshot_body_cache(BodyCacheEntry *out, std::size_t cap) noexcept
     {
         if (out == nullptr || cap == 0)
-        {
             return 0;
-        }
         std::shared_lock<std::shared_mutex> lk(s_bodyCacheMutex);
         std::size_t written = 0;
         for (const auto &kv : s_bodyKeyCache)
         {
             if (written >= cap)
-            {
                 break;
-            }
             std::uint32_t idx = 0;
             switch (kv.second)
             {
@@ -1001,61 +842,57 @@ namespace CDCore
 
     bool radial_swap_pending() noexcept
     {
-        /* Two-load probe of the pending-key record. The radial-swap
-           safetyhook callback writes deadline-then-key with release
-           ordering; the matching acquire-loads here pair with that to
-           guarantee an observer that sees a non-zero key also sees
-           the deadline written for it. A consumer (try_commit_pending)
-           sets both back to zero on commit/expiry; either zero short-
-           circuits the answer. Tick comparison uses GetTickCount64
-           for parity with the writer's clock source. */
-        const auto key = s_pendingKey.load(std::memory_order_acquire);
-        if (key == 0)
+        const auto t =
+            s_radialSwapTimestampMs.load(std::memory_order_acquire);
+        if (t == 0)
             return false;
-        const auto deadline =
-            s_pendingDeadlineMs.load(std::memory_order_acquire);
-        return GetTickCount64() <= deadline;
+        const auto now = GetTickCount64();
+        return (now >= t) && ((now - t) <= k_radialSwapPendingWindowMs);
     }
 
     void invalidate_swap_caches() noexcept
     {
-        // Release ordering pairs with the acquire load in
-        // current_controlled_character() so any reader that subsequently
-        // observes the Unknown sentinel also observes side effects the
-        // caller performed before invalidating (e.g. clearing per-character
-        // preset caches in preparation for the swap settling).
-        s_lastGoodChar.store(
-            static_cast<std::uint8_t>(ControlledCharacter::Unknown),
-            std::memory_order_release);
-
-        // In-session radial swaps rotate user+0xD8 between existing body
-        // pointers in the pool but reallocate the userActor parent only
-        // on save-load. The actor->character cache keys on the userActor
-        // pointer; clearing it on every swap is the safe choice because
-        // the cache is bounded by the number of distinct userActor
-        // singletons the engine produces (typically one per session) and
-        // a stale entry would otherwise short-circuit the resolver to a
-        // pre-swap identity. The pending radial-swap-key record is also
-        // cleared because any in-flight commit it referenced is moot
-        // once the swap completes.
-        {
-            std::unique_lock<std::shared_mutex> lk(s_actorCacheMutex);
-            s_actorKeyCache.clear();
-        }
-
-        s_pendingKey.store(0, std::memory_order_release);
-        s_pendingDeadlineMs.store(0, std::memory_order_release);
+        // Swap-scope invalidation: clear ONLY the radial-swap
+        // timestamp. Tier-0 (`s_focusBroadcastChar`) and the LKG
+        // cache are deliberately left intact -- they self-update on
+        // every focus broadcast, and a manual clear here would open
+        // an Unknown window between the swap-detect callback and the
+        // next resolver query that the resolver has no pull-mode
+        // fallback for.
+        //
+        // The timestamp itself must be cleared because consumer
+        // save-load disambiguation (`radial_swap_pending()`) must
+        // not false-positive across a save-load that immediately
+        // follows a radial swap.
+        s_radialSwapTimestampMs.store(0, std::memory_order_release);
     }
 
     void invalidate_controlled_character() noexcept
     {
         // Full world-reload clear. Save-load transitions reallocate
         // every chain pointer including the body pool; flushing the
-        // body cache here prevents post-load mis-attribution where
-        // the engine reuses a previously-cached body address for a
-        // different protagonist. The swap-scope state (LKG, actor
-        // cache, pending record) is cleared by the helper below.
-        invalidate_swap_caches();
+        // body cache here prevents post-load mis-attribution where the
+        // engine reuses a previously-cached body address for a
+        // different protagonist.
+        //
+        // Unlike invalidate_swap_caches(), this DOES clear Tier-0 +
+        // LKG because the engine is about to fire a fresh focus
+        // broadcast for the new world's controlled character; the
+        // brief Unknown window is intentional and bounded by the
+        // engine's world-spawn focus event (typically <1 s).
+        s_focusBroadcastChar.store(
+            static_cast<std::uint8_t>(ControlledCharacter::Unknown),
+            std::memory_order_release);
+        s_lastGoodChar.store(
+            static_cast<std::uint8_t>(ControlledCharacter::Unknown),
+            std::memory_order_release);
+        s_radialSwapTimestampMs.store(0, std::memory_order_release);
+
+        // `s_lastKnownNonKliff` is deliberately PRESERVED. It is
+        // the only signal that recovers identity on a same-non-
+        // Kliff save reload, where the engine fires an intermediate
+        // Kliff broadcast and never re-broadcasts the actual
+        // Damiane/Oongka body.
 
         {
             std::unique_lock<std::shared_mutex> lk(s_bodyCacheMutex);

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Title for next release]
+## Save-load and radial swap reliability
 
-- New feature
-- Bug fix
-- Improvement
+- More reliable per-character hide rules on save-load and radial swap; the active protagonist's Parts list is picked up from the engine's own focus broadcast instead of needing a chain walk to settle.

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -36,8 +36,6 @@ namespace EquipHide
 
     inline constexpr auto &k_worldSystemCandidates =
         CDCore::Anchors::k_worldSystemCandidates;
-    inline constexpr auto &k_playerStaticCandidates =
-        CDCore::Anchors::k_playerStaticCandidates;
     inline constexpr auto &k_mapLookupCandidates =
         CDCore::Anchors::k_mapLookupCandidates;
     inline constexpr auto &k_partAddShowCandidates =

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -403,37 +403,18 @@ namespace EquipHide
             k_worldSystemCandidates, std::size(k_worldSystemCandidates),
             "WorldSystem");
 
-        // Publish the WorldSystem holder to Core. The WorldSystem chain
-        // is the client-side reach used by the per-frame body-pool walk
-        // and by other client-side state. Identity decoding no longer
-        // consumes this pointer on v1.04.00 (the discriminator byte
-        // ceased to be unique in this build); the player static
-        // resolved below feeds the controlled-character resolver
-        // instead. Idempotent across consumers: when LiveTransmog is
-        // loaded alongside, both publish the same address and the
-        // later writer wins.
+        // Publish the WorldSystem holder to Core. CDCore walks this
+        // chain to reach the rotating `user+0xD8` client body pointer
+        // that the body learning cache keys on. Idempotent across
+        // consumers: when LiveTransmog is loaded alongside, both
+        // publish the same address and the later writer wins.
         CDCore::set_world_system_holder(addrs.worldSystem);
 
-        addrs.playerStatic = resolve_address(
-            k_playerStaticCandidates, std::size(k_playerStaticCandidates),
-            "PlayerStatic");
-
-        // Publish the player static to the Core controlled-character
-        // resolver. The chain (root -> NwVirtualAsyncSession ->
-        // ServerUserActor -> ServerChildOnlyInGameActor) reaches the
-        // server-side party container, where each protagonist occupies
-        // a fixed-offset slot (Kliff=0x68, Damiane=0x168, Oongka=0x268)
-        // and the active-flag byte at slot+0x2C identifies the
-        // currently-controlled character. Idempotent with the matching
-        // publish in LiveTransmog.
-        CDCore::set_player_static_holder(addrs.playerStatic);
-
-        // Install the radial-swap-key capture mid-hook via Core. Core
-        // owns this DLL's SafetyHook instance and the per-DLL
-        // actor->character cache; EquipHide's role is to publish the
-        // resolved hook address so the controlled-character resolver
-        // gains its deterministic ghost-roster layer even when
-        // LiveTransmog is not loaded.
+        // Install the radial-swap-input capture mid-hook via Core.
+        // CDCore owns this DLL's SafetyHook instance; the callback
+        // stamps a monotonic timestamp consumed by
+        // `radial_swap_pending()` to disambiguate user radial swaps
+        // from save-load arena rotations.
         //
         // Two-consumer (EH + LT) coordination: CrimsonDesertCore is a
         // STATIC library, so this DLL owns its own MidHook independent
@@ -453,14 +434,49 @@ namespace EquipHide
             {
                 if (!CDCore::install_radial_swap_hook(radialAddr))
                     logger.warning(
-                        "Radial-swap key hook install failed -- "
-                        "ghost-roster character resolution disabled");
+                        "Radial-swap input hook install failed -- "
+                        "save-load disambiguation will fall back to "
+                        "the conservative path");
             }
             else
             {
                 logger.warning(
-                    "RadialSwapKey AOB failed -- ghost-roster "
-                    "character resolution disabled");
+                    "RadialSwapKey AOB failed -- save-load "
+                    "disambiguation will fall back to the "
+                    "conservative path");
+            }
+        }
+
+        // Tier-0 controlled-character resolver: focus-actor broadcast
+        // capture. AOB-resolve the three engine-interned focus-actor
+        // hash globals, then hook sub_14353BA60 entry to capture R9 on
+        // each broadcast. Failure on either step degrades gracefully
+        // to the structural-Kliff anchor and the LKG cache.
+        {
+            const bool published =
+                CDCore::resolve_and_publish_focus_actor_globals();
+            if (!published)
+                logger.warning(
+                    "Focus-actor hash global resolution failed -- "
+                    "Tier-0 controlled-character signal disabled");
+
+            const auto bcastAddr = resolve_address(
+                CDCore::Anchors::k_focusBroadcastCandidates,
+                std::size(CDCore::Anchors::k_focusBroadcastCandidates),
+                "FocusBroadcast");
+
+            if (bcastAddr)
+            {
+                if (!CDCore::install_focus_broadcast_hook(bcastAddr))
+                    logger.warning(
+                        "Focus-broadcast hook install failed -- "
+                        "Tier-0 controlled-character signal disabled");
+            }
+            else
+            {
+                logger.warning(
+                    "FocusBroadcast AOB failed -- Tier-0 controlled-"
+                    "character signal disabled");
             }
         }
 
@@ -801,6 +817,9 @@ namespace EquipHide
         // SafetyHook trampoline pages can be touched by a late-firing
         // game thread. Idempotent.
         CDCore::uninstall_radial_swap_hook();
+        // Same ordering: tear down the focus-broadcast mid-hook before
+        // the SafetyHook trampoline pages can be unmapped.
+        CDCore::uninstall_focus_broadcast_hook();
         logger.flush();
 
         logger.info("{} shutdown: step 5 DMK_Shutdown", MOD_NAME);

--- a/CrimsonDesertEquipHide/src/shared_state.hpp
+++ b/CrimsonDesertEquipHide/src/shared_state.hpp
@@ -16,7 +16,6 @@ namespace EquipHide
     struct ResolvedAddresses
     {
         uintptr_t worldSystem = 0;
-        uintptr_t playerStatic = 0;
         uintptr_t childActorVtbl = 0;
         uintptr_t mapLookup = 0;
         uintptr_t mapInsert = 0;

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -238,8 +238,8 @@ namespace EquipHide
                 orphanRestored);
         restoredCount += orphanRestored;
 
-        logger.trace("DirectWrite: {} protagonists, {} hidden, {} restored",
-                     n, hiddenCount, restoredCount);
+        logger.info("DirectWrite: {} protagonists, {} hidden, {} restored",
+                    n, hiddenCount, restoredCount);
     }
 
     void apply_direct_vis_write() noexcept

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -4,3 +4,7 @@
 - Color Override is OFF by default; enable it by setting `ColorOverride = true` under a new `[Experimental]` section in the INI, then relaunch the game.
 - New per-slot "Sync from live" button captures the dye you applied to a real item in-game and stores it in the active preset for that slot.
 - Cleanup pass on the existing dye apply path so unset slots no longer silently inherit your real item's colours.
+- New "Save as New" button in the Presets section forks your pending edits into a brand-new preset without overwriting the one you started from.
+- Copy now clones the active preset's saved state only; pending picker edits are discarded so you get a clean baseline. Use "Save as New" if you want to keep your pending edits.
+- Prefab picker's Exact filter is stricter: knowledge images and other UI assets that happened to share a body-mesh name no longer leak into the list.
+- More reliable character detection on save-load and radial swap; the active preset now follows your real protagonist across reloads without needing a manual swap-and-back.

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -29,8 +29,6 @@ namespace Transmog
     // single source of truth lives in cdcore/anchors.hpp).
     inline constexpr auto &k_worldSystemCandidates =
         CDCore::Anchors::k_worldSystemCandidates;
-    inline constexpr auto &k_playerStaticCandidates =
-        CDCore::Anchors::k_playerStaticCandidates;
     inline constexpr auto &k_mapLookupCandidates =
         CDCore::Anchors::k_mapLookupCandidates;
     inline constexpr auto &k_partAddShowCandidates =

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -1703,18 +1703,36 @@ static void draw_overlay_content()
 
         ImGui::SameLine();
 
-        // Copy forks the current slot rows (from the active preset + any
-        // edits) into a brand-new preset so the user can tweak without
-        // overwriting the source.
+        // Copy forks the active preset's saved state into a brand-new
+        // preset, ignoring any unsaved edits in slot_mappings. Use to
+        // get a clean clone to start altering on. For forking the
+        // current pending edits, use "Save as New" instead.
         if (ImGui::Button("Copy"))
         {
             pm.duplicate_current();
             manual_apply();
         }
         if (ImGui::IsItemHovered())
-            ui_tooltip("Duplicate the current slot rows into a new "
-                       "preset, then apply it. Use after selecting a "
-                       "preset and tweaking the rows to fork it.");
+            ui_tooltip("Clone the active preset's saved state into a "
+                       "new preset (pending edits are discarded). Use "
+                       "to start altering a clean copy without touching "
+                       "the source.");
+
+        ImGui::SameLine();
+
+        // Save as New forks the current pending state (slot_mappings +
+        // in-place dye/swatch) into a new preset, leaving the active
+        // preset's saved rows untouched. Lets the user alter freely
+        // mid-edit and bottle the result up without overwriting.
+        if (ImGui::Button("Save as New"))
+        {
+            pm.save_as_new_from_state();
+            manual_apply();
+        }
+        if (ImGui::IsItemHovered())
+            ui_tooltip("Save the current pending state (including "
+                       "unsaved picks) as a new preset. The active "
+                       "preset's saved rows are left unchanged.");
 
         ImGui::SameLine();
 

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -1065,12 +1065,44 @@ namespace Transmog
     void PresetManager::duplicate_current()
     {
         auto &cp = ensure_character(m_editingCharacter);
-        int idx = static_cast<int>(cp.presets.size());
+        const int idx = static_cast<int>(cp.presets.size());
+        std::string name = "Preset " + std::to_string(idx);
+
+        Preset clone;
+        clone.name = name;
+        // Pure clone of the source preset's in-memory state. Pending
+        // edits in slot_mappings are intentionally ignored so the new
+        // preset reflects what the source would look like reloaded
+        // from disk. For forking pending edits instead, use
+        // save_as_new_from_state.
+        if (const auto *src = active_preset())
+        {
+            clone.slots               = src->slots;
+            clone.swatch_overrides    = src->swatch_overrides;
+            clone.swatch_palette      = src->swatch_palette;
+            clone.swatch_slot_enabled = src->swatch_slot_enabled;
+        }
+        cp.presets.push_back(std::move(clone));
+        cp.activePreset = idx;
+
+        apply_to_state();
+
+        DMK::Logger::get_instance().info(
+            "Preset duplicated (clean clone): '{}' (index {})", name, idx);
+        save();
+    }
+
+    void PresetManager::save_as_new_from_state()
+    {
+        auto &cp = ensure_character(m_editingCharacter);
+        const int idx = static_cast<int>(cp.presets.size());
         std::string name = "Preset " + std::to_string(idx);
         auto captured = capture_from_state(name);
-        // Preserve dye from the source preset (slot_mappings does not
-        // carry dye state -- see replace_current_from_state).
-        if (auto *src = active_preset_mut())
+        // Preserve dye/swatch from the source preset. slot_mappings
+        // does not carry dye state, and dye/swatch are written in-place
+        // on the active preset by the picker, so src already reflects
+        // the user's current live state on those axes.
+        if (const auto *src = active_preset())
         {
             for (std::size_t i = 0;
                  i < src->slots.size() && i < captured.slots.size();
@@ -1078,21 +1110,16 @@ namespace Transmog
             {
                 captured.slots[i].dye = src->slots[i].dye;
                 // Carry the source slot's sparse/dense origin flag
-                // across the duplicate. capture_from_state() builds
-                // a fresh PresetSlot from slot_mappings, which has
-                // no notion of dyeSparse, so the captured slot is
-                // left at the PresetSlot default. That default does
-                // not necessarily match the source preset's mode
-                // (a captured preset uses sparse, a picker-built
-                // preset may not), so we copy the source value
-                // explicitly to keep duplicates visually identical
-                // to their origin.
+                // across the fork. capture_from_state() builds a fresh
+                // PresetSlot from slot_mappings, which has no notion of
+                // dyeSparse, so the captured slot is left at the
+                // PresetSlot default. That default does not necessarily
+                // match the source preset's mode (a captured preset
+                // uses sparse, a picker-built preset may not), so we
+                // copy the source value explicitly to keep the fork
+                // visually identical to its origin.
                 captured.slots[i].dyeSparse = src->slots[i].dyeSparse;
             }
-            // Carry ColorOverride swatch state across the duplicate
-            // so the new preset starts identical to the source
-            // (independent of dye_mods). Live SwatchTable already
-            // reflects this state -- no need to wipe/restore.
             captured.swatch_overrides    = src->swatch_overrides;
             captured.swatch_palette      = src->swatch_palette;
             captured.swatch_slot_enabled = src->swatch_slot_enabled;
@@ -1103,7 +1130,7 @@ namespace Transmog
         apply_to_state();
 
         DMK::Logger::get_instance().info(
-            "Preset duplicated: '{}' (index {})", name, idx);
+            "Preset saved as new (pending state): '{}' (index {})", name, idx);
         save();
     }
 

--- a/CrimsonDesertLiveTransmog/src/preset_manager.hpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.hpp
@@ -262,11 +262,20 @@ namespace Transmog
         /// caller can manual_apply() immediately.
         void append_from_state();
 
-        /// Append a new preset that snapshots the current slot_mappings
-        /// (active character's picker rows). Unlike append_from_state, this
-        /// preserves the currently-loaded item selections so the user can
-        /// fork-edit an existing preset without overwriting the source.
+        /// Append a new preset that is a pure clone of the active
+        /// preset's in-memory state (items, dye, swatches). Ignores any
+        /// unsaved edits in slot_mappings -- the clone reflects what the
+        /// source preset would look like if reloaded from disk. Use when
+        /// you want a clean fork to alter without touching the original.
         void duplicate_current();
+
+        /// Append a new preset that captures the current pending state
+        /// (slot_mappings + in-place dye/swatch on the active preset)
+        /// without overwriting the active preset's saved item rows.
+        /// Use to fork-save mid-edit (e.g. after picking a new helmet
+        /// on the active preset, save those edits to a new preset and
+        /// leave the source's saved rows untouched).
+        void save_as_new_from_state();
 
         /// Overwrite the active preset with current slot_mappings state.
         void replace_current_from_state();

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -50,7 +50,6 @@ namespace Transmog
     static std::atomic<std::size_t> s_pendingSlotIndex{k_slotCount};
     static std::array<std::uint16_t, k_slotCount> s_lastAppliedCarrierIds{};
     static std::array<bool, k_slotCount> s_forceApplyPending{};
-    static std::atomic<std::uintptr_t> s_swapStaleComp{0};
 
     ResolvedAddresses &resolved_addrs() { return s_resolvedAddrs; }
     std::array<SlotMapping, k_slotCount> &slot_mappings() { return s_slotMappings; }
@@ -70,11 +69,10 @@ namespace Transmog
 
     std::string current_controlled_character_name() noexcept
     {
-        // Delegates to the shared Core resolver, which walks the live
-        // WorldSystem chain to the controlled actor and decodes its
-        // identity u32s. Returns an empty string when the WorldSystem
-        // holder has not been published yet or the chain walk yields
-        // an unknown key with no cached fallback.
+        // Delegates to the shared Core resolver (focus-broadcast cache
+        // populated by sub_14353BA60's R9 hash, with LKG / structural
+        // Kliff fallbacks). Returns an empty string when the resolver
+        // has not yet observed a known identity this session.
         const auto name = CDCore::current_controlled_character_name();
         return std::string(name);
     }
@@ -86,6 +84,5 @@ namespace Transmog
     std::atomic<bool> &clear_pending() { return s_clearPending; }
     std::atomic<bool> &dye_dirty() { return s_dyeDirty; }
     std::atomic<std::size_t> &pending_slot_index() { return s_pendingSlotIndex; }
-    std::atomic<std::uintptr_t> &swap_stale_comp() { return s_swapStaleComp; }
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -196,27 +196,6 @@ namespace Transmog
     /// effect. This is acceptable -- the user's most recent action wins.
     std::atomic<std::size_t> &pending_slot_index();
 
-    /// Stale-body guard for the load-time char-swap window.
-    ///
-    /// On a save-load with a non-Kliff protagonist the engine first
-    /// spawns Kliff's body, then transitions `user+0xD8` to the saved
-    /// character's body several seconds later. Between those two events
-    /// the in-session swap detector observes the identity change and
-    /// schedules an apply, but the WS-chain walk inside
-    /// `resolve_player_component()` still resolves the soon-to-be-
-    /// obsolete (Kliff) body. That apply would write the new
-    /// character's preset onto the wrong actor, leaving the previous
-    /// body wearing the wrong outfit once the engine finishes rotating.
-    ///
-    /// The detector stamps the about-to-be-stale `comp` here; the
-    /// apply entry returns early when `a1` matches. Once `user+0xD8`
-    /// rotates and the next apply runs against a different `a1`, the
-    /// guard clears itself. Save-load invalidation also clears it
-    /// because all queued state is wiped at that boundary anyway.
-    /// Zero means "no stale body in flight"; a successful skip is
-    /// silent except for a debug log line.
-    std::atomic<std::uintptr_t> &swap_stale_comp();
-
     // --- Hot-path utilities ---
 
     inline int64_t steady_ms() noexcept

--- a/CrimsonDesertLiveTransmog/src/slot_metadata.hpp
+++ b/CrimsonDesertLiveTransmog/src/slot_metadata.hpp
@@ -190,6 +190,27 @@ namespace Transmog
             return name.find(tag) != std::string::npos;
         };
 
+        // Reject UI/knowledge/icon assets that embed a real prefab as a
+        // substring (e.g.
+        // "cd_knowledgeimage_Knowledge_ItemIcon_Prefab_cd_phm_00_hel_00_0363_c"
+        // would otherwise match `_hel_` and pollute the Helm Exact
+        // list). Body-mesh prefab names are all-lowercase snake_case by
+        // engine convention -- any uppercase ASCII letter means the
+        // name is a UI / knowledge / icon asset that happens to embed
+        // an armor prefab in its identifier. Structural rather than
+        // allowlist-based so new lowercase role families (mounts,
+        // future NPC variants, etc.) keep working without a code change.
+        for (unsigned char c : name) {
+            if (c >= 'A' && c <= 'Z')
+                return std::nullopt;
+        }
+        // Real prefab names also start with the engine's `cd_` family
+        // marker. Reject anything that doesn't (cheap sanity check
+        // against accidentally-lowercased UI strings).
+        if (name.size() < 3 ||
+            name[0] != 'c' || name[1] != 'd' || name[2] != '_')
+            return std::nullopt;
+
         // Extract the first `_NN_` (two-digit) numeric role marker
         // after the `cd_<role>_` prefix. -1 when absent (NPC, t0000,
         // m0001 families). Cheap manual scan; no <regex> dependency.

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -1019,13 +1019,9 @@ namespace Transmog
         // --- Input ---
 
         // Resolve WorldSystem pointer for player detection on load and
-        // publish the same address to Core. The WorldSystem chain is the
-        // client-side reach used by load-time transmog and the per-frame
-        // body-pool walk; on v1.04.00 it no longer participates in
-        // controlled-character identification (the +0x50 byte that used
-        // to discriminate between protagonists ceased to be unique in
-        // this build). Identity decoding now consumes the player static
-        // resolved below.
+        // publish it to Core. CDCore walks this chain to reach the
+        // rotating `user+0xD8` client body pointer that powers the body
+        // learning cache and the structural Kliff anchor.
         {
             auto wsAddr = resolve_address(
                 k_worldSystemCandidates,
@@ -1045,43 +1041,11 @@ namespace Transmog
             }
         }
 
-        // Resolve the server-side player static and publish it to Core.
-        // The cascade exposes a RIP-relative load-or-store of the static
-        // qword (writer in P1, two readers in P2/P3); the resolver walks
-        // root -> NwVirtualAsyncSession (+0x18) -> ServerUserActor (+0xA0)
-        // -> ServerChildOnlyInGameActor (+0xD0) and identifies the
-        // controlled character by which fixed-offset slot inside the
-        // party container has slot+0x2C set to 1. An unresolved holder
-        // degrades the resolver to Unknown without crashing; consumer
-        // code already treats Unknown as "preserve previous identity".
-        {
-            auto playerAddr = resolve_address(
-                k_playerStaticCandidates,
-                std::size(k_playerStaticCandidates),
-                "PlayerStatic");
-            if (playerAddr)
-            {
-                logger.info("Player static at 0x{:X}", playerAddr);
-                CDCore::set_player_static_holder(playerAddr);
-            }
-            else
-            {
-                logger.warning(
-                    "PlayerStatic AOB failed -- controlled-character "
-                    "detection disabled, presets cannot route by character");
-            }
-        }
-
-        // Resolve the radial-UI swap-key capture site and install the
-        // mid-hook in Core. The hook stamps a pending characterinfo key
-        // (1 = Kliff, 4 = Damiane, 6 = Oongka) every time the radial UI
-        // commits a swap; the resolver consumes that key on the next
-        // chain walk to bind the live userActor pointer to a known
-        // character, providing deterministic identity for ghost-roster
-        // states the slot-offset decode cannot resolve. Optional
-        // feature -- failure leaves the slot-offset decode and the LKG
-        // cache as the resolver's only layers, which is the pre-fix
-        // behaviour.
+        // Resolve the radial-swap-input site and install the CDCore
+        // mid-hook. The callback stamps a monotonic timestamp consumed
+        // by `radial_swap_pending()` to distinguish a user swap from a
+        // save-load arena rotation; the character identity itself
+        // comes from the focus-broadcast hook below.
         //
         // Two-consumer (LT + EH) coordination: CrimsonDesertCore is a
         // STATIC library, so this DLL owns its own MidHook independent
@@ -1102,15 +1066,62 @@ namespace Transmog
                 if (!CDCore::install_radial_swap_hook(radialAddr))
                 {
                     logger.warning(
-                        "Radial-swap key hook install failed -- "
-                        "ghost-roster character resolution disabled");
+                        "Radial-swap input hook install failed -- "
+                        "save-load disambiguation will fall back to "
+                        "the conservative path");
                 }
             }
             else
             {
                 logger.warning(
-                    "RadialSwapKey AOB failed -- ghost-roster "
-                    "character resolution disabled");
+                    "RadialSwapKey AOB failed -- save-load "
+                    "disambiguation will fall back to the "
+                    "conservative path");
+            }
+        }
+
+        // Tier-0 controlled-character resolver: focus-actor broadcast
+        // capture. Two parts:
+        //   1) AOB-resolve the three engine-interned focus-actor hash
+        //      globals (Kliff/Oongka/Damian). The numeric handles vary
+        //      per game version so we read them from RAM each session.
+        //   2) Hook sub_14353BA60 entry. The MidHook reads ctx.r9
+        //      (the new focus handle), filters against the three
+        //      published globals, and stamps the resolved character.
+        //
+        // This layer is the canonical cold-load / save-load identity
+        // signal: the engine fires the broadcast during world-spawn
+        // before the player can interact, so the cache is populated
+        // before any mod query occurs. Failure on either step degrades
+        // gracefully to the structural-Kliff anchor + LKG cache.
+        {
+            const bool published =
+                CDCore::resolve_and_publish_focus_actor_globals();
+            if (!published)
+            {
+                logger.warning(
+                    "Focus-actor hash global resolution failed -- "
+                    "Tier-0 controlled-character signal disabled");
+            }
+
+            const auto bcastAddr = resolve_address(
+                CDCore::Anchors::k_focusBroadcastCandidates,
+                std::size(CDCore::Anchors::k_focusBroadcastCandidates),
+                "FocusBroadcast");
+            if (bcastAddr)
+            {
+                if (!CDCore::install_focus_broadcast_hook(bcastAddr))
+                {
+                    logger.warning(
+                        "Focus-broadcast hook install failed -- "
+                        "Tier-0 controlled-character signal disabled");
+                }
+            }
+            else
+            {
+                logger.warning(
+                    "FocusBroadcast AOB failed -- Tier-0 controlled-"
+                    "character signal disabled");
             }
         }
 
@@ -1190,6 +1201,11 @@ namespace Transmog
         // installed and when the matching uninstall has already run
         // from a sibling consumer.
         CDCore::uninstall_radial_swap_hook();
+
+        // Same pre-DMK_Shutdown ordering as the radial-swap teardown:
+        // tear down the focus-broadcast mid-hook before the SafetyHook
+        // pages can be touched by a late-firing engine focus event.
+        CDCore::uninstall_focus_broadcast_hook();
 
         PrefabWrapperSwap::shutdown();
 

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -16,6 +16,8 @@
 #include "transmog_map.hpp"
 #include "transmog_worker.hpp"
 
+#include <cdcore/controlled_char.hpp>
+
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
@@ -964,58 +966,11 @@ namespace Transmog
             return;
         }
 
-        // Stale-body guard. The load-detect thread stamps the
-        // about-to-be-obsolete body pointer into swap_stale_comp()
-        // when an in-session character swap fires before the engine
-        // has rotated `user+0xD8` to the new body. If our resolver
-        // still walks to that pre-rotation body, applying here would
-        // paint the new character's preset onto the previous body
-        // (e.g. on a Damiane save: Kliff's body ends up wearing
-        // Damiane's outfit until the engine finally rotates and the
-        // load-detect retry fires a fresh apply on the correct body).
-        // Skipping returns control to the load-detect retry budget,
-        // which will see the new component address on its next tick.
-        // Apply paths that run on a body other than the stale one
-        // clear the guard; save-load invalidation also clears it.
-        {
-            const auto staleComp =
-                swap_stale_comp().load(std::memory_order_acquire);
-            if (staleComp != 0 &&
-                staleComp == static_cast<std::uintptr_t>(a1))
-            {
-                logger.debug(
-                    "[dispatch] apply_all_transmog skipped: body still "
-                    "pre-swap, a1={:#018x}, stale={:#018x}",
-                    static_cast<uint64_t>(a1),
-                    static_cast<uint64_t>(staleComp));
-                return;
-            }
-        }
-
         // Suppress VEC hook for the entire operation.
         suppress_vec().store(true, std::memory_order_release);
 
         logger.trace("[dispatch] apply_all_transmog entry a1={:#018x}",
                      static_cast<uint64_t>(a1));
-
-        // Body has rotated past the stale one (or no swap was in
-        // flight) -- this apply will run against the live body, so
-        // any captured stale value is now obsolete. CAS-clear under
-        // the original captured value to avoid stomping a fresh
-        // capture from a later swap that raced into the worker
-        // between the early-out above and here.
-        {
-            auto staleComp =
-                swap_stale_comp().load(std::memory_order_acquire);
-            if (staleComp != 0 &&
-                staleComp != static_cast<std::uintptr_t>(a1))
-            {
-                swap_stale_comp().compare_exchange_strong(
-                    staleComp, 0,
-                    std::memory_order_release,
-                    std::memory_order_relaxed);
-            }
-        }
 
         // Snapshot lastIds for diagnostic logging.
         const std::array<uint16_t, k_slotCount> prevIds = lastIds;

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -210,21 +210,20 @@ namespace Transmog
 
     // True while load_detect_thread_fn has a controlled-character
     // change parked in its settle window but not yet committed. The
-    // settle-window branch is the authoritative committer: it stamps
-    // swap_stale_comp() before flipping pm.active_character() so the
-    // next apply skips writing the new preset onto the pre-rotation
-    // body.
+    // settle-window branch is the authoritative committer: it flips
+    // pm.active_character() and schedules the apply once the
+    // candidate identity holds for k_charSwapSettleMs.
     //
-    // Without this gate, sync_active_char_to_live() flips inline the
-    // moment the controlled-char probe returns the new identity, but
-    // the engine has not yet rotated user+0xD8 to the new actor. A
-    // hook-driven apply that races into run_debounced_apply during
-    // that window resolves a1 to the previous body, then writes the
-    // new character's preset onto it (e.g. save-load on Kliff that
-    // auto-toggles to Oongka leaves Kliff wearing Oongka's preset).
-    // sync_active_char_to_live consults this flag and returns false
-    // to defer; the caller re-arms the debounce until the settle
-    // commits.
+    // Without this gate, sync_active_char_to_live() would flip inline
+    // the moment the controlled-char probe returns the new identity,
+    // but the engine may not have rotated user+0xD8 to the new actor
+    // yet. A hook-driven apply that races into run_debounced_apply
+    // during that window would resolve a1 to the previous body and
+    // paint the new character's preset onto it (e.g. save-load on
+    // Kliff that auto-toggles to Oongka leaving Kliff wearing
+    // Oongka's preset). sync_active_char_to_live consults this flag
+    // and returns false to defer; the caller re-arms the debounce
+    // until the settle commits.
     static std::atomic<bool> s_charSwapPending{false};
 
     static std::mutex s_applyCvMtx;
@@ -259,10 +258,7 @@ namespace Transmog
             return true;
 
         // Defer when load_detect_thread_fn has a pending swap in
-        // flight. The settle-window branch is the authoritative
-        // committer: it stamps swap_stale_comp() before flipping so
-        // the apply does not paint the new preset onto the pre-
-        // rotation body. Convergence is bounded by the settle window
+        // flight. Convergence is bounded by the settle window
         // (k_charSwapSettleMs); the caller re-arms via a 200ms
         // schedule_transmog_ms() until then.
         if (s_charSwapPending.load(std::memory_order_acquire))
@@ -315,9 +311,8 @@ namespace Transmog
         // char swap parked in its settle window. In that case the
         // engine has not yet rotated user+0xD8 to the new body, so
         // applying here would paint the incoming preset onto the
-        // previous body. Re-arm the debounce; the load-detect
-        // commit will both flip the controlled axis and stamp
-        // swap_stale_comp() so the next apply lands correctly.
+        // previous body. Re-arm the debounce; the load-detect commit
+        // will flip the controlled axis once the candidate settles.
         if (!sync_active_char_to_live())
         {
             schedule_transmog_ms(200);
@@ -520,6 +515,46 @@ namespace Transmog
         }
     }
 
+    /** @brief SEH-isolated read of `user+0xD8` (the rotating CLIENT
+     *         body pointer that EH watches as its save-load signal).
+     *  @details Mirrors EH/player_detection.cpp:226 so LT can detect
+     *           the same X->0->Y / atomic-swap save-load transitions
+     *           EH does and clear preset_manager.active_character()
+     *           on the wipe paths. Returns 0 on any fault, on an
+     *           unresolved chain, or when the controlled body has
+     *           been published as null (engine mid-transition). */
+    static std::uintptr_t read_controlled_actor_ptr_seh() noexcept
+    {
+        const auto wsBase =
+            world_system_ptr().load(std::memory_order_acquire);
+        if (!wsBase)
+            return 0;
+        __try
+        {
+            auto ws = *reinterpret_cast<uintptr_t *>(wsBase);
+            if (ws < 0x10000)
+                return 0;
+            auto am = *reinterpret_cast<uintptr_t *>(ws + 0x30);
+            if (am < 0x10000)
+                return 0;
+            auto user = *reinterpret_cast<uintptr_t *>(am + 0x28);
+            if (user < 0x10000)
+                return 0;
+            // user+0xD8 is the CLIENT body pointer (rotates per
+            // radial swap or save-load arena allocation). Unlike
+            // the other chain reads above, we DO NOT reject 0 here
+            // because an X->0 transition is the save-load signal
+            // we want to detect.
+            auto controlled =
+                *reinterpret_cast<uintptr_t *>(user + 0xD8);
+            return controlled;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return 0;
+        }
+    }
+
     /** @brief Settle window for the character-swap detector.
      *  @details During world load the engine rotates `user+0xD8` through
      *           the party members as it wires each actor (e.g. Kliff ->
@@ -547,6 +582,15 @@ namespace Transmog
         // commits only when (now - pendingFirstSeenTick) >= settle window.
         std::string pendingCharName;
         std::uint64_t pendingFirstSeenTick = 0;
+
+        // Mirror of EH's save-load detection state. Tracks the
+        // CLIENT body pointer (user+0xD8) across ticks. An X->0
+        // transition latches s_pendingReloadInvalidation; the
+        // following 0->Y (with the flag set) OR a non-zero atomic
+        // X->Y (when the new body is absent from the body cache and
+        // no radial input was just observed) triggers the wipe.
+        std::uintptr_t prevControlledActor = 0;
+        bool pendingReloadInvalidation = false;
 
         while (!shutdown_requested().load(std::memory_order_relaxed))
         {
@@ -590,15 +634,6 @@ namespace Transmog
                         CDCore::invalidate_controlled_character();
                         prevCharName.clear();
                         pendingCharName.clear();
-                        // Save-load wipes every pending state -- any
-                        // body the swap guard had captured against the
-                        // outgoing world is by definition gone now, so
-                        // clear it. Leaving a stale value here would
-                        // suppress the first post-load apply if the new
-                        // world happened to recycle the same component
-                        // address.
-                        swap_stale_comp().store(
-                            0, std::memory_order_release);
                         // Re-populate the body-mesh prefab catalog. Save
                         // loads can rotate the AppearanceTableLoader
                         // registry's resident wrapper set as zone-/
@@ -611,6 +646,107 @@ namespace Transmog
                         PrefabWrapperSwap::populate_slot_catalogs();
                     }
                     prevUser = curUser;
+                }
+            }
+
+            // --- Save-load detected (controlled-actor signal) ---
+            //
+            // Mirrors EquipHide/player_detection.cpp:226-327. Polls
+            // user+0xD8 (the CLIENT controlled body pointer) and
+            // disambiguates three transitions:
+            //   1. X->0 : engine published null -> latch deferred wipe
+            //   2. 0->Y with flag set : world live again -> wipe
+            //   3. X->Y atomic : disambiguate via body cache + radial
+            //                    pending; treat as save-load only if
+            //                    the new body is absent from cache AND
+            //                    no radial input was just observed.
+            //
+            // On every wipe path we ALSO clear LT-local state that
+            // would otherwise route through the previously-active
+            // character's preset (preset_manager.active_character()
+            // and the prevCharName/pendingCharName settle window).
+            // This is the "On save load detected, should clear current
+            // char of LT" requirement: empty active_character()
+            // resolves to no preset -> engine vanilla items show
+            // until the next focus broadcast fires and the swap
+            // detector below repopulates the correct identity.
+            {
+                const auto controlledActor =
+                    read_controlled_actor_ptr_seh();
+                if (controlledActor != prevControlledActor)
+                {
+                    auto wipe_lt_state = [&]()
+                    {
+                        CDCore::invalidate_controlled_character();
+                        PresetManager::instance().set_active_character("");
+                        prevCharName.clear();
+                        pendingCharName.clear();
+                    };
+
+                    if (controlledActor == 0 && prevControlledActor != 0)
+                    {
+                        logger.info(
+                            "Save-load detected: controlled actor "
+                            "(0x{:X} -> 0x0); deferring full cache wipe "
+                            "until new world is live",
+                            static_cast<uint64_t>(prevControlledActor));
+                        pendingReloadInvalidation = true;
+                    }
+                    else if (controlledActor != 0 &&
+                             prevControlledActor == 0 &&
+                             pendingReloadInvalidation)
+                    {
+                        logger.info(
+                            "Save-load complete: new controlled actor "
+                            "0x{:X} -- clearing LT preset_manager "
+                            "active character + swap-scope state",
+                            static_cast<uint64_t>(controlledActor));
+                        wipe_lt_state();
+                        pendingReloadInvalidation = false;
+                    }
+                    else if (prevControlledActor != 0 &&
+                             controlledActor != 0)
+                    {
+                        // Atomic X->Y. Disambiguate via body cache +
+                        // radial pending (same heuristic as EH).
+                        std::array<CDCore::BodyCacheEntry, 3> peek;
+                        const auto peekN = CDCore::snapshot_body_cache(
+                            peek.data(), peek.size());
+                        bool inCache = false;
+                        for (std::size_t i = 0; i < peekN; ++i)
+                        {
+                            if (peek[i].body == controlledActor)
+                            {
+                                inCache = true;
+                                break;
+                            }
+                        }
+                        const bool atomicSaveLoad =
+                            peekN >= 1 && !inCache &&
+                            !CDCore::radial_swap_pending();
+
+                        if (atomicSaveLoad)
+                        {
+                            logger.info(
+                                "Save-load detected (atomic swap): "
+                                "controlled actor (0x{:X} -> 0x{:X}) "
+                                "absent from body cache (n={}, no "
+                                "pending radial) -- clearing LT "
+                                "preset_manager active character + "
+                                "swap-scope state",
+                                static_cast<uint64_t>(prevControlledActor),
+                                static_cast<uint64_t>(controlledActor),
+                                peekN);
+                            wipe_lt_state();
+                            pendingReloadInvalidation = false;
+                        }
+                        // else: normal char swap -- LT's existing
+                        // char-swap auto-detect block (below) will
+                        // pick up the identity change via Tier-0
+                        // and call set_active_character. Body cache
+                        // is preserved.
+                    }
+                    prevControlledActor = controlledActor;
                 }
             }
 
@@ -664,11 +800,7 @@ namespace Transmog
                     pendingCharName.clear();
                     // Clear BEFORE schedule_transmog_ms below so the
                     // scheduled run_debounced_apply observes the
-                    // committed flip and does not defer again. The
-                    // stale-body guard stamped further down is the
-                    // mechanism that prevents writing onto the pre-
-                    // rotation body; this flag only gates the early
-                    // race window.
+                    // committed flip and does not defer again.
                     s_charSwapPending.store(false,
                                             std::memory_order_release);
 
@@ -690,30 +822,6 @@ namespace Transmog
                         }
                         logger.info("Char swap detected: {} -> {}",
                                     oldName, liveName);
-                        // Stale-body guard. On a save-load that
-                        // reaches the swap branch (e.g. loading a
-                        // Damiane save), the engine spawns Kliff's
-                        // body first and routes the saved-character
-                        // transition through this same handler ~10s
-                        // later, but `user+0xD8` does not rotate to
-                        // the new body until several seconds AFTER
-                        // we schedule the apply. Without a guard the
-                        // apply runs while resolve_player_component()
-                        // still walks to the soon-to-be-obsolete body
-                        // (Kliff) and writes the new character's
-                        // preset onto the wrong actor. Stamp the
-                        // body we last observed so the apply entry
-                        // can short-circuit until the engine
-                        // finishes rotating; the load-detect block
-                        // below fires its own apply on the new body
-                        // once the rotation completes. Skip the
-                        // store on first-tick (prevComp == 0): no
-                        // observation has been made, so there is
-                        // nothing to mark stale.
-                        if (prevComp > 0x10000)
-                            swap_stale_comp().store(
-                                static_cast<std::uintptr_t>(prevComp),
-                                std::memory_order_release);
                         if (flag_enabled().load(std::memory_order_relaxed))
                             schedule_transmog_ms(200);
                         pm.save();
@@ -726,30 +834,14 @@ namespace Transmog
             // Detect change: new component appeared or address changed.
             if (comp > 0x10000 && comp != prevComp)
             {
-                // Resolve identity WITHOUT invalidating the LKG cache.
-                //
-                // The new resolver in CDCore walks a fresh chain every
-                // call (Player static -> party container -> per-slot
-                // active-flag bytes) and never caches a per-actor
-                // pointer that could go stale, so the historical reason
-                // for invalidating on every player_component change no
-                // longer applies.
-                //
-                // Trade-off resolved against keeping LKG: the engine
-                // rotates player_component before it commits the new
-                // active-flag byte to the server-side party container.
-                // During that window the chain reads all-zero flags and
-                // the resolver returns Unknown. Invalidating LKG here
-                // would force the auto-apply gate to defer until the
-                // engine settled, which on certain saves (Prologue,
-                // post-cutscene resume) it never does until the player
-                // takes a control action. Letting LKG persist makes the
-                // resolver fall back to the previously-controlled
-                // character through that window. The fallback is
-                // correct for save-load resuming the same identity
-                // (the dominant case) and self-corrects within one
-                // tick after the engine writes the new flag for an
-                // in-session swap.
+                // Resolve identity WITHOUT invalidating any CDCore
+                // cache. The focus-broadcast resolver stamps Tier-0
+                // on every engine focus event, so a stale read here is
+                // self-correcting within one tick. Calling
+                // invalidate_controlled_character() inline would force
+                // an Unknown window on saves whose first broadcast has
+                // not arrived yet (Prologue / post-cutscene resume),
+                // gating the auto-apply indefinitely.
                 const std::string liveChar =
                     current_controlled_character_name();
 


### PR DESCRIPTION
## Summary
- New layered controlled-character resolver in `CrimsonDesertCore`: structural Kliff anchor + focus-broadcast capture + last-known-non-Kliff fallback, with EH-mirrored save-load detection that wipes per-character state on character change.
- `EquipHide` and `LiveTransmog` now consume the shared resolver and drop per-module chain-walk fallbacks, stale slot caches, and key-cache scaffolding.
- LiveTransmog UX: **Save as New** preset button, stricter Exact prefab-picker filter, Copy clones only the saved state (pending edits discarded), and active preset follows the real protagonist across reloads without a manual swap-and-back.
