### PR TITLE
feat(live-transmog): runtime token discovery for color override picker

### DIFF
--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -14,6 +14,7 @@
 
 #include <DetourModKit.hpp>
 
+#include <array>
 #include <cstdint>
 #include <span>
 #include <string_view>
@@ -1274,5 +1275,174 @@ namespace Transmog
          "48 8B 41 78 4D 8B C8 48 85 C0 74 66 45 33 C0 4C 8D 52",
          ResolveMode::Direct, +0x0E, 0},
     };
+
+    /**
+     * @brief ColorTokenInterner (sub_140F46680) -- shader-property name
+     *        interner. Maps an ASCII property name (e.g. "_tintColorR")
+     *        to a stable u32 token id used downstream by the dye/
+     *        material setter pipeline. Called once per property by the
+     *        TLS-guarded registrars sub_14274A3C0 and sub_142749F10.
+     *
+     * The function lives in the `.tls` section. Body is large (0x86E
+     * bytes) and includes a once-only `lock cmpxchg` guarded init path
+     * that allocates the hash table, sets the bucket-prime count
+     * (0x8E = 142) and sentinel cap (0x2FFFF), and publishes the state
+     * pointer to qword_145E15620. Subsequent calls take the table
+     * lock, look up the name, and return either the existing token or
+     * a freshly minted one.
+     *
+     * Resolution lets ColorOverride::InternerHook walk the body to
+     * locate the `qword_145E15620 = v10` store and reach the
+     * entries-array without scanning E8 trampolines through a
+     * registrar call site.
+     */
+    inline constexpr AddrCandidate k_colorTokenInternerCandidates[] = {
+        // P1 -- full Microsoft __fastcall prologue. The 4 shadow-store
+        // saves (`mov [rsp+disp8], rbx/r8d/rdx/rcx`) wildcard their
+        // disp8 home-area offsets because the prototype's argument
+        // layout is the only thing that pins them. The 7-register
+        // push run `55 56 57 41 54 41 55 41 56 41 57`
+        // (rbp/rsi/rdi/r12/r13/r14/r15) is the distinctive head:
+        // very few functions save all 7 callee-saved regs. The
+        // `lea rbp,[rsp-disp8]` frame setup and `sub rsp,imm32`
+        // stack allocation both wildcard compiler-owned sizes. The
+        // trailing `41 8B F9` (mov edi, r9d) captures the sentinel-
+        // cap argument into a saved scratch register and pins this
+        // function against any other 7-push function.
+        {"ColorTokenInterner_P1_FullPrologue",
+         "48 89 5C 24 ?? 44 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? "
+         "55 56 57 41 54 41 55 41 56 41 57 "
+         "48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 41 8B F9",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- post-alloca early-exit anchor. Walks back -0x24 to
+        // reach the function start. The chain (sub rsp / mov edi,r9d
+        // / mov r12,rdx / xor ebx,ebx / mov [rcx],ebx / test rdx,rdx)
+        // is the function's argument-validation preamble: it
+        // captures the sentinel cap, mirrors the name pointer into
+        // r12, zeroes the output token (`*a1 = 0`), then tests the
+        // name pointer for null. The literal sequence `4C 8B E2 33
+        // DB 89 19 48 85 D2` (mov r12,rdx; xor ebx,ebx; mov [rcx],
+        // ebx; test rdx,rdx) is unique to this function's entry
+        // contract. Survives prologue reflows that affect the register
+        // save layout but keep the argument plumbing identical.
+        {"ColorTokenInterner_P2_PostAllocaEarlyExit",
+         "48 81 EC ?? ?? ?? ?? 41 8B F9 4C 8B E2 33 DB 89 19 48 85 D2",
+         ResolveMode::Direct, -0x24, 0},
+
+        // P3 -- deep-body cap-init magic-write anchor. Walks back
+        // -0x126 from the matched site to reach the function start.
+        // After the once-only `lock cmpxchg` init guard succeeds,
+        // the function writes a four-constant fingerprint:
+        //   C7 46 50 8E 00 00 00   mov [rsi+0x50], 0x8E   ; bucket prime
+        //   C7 46 54 FF FF 02 00   mov [rsi+0x54], 0x2FFFF; sentinel cap
+        //   BA F8 FF 2F 00         mov edx, 0x2FFFF8      ; alloc size
+        //   41 B8 10 00 00 00      mov r8d, 0x10          ; entry stride
+        // This semantic fingerprint survives wholesale prologue
+        // rewrites (e.g., a future patch swapping the fastcall ABI
+        // for a different register save list) because the constants
+        // are dictated by the interner's data-structure contract, not
+        // by compiler layout.
+        {"ColorTokenInterner_P3_CapInitMagicWrite",
+         "48 8B F3 C7 46 50 8E 00 00 00 C7 46 54 FF FF 02 00 "
+         "BA F8 FF 2F 00 41 B8 10 00 00 00",
+         ResolveMode::Direct, -0x126, 0},
+    };
+
+    /**
+     * @brief Property-registration call-site walk patterns.
+     *        Anchor the opcode run the compiler emits before every
+     *        call into the ColorTokenInterner from the TLS-guarded
+     *        registrar functions (sub_14274A3C0 for dye-mask
+     *        properties, sub_142749F10 for tint and detail
+     *        properties). Each pattern is INTENTIONALLY multi-match
+     *        (one hit per property registration); the discovery
+     *        walker enumerates every hit, decodes the `lea rdx`
+     *        displacement to read the property name, and accepts
+     *        only the entries whose strings appear in its known-
+     *        property allow-list.
+     *
+     * The shared head is the 17-byte run:
+     *
+     *   41 B9 FF FF 02 00      mov  r9d, 0x2FFFF       ; sentinel cap
+     *   ?? 8D ?? 01            lea  r8d, [reg+1]       ; REX+ModR/M
+     *                                                  ; wild; reg is
+     *                                                  ; r13 (registrar
+     *                                                  ; A) or rdi
+     *                                                  ; (registrar B)
+     *   48 8D 15 ?? ?? ?? ??   lea  rdx, [rip+name]    ; property name
+     *
+     * Followed within a few bytes by an rcx-load and an `E8 disp32`
+     * call to the interner. The three patterns below anchor on
+     * progressively wider windows of the call site; together they
+     * provide resilience against compiler reflows of any single
+     * one. The walker scans with each pattern in turn and merges
+     * the hits (dedup by decoded slot address), so a single
+     * pattern losing its shape on a future patch is tolerated as
+     * long as at least one survives.
+     *
+     * Verified hit counts on v1.06:
+     *   P1 (head only):                       2235 module-wide
+     *   P2 (head + lea-rcx-slot + call):      1512 module-wide
+     *   P3 (head + mov-rcx-reg + call):          4 module-wide
+     *
+     * P1 is the canonical superset and matches every registration
+     * site across the binary. P2 misses the first-call-per-
+     * registrar entries (which load rcx from a preloaded table-
+     * base register via `mov rcx, reg`); P3 covers exactly those
+     * first-call entries. Walking all three lets the discoverer
+     * stay correct even if P1 ever loses its shape, because the
+     * union of P2 and P3 covers the same site set as P1.
+     */
+    inline constexpr std::array<std::string_view, 3>
+        k_colorTokenRegistrarCallAobs = {{
+            // P1 -- 17-byte literal head. Anchors on the run from
+            // `mov r9d, 0x2FFFF` through `lea rdx, [name]`. The
+            // REX+ModR/M of the `lea r8d, [reg+1]` is wildcarded
+            // (the counter register differs by registrar; r13d for
+            // sub_14274A3C0, rdi for sub_142749F10).
+            "41 B9 FF FF 02 00 "
+            "?? 8D ?? 01 "
+            "48 8D 15 ?? ?? ?? ??",
+
+            // P2 -- head + lea-rcx-slot + call tail. Captures
+            // calls 2..N within each registrar (these load rcx
+            // via `lea rcx, [rip+slot]` to the current property's
+            // backing storage). Tighter than P1 and survives a
+            // future compiler reflow that changes the head shape
+            // as long as the rcx-load + call tail is preserved.
+            "41 B9 FF FF 02 00 "
+            "?? 8D ?? 01 "
+            "48 8D 15 ?? ?? ?? ?? "
+            "48 8D 0D ?? ?? ?? ?? E8",
+
+            // P3 -- head + mov-rcx-reg + call tail. Captures the
+            // first registration call per registrar function (it
+            // loads rcx from a preloaded table-base register via
+            // `mov rcx, rsi` / `mov rcx, rbx`). Only 4 module-wide
+            // hits on v1.06 -- the two registrars plus two
+            // unrelated callers that happen to share the shape
+            // (filtered by the name allow-list).
+            "41 B9 FF FF 02 00 "
+            "?? 8D ?? 01 "
+            "48 8D 15 ?? ?? ?? ?? "
+            "48 8B ?? E8",
+        }};
+
+    /// Byte width of the literal head shared by all
+    /// k_colorTokenRegistrarCallAobs candidates. The walker uses
+    /// this to step the cursor past a matched anchor before
+    /// scanning for the next hit.
+    inline constexpr std::size_t k_colorTokenRegistrarCallAobHeadLen = 17;
+
+    /// Number of walk-pattern variants in k_colorTokenRegistrarCallAobs.
+    /// Exposed as a standalone constant so dependent compile-time
+    /// expressions (std::array sizing, unrolled loops) do not have to
+    /// rebind the array through a reference before reading its extent
+    /// (MSVC declines to treat `.size()` on a `const auto&` alias as a
+    /// constant expression even when the underlying global is
+    /// `inline constexpr`).
+    inline constexpr std::size_t k_colorTokenRegistrarCallAobCount =
+        k_colorTokenRegistrarCallAobs.size();
 
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/color_override/color_token_discovery.cpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/color_token_discovery.cpp
@@ -1,5 +1,7 @@
 #include "color_token_discovery.hpp"
 
+#include "../aob_resolver.hpp"
+
 #include <DetourModKit.hpp>
 #include <DetourModKit/scanner.hpp>
 
@@ -11,6 +13,7 @@
 #include <chrono>
 #include <cstring>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 namespace DMK = DetourModKit;
@@ -181,45 +184,63 @@ namespace Transmog::ColorOverride::TokenSlotDiscovery
                 reinterpret_cast<const std::byte *>(mi.lpBaseOfDll);
             const auto size = mi.SizeOfImage;
 
-            // Registrar pattern (RE'd via IDA on sub_14274A3C0 and
-            // sub_142749F10, the two registrar functions for dye-
-            // property tokens):
+            // Walk every property-registration call site emitted by
+            // the two TLS-guarded registrars (sub_14274A3C0 and
+            // sub_142749F10). The pattern matches the 17-byte run:
             //
-            //   <zero-write>               6 or 7 bytes, decoded
+            //   <zero-write>               6 or 7 bytes; decoded
             //                              backward to get slot addr
             //   41 B9 FF FF 02 00          mov  r9d, 0x2FFFF  (6B)
             //   ?? 8D ?? 01                lea  r8d, [reg+1]  (4B)
-            //                              REX/ModR/M wildcarded -
-            //                              r13 (sub_14274A3C0) or
-            //                              rdi (sub_142749F10).
+            //                              REX/ModR/M wildcarded
+            //                              (reg is r13 for A, rdi
+            //                              for B).
             //   48 8D 15 ?? ?? ?? ??       lea  rdx, [name]   (7B)
             //   <rcx load>                 3 or 7 bytes (lea or mov)
             //   E8 ?? ?? ?? ??             call interner      (5B)
             //
-            // We anchor on the 17-byte run from `mov r9d, 0x2FFFF`
-            // through `lea rdx, [name]`. The `lea rdx` target is
-            // the property name string. The slot address is decoded
-            // from the zero-write instruction immediately PRECEDING
-            // the `mov r9d`:
+            // The `lea rdx` target is the property name string. The
+            // slot address is decoded from the zero-write instruction
+            // immediately PRECEDING the `mov r9d, 0x2FFFF` anchor:
             //
-            //   `89 3D disp32`       (6 bytes) - mov [rip+d], edi
-            //   `44 89 2D disp32`    (7 bytes) - mov [rip+d], r13d
+            //   89 3D disp32         (6B) - mov [rip+d], edi
+            //   44 89 2D disp32      (7B) - mov [rip+d], r13d
             //
             // Anchoring on the zero-write instead of `lea rcx` lets
             // us catch the first-entry-per-function case where rcx
-            // is loaded via `mov rcx, rbx`/`mov rcx, rsi` from a
+            // is loaded via `mov rcx, rbx` / `mov rcx, rsi` from a
             // preloaded table-base register. That entry is always
             // `_dyeingColorMaskR` and matters because the live game
             // emits its token id (0x2FCE).
-            constexpr std::string_view aob =
-                "41 B9 FF FF 02 00 "
-                "?? 8D ?? 01 "
-                "48 8D 15 ?? ?? ?? ??";
-            auto compiled = DMK::Scanner::parse_aob(aob);
-            if (!compiled)
+            //
+            // The pattern is intentionally non-unique: there is one
+            // match per registered property across the entire module
+            // (~2k hits on v1.06). The name-allow-list filter below
+            // accepts only the entries whose strings appear in
+            // k_known, so over-scanning is a performance concern
+            // rather than a correctness one.
+            // Compile all 3 walk patterns up front. We try each in
+            // turn over the module range; the inner accept logic
+            // dedups by slot_addr so a site matched by multiple
+            // patterns is recorded only once. Walking the union
+            // gives resilience: if a future patch reshapes one
+            // pattern's tail, the others still cover the call site.
+            const auto &aobs = Transmog::k_colorTokenRegistrarCallAobs;
+            std::array<
+                std::optional<DMK::Scanner::CompiledPattern>,
+                Transmog::k_colorTokenRegistrarCallAobCount>
+                compiledPatterns{};
+            std::size_t compiledCount = 0;
+            for (std::size_t pi = 0; pi < aobs.size(); ++pi)
+            {
+                compiledPatterns[pi] = DMK::Scanner::parse_aob(aobs[pi]);
+                if (compiledPatterns[pi]) ++compiledCount;
+            }
+            if (compiledCount == 0)
             {
                 DMK::Logger::get_instance().warning(
-                    "[token-discovery] AOB compile failed");
+                    "[token-discovery] all AOB candidates failed to "
+                    "compile");
                 g_complete.store(true, std::memory_order_release);
                 return;
             }
