### PR TITLE
fix(core,equip-hide): v1.08.00 compatibility

### DIFF
--- a/CrimsonDesertCore/include/cdcore/anchors.hpp
+++ b/CrimsonDesertCore/include/cdcore/anchors.hpp
@@ -295,6 +295,83 @@ namespace CDCore::Anchors
          ResolveMode::Direct, -0x25, 0},
     };
 
+    // -----------------------------------------------------------------------
+    // ClientActorManagerGlobal -- module-static slot holding the published
+    // pa::ClientActorManager* singleton. Source of truth for the entire
+    // controlled-character resolver chain:
+    //
+    //   [global] -> mgr (pa::ClientActorManager)
+    //   mgr  +0x28 -> userActor (pa::ClientUserActor)
+    //   user +0x08 -> subMgr
+    //   sub  +0x30 -> Kliff CCOIA (always present)
+    //   sub  +0x38 -> currently-controlled CCOIA
+    //
+    // The slot's module-relative offset drifts between game patches
+    // (e.g., 0x5FA0430 on v1.06 / v1.07, 0x6012110 on v1.08), so a
+    // hardcoded offset silently reads unrelated `.data` on the wrong
+    // build (the v1.06 offset on a v1.08 binary lands inside a
+    // packed string table, dereferencing to ASCII content rather
+    // than a heap pointer). All three candidates anchor on distinct
+    // instructions inside the same lazy-init function that publishes
+    // the singleton and resolve to the same global slot.
+    //
+    // All candidates use RipRelative mode. Each yields the absolute
+    // address of the slot whose qword is the manager pointer.
+    // -----------------------------------------------------------------------
+    inline constexpr AddrCandidate k_clientActorManagerGlobalCandidates[] = {
+        // P1 -- publish-store + sibling sub-pointer assignments:
+        //   mov [rip+disp32], rdi         ; <-- publishes the manager
+        //   lea rax, [rdi+0x100]
+        //   mov [rip+disp32], rax         ; sibling slot +8
+        //   lea rax, [rdi+0x180]
+        //   mov [rip+disp32], rax         ; sibling slot +16
+        // The literal +0x100 / +0x180 sub-field offsets are the
+        // manager's published sub-pointers and pin the function
+        // tightly without depending on any compiler-owned values.
+        // disp32 of `mov [rip+disp32], rdi` is at match+3; the
+        // instruction is 7 bytes long.
+        {"ClientActorManagerGlobal_P1_PublishStore",
+         "48 89 3D ?? ?? ?? ?? 48 8D 87 00 01 00 00 "
+         "48 89 05 ?? ?? ?? ?? 48 8D 87 80 01 00 00 "
+         "48 89 05",
+         ResolveMode::RipRelative, 3, 7},
+
+        // P2 -- zero-init prologue that precedes the publish store:
+        //   vpxor   xmm0,xmm0,xmm0                ; C5 F9 EF C0
+        //   vmovdqu xmmword [rip+disp32], xmm0    ; C5 FA 7F 05 + disp32
+        //   mov     [rip+disp32], r12             ; 4C 89 25 + disp32
+        //   mov     byte [rip+disp32], 0          ; C6 05 + disp32 + 00
+        // The r12 register choice and the byte-store of 0 distinguish
+        // this from ordinary AVX zero-init blocks. The vmovdqu
+        // resolves to the same global slot as P1. disp32 lives at
+        // match+8; vmovdqu instruction ends at match+12.
+        {"ClientActorManagerGlobal_P2_ZeroInitPrologue",
+         "C5 F9 EF C0 C5 FA 7F 05 ?? ?? ?? ?? "
+         "4C 89 25 ?? ?? ?? ?? "
+         "C6 05 ?? ?? ?? ?? 00",
+         ResolveMode::RipRelative, 8, 12},
+
+        // P3 -- mid-body address-of-global use:
+        //   lea rdx, cs:[rip+disp32]              ; 48 8D 15 + disp32
+        //   lea rcx, [rbp+disp32]                 ; 48 8D 8D + disp32
+        //   call helper                           ; E8 + rel32
+        //   nop
+        //   mov byte [rsp+disp8], 0               ; C6 44 24 + disp8 + 00
+        //   vpxor xmm0,xmm0,xmm0                  ; C5 F9 EF C0
+        // The `lea rdx, [rip+disp32]` is the only address-of-global
+        // use in this function (the publish store uses mov, not lea).
+        // The post-call tail (`90 C6 44 24 ?? 00 C5 F9 EF C0`) is
+        // necessary to disambiguate: without it the leading
+        // `lea rdx; lea rcx,[rbp+]; call; nop` shape matched ten
+        // sites in v1.08. disp32 of the `lea rdx` lives at match+3;
+        // the instruction is 7 bytes long.
+        {"ClientActorManagerGlobal_P3_LeaCallBody",
+         "48 8D 15 ?? ?? ?? ?? 48 8D 8D ?? ?? ?? ?? "
+         "E8 ?? ?? ?? ?? 90 C6 44 24 ?? 00 "
+         "C5 F9 EF C0",
+         ResolveMode::RipRelative, 3, 7},
+    };
+
 } // namespace CDCore::Anchors
 
 #endif // CDCORE_ANCHORS_HPP

