### PR TITLE
fix(live-transmog): run item-prefab TSV dump on detached thread

### DIFF
--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -734,7 +734,14 @@ namespace Transmog
                 if (flag_dump_item_catalog().load(std::memory_order_relaxed))
                     ItemNameTable::instance().dump_catalog_tsv();
                 if (flag_dump_item_prefabs().load(std::memory_order_relaxed))
-                    dump_itemmesh_tsv();
+                {
+                    // Targeted phantom-recovery sweep can take ~minutes
+                    // on a cold registry. Detach so the rest of transmog
+                    // init (hooks, color-override) doesn't block waiting
+                    // for the TSV write -- nothing downstream depends on
+                    // the dump.
+                    std::thread{[] { dump_itemmesh_tsv(); }}.detach();
+                }
             }
             else if (result == BR::Deferred)
             {

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -85,7 +85,13 @@ namespace Transmog
                 if (flag_dump_item_catalog().load(std::memory_order_relaxed))
                     ItemNameTable::instance().dump_catalog_tsv();
                 if (flag_dump_item_prefabs().load(std::memory_order_relaxed))
-                    dump_itemmesh_tsv();
+                {
+                    // Targeted phantom-recovery sweep can take ~minutes.
+                    // Detach so reresolve_all_names + manual_apply
+                    // happen immediately and the live transmog state
+                    // refreshes without waiting on the TSV write.
+                    std::thread{[] { dump_itemmesh_tsv(); }}.detach();
+                }
 
                 // Re-resolve all loaded preset slots against the now-
                 // populated catalog and re-apply the active preset so


### PR DESCRIPTION
## Fix
Detach `dump_itemmesh_tsv()` at both call sites (`transmog.cpp` synchronous-init path and `transmog_worker.cpp` deferred path). The dump only writes a diagnostic TSV, nothing downstream reads it, so fire-and-forget is safe. The two paths remain mutually exclusive at startup, so no double-dump risk.