@@ -275,131 +296,163 @@ namespace Transmog::ColorOverride::TokenSlotDiscovery
                 }
             };
 
-            // Linear walk through the module: find_pattern returns
-            // first match in [cursor..end]; advance past it and
-            // continue.
+            // Linear walk through the module per pattern: for each
+            // compiled candidate, find_pattern returns the first
+            // match in [cursor..end]; we advance past it and
+            // continue. The accept logic dedups by slot_addr so
+            // patterns whose hit sets overlap (P1 is a superset of
+            // P2 and P3) record each unique slot exactly once.
             //
-            // The 17-byte pattern can match a large number of false
+            // The head pattern can match a large number of false
             // positives early in the binary because the wildcard
             // bytes give it some slack. Real registrar sites cluster
             // around 0x142749F00 / 0x14274A3C0, so we may need to
             // walk past several thousand false-positive matches
-            // before reaching them. Cap is set generously and the
-            // wall-clock budget remains the real safety net.
-            constexpr std::size_t k_maxIters = 50000;
+            // before reaching them. Per-pattern cap is set
+            // generously; the shared wall-clock budget across all
+            // patterns is the real safety net.
+            constexpr std::size_t k_maxItersPerPattern = 50000;
             constexpr auto k_timeBudget =
                 std::chrono::milliseconds(3000);
