### PR TITLE
refactor(logging): demote deferred-scan heartbeats to DEBUG

### DIFF
--- a/CrimsonDesertEquipHide/src/background_threads.cpp
+++ b/CrimsonDesertEquipHide/src/background_threads.cpp
@@ -57,7 +57,7 @@ namespace EquipHide
         //       has finished growing for this load.
         constexpr int         k_scanRetryMs       = 2000;
         constexpr int         k_scanInitialDelayMs = 8000;
-        constexpr int         k_scanWarnEvery     = 30;
+        constexpr int         k_scanHeartbeatEvery = 30;
         constexpr int         k_stabilityRequired = 5;
         constexpr std::size_t k_minStableCount    = 32;
 
@@ -120,8 +120,8 @@ namespace EquipHide
                 // almost-empty hash map.
                 if (read_controlled_actor_ptr_seh() == 0)
                 {
-                    if (attempt % k_scanWarnEvery == 0)
-                        logger.warning(
+                    if (attempt % k_scanHeartbeatEvery == 0)
+                        logger.debug(
                             "IndexedStringA deferred scan: still waiting "
                             "after {} attempts (controlled actor not yet "
                             "live)",
@@ -138,8 +138,8 @@ namespace EquipHide
                 {
                     // Table still entirely empty: reset streak so we never
                     // commit the empty state on stability.
-                    if (attempt % k_scanWarnEvery == 0)
-                        logger.warning(
+                    if (attempt % k_scanHeartbeatEvery == 0)
+                        logger.debug(
                             "IndexedStringA deferred scan: still waiting "
                             "after {} attempts (table empty)",
                             attempt);
@@ -161,8 +161,8 @@ namespace EquipHide
                             "{} entries (below min {}, awaiting growth)",
                             attempt, curCount, k_minStableCount);
                     }
-                    if (attempt % k_scanWarnEvery == 0)
-                        logger.warning(
+                    if (attempt % k_scanHeartbeatEvery == 0)
+                        logger.debug(
                             "IndexedStringA deferred scan: {} entries "
                             "after {} attempts (below min commit "
                             "threshold {}, registry still loading)",
@@ -182,8 +182,8 @@ namespace EquipHide
                         "entries (changed, stability streak reset)",
                         attempt, curCount);
 
-                    if (attempt % k_scanWarnEvery == 0)
-                        logger.warning(
+                    if (attempt % k_scanHeartbeatEvery == 0)
+                        logger.debug(
                             "IndexedStringA deferred scan: still waiting "
                             "after {} attempts ({} entries currently, "
                             "table still settling)",
@@ -200,8 +200,8 @@ namespace EquipHide
                         attempt, curCount, stableStreak,
                         k_stabilityRequired);
 
-                    if (attempt % k_scanWarnEvery == 0)
-                        logger.warning(
+                    if (attempt % k_scanHeartbeatEvery == 0)
+                        logger.debug(
                             "IndexedStringA deferred scan: {} entries "
                             "after {} attempts (stable streak {}/{}, "
                             "need {} consecutive identical scans)",

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -138,7 +138,7 @@ namespace Transmog
             // populates the catalog or shutdown is requested.
             ++attempt;
             if (attempt % 50 == 0)
-                logger.warning(
+                logger.debug(
                     "[nametable] still waiting after {} attempts", attempt);
 
             for (int slept = 0; slept < k_nametableRetryMs; slept += 250)
@@ -234,7 +234,7 @@ namespace Transmog
             if (!Transmog::is_world_ready())
             {
                 if (attempt % 50 == 0)
-                    logger.warning(
+                    logger.debug(
                         "[dispatch] slot-hash deferred scan: waiting "
                         "for world after {} attempts",
                         attempt);
@@ -245,7 +245,7 @@ namespace Transmog
             if (nameToHash.empty())
             {
                 if (attempt % 50 == 0)
-                    logger.warning(
+                    logger.debug(
                         "[dispatch] slot-hash deferred scan: "
                         "IndexedStringA empty after world-ready "
                         "({} attempts)",
@@ -291,7 +291,7 @@ namespace Transmog
             // Plateaued -- sleep and retry indefinitely until every
             // expected key registers or shutdown is requested.
             if (attempt % 50 == 0)
-                logger.warning(
+                logger.debug(
                     "[dispatch] slot-hash deferred scan: still "
                     "waiting after {} attempts ({}/{} resolvable)",
                     attempt, resolvable, expectedCount);


### PR DESCRIPTION
## Summary

The IndexedStringA deferred-scan loops in EquipHide and LiveTransmog emit periodic log lines while waiting for the controlled actor, world, or part registry to become ready. These states are expected during save-load, not anomalies, so they shouldn't surface at WARNING in a clean session.