--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -13,7 +13,7 @@
 // body-mesh asset-path read on the CCOIA
 // (pa::ClientChildOnlyInGameActor):
 //
-//   [playerBase]                        ; = moduleBase + 0x5FA0430
+//   [playerBase]                        ; AOB-resolved module-static slot
 //      -> +0x28  = pa::ClientUserActor
 //          -> +0x08  = CCOIA sub-manager
 //              -> +0x30 = Kliff CCOIA           (always-present anchor)
@@ -53,7 +53,9 @@
 //   From any thread, call current_controlled_character() etc. -- the
 //   resolver walks the chain on every call (SEH-guarded). No hooks,
 //   no learning caches, no broadcast subscriptions. The player-base
-//   static (`moduleBase + 0x5FA0430`) is resolved lazily on first use.
+//   slot is AOB-resolved lazily on first use via
+//   CDCore::Anchors::k_clientActorManagerGlobalCandidates (3-tier
+//   cascade across distinct instructions in the publishing function).
 //
 // Thread safety:
 //   - All functions are non-blocking and SEH-guarded; safe from any thread

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -2,6 +2,9 @@
 
 #include <Windows.h>
 
+#include <cdcore/anchors.hpp>
+#include <cdcore/dmk_glue.hpp>
+
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -33,11 +36,6 @@ namespace CDCore
 {
     namespace
     {
-        // Default static address (image-base + 0x5FA0430). The engine
-        // writer is a single `mov cs:<rva>h, rdi` against this slot;
-        // every published actor manager pointer flows through it.
-        constexpr std::uintptr_t k_defaultPlayerBaseOffset = 0x5FA0430;
-
         // Lower bound for "looks like a heap pointer". Catches both real
         // null pointers and small enum-shaped values an uninitialised
         // slot may carry before the engine singleton is wired up.
@@ -104,6 +102,36 @@ namespace CDCore
         // while the appearance codename is character-keyed and stays
         // unique even if the game adds a 4th protagonist sharing
         // Damiane's skeleton.
+        //
+        // Step-2 caveat: the holder at ccoia+0x68 is a dense component
+        // pointer table that grows as actor components register, so
+        // the target component (pa::ClientCharacterControlActorComponent)
+        // lands at a different slot index depending on how many
+        // components have been wired up at the moment we read.
+        // Observed Kliff layouts:
+        //
+        //   early load (~5 components present):
+        //     ccoia +0x68 -> p1
+        //       p1 +0x40 -> pa::ClientEquipSlotActorComponent (wrong branch)
+        //       p1 +0x48 -> pa::ClientCharacterControlActorComponent
+        //
+        //   later load (~22 components present):
+        //     ccoia +0x68 -> p1
+        //       p1 +0x38 -> pa::ClientEquipSlotActorComponent
+        //       p1 +0x40 -> pa::ClientCharacterControlActorComponent
+        //       p1 +0x48 -> pa::ClientVehicleActorComponent
+        //
+        // The +0x40 offset is correct in the steady state where every
+        // expected component has registered; during cold load it can
+        // transiently miss, and current callers retry-on-failure to
+        // ride that out. Steps 3 (+0x40) and 4 (+0x38) dereference
+        // fixed members of the resolved component and are
+        // structurally stable.
+        //
+        // TODO: walk p1 by RTTI/vtable to land on
+        // pa::ClientCharacterControlActorComponent regardless of slot
+        // so the chain becomes session-stable; the vtable is in image
+        // and can be cached at startup.
         constexpr std::ptrdiff_t k_offAppearChain1 = 0x68;
         constexpr std::ptrdiff_t k_offAppearChain2 = 0x40;
         constexpr std::ptrdiff_t k_offAppearChain3 = 0x40;
@@ -206,18 +234,23 @@ namespace CDCore
 
         std::uintptr_t resolve_player_base_address() noexcept
         {
-            // Lazy one-shot: moduleBase + k_defaultPlayerBaseOffset.
-            static std::atomic<std::uintptr_t> s_cachedDefault{0};
+            // Lazy one-shot AOB resolve. The engine publishes the
+            // pa::ClientActorManager* into a single static slot whose
+            // module-relative offset drifts between game patches; the
+            // cascade in anchors.hpp anchors on three distinct
+            // instructions inside the publishing function so partial
+            // recompiles or compiler reorderings still resolve.
+            static std::atomic<std::uintptr_t> s_cached{0};
             const auto cached =
-                s_cachedDefault.load(std::memory_order_acquire);
+                s_cached.load(std::memory_order_acquire);
             if (cached >= k_minValidPtr)
                 return cached;
-            const auto mod = reinterpret_cast<std::uintptr_t>(
-                GetModuleHandleW(nullptr));
-            if (mod < k_minValidPtr)
+            const auto addr = CDCore::Glue::resolve_address(
+                CDCore::Anchors::k_clientActorManagerGlobalCandidates,
+                "ClientActorManagerGlobal");
+            if (addr < k_minValidPtr)
                 return 0;
-            const auto addr = mod + k_defaultPlayerBaseOffset;
-            s_cachedDefault.store(addr, std::memory_order_release);
+            s_cached.store(addr, std::memory_order_release);
             return addr;
         }
 

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -5,3 +5,4 @@
 - All three protagonists are tracked from frame zero without needing the user to cycle to each one first.
 - Fixed cases where part hide rules silently failed to take effect when the mod started while still on the main menu.
 - A single typo in the Parts list no longer blocks every other entry from taking effect.
+- Compatibility fix for Crimson Desert game version 1.08.00

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -149,8 +149,24 @@ namespace EquipHide
          "4C 89 4C 24 20 53 55 56 57 41 54 41 55 48 83 EC 28 44 8B 11 48 8B D9 4D 8B E1 41 8B F0 4C 8B EA",
          ResolveMode::Direct, 0, 0},
 
+        // P2 -- inner body anchor (post-prologue arg shuffle through the
+        // following `test r10d, r10d ; jne ; mov edx,r8d ; mov rcx,rbx ;
+        // call helper ; mov r10d,[rbx] ; mov ecx,r10d ; xor ebp,ebp ;
+        // test ecx,ecx`). Original 15-byte body was unique on earlier
+        // builds but matched twice on v1.08 -- a sibling actor-component
+        // init at 0x142469B1C ran the exact same arg-shuffle plus the
+        // exact same `test/jne/call` follow-on. The differentiator is
+        // the `33 ED` (xor ebp, ebp) just before the `test ecx, ecx` --
+        // the false-positive site jumps straight to `test ecx, ecx`
+        // without zeroing ebp first. Extending the suffix through that
+        // discriminator restores uniqueness. The intervening rel8 short
+        // branch and rel32 call target are wildcarded (compiler-owned
+        // values, see aob-signatures.md §2). disp_offset stays -0x11
+        // (walks back to function start from the first byte of P2).
         {"MapInsert_P2_InnerBody",
-         "44 8B 11 48 8B D9 4D 8B E1 41 8B F0 4C 8B EA",
+         "44 8B 11 48 8B D9 4D 8B E1 41 8B F0 4C 8B EA "
+         "41 8B CA 45 85 D2 75 ?? 41 8B D0 48 8B CB "
+         "E8 ?? ?? ?? ?? 44 8B 13 41 8B CA 33 ED 85 C9",
          ResolveMode::Direct, -0x11, 0},
 
         {"MapInsert_P3_PrologueBody",
@@ -178,10 +194,17 @@ namespace EquipHide
      *   [RBP+0x67] = a4 (transition type byte, saved from R9B at prologue)
      *   [RBP+0x4F] = a1 context pointer
      *
-     * Cross-version cascade. v1.03.01 candidates come first (current live
-     * game returns 1 hit for each); v1.02.00 candidates are retained for
-     * users still on the older build and return 0 on the v1.03.01 game --
-     * that's expected, not broken.
+     * Cross-version cascade. v1.08.00 candidates come first (current
+     * live game returns 1 hit for each); v1.05.00 and v1.04.00 / v1.02.00
+     * candidates are retained for users still on older builds and return
+     * 0 on the v1.08.00 game -- that's expected, not broken.
+     *
+     * Register layout at hook point (v1.08.00):
+     *   v1.08 spills the visibility byte itself to a stack arg slot
+     *   (default `[rsp+0x20]`) before the cmp; the `mov r8b, 1` that
+     *   sets the exclusion-list flag still precedes the read. The
+     *   PartInOutSocket struct is no longer dereferenced inline at the
+     *   hook point, only by the surrounding code that fed the spill.
      *
      * Branch-encoding caveat (aob-signatures.md section 8):
      *       The hook point is movzx eax, byte [<vis>+0x1C] ; cmp al, 3.
@@ -194,13 +217,38 @@ namespace EquipHide
      *       only shortens the verified suffix, not the match start).
      */
     inline constexpr AddrCandidate k_hookSiteCandidates[] = {
+        // PN1 -- v1.08.00. The PartInOutSocket arg-passing convention
+        // changed: the visibility byte is no longer fetched through
+        // `mov rax, [rbp+0x5F] ; movzx eax, byte [rax+0x1C]` (which
+        // anchored P0..P3). The compiler now spills the byte itself to
+        // a stack arg slot and reads it directly: `movzx eax, byte
+        // [rsp+0x20] ; cmp al, 3`. The `mov r8b, 1` (set-exclusion-
+        // list flag) idiom that precedes the load is retained, so we
+        // anchor on the pair: `41 B0 01 41 0F B6 44 24 ?? 3C 03`.
+        // The stack disp8 is wildcarded -- the slot can drift across
+        // builds. Hook lands on the movzx at match + 3 (skip the
+        // `41 B0 01`). 1 hit on v1.08.00, 0 on v1.04.00 / v1.05.00.
+        {"PartInOut_PN1_v108_StackArgVisRead",
+         "41 B0 01 41 0F B6 44 24 ?? 3C 03",
+         ResolveMode::Direct, 3, 0},
+
+        // PN2 -- v1.08.00 wider: prefixed with the `EB 03` short jmp
+        // that lands on the `mov r8b, 1` from the loop-not-found
+        // branch. Provides extra structural pinning if a future
+        // recompile shuffles the `mov r8b, 1` away from PN1. Hook
+        // still lands on the movzx, at match + 5. 1 hit on v1.08.00.
+        {"PartInOut_PN2_v108_LoopExitJoin",
+         "EB 03 41 B0 01 41 0F B6 44 24 ?? 3C 03",
+         ResolveMode::Direct, 5, 0},
+
         // P0 -- v1.05.00. The visibility byte field on PartInOutSocket
         // shifted from +0x1C to +0x20, so the movzx disp8 byte is
         // wildcarded. The movzx-cmp idiom plus the literal 3 sentinel
         // are still distinctive enough for a unique CrimsonDesert.exe
         // match (1 hit on v1.05.00 at the PartInOut site). Hook lands
         // on the cmp at match + 4 (same offset semantics as P1; only
-        // the byte value differs, length is unchanged).
+        // the byte value differs, length is unchanged). Inert on
+        // v1.08.00 (the `mov rax,[rbp+0x5F]` load was rewritten away).
         {"PartInOut_P0_v105_WildcardVisOffset",
          "48 8B 45 5F 0F B6 40 ?? 3C 03",
          ResolveMode::Direct, 4, 0},


### PR DESCRIPTION
## Summary
- Resolve the published `pa::ClientActorManager*` slot via AOB cascade so the controlled-character chain survives the v1.08 module-base shift (slot moved from `moduleBase+0x5FA0430` on v1.06/v1.07 to `moduleBase+0x6012110` on v1.08). Three candidates anchor on distinct instructions inside the same publishing function.
- Add v1.08-specific `PartInOut` hook-site candidates (`PN1` / `PN2`): the compiler now spills the visibility byte to a stack arg slot rather than dereferencing through `[rbp+0x5F]`.
- Extend `MapInsert_P2_InnerBody` past a sibling actor-component init that started colliding on v1.08 (`33 ED` xor before `test ecx,ecx` is the discriminator).
- Reword the `+0x68` step-2 caveat to document the dense-component-table slot drift and the steady-state vs. cold-load retry contract.