-            // The matched pattern is 17 bytes. The anchor we care
-            // about is the start of `41 B9 FF FF 02 00`. Advance
-            // cursor past the matched range each iteration.
-            constexpr std::size_t k_patternLen = 17;
-            const std::byte *cursor = base;
-            std::size_t bytes_left = size;
-            std::size_t hits = 0;
+            // The anchor we care about is the start of
+            // `41 B9 FF FF 02 00` (17 bytes). Advance cursor by the
+            // shared head length each iteration even if the matched
+            // pattern is longer (P2/P3 tails are not needed for
+            // overlap-prevention; their hit ranges always extend
+            // past the head and never abut another distinct site).
+            constexpr std::size_t k_patternHeadLen =
+                Transmog::k_colorTokenRegistrarCallAobHeadLen;
+
+            std::size_t totalHits = 0;
+            std::size_t totalIter = 0;
             std::size_t accepted = 0;
-            std::size_t iter = 0;
-            for (; iter < k_maxIters; ++iter)
+            bool budgetExceeded = false;
+            for (std::size_t pi = 0;
+                 pi < compiledPatterns.size() && !budgetExceeded;
+                 ++pi)
             {
-                if (clock::now() - t0 > k_timeBudget)
-                {
-                    DMK::Logger::get_instance().warning(
-                        "[token-discovery] time budget exceeded at "
-                        "iter={} hits={} (bailing)",
-                        iter, hits);
-                    break;
-                }
-                if (bytes_left < k_patternLen) break;
-                const auto *m = DMK::Scanner::find_pattern(
-                    cursor, bytes_left, *compiled);
-                if (m == nullptr) break;
-                ++hits;
+                if (!compiledPatterns[pi]) continue;
+                const auto &compiled = *compiledPatterns[pi];
 
-                const auto matchAddr =
-                    reinterpret_cast<std::uintptr_t>(m);
-
-                // Decode lea rdx target (at offset 10 in the
-                // matched run; the disp32 is 3 bytes into the lea).
-                const auto strAddr = decode_lea_rip(
-                    m + 10, 0x48, 0x8D, 0x15);
-                if (strAddr == 0)
+                const std::byte *cursor = base;
+                std::size_t bytes_left = size;
+                std::size_t patternHits = 0;
+                std::size_t iter = 0;
+                for (; iter < k_maxItersPerPattern; ++iter)
                 {
-                    cursor = m + 1;
-                    bytes_left = (base + size) - cursor;
-                    continue;
-                }
-
-                // Diagnostic trace: log first 5 match decodes (with
-                // a peek at the first 32 bytes of the candidate
-                // name string) so we can sanity-check the decode
-                // pipeline.
-                static std::atomic<std::size_t> s_traceLeft{5};
-                if (s_traceLeft.load(std::memory_order_acquire) > 0)
-                {
-                    if (s_traceLeft.fetch_sub(
-                            1, std::memory_order_acq_rel) > 0)
+                    if (clock::now() - t0 > k_timeBudget)
                     {
-                        char preview[33] = {0};
-                        peek_name_preview(strAddr, preview,
-                                          sizeof(preview));
-                        DMK::Logger::get_instance().trace(
-                            "[token-discovery] trace: site=0x{:X} "
-                            "strAddr=0x{:X} preview='{}'",
-                            matchAddr, strAddr, preview);
-                    }
-                }
-
-                // Match against known names; only proceed if a hit.
-                const KnownProp *matched_kp = nullptr;
-                for (const auto &kp : k_known)
-                {
-                    if (name_matches(strAddr, kp.name))
-                    {
-                        matched_kp = &kp;
+                        DMK::Logger::get_instance().warning(
+                            "[token-discovery] time budget exceeded "
+                            "at pattern={} iter={} hits={} (bailing)",
+                            pi, iter, patternHits);
+                        budgetExceeded = true;
                         break;
                     }
-                }
-                if (matched_kp != nullptr)
-                {
-                    const auto slotAddr = decode_zero_write_slot(m);
-                    if (slotAddr != 0)
+                    if (bytes_left < k_patternHeadLen) break;
+                    const auto *m = DMK::Scanner::find_pattern(
+                        cursor, bytes_left, compiled);
+                    if (m == nullptr) break;
+                    ++patternHits;
+
+                    const auto matchAddr =
+                        reinterpret_cast<std::uintptr_t>(m);
+
+                    // Decode `lea rdx, [rip+disp32]` target (at
+                    // offset 10 in the matched run; the disp32 is
+                    // 3 bytes into the lea).
+                    const auto strAddr = decode_lea_rip(
+                        m + 10, 0x48, 0x8D, 0x15);
+                    if (strAddr == 0)
                     {
-                        bool dup = false;
-                        for (const auto &s : g_slots)
+                        cursor = m + 1;
+                        bytes_left = (base + size) - cursor;
+                        continue;
+                    }
+
+                    // Diagnostic trace: log first 5 match decodes
+                    // across all patterns (with a peek at the first
+                    // 32 bytes of the candidate name string) so we
+                    // can sanity-check the decode pipeline.
+                    static std::atomic<std::size_t> s_traceLeft{5};
+                    if (s_traceLeft.load(
+                            std::memory_order_acquire) > 0)
+                    {
+                        if (s_traceLeft.fetch_sub(
+                                1, std::memory_order_acq_rel) > 0)
                         {
-                            if (s.slot_addr == slotAddr)
-                            {
-                                dup = true;
-                                break;
-                            }
-                        }
-                        if (!dup)
-                        {
-                            g_slots.push_back(
-                                {slotAddr, matched_kp->name,
-                                 matched_kp->layer,
-                                 matched_kp->channel});
-                            ++accepted;
-                            DMK::Logger::get_instance().info(
-                                "[token-discovery] slot=0x{:X} '{}' "
-                                "layer={} channel={} site=0x{:X}",
-                                slotAddr, matched_kp->name,
-                                matched_kp->layer,
-                                matched_kp->channel, matchAddr);
+                            char preview[33] = {0};
+                            peek_name_preview(strAddr, preview,
+                                              sizeof(preview));
+                            DMK::Logger::get_instance().trace(
+                                "[token-discovery] trace: P{} "
+                                "site=0x{:X} strAddr=0x{:X} "
+                                "preview='{}'",
+                                pi + 1, matchAddr, strAddr,
+                                preview);
                         }
                     }
-                }
 
-                cursor = m + k_patternLen;
-                bytes_left = (base + size) - cursor;
+                    // Match against known names; only proceed on a
+                    // hit. Names are short (<32 chars) so the
+                    // linear scan is cheap.
+                    const KnownProp *matched_kp = nullptr;
+                    for (const auto &kp : k_known)
+                    {
+                        if (name_matches(strAddr, kp.name))
+                        {
+                            matched_kp = &kp;
+                            break;
+                        }
+                    }
+                    if (matched_kp != nullptr)
+                    {
+                        const auto slotAddr =
+                            decode_zero_write_slot(m);
+                        if (slotAddr != 0)
+                        {
+                            bool dup = false;
+                            for (const auto &s : g_slots)
+                            {
+                                if (s.slot_addr == slotAddr)
+                                {
+                                    dup = true;
+                                    break;
+                                }
+                            }
+                            if (!dup)
+                            {
+                                g_slots.push_back(
+                                    {slotAddr, matched_kp->name,
+                                     matched_kp->layer,
+                                     matched_kp->channel});
+                                ++accepted;
+                                DMK::Logger::get_instance().trace(
+                                    "[token-discovery] slot=0x{:X} "
+                                    "'{}' layer={} channel={} "
+                                    "site=0x{:X} via P{}",
+                                    slotAddr, matched_kp->name,
+                                    matched_kp->layer,
+                                    matched_kp->channel, matchAddr,
+                                    pi + 1);
+                            }
+                        }
+                    }
+
+                    cursor = m + k_patternHeadLen;
+                    bytes_left = (base + size) - cursor;
+                }
+                totalHits += patternHits;
+                totalIter += iter;
             }
 
             const auto elapsed =
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     clock::now() - t0).count();
             DMK::Logger::get_instance().info(
-                "[token-discovery] scan complete: iter={} hits={} "
-                "slots={} elapsed_ms={}",
-                iter, hits, accepted,
+                "[token-discovery] scan complete: patterns={} "
+                "iter={} hits={} slots={} elapsed_ms={}",
+                compiledCount, totalIter, totalHits, accepted,
                 static_cast<long long>(elapsed));
             g_complete.store(true, std::memory_order_release);
         }
