### PR TITLE
fix(live-transmog): hard-fail init when display_names.tsv is missing

### DIFF
--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -33,6 +33,7 @@
 #include <array>
 #include <atomic>
 #include <chrono>
+#include <fstream>
 #include <string>
 #include <thread>
 
@@ -764,6 +765,38 @@ namespace Transmog
     bool init()
     {
         auto &logger = DMK::Logger::get_instance();
+
+        // --- Required asset gate ---
+        //
+        // The display-names TSV ships with the mod and is required for
+        // the catalog UI and name-keyed preset resolution. Missing file
+        // means the user installed incorrectly; surface a hard, visible
+        // error (modal popup) and bail out of init so the failure cannot
+        // be silently ignored by skipping the log.
+        {
+            const auto rtDir = runtime_dir_utf8();
+            std::string tsvPath =
+                rtDir.empty() ? std::string{DISPLAY_NAMES_FILE}
+                              : rtDir + DISPLAY_NAMES_FILE;
+            const bool dirOk = !rtDir.empty();
+            std::ifstream probe(tsvPath);
+            if (!dirOk || !probe.is_open())
+            {
+                std::string body =
+                    "Required asset '" + std::string{DISPLAY_NAMES_FILE} +
+                    "' was not found.\n\nExpected location:\n  " + tsvPath +
+                    "\n\nThe TSV must sit next to the mod DLL (same folder, "
+                    "wherever you installed it). Reinstall the mod and "
+                    "verify all files are present.\n\nThe mod will not "
+                    "function.";
+                logger.error("{}", body);
+                ::MessageBoxA(nullptr, body.c_str(),
+                              "CrimsonDesertLiveTransmog -- missing asset",
+                              MB_OK | MB_ICONERROR | MB_TOPMOST |
+                                  MB_SYSTEMMODAL);
+                return false;
+            }
+        }
 
         if (!DMK::Memory::init_cache())
             logger.warning("Memory cache init failed -- pointer reads may be slower");


### PR DESCRIPTION
## Summary

If `CrimsonDesertLiveTransmog_display_names.tsv` is missing from the
mod DLL's directory, `Transmog::init()` now:

1. Logs an error with the expected path.
2. Shows a modal `MessageBoxA` (icon-error, topmost, system-modal)
   telling the user to reinstall and confirming the file must sit
   next to the mod DLL.
3. Returns `false` so `init_mod()` cleanly aborts mod startup.

Previously the mod loaded in a half-broken state, preset name resolution and the catalog UI silently degraded with only a log warning, which most users never see.

The game keeps running; only the mod is disabled.