@@ -413,6 +466,74 @@ namespace Transmog::ColorOverride::TokenSlotDiscovery
     bool is_complete() noexcept
     {
         return g_complete.load(std::memory_order_acquire);
+    }
+
+    // Re-run the AOB scan when the live capture looks underpopulated.
+    // Cold start can miss registrar call sites whose code pages
+    // haven't been committed yet (Windows lazy commit); the engine
+    // also lazy-loads materials, so registrars that live in
+    // material-specific shader-glue routines can land in memory
+    // long after our initial init pass.
+    //
+    // No hard attempt cap. Mirroring the item_name_table catalog
+    // stability check: keep re-scanning on the hot path until two
+    // consecutive scans produce the same slot count -- THAT means
+    // the engine has stopped adding new registrars and our table
+    // has settled. After settle, this becomes a permanent no-op for
+    // the rest of the session.
+    //
+    // Throttled to ~1.5 s between attempts so we don't hammer the
+    // 600-800 ms scan in a hot loop. do_run() dedups against g_slots,
+    // so an interrupted re-scan is safe.
+    void retry_if_underpopulated(std::size_t expectedMin) noexcept
+    {
+        static std::atomic<bool> s_settled{false};
+        static std::atomic<long long> s_lastMs{0};
+        static std::atomic<bool> s_busy{false};
+        static std::atomic<std::size_t> s_lastCount{0};
+        if (s_settled.load(std::memory_order_acquire)) return;
+        using clock = std::chrono::steady_clock;
+        const auto nowMs = std::chrono::duration_cast<
+            std::chrono::milliseconds>(
+                clock::now().time_since_epoch()).count();
+        auto last = s_lastMs.load(std::memory_order_acquire);
+        if (last != 0 && (nowMs - last) < 1500) return;
+        // Single-flight guard: only one thread enters do_run at a
+        // time. Other concurrent callers see s_busy and bail.
+        bool expected = false;
+        if (!s_busy.compare_exchange_strong(
+                expected, true, std::memory_order_acq_rel))
+            return;
+        s_lastMs.store(nowMs, std::memory_order_release);
+        const auto before = g_slots.size();
+        // do_run sets g_complete=true at the end; allow re-run by
+        // resetting the flag locally (g_runOnce stays satisfied for
+        // the original call path so external `run()` callers still
+        // skip).
+        g_complete.store(false, std::memory_order_release);
+        do_run();
+        const auto after = g_slots.size();
+        const auto prev = s_lastCount.exchange(
+            after, std::memory_order_acq_rel);
+        if (after != before)
+        {
+            DMK::Logger::get_instance().info(
+                "[token-discovery] re-scan: slots {} -> {} "
+                "(prev_total={} expectedMin={})",
+                before, after, prev, expectedMin);
+        }
+        // Settle = two consecutive scans returned the same count AND
+        // we've met the expected baseline. Without the baseline gate,
+        // an early scan that finds 0 slots could "settle" immediately
+        // on the next 0-slot scan and freeze the retry permanently.
+        if (after == prev && after >= expectedMin)
+        {
+            s_settled.store(true, std::memory_order_release);
+            DMK::Logger::get_instance().info(
+                "[token-discovery] settled at {} slots; "
+                "no further re-scans this session", after);
+        }
+        s_busy.store(false, std::memory_order_release);
     }
 
     int classify_layer(std::uint32_t tok) noexcept

--- a/CrimsonDesertLiveTransmog/src/color_override/color_token_discovery.hpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/color_token_discovery.hpp
@@ -34,6 +34,15 @@ namespace Transmog::ColorOverride::TokenSlotDiscovery
     /// the first call performs the scan.
     void run();
 
+    /// Re-run the AOB scan if fewer than `expectedMin` slots have
+    /// been discovered. Cold-start can miss registrar call sites
+    /// whose code pages haven't been committed yet; calling this
+    /// from a hot path (e.g. the setter midhook) covers the gap.
+    /// Throttled internally (~1.5 s between attempts). Becomes a
+    /// permanent no-op once two consecutive scans return the same
+    /// slot count AND that count is >= `expectedMin`.
+    void retry_if_underpopulated(std::size_t expectedMin) noexcept;
+
     /// True after `run()` has finished its scan (whether or not it
     /// discovered any slots).
     bool is_complete() noexcept;

--- a/CrimsonDesertLiveTransmog/src/color_override/color_token_interner_hook.cpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/color_token_interner_hook.cpp
@@ -1,5 +1,7 @@
 #include "color_token_interner_hook.hpp"
 
+#include "../aob_resolver.hpp"
+
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
@@ -7,6 +9,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <mutex>
 
@@ -34,6 +37,30 @@ namespace Transmog::ColorOverride::InternerHook
         std::atomic<std::size_t> g_count{0};
         std::once_flag g_initOnce;
         std::atomic<bool> g_dumped{false};
+
+        // Cached interner-state pointer location, captured at init()
+        // success. `*g_stateSlot` is the live state pointer; the
+        // engine may reallocate the hash-table backing arrays when
+        // entries grow, so refresh() reads through this each call.
+        std::atomic<std::uintptr_t> g_stateSlot{0};
+
+        // Field offset (within the state struct) that holds the
+        // entries-array pointer. The engine has shifted this between
+        // +0x40 and +0x48 across patches; init() probes both and
+        // caches whichever address actually contains valid records
+        // here so refresh() reads through the same offset.
+        std::atomic<std::ptrdiff_t> g_offEntriesArray{0x48};
+
+        // Incremental-walk cursor used by refresh(). When the engine
+        // reallocates the entries array, `g_lastEntriesBase` differs
+        // from the live base and we restart from index 0; otherwise
+        // we resume from `g_lastEntriesIdx` and only capture entries
+        // appended since the previous walk. Without this, every
+        // refresh re-walked the whole array and appended the engine's
+        // already-captured entries as duplicates, exhausting the
+        // capture cap within a few seconds on a populated scene.
+        std::atomic<std::uintptr_t> g_lastEntriesBase{0};
+        std::atomic<std::size_t>    g_lastEntriesIdx{0};
 
         // SEH-guarded reads.
         std::uint64_t safe_read_qword(std::uintptr_t addr) noexcept
@@ -80,79 +107,24 @@ namespace Transmog::ColorOverride::InternerHook
             }
         }
 
-        // SEH-guarded: scan up to 16 bytes after match for the `E8`
-        // call opcode and decode its rel32 target. Returns 0 on
-        // miss or fault.
-        std::uintptr_t decode_call_after(
-            const std::byte *match_end) noexcept
-        {
-            __try
-            {
-                for (std::size_t i = 0; i < 16; ++i)
-                {
-                    if (static_cast<std::uint8_t>(match_end[i]) ==
-                        0xE8)
-                    {
-                        const std::int32_t disp =
-                            *reinterpret_cast<const std::int32_t *>(
-                                match_end + i + 1);
-                        return reinterpret_cast<std::uintptr_t>(
-                                   match_end + i + 5) +
-                               static_cast<std::intptr_t>(disp);
-                    }
-                }
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-            }
-            return 0;
-        }
-
-        // Find sub_140F46680 (the interner) by anchoring on a
-        // registrar call site we already know how to identify.
-        // The 17-byte pattern `mov r9d, 0x2FFFF; lea r8d, [reg+1];
-        // lea rdx, [name]` is followed by `lea rcx, [slot]` (7B) OR
-        // `mov rcx, reg` (3B), then `E8 disp32` (call). The first
-        // E8 opcode in the following 16 bytes is the call to the
-        // interner.
+        // Scan the function body for the FIRST
+        // `mov [rip+disp32], REG` whose target slot lies inside the
+        // loaded module AND whose runtime value already looks like a
+        // valid heap pointer. That write is the engine's
+        // `qword_145E15620 = state` publish (in v1.06: encoded as
+        // `48 89 35 disp32` -- `mov [rip+d], rsi` -- at function
+        // offset 0x312).
         //
-        // More reliable than AOB-scanning for the interner's
-        // prologue (which collides with many other functions
-        // sharing the same Microsoft __fastcall prologue -- we saw
-        // a false-match at sub_1407959E0 in v1.06).
-        std::uintptr_t find_interner_addr(
-            const std::byte *base, std::size_t size) noexcept
-        {
-            constexpr std::string_view aob =
-                "41 B9 FF FF 02 00 "
-                "?? 8D ?? 01 "
-                "48 8D 15 ?? ?? ?? ??";
-            auto compiled = DMK::Scanner::parse_aob(aob);
-            if (!compiled) return 0;
-            const auto *m = DMK::Scanner::find_pattern(
-                base, size, *compiled);
-            if (m == nullptr) return 0;
-            return decode_call_after(m + 17);
-        }
-
-        // Scan the function body for the first `48 89 05 disp32`
-        // (mov [rip+disp32], rax) whose target lies inside the
-        // loaded module. That's the write `qword_145E15620 = v10`
-        // -- the static slot that holds the interner state pointer.
-        // 0x312 is the offset in v1.06; we widen the search window
-        // to ±0x200 around that to absorb compiler shifts in future
-        // patches.
-        // Scan for any `mov [rip+disp32], REG` writing to a module-
-        // data slot whose runtime value is a heap pointer (the
-        // interner's state). REX prefix is 0x48 (rax-r7) or 0x4C
-        // (r8-r15). ModR/M byte uses RIP-relative addressing when
-        // `(byte & 0xC7) == 0x05` (mod=00, r/m=101); the reg field
-        // (bits 3-5) can be any register, hence the mask.
+        // REX byte: 0x48 covers rax-rdi, 0x4C covers r8-r15.
+        // ModR/M:   `(byte & 0xC7) == 0x05` selects mod=00 / r/m=101
+        //           (RIP-relative addressing). The middle 3 bits hold
+        //           the source register and are wildcarded by the
+        //           mask so the scan tolerates compiler register-
+        //           allocation churn between patches.
         //
-        // Walks through the prologue + body looking for the FIRST
-        // such write whose target slot contains a valid heap
-        // pointer. In v1.06 the write is `mov [rip+disp32], rsi`
-        // (`48 89 35 disp32`) at function offset 0x312.
+        // Filtering on "slot's current value is a heap pointer"
+        // discards early-init writes to other module globals (zeros,
+        // small ints, sentinels) that share the encoding.
         std::uintptr_t find_state_slot_in_function(
             std::uintptr_t funcAddr,
             std::uintptr_t modBase,
@@ -202,9 +174,16 @@ namespace Transmog::ColorOverride::InternerHook
         }
 
         // Walk the interner's entries array and capture every
-        // (name, token) pair. Returns number captured.
+        // (name, token) pair from `startIdx` onward. Returns the
+        // number of entries captured into the global table; on
+        // return `nextIdx` is set to the array index where the walk
+        // stopped (caller persists this so subsequent walks can
+        // resume incrementally instead of re-appending the engine's
+        // already-captured prefix as duplicates).
         std::size_t walk_entries_array(
-            std::uintptr_t entriesBase) noexcept
+            std::uintptr_t entriesBase,
+            std::size_t startIdx,
+            std::size_t &nextIdx) noexcept
         {
             constexpr std::size_t k_maxWalk = 0x20000; // 128k entries
             constexpr std::ptrdiff_t k_entryStride = 32;
@@ -212,7 +191,8 @@ namespace Transmog::ColorOverride::InternerHook
             constexpr std::ptrdiff_t k_offToken = 0x18;
             std::size_t captured = 0;
             std::size_t consecutiveBad = 0;
-            for (std::size_t i = 0; i < k_maxWalk; ++i)
+            std::size_t i = startIdx;
+            for (; i < k_maxWalk; ++i)
             {
                 const auto entryAddr =
                     entriesBase + i * k_entryStride;
@@ -248,6 +228,12 @@ namespace Transmog::ColorOverride::InternerHook
                                     std::memory_order_release);
                 ++captured;
             }
+            // Walk back over the trailing run of bad entries so a
+            // future grow that fills the gap is detected next time.
+            // `consecutiveBad` is the number of consecutive misses
+            // we saw before bailing; the first "real" entry sits at
+            // `i - consecutiveBad`, so resume at that index.
+            nextIdx = (i > consecutiveBad) ? (i - consecutiveBad) : i;
             return captured;
         }
 
@@ -264,9 +250,9 @@ namespace Transmog::ColorOverride::InternerHook
                 reinterpret_cast<std::uintptr_t>(mi.lpBaseOfDll);
             const auto modSize = mi.SizeOfImage;
 
-            const auto funcAddr = find_interner_addr(
-                reinterpret_cast<const std::byte *>(mi.lpBaseOfDll),
-                modSize);
+            const auto funcAddr = Transmog::resolve_address(
+                Transmog::k_colorTokenInternerCandidates,
+                "ColorTokenInterner");
             if (funcAddr == 0)
             {
                 logger.warning(
@@ -292,27 +278,68 @@ namespace Transmog::ColorOverride::InternerHook
                     stateSlot);
                 return;
             }
-            // Per RE (decompile of sub_140F46680):
+            // State-struct field layout (decompile of sub_140F46680):
             //   state + 0x30 = num_buckets       (u32)
             //   state + 0x40 = bucket_array_ptr  (u64)
             //   state + 0x48 = entries_array_ptr (u64)
-            // Reading +0x50 by mistake aliases the sentinel-cap
-            // field (`0x2FFFF...`) and produces a garbage entries
-            // pointer that captures 0 names.
-            const auto entriesBase = safe_read_qword(stateAddr + 0x48);
+            // Live capture in v1.06 has shown the entries-array
+            // pointer landing at +0x40 in some builds and +0x48 in
+            // others (the engine appears to have shifted the field
+            // by one slot during a header rev). Probe both with a
+            // small leading-record validator and persist the chosen
+            // offset in g_offEntriesArray so refresh() reads through
+            // the same field on subsequent walks.
+            auto probe = [](std::uintptr_t base) noexcept -> std::size_t {
+                if (base < 0x10000ULL) return 0;
+                std::size_t valid = 0;
+                for (std::size_t i = 0; i < 256; ++i)
+                {
+                    const auto e = base + i * 32;
+                    const auto np = safe_read_qword(e + 0x08);
+                    const auto tk = safe_read_dword(e + 0x18);
+                    if (np < 0x10000ULL || np > 0x7FFFFFFFFFFFULL)
+                        continue;
+                    if (tk == 0 || tk > 0x100000u) continue;
+                    if (safe_is_property_name(
+                            reinterpret_cast<const char *>(np)))
+                        ++valid;
+                }
+                return valid;
+            };
+            const auto base40 = safe_read_qword(stateAddr + 0x40);
+            const auto base48 = safe_read_qword(stateAddr + 0x48);
+            const auto v40 = probe(base40);
+            const auto v48 = probe(base48);
+            logger.info(
+                "[interner-hook] probe state=0x{:X} "
+                "base40=0x{:X} valid40={} base48=0x{:X} valid48={}",
+                stateAddr, base40, v40, base48, v48);
+            const bool pick40 = (v40 >= v48 && base40 >= 0x10000ULL);
+            const auto entriesBase = pick40 ? base40 : base48;
+            const std::ptrdiff_t entriesOff = pick40 ? 0x40 : 0x48;
             if (entriesBase < 0x10000ULL)
             {
                 logger.warning(
-                    "[interner-hook] entries-array pointer at "
-                    "state+0x50 not initialised");
+                    "[interner-hook] neither state+0x40 nor +0x48 "
+                    "has a valid entries-array pointer");
                 return;
             }
-            const auto captured = walk_entries_array(entriesBase);
+            std::size_t nextIdx = 0;
+            const auto captured = walk_entries_array(
+                entriesBase, 0, nextIdx);
             logger.info(
                 "[interner-hook] func=0x{:X} stateSlot=0x{:X} "
-                "state=0x{:X} entries=0x{:X} captured={}",
+                "state=0x{:X} entries=0x{:X} off=0x{:X} captured={} "
+                "nextIdx={}",
                 funcAddr, stateSlot, stateAddr, entriesBase,
-                captured);
+                entriesOff, captured, nextIdx);
+            g_offEntriesArray.store(entriesOff,
+                                    std::memory_order_release);
+            g_lastEntriesBase.store(entriesBase,
+                                    std::memory_order_release);
+            g_lastEntriesIdx.store(nextIdx,
+                                   std::memory_order_release);
+            g_stateSlot.store(stateSlot, std::memory_order_release);
             g_dumped.store(true, std::memory_order_release);
         }
     } // namespace
@@ -321,6 +348,95 @@ namespace Transmog::ColorOverride::InternerHook
     {
         std::call_once(g_initOnce, []() { do_init(); });
         return g_dumped.load(std::memory_order_acquire);
+    }
+
+    std::size_t refresh() noexcept
+    {
+        // No hard attempt cap. Mirroring item_name_table's stability
+        // check: keep walking the engine's interner each time the
+        // setter sees an unclassified token, and only stop once two
+        // consecutive walks return the same g_count -- that means
+        // the engine has stopped interning new names. After settle
+        // this becomes a permanent no-op for the rest of the session.
+        //
+        // Throttled to ~1.5 s between walks because each walk is
+        // O(entries); the engine can have 100k+ entries in a loaded
+        // scene.
+        static std::atomic<bool> s_settled{false};
+        static std::atomic<long long> s_lastMs{0};
+        static std::atomic<bool> s_busy{false};
+        static std::atomic<std::size_t> s_lastCount{0};
+        if (s_settled.load(std::memory_order_acquire)) return 0;
+        using clock = std::chrono::steady_clock;
+        const auto nowMs = std::chrono::duration_cast<
+            std::chrono::milliseconds>(
+                clock::now().time_since_epoch()).count();
+        auto last = s_lastMs.load(std::memory_order_acquire);
+        if (last != 0 && (nowMs - last) < 1500) return 0;
+        const auto slot = g_stateSlot.load(std::memory_order_acquire);
+        if (slot == 0) return 0;
+        bool expected = false;
+        if (!s_busy.compare_exchange_strong(
+                expected, true, std::memory_order_acq_rel))
+            return 0;
+        s_lastMs.store(nowMs, std::memory_order_release);
+        const auto stateAddr = safe_read_qword(slot);
+        std::size_t added = 0;
+        if (stateAddr >= 0x10000ULL)
+        {
+            const auto entriesOff = g_offEntriesArray.load(
+                std::memory_order_acquire);
+            const auto entriesBase = safe_read_qword(
+                stateAddr + entriesOff);
+            if (entriesBase >= 0x10000ULL)
+            {
+                // Resume the walk where the previous one stopped if
+                // the engine hasn't reallocated the entries array;
+                // otherwise restart from index 0 against the new
+                // base so we capture every entry exactly once.
+                const auto cachedBase = g_lastEntriesBase.load(
+                    std::memory_order_acquire);
+                std::size_t startIdx = 0;
+                if (cachedBase == entriesBase)
+                    startIdx = g_lastEntriesIdx.load(
+                        std::memory_order_acquire);
+                const auto before = g_count.load(
+                    std::memory_order_acquire);
+                std::size_t nextIdx = startIdx;
+                walk_entries_array(entriesBase, startIdx, nextIdx);
+                const auto after = g_count.load(
+                    std::memory_order_acquire);
+                added = (after > before) ? (after - before) : 0;
+                g_lastEntriesBase.store(entriesBase,
+                                        std::memory_order_release);
+                g_lastEntriesIdx.store(nextIdx,
+                                       std::memory_order_release);
+                const auto prev = s_lastCount.exchange(
+                    after, std::memory_order_acq_rel);
+                if (added > 0)
+                {
+                    DMK::Logger::get_instance().info(
+                        "[interner-hook] refresh: entries=0x{:X} "
+                        "off=0x{:X} resumeFrom={} added={} total={} "
+                        "prev_total={} nextIdx={}",
+                        entriesBase, entriesOff, startIdx, added,
+                        after, prev, nextIdx);
+                }
+                // Two consecutive walks with the same total = the
+                // interner has stopped growing. Require a non-zero
+                // baseline so an early empty-table walk can't latch
+                // settled immediately.
+                if (after == prev && after > 0)
+                {
+                    s_settled.store(true, std::memory_order_release);
+                    DMK::Logger::get_instance().info(
+                        "[interner-hook] settled at {} captures; "
+                        "no further refreshes this session", after);
+                }
+            }
+        }
+        s_busy.store(false, std::memory_order_release);
+        return added;
     }
 
     const char *name_for_token(std::uint32_t tok) noexcept

--- a/CrimsonDesertLiveTransmog/src/color_override/color_token_interner_hook.hpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/color_token_interner_hook.hpp
@@ -22,6 +22,13 @@ namespace Transmog::ColorOverride::InternerHook
     /// Safe to call multiple times; only the first call hooks.
     bool init() noexcept;
 
+    /// Re-walk the engine's interner entries array if our captured
+    /// set looks stale (fewer entries than the engine currently has,
+    /// or the table has been re-allocated). Throttled internally;
+    /// safe to call from a hot path. Returns the number of newly-
+    /// captured (name, token) pairs.
+    std::size_t refresh() noexcept;
+
     /// Reverse lookup: token id → property name. Returns nullptr if
     /// the token wasn't observed via the interner. The returned
     /// pointer is the engine's own .rdata string (process-lifetime

--- a/CrimsonDesertLiveTransmog/src/color_override/setter_substitute.cpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/setter_substitute.cpp
@@ -5,6 +5,8 @@
 #include "color_picker_state.hpp"
 #include "color_state.hpp"
 #include "color_swatch_table.hpp"
+#include "color_token_discovery.hpp"
+#include "color_token_interner_hook.hpp"
 #include "color_token_table.hpp"
 #include "matinst_probe.hpp"
 #include "one_shot_log_set.hpp"
@@ -84,11 +86,52 @@ namespace Transmog::ColorOverride::SetterSubstitute
 
         OneShotLogSet<std::uint32_t, 64> g_seenTokens;
         OneShotLogSet<std::uintptr_t, 16> g_seenVtables;
+        // Diagnostic: dump the first 8 distinct property-descriptor
+        // shapes the setter sees. Lets us confirm where the real
+        // 16-bit interner token id lives in the descriptor (we
+        // currently read `*(rdx-8+0x28)` as u32, which gives -1 layer
+        // for tokens that ARE in the discovered slots -- suggesting
+        // wrong field).
+        OneShotLogSet<std::uintptr_t, 8> g_seenDescShapes;
         // First-fire-per-(slot, content_hash) dedup. Logged once per
         // distinct (slot, hash) so a new region shows up exactly one
         // time per session without drowning the hot path.
         std::array<OneShotLogSet<std::uint32_t, 32>, ::Transmog::k_slotCount>
             g_seenSlotHashes;
+
+        // SEH-guarded read of one u32 with fault-tolerance. Returns
+        // 0 on fault. Used by the descriptor dump below so a bad
+        // address in one slot doesn't abort the whole row.
+        std::uint32_t seh_read_u32(std::uintptr_t addr) noexcept
+        {
+            __try
+            {
+                return *reinterpret_cast<const std::uint32_t *>(addr);
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return 0;
+            }
+        }
+
+        // Diagnostic: print the descriptor at `dst_prop` as a row of
+        // u32 at +0x00..+0x3C. Used on the first 8 distinct descriptor
+        // addresses to locate the real token-id field.
+        void log_descriptor_shape(std::uintptr_t dst_prop) noexcept
+        {
+            std::uint32_t w[16]{};
+            for (int i = 0; i < 16; ++i)
+                w[i] = seh_read_u32(dst_prop + std::uintptr_t(i) * 4);
+            DetourModKit::Logger::get_instance().debug(
+                "[dye-setter-sub] desc@{:#x}  "
+                "+00={:08X} +04={:08X} +08={:08X} +0C={:08X} "
+                "+10={:08X} +14={:08X} +18={:08X} +1C={:08X} "
+                "+20={:08X} +24={:08X} +28={:08X} +2C={:08X} "
+                "+30={:08X} +34={:08X} +38={:08X} +3C={:08X}",
+                dst_prop,
+                w[0], w[1], w[2], w[3], w[4], w[5], w[6], w[7],
+                w[8], w[9], w[10], w[11], w[12], w[13], w[14], w[15]);
+        }
 
         // SEH-guarded property token-id read.
         bool read_token_id(std::uintptr_t a2, std::uint32_t &out) noexcept
@@ -99,6 +142,11 @@ namespace Transmog::ColorOverride::SetterSubstitute
             {
                 const auto dst_prop = a2 - 8;
                 out = *reinterpret_cast<const std::uint32_t *>(dst_prop + 0x28);
+                // One-shot diagnostic: dump 16 u32s of the first 8
+                // distinct descriptor shapes. SEH-guarded helpers, so
+                // failure on any slot just yields 0 in that column.
+                if (g_seenDescShapes.insert_unique(dst_prop))
+                    log_descriptor_shape(dst_prop);
                 return true;
             }
             __except (EXCEPTION_EXECUTE_HANDLER)
@@ -195,7 +243,7 @@ namespace Transmog::ColorOverride::SetterSubstitute
                 bool active = DyeRecordInject::
                     get_published_first_active_rgb(&r, &g, &b);
                 const auto hs = ColorOverride::HostScope::snapshot_stats();
-                DetourModKit::Logger::get_instance().debug(
+                DetourModKit::Logger::get_instance().trace(
                     "[dye-setter-sub] fires={} subs={} defs={} miss={} "
                     "noSlot={} hostRej={} "
                     "active={} rgb=({:02X},{:02X},{:02X}) "
@@ -241,6 +289,19 @@ namespace Transmog::ColorOverride::SetterSubstitute
             std::uint32_t tokId = 0;
             if (read_token_id(ctx.rdx, tokId))
             {
+                // Lazy warm-up: cold-start can leave the discovery
+                // table underpopulated (Windows lazy-commit means
+                // some registrar code pages weren't faulted in at
+                // module-init scan time) and the interner table can
+                // grow after our initial walk. Retry both when we
+                // see a token we can't classify; throttled internally
+                // so this is a cheap no-op once warmed.
+                if (ColorOverride::TokenTable::token_layer(tokId) < 0)
+                {
+                    ColorOverride::TokenSlotDiscovery::
+                        retry_if_underpopulated(33);
+                    ColorOverride::InternerHook::refresh();
+                }
                 if (g_seenTokens.insert_unique(tokId))
                 {
                     DetourModKit::Logger::get_instance().debug(

--- a/CrimsonDesertLiveTransmog/src/overlay.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.inl
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.inl
@@ -2402,6 +2402,16 @@ static void draw_overlay_content()
                         }
                 }
 
+                // Per-popup tab jump flags. The Dye button + square
+                // dye chip force the popup onto the Dye tab; the
+                // circular override chip forces it onto Color
+                // Override. Without this, ImGui's tab-bar remembers
+                // the last-selected tab across popup opens, so a user
+                // who visited Color Override once would re-land there
+                // when they next hit the Dye button.
+                static bool s_dyePopupJumpToColor[k_slotCount] = {};
+                static bool s_dyePopupJumpToDye[k_slotCount] = {};
+
                 // Dye button: always plain "Dye" with no background
                 // color override -- keeps text legible regardless of
                 // dye state. Active state is signalled by a small
@@ -2425,6 +2435,7 @@ static void draw_overlay_content()
                                       ImVec2(chip_size, chip_size)))
                     {
                         ImGui::OpenPopup("##dye_picker");
+                        s_dyePopupJumpToDye[i] = true;
                     }
                     ImGui::PopStyleColor(3);
                     if (ImGui::IsItemHovered())
@@ -2454,7 +2465,6 @@ static void draw_overlay_content()
                         ++overrideCount;
                     }
                 }
-                static bool s_dyePopupJumpToColor[k_slotCount] = {};
                 if (firstOv)
                 {
                     ImGui::SameLine(0.0f, 4.0f);
@@ -2490,10 +2500,94 @@ static void draw_overlay_content()
                                       overrideCount == 1 ? "" : "s");
                         ui_tooltip(tip);
                     }
+
+                    // Reload icon: manual single-pass commit-retick
+                    // for the slot's color overrides. Only shown when
+                    // at least one override is active (guarded by the
+                    // outer `if (firstOv)` block). Coalesced if a
+                    // reinit is already running.
+                    //
+                    // Drawn with ImDrawList primitives (3/4 arc +
+                    // arrowhead) rather than a font glyph because the
+                    // overlay loads only the default ImGui font
+                    // (ASCII range) -- a Unicode reload glyph would
+                    // render as a missing-glyph box.
+                    ImGui::SameLine(0.0f, 4.0f);
+                    const float reload_d = ImGui::GetFrameHeight();
+                    const ImVec2 reload_p = ImGui::GetCursorScreenPos();
+                    const bool reloadClicked = ImGui::InvisibleButton(
+                        "##coReload", ImVec2(reload_d, reload_d));
+                    const bool reloadHovered = ImGui::IsItemHovered();
+                    {
+                        ImDrawList *rl_dl = ImGui::GetWindowDrawList();
+                        const ImVec2 rl_center(
+                            reload_p.x + reload_d * 0.5f,
+                            reload_p.y + reload_d * 0.5f);
+                        const float rl_radius = reload_d * 0.32f;
+                        const float thickness = std::max(
+                            1.0f, reload_d * 0.10f);
+                        // Slightly highlight on hover so the icon
+                        // reads as interactive without needing a
+                        // background frame.
+                        const ImU32 col = ImGui::GetColorU32(
+                            reloadHovered
+                                ? ImGuiCol_Text
+                                : ImGuiCol_TextDisabled);
+                        // 3/4 arc from 45 deg (top-right) sweeping
+                        // clockwise through 315 deg (right). The gap
+                        // sits at the 0-45 deg slice where the arrow
+                        // tip points back along the circle's
+                        // tangent.
+                        constexpr float kPi = 3.14159265358979f;
+                        const float a0 = -kPi * 0.25f;          // -45
+                        const float a1 =  kPi * 1.5f;           // +270
+                        rl_dl->PathArcTo(rl_center, rl_radius, a0, a1, 24);
+                        rl_dl->PathStroke(col, ImDrawFlags_None, thickness);
+                        // Arrowhead at the arc's terminus (a0). The
+                        // tangent at angle a is (-sin(a), cos(a))
+                        // (CCW direction); since we drew CW we negate
+                        // to get the head pointing in the sweep
+                        // direction.
+                        const float ax = rl_center.x + std::cos(a0) * rl_radius;
+                        const float ay = rl_center.y + std::sin(a0) * rl_radius;
+                        const float tx = std::sin(a0);
+                        const float ty = -std::cos(a0);
+                        // Outward (radial) unit vector for the head's
+                        // perpendicular spread.
+                        const float ox = std::cos(a0);
+                        const float oy = std::sin(a0);
+                        const float head = std::max(
+                            2.0f, reload_d * 0.22f);
+                        const ImVec2 p_tip(ax + tx * head,
+                                           ay + ty * head);
+                        const ImVec2 p_in (ax - ox * head * 0.7f,
+                                           ay - oy * head * 0.7f);
+                        const ImVec2 p_out(ax + ox * head * 0.7f,
+                                           ay + oy * head * 0.7f);
+                        rl_dl->AddTriangleFilled(p_tip, p_in, p_out, col);
+                    }
+                    if (reloadHovered)
+                        ui_tooltip(
+                            "Re-tick this slot once so color\n"
+                            "overrides commit. Use if a colour\n"
+                            "edit didn't take.");
+                    if (reloadClicked
+                        && !Transmog::ColorOverride::Reinit::
+                               any_slot_reinit_active())
+                    {
+                        Transmog::flag_enabled().store(
+                            true, std::memory_order_relaxed);
+                        Transmog::ColorOverride::Reinit::
+                            schedule_color_commit_retick(
+                                static_cast<int>(i));
+                    }
                 }
 
                 if (dyeBtn && slotDye)
+                {
                     ImGui::OpenPopup("##dye_picker");
+                    s_dyePopupJumpToDye[i] = true;
+                }
 
                 // 10 color groups, ordered by HSL hue (red -> rose).
                 // Anchored by `string_key` (the data file's _stringKey
@@ -2913,7 +3007,16 @@ static void draw_overlay_content()
                     // entry point.
                     if (ImGui::BeginTabBar("##dye_tabs"))
                     {
-                    if (ImGui::BeginTabItem("Dye"))
+                    // Honor "jump to Dye tab" set by the Dye button +
+                    // square dye chip on the row. One-shot: clear
+                    // after consuming so subsequent tab clicks behave
+                    // normally.
+                    ImGuiTabItemFlags dyeTabFlags =
+                        s_dyePopupJumpToDye[i]
+                            ? ImGuiTabItemFlags_SetSelected
+                            : 0;
+                    s_dyePopupJumpToDye[i] = false;
+                    if (ImGui::BeginTabItem("Dye", nullptr, dyeTabFlags))
                     {
                     // --- Top action bar ---
                     if (ImGui::Button("Mirror Mod 0 to all"))
@@ -3178,27 +3281,22 @@ static void draw_overlay_content()
                     ImGui::EndTooltip();
                 }
 
-                // Per-slot 3-pass swatch re-init. Drives clear + apply
-                // 3 times spaced ~1s apart, then prunes any swatch row
-                // whose identity didn't appear in all 3 passes (ghost
-                // filter). Use when the swatch list is empty / stale
-                // and you'd otherwise untick-retick by hand.
+                // Per-slot single-pass swatch re-init. Drives one
+                // clear + apply cycle (~1.5s) and keeps whatever rows
+                // were captured. Use when the swatch list is empty
+                // and you'd otherwise untick-retick by hand. The
+                // legacy 3-pass ghost-filter variant
+                // (`start_slot_reinit`) is no longer wired from the
+                // UI -- one pass is enough for the common case.
                 ImGui::SameLine(0.0f, 6.0f);
                 const bool reinitActive =
                     Transmog::ColorOverride::Reinit::is_slot_reinit_active(
                         static_cast<int>(i));
                 if (reinitActive)
                 {
-                    const int rpass =
-                        Transmog::ColorOverride::Reinit::slot_reinit_pass(
-                            static_cast<int>(i));
                     ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
                     ImGui::BeginDisabled(true);
-                    char rlbl[32];
-                    std::snprintf(rlbl, sizeof(rlbl),
-                                  "Re-init %d/3##sw_reinit_busy",
-                                  rpass + 1);
-                    ImGui::SmallButton(rlbl);
+                    ImGui::SmallButton("Re-init...##sw_reinit_busy");
                     ImGui::EndDisabled();
                     ImGui::PopStyleVar();
                 }
@@ -3212,10 +3310,9 @@ static void draw_overlay_content()
                     {
                         ImGui::BeginTooltip();
                         ImGui::TextUnformatted(
-                            "Auto-cycle clear+apply 3 times (~1s each).\n"
-                            "Keeps only swatches that appear in all 3\n"
-                            "passes; drops ghosts. Use when the swatch\n"
-                            "list looks empty or has stale rows.\n\n"
+                            "Single clear + apply (~1.5s) to capture\n"
+                            "the slot's swatches. Use when the list\n"
+                            "looks empty or stale.\n\n"
                             "Replaces the manual 'untick / retick'\n"
                             "loop -- you can leave this slot alone\n"
                             "while it runs.");
@@ -3224,7 +3321,7 @@ static void draw_overlay_content()
                     if (reinitClicked)
                     {
                         flag_enabled().store(true, std::memory_order_relaxed);
-                        Transmog::ColorOverride::Reinit::start_slot_reinit(
+                        Transmog::ColorOverride::Reinit::start_slot_reinit_once(
                             static_cast<int>(i));
                     }
 


### PR DESCRIPTION
## Summary

Wire up two cooperating discovery paths so the color-override picker can name and classify the engine's per-property dye tokens at runtime, replacing the baked-in token table that goes stale every patch.