### PR TITLE
fix(live-transmog,equip-hide): v1.08.00 compatibility

### DIFF
--- a/CrimsonDesertCore/include/cdcore/anchors.hpp
+++ b/CrimsonDesertCore/include/cdcore/anchors.hpp
@@ -162,14 +162,6 @@ namespace CDCore::Anchors
         {"PartAddShow_P2_PostPrologue",
          "48 83 EC ?? 48 8B 79 ?? 4D 8B E8 44 8B 49 ??",
          ResolveMode::Direct, -6, 0},
-
-        // P3 -- SIMD-save / shift anchor deeper in the body. Offset -0x1B
-        // backs up to function start. Anchors on `movaps [rsp+X],xmm6 ;
-        // shl rax,04 ; movaps xmm6,xmm3 ; add rax,rdi` which is
-        // structurally rare.
-        {"PartAddShow_P3_SimdBody",
-         "0F 29 74 24 ?? 48 C1 E0 04 0F 28 F3 48 03 C7",
-         ResolveMode::Direct, -0x1B, 0},
     };
 
     // -----------------------------------------------------------------------

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -194,11 +194,6 @@ namespace EquipHide
      *   [RBP+0x67] = a4 (transition type byte, saved from R9B at prologue)
      *   [RBP+0x4F] = a1 context pointer
      *
-     * Cross-version cascade. v1.08.00 candidates come first (current
-     * live game returns 1 hit for each); v1.05.00 and v1.04.00 / v1.02.00
-     * candidates are retained for users still on older builds and return
-     * 0 on the v1.08.00 game -- that's expected, not broken.
-     *
      * Register layout at hook point (v1.08.00):
      *   v1.08 spills the visibility byte itself to a stack arg slot
      *   (default `[rsp+0x20]`) before the cmp; the `mov r8b, 1` that
@@ -206,15 +201,14 @@ namespace EquipHide
      *   PartInOutSocket struct is no longer dereferenced inline at the
      *   hook point, only by the surrounding code that fed the spill.
      *
-     * Branch-encoding caveat (aob-signatures.md section 8):
-     *       The hook point is movzx eax, byte [<vis>+0x1C] ; cmp al, 3.
-     *       All candidates below previously extended past that compare
-     *       into the 74 ?? / 75 ?? conditional branches that follow.
-     *       Each candidate has been truncated 2026-04-19 to terminate at
-     *       or before the first rel8 branch so the signatures no longer
-     *       hardcode a rel8 opcode. offsetToHook still points at the
-     *       movzx instruction from the same match position (truncation
-     *       only shortens the verified suffix, not the match start).
+     * Cascade contract: 1-hit-only on the current target build. Older
+     * `mov rax,[rbp+0x5F] ; movzx eax,byte [rax+0x1C]` candidates from
+     * the v1.04 / v1.05 era are intentionally NOT retained: most go
+     * 0-hit on v1.08, but the wider-context shape still resolved once
+     * on v1.08 with its disp_offset landing MID-INSTRUCTION because
+     * the function body shifted. Re-adding a legacy tier requires
+     * per-version CE verification of both match count AND the
+     * match-to-hook displacement against the target build.
      */
     inline constexpr AddrCandidate k_hookSiteCandidates[] = {
         // PN1 -- v1.08.00. The PartInOutSocket arg-passing convention
@@ -240,47 +234,6 @@ namespace EquipHide
         {"PartInOut_PN2_v108_LoopExitJoin",
          "EB 03 41 B0 01 41 0F B6 44 24 ?? 3C 03",
          ResolveMode::Direct, 5, 0},
-
-        // P0 -- v1.05.00. The visibility byte field on PartInOutSocket
-        // shifted from +0x1C to +0x20, so the movzx disp8 byte is
-        // wildcarded. The movzx-cmp idiom plus the literal 3 sentinel
-        // are still distinctive enough for a unique CrimsonDesert.exe
-        // match (1 hit on v1.05.00 at the PartInOut site). Hook lands
-        // on the cmp at match + 4 (same offset semantics as P1; only
-        // the byte value differs, length is unchanged). Inert on
-        // v1.08.00 (the `mov rax,[rbp+0x5F]` load was rewritten away).
-        {"PartInOut_P0_v105_WildcardVisOffset",
-         "48 8B 45 5F 0F B6 40 ?? 3C 03",
-         ResolveMode::Direct, 4, 0},
-
-        // P0b -- v1.05.00 widened with the leading `mov r8b, 1`
-        // (41 B0 01) for extra structural pinning. Same wildcarded
-        // disp8 as P0; hook lands on the cmp at match + 7.
-        {"PartInOut_P0b_v105_PrecedingGate",
-         "41 B0 01 48 8B 45 5F 0F B6 40 ?? 3C 03",
-         ResolveMode::Direct, 7, 0},
-
-        // P1 -- v1.04.00. Ends at `cmp al, 3` and does not cross the
-        // following jz. Hook lands on the cmp at match + 4. Inert on
-        // v1.05.00 because the visibility byte sits at +0x20, not +0x1C.
-        {"PartInOut_P1_DirectSite",
-         "48 8B 45 5F 0F B6 40 1C 3C 03",
-         ResolveMode::Direct, 4, 0},
-
-        // P2 -- v1.04.00 wider context. Tied to specific register
-        // assignments (r13/r15) that the v1.05.00 compiler reshuffled,
-        // so this candidate is inert on v1.05.00; retained for the
-        // v1.04.00 path.
-        {"PartInOut_P2_WiderContext",
-         "45 32 C0 49 8B 45 ?? 41 8B 4D ?? 48 C1 E1 04 48 03 C8 48 3B C1",
-         ResolveMode::Direct, 0x30, 0},
-
-        // P3 -- v1.04.00 with the `mov r8b, 1` prefix. Ends at the cmp,
-        // does not cross the jz. Hook lands at match + 7. Inert on
-        // v1.05.00 (same reason as P1).
-        {"PartInOut_P3_PrecedingGate",
-         "41 B0 01 48 8B 45 5F 0F B6 40 1C 3C 03",
-         ResolveMode::Direct, 7, 0},
     };
 
     /**

--- a/CrimsonDesertEquipHide/src/armor_injection.cpp
+++ b/CrimsonDesertEquipHide/src/armor_injection.cpp
@@ -65,137 +65,147 @@ namespace EquipHide
         if (!mtx.try_lock())
             return 0;
 
+        /* __try/__finally guarantees mtx.unlock() on every exit path.
+           Required because MSVC /EHsc does NOT route C++ exceptions
+           (logger format error, std::bad_alloc, etc.) through the SEH
+           __except below, so without __finally a thrown C++ exception
+           would leak the lock and stall every subsequent ArmorInject
+           + DirectWrite call. __leave skips to __finally when the
+           addrs guard short-circuits. */
         int result = 0;
         __try
         {
-            auto &addrs = resolved_addrs();
-            if (!addrs.mapInsert || !addrs.mapLookup)
+            __try
             {
-                mtx.unlock();
-                return 0;
-            }
+                auto &addrs = resolved_addrs();
+                if (!addrs.mapInsert || !addrs.mapLookup)
+                    __leave;
 
-            auto insert = reinterpret_cast<MapInsertFn>(addrs.mapInsert);
-            auto lookup = reinterpret_cast<MapLookupFn>(addrs.mapLookup);
+                auto insert = reinterpret_cast<MapInsertFn>(addrs.mapInsert);
+                auto lookup = reinterpret_cast<MapLookupFn>(addrs.mapLookup);
 
-            auto &logger = DMK::Logger::get_instance();
-            int injected = 0;
-            int existing_set = 0;
-            int skipped_key = 0;
+                auto &logger = DMK::Logger::get_instance();
+                int injected = 0;
+                int existing_set = 0;
+                int skipped_key = 0;
 
-            const bool cascadeOn =
-                flag_cascade_fix().load(std::memory_order_relaxed);
+                const bool cascadeOn =
+                    flag_cascade_fix().load(std::memory_order_relaxed);
 
-            // Legs, gloves, boots share a ConditionalPartPrefab cascade
-            // with chest -- hiding chest deletes their map entries.
-            // Injecting vis=0 for visible body parts keeps them alive.
-            constexpr CategoryMask k_cascadeBodyMask =
-                category_bit(Category::Legs) |
-                category_bit(Category::Gloves) |
-                category_bit(Category::Boots);
+                // Legs, gloves, boots share a ConditionalPartPrefab cascade
+                // with chest -- hiding chest deletes their map entries.
+                // Injecting vis=0 for visible body parts keeps them alive.
+                constexpr CategoryMask k_cascadeBodyMask =
+                    category_bit(Category::Legs) |
+                    category_bit(Category::Gloves) |
+                    category_bit(Category::Boots);
 
-            // Per-character map drives both the part list AND the
-            // hide-mask classification: charIdx=-1 (unknown body or
-            // fallback path) collapses to the active-character map
-            // through get_part_map_for / is_any_category_hidden_for so
-            // single-character behaviour is preserved for unidentified
-            // slots.
-            const auto &partMap =
-                (charIdx >= 0 && charIdx < static_cast<int>(kCharIdxCount))
-                    ? get_part_map_for(charIdx)
-                    : get_part_map();
+                // Per-character map drives both the part list AND the
+                // hide-mask classification: charIdx=-1 (unknown body or
+                // fallback path) collapses to the active-character map
+                // through get_part_map_for / is_any_category_hidden_for so
+                // single-character behaviour is preserved for unidentified
+                // slots.
+                const auto &partMap =
+                    (charIdx >= 0 && charIdx < static_cast<int>(kCharIdxCount))
+                        ? get_part_map_for(charIdx)
+                        : get_part_map();
 
-            int reinjected = 0;
+                int reinjected = 0;
 
-            for (const auto &[hash, mask] : partMap)
-            {
-                const bool hidden = is_any_category_hidden_for(mask, charIdx);
-                auto existing = lookup(mapBase, &hash);
-
-                if (!hidden)
+                for (const auto &[hash, mask] : partMap)
                 {
-                    /* Toggle-off cache flush. The engine caches a
-                       hidden render-state when our inject inserts an
-                       entry with vis=2; the cache is read from a
-                       struct field that direct vis-byte writes do not
-                       reach, so body armor stays visually hidden after
-                       toggle-off unless we re-insert with vis=0. The
-                       re-insert path below forces the engine to
-                       re-process the entry and clear its cached
-                       hidden state. Visible parts with no existing
-                       entry have nothing to flush, so skip unless the
-                       cascade-fix path needs them. */
-                    if (!existing)
+                    const bool hidden = is_any_category_hidden_for(mask, charIdx);
+                    auto existing = lookup(mapBase, &hash);
+
+                    if (!hidden)
                     {
-                        if (!cascadeOn || (mask & k_cascadeBodyMask) == 0)
-                            continue;
+                        /* Toggle-off cache flush. The engine caches a
+                           hidden render-state when our inject inserts an
+                           entry with vis=2; the cache is read from a
+                           struct field that direct vis-byte writes do not
+                           reach, so body armor stays visually hidden after
+                           toggle-off unless we re-insert with vis=0. The
+                           re-insert path below forces the engine to
+                           re-process the entry and clear its cached
+                           hidden state. Visible parts with no existing
+                           entry have nothing to flush, so skip unless the
+                           cascade-fix path needs them. */
+                        if (!existing)
+                        {
+                            if (!cascadeOn || (mask & k_cascadeBodyMask) == 0)
+                                continue;
+                        }
+                    }
+                    else if (existing)
+                    {
+                        /* Hidden category, entry already present: vis byte
+                           is updated in-place by the direct-write path; no
+                           re-insert needed. */
+                        ++existing_set;
+                        continue;
+                    }
+
+                    auto bucketKey = compute_bucket_key(hash);
+                    if (bucketKey == 0)
+                    {
+                        logger.trace("  0x{:X} -- skipped (no bucket key)", hash);
+                        ++skipped_key;
+                        continue;
+                    }
+
+                    alignas(8) uint8_t entryData[32] = {};
+                    entryData[0x1C] = hidden ? 2 : 0;
+
+                    uint32_t hashCopy = hash;
+                    int *hashPtr = reinterpret_cast<int *>(&hashCopy);
+                    uint8_t outExisted = 0;
+                    __int64 outHashPtr = 0;
+                    __int64 outDataPtr = 0;
+
+                    auto *mapBasePtr = reinterpret_cast<unsigned int *>(mapBase);
+
+                    insert(
+                        mapBasePtr,
+                        &hashPtr,
+                        bucketKey,
+                        reinterpret_cast<__int64>(entryData),
+                        0,
+                        &outExisted,
+                        &outHashPtr,
+                        &outDataPtr);
+
+                    if (!outExisted)
+                    {
+                        logger.debug("  0x{:X} -- INJECTED new entry", hash);
+                        ++injected;
+                    }
+                    else if (!hidden)
+                    {
+                        logger.trace("  0x{:X} -- RE-INJECTED visible (cache flush)",
+                                     hash);
+                        ++reinjected;
                     }
                 }
-                else if (existing)
-                {
-                    /* Hidden category, entry already present: vis byte
-                       is updated in-place by the direct-write path; no
-                       re-insert needed. */
-                    ++existing_set;
-                    continue;
-                }
 
-                auto bucketKey = compute_bucket_key(hash);
-                if (bucketKey == 0)
-                {
-                    logger.trace("  0x{:X} -- skipped (no bucket key)", hash);
-                    ++skipped_key;
-                    continue;
-                }
-
-                alignas(8) uint8_t entryData[32] = {};
-                entryData[0x1C] = hidden ? 2 : 0;
-
-                uint32_t hashCopy = hash;
-                int *hashPtr = reinterpret_cast<int *>(&hashCopy);
-                uint8_t outExisted = 0;
-                __int64 outHashPtr = 0;
-                __int64 outDataPtr = 0;
-
-                auto *mapBasePtr = reinterpret_cast<unsigned int *>(mapBase);
-
-                insert(
-                    mapBasePtr,
-                    &hashPtr,
-                    bucketKey,
-                    reinterpret_cast<__int64>(entryData),
-                    0,
-                    &outExisted,
-                    &outHashPtr,
-                    &outDataPtr);
-
-                if (!outExisted)
-                {
-                    logger.debug("  0x{:X} -- INJECTED new entry", hash);
-                    ++injected;
-                }
-                else if (!hidden)
-                {
-                    logger.trace("  0x{:X} -- RE-INJECTED visible (cache flush)",
-                                 hash);
-                    ++reinjected;
-                }
+                logger.debug("ArmorInject map: {} injected, {} existing updated, "
+                             "{} re-injected, {} skipped (no bucket key)",
+                             injected, existing_set, reinjected, skipped_key);
+                result = injected;
             }
-
-            logger.debug("ArmorInject map: {} injected, {} existing updated, "
-                         "{} re-injected, {} skipped (no bucket key)",
-                         injected, existing_set, reinjected, skipped_key);
-            result = injected;
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                static std::atomic<bool> s_crashLogged{false};
+                if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
+                    DMK::Logger::get_instance().warning(
+                        "ArmorInject: SEH caught crash during map insertion");
+                result = -1;
+            }
         }
-        __except (EXCEPTION_EXECUTE_HANDLER)
+        __finally
         {
-            static std::atomic<bool> s_crashLogged{false};
-            if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
-                DMK::Logger::get_instance().warning(
-                    "ArmorInject: SEH caught crash during map insertion");
-            result = -1;
+            mtx.unlock();
         }
-        mtx.unlock();
         return result;
     }
 

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -431,30 +431,43 @@ namespace EquipHide
                 auto &mtx = vis_write_mutex();
                 if (mtx.try_lock())
                 {
-                    bool changed = (count != s_prevCount);
-                    if (!changed)
+                    /* __try/__finally guarantees mtx.unlock() on every
+                       exit path. The outer __try/__except (further
+                       below) catches SEH from the inner body; __finally
+                       handles the C++ exception propagation that MSVC
+                       /EHsc lets through SEH, so the mutex is always
+                       released even when a logger format error or
+                       std::bad_alloc unwinds out of the body. */
+                    __try
                     {
-                        for (int j = 0; j < count; ++j)
+                        bool changed = (count != s_prevCount);
+                        if (!changed)
                         {
-                            if (ps.visCtrls[j].load(std::memory_order_relaxed) != s_prevVisCtrls[j])
+                            for (int j = 0; j < count; ++j)
                             {
-                                changed = true;
-                                break;
+                                if (ps.visCtrls[j].load(std::memory_order_relaxed) != s_prevVisCtrls[j])
+                                {
+                                    changed = true;
+                                    break;
+                                }
                             }
                         }
+                        if (changed)
+                        {
+                            s_prevCount = count;
+                            for (int j = 0; j < count; ++j)
+                                s_prevVisCtrls[j] = ps.visCtrls[j].load(std::memory_order_relaxed);
+                            for (int j = 0; j < k_maxProtagonists; ++j)
+                                ps.armorInjected[j].store(false, std::memory_order_relaxed);
+                            needs_direct_write().store(true, std::memory_order_relaxed);
+                            DMK::Logger::get_instance().debug(
+                                "Player set changed -- scheduling injection + direct write");
+                        }
                     }
-                    if (changed)
+                    __finally
                     {
-                        s_prevCount = count;
-                        for (int j = 0; j < count; ++j)
-                            s_prevVisCtrls[j] = ps.visCtrls[j].load(std::memory_order_relaxed);
-                        for (int j = 0; j < k_maxProtagonists; ++j)
-                            ps.armorInjected[j].store(false, std::memory_order_relaxed);
-                        needs_direct_write().store(true, std::memory_order_relaxed);
-                        DMK::Logger::get_instance().debug(
-                            "Player set changed -- scheduling injection + direct write");
+                        mtx.unlock();
                     }
-                    mtx.unlock();
                 }
             }
         }

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -249,7 +249,14 @@ namespace EquipHide
             return;
         /* Manual lock/unlock: MSVC SEH does not run C++ destructors on
            unwind under /EHsc, so an RAII lock would stay held after a
-           caught fault. */
+           caught fault. The __try/__finally wrapper below provides the
+           same guarantee in SEH terms: __finally runs on every exit
+           path (normal return, SEH propagation, C++ exception unwind
+           through the noexcept barrier) so the mutex is always
+           released even if mtx.unlock() itself raises SEH or if the
+           impl propagates an uncaught C++ exception. Without this the
+           mid-hook re-fires the work on every frame, producing a
+           tight try_lock failure spam loop. */
         auto &mtx = vis_write_mutex();
         if (!mtx.try_lock())
         {
@@ -269,15 +276,22 @@ namespace EquipHide
 
         __try
         {
-            apply_direct_vis_write_impl();
+            __try
+            {
+                apply_direct_vis_write_impl();
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                static std::atomic<bool> s_crashLogged{false};
+                if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
+                    DMK::Logger::get_instance().warning(
+                        "DirectWrite: SEH caught crash");
+            }
         }
-        __except (EXCEPTION_EXECUTE_HANDLER)
+        __finally
         {
-            static std::atomic<bool> s_crashLogged{false};
-            if (!s_crashLogged.exchange(true, std::memory_order_relaxed))
-                DMK::Logger::get_instance().warning("DirectWrite: SEH caught crash");
+            mtx.unlock();
         }
-        mtx.unlock();
     }
 
     /* Implementation body for cleanup_vis_bytes(): structured binding on
@@ -305,14 +319,25 @@ namespace EquipHide
         auto &mtx = vis_write_mutex();
         mtx.lock();
 
+        /* __try/__finally so the unlock runs even if cleanup_vis_bytes_impl
+           propagates a C++ exception (logger format error, bad_alloc) that
+           the SEH __except below does not catch under /EHsc, or if
+           mtx.unlock() itself raises an SEH. Either path would leak the
+           lock and stall every subsequent try_lock from the mid-hook. */
         __try
         {
-            cleanup_vis_bytes_impl();
+            __try
+            {
+                cleanup_vis_bytes_impl();
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+            }
         }
-        __except (EXCEPTION_EXECUTE_HANDLER)
+        __finally
         {
+            mtx.unlock();
         }
-        mtx.unlock();
     }
 
 } // namespace EquipHide

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -10,3 +10,4 @@
 - Fixed brief part flashes during animation transitions that could persist for the whole session when the mod was loaded before reaching the main menu.
 - New "Apply To Selected" checkbox next to the character dropdown: edits while pinned to a non-controlled character now render on that character's body, not on the one you control. Untick to keep the old cross-body behavior.
 - Preset swaps on a non-controlled character now correctly remove the previous preset's items before installing the new ones, instead of stacking outfits on top of each other.
+- Compatibility fix for Crimson Desert game version 1.08.00

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -115,22 +115,6 @@ namespace Transmog
         {"SafeTearDown_P2_PostAlloca",
          "48 81 EC ?? ?? ?? ?? 41 0F B7 F8 48 8B F1",
          ResolveMode::Direct, -0x1A, 0},
-
-        // P3 -- deep-body anchor at the global-pointer call site. The
-        // 48 83 C1 60 is a game-ABI struct offset (stable ABI), kept
-        // literal. Stack disp32 in lea rdx,[rbp+disp32] and the
-        // rel32 jz target are wildcarded (both compiler-owned). The
-        // trailing stack disp E0 00 00 00 is kept literal to
-        // disambiguate from 4 sibling functions that share the same
-        // add rcx,60 / lea rdx / call / test / jz / movzx / mov [rbp+X]
-        // body shape (CE aob_scan 2026-04-19: 5 hits without it, 1 hit
-        // with). The B9 FF FF 00 00 66 3B C8 tail is a semantic
-        // sentinel check specific to this function.
-        {"SafeTearDown_P3_GlobalPtrCall",
-         "48 83 C1 60 48 8D 95 ?? ?? ?? ?? E8 ?? ?? ?? ?? "
-         "48 85 C0 0F 84 ?? ?? ?? ?? 0F B7 00 66 89 85 E0 00 00 00 "
-         "B9 FF FF 00 00 66 3B C8",
-         ResolveMode::Direct, -0x4A, 0},
     };
 
     /**
@@ -171,34 +155,6 @@ namespace Transmog
          "41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4C 24 ?? E8 ?? ?? ?? ?? "
          "90 48 8B D0 48 8B CF E8",
          ResolveMode::Direct, -0x1C, 0},
-
-        // P1 -- v1.04.00 full prologue. Stack disp8 (B9), stack-alloc
-        // size (00 01 00 00), and the two local-variable disp8 values
-        // in lea rdx,[rbp+X] / lea rcx,[rbp+Y] wildcarded. The
-        // 41 B8 01 00 00 00 (mov r8d, 1) is a SEMANTIC argument flag
-        // and is kept literal. Inert on v1.05.00 (lea encoding shift).
-        {"SubTranslator_P1_FullPrologue",
-         "48 89 5C 24 08 66 89 54 24 10 55 56 57 "
-         "48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? "
-         "48 8B F9 41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4D ??",
-         ResolveMode::Direct, 0, 0},
-
-        // P2 -- v1.04.00 post-alloca scratch-buffer prep anchor. Same
-        // disp8 wildcarding as P1. Inert on v1.05.00.
-        {"SubTranslator_P2_PostAlloca",
-         "48 8B F9 41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4D ?? E8",
-         ResolveMode::Direct, -0x19, 0},
-
-        // P3 -- v1.04.00 deeper anchor without the leading `mov rdi,
-        // rcx`. Without the 90 48 8B D0 48 8B CF E8 post-call suffix
-        // this shortened pattern matches 5 sibling call sites (same
-        // mov r8d,1 / lea rdx / lea rcx / call boilerplate); the
-        // suffix pins this function's second call (CE aob_scan
-        // 2026-04-19). Inert on v1.05.00.
-        {"SubTranslator_P3_ScratchBufPrep",
-         "41 B8 01 00 00 00 48 8D 55 ?? 48 8D 4D ?? E8 ?? ?? ?? ?? "
-         "90 48 8B D0 48 8B CF E8",
-         ResolveMode::Direct, -0x1C, 0},
     };
 
     /**
@@ -219,19 +175,6 @@ namespace Transmog
          "48 89 4C 24 08 53 48 83 EC 20 48 8B D9 "
          "48 C7 C0 FF FF FF FF 48 89 01 B9 FF FF 00 00",
          ResolveMode::Direct, 0, 0},
-
-        // P2 -- post-prologue field-init chain (mov [rbx+20h],rdx / ... /
-        // lea rax,[rbx+58h]).
-        {"InitSwapEntry_P2_FieldInitChain",
-         "48 89 53 20 48 89 53 28 48 89 53 30 66 89 53 38 "
-         "48 89 53 40 48 89 53 48 66 89 53 50 48 8D 43 58",
-         ResolveMode::Direct, -0x26, 0},
-
-        // P3 -- xor edx,edx + field-init chain (slightly tighter than P2).
-        {"InitSwapEntry_P3_XorInitChain",
-         "33 D2 48 89 53 20 48 89 53 28 48 89 53 30 "
-         "66 89 53 38 48 89 53 40 48 89 53 48 66 89 53 50",
-         ResolveMode::Direct, -0x24, 0},
     };
 
     /**
@@ -334,16 +277,6 @@ namespace Transmog
         {"StringInfoRegistry_P1_LoadAddCallSite",
          "8B 45 B0 89 45 58 48 8B 0D ?? ?? ?? ?? 48 83 C1 60 48 8D 55 58",
          ResolveMode::RipRelative, 9, 13},
-
-        // P2 -- xref in sub_142144B10 (large parser, 0x1d6f bytes). A
-        // distinctive `mov [rbp-0x6A], al` + 32-bit local-store sequence
-        // precedes a `mov r15, [rip+disp32]` registry load. The local
-        // disp32 sequence (90 00 00 00) is kept literal -- it's the
-        // local frame's outer-scope variable offset.
-        {"StringInfoRegistry_P2_OuterScopeFrame",
-         "88 45 96 89 8D 90 00 00 00 4C 8B 3D ?? ?? ?? ?? "
-         "48 8D 95 90 00 00 00 49 8D 4F 60",
-         ResolveMode::RipRelative, 12, 16},
 
         // P3 -- xref in sub_14074DD40. Conditional load+jump shape:
         // load r9d, test, jz, store dword to [rbp+0x70], then load
@@ -572,13 +505,16 @@ namespace Transmog
      */
     inline constexpr AddrCandidate k_apptLoaderCtorCandidates[] = {
         // P1 -- full prologue (8 callee-saved regs + frame setup).
-        // Distinctive in v1.05.01: 1 unique hit. The 41 54 41 55 41 56
-        // 41 57 (push r12-r15) is the largest possible callee-save set,
-        // typical of a 540-byte function with many locals.
+        // The 41 54 41 55 41 56 41 57 (push r12-r15) is the largest
+        // possible callee-save set, typical of a 540-byte function with
+        // many locals. The leading `48 89 54 24 10` (mov [rsp+0x10], rdx)
+        // shadow-store the compiler used on earlier builds was dropped,
+        // so the prologue now starts directly with `48 89 4C 24 08`
+        // (mov [rsp+8], rcx).
         {"ApptLoaderCtor_P1_FullPrologue",
-         "48 89 54 24 10 48 89 4C 24 08 53 55 56 57 41 54 41 55 41 56 41 57 "
+         "48 89 4C 24 08 53 55 56 57 41 54 41 55 41 56 41 57 "
          "48 83 EC 38 48 8B F1 45 33 F6 4C 89 31 4C 89 71 08 4C 89 71 10 "
-         "4C 89 71 18 44 88 71 20",
+         "4C 89 71 18 44",
          ResolveMode::Direct, 0, 0},
 
         // P2 -- mid-prologue + first field-init. Skips the `mov rcx,rdx
@@ -843,30 +779,13 @@ namespace Transmog
          "8B 88 ?? ?? ?? ?? 48 83 C1 70 48 8B D3 E8 | ?? ?? ?? ??",
          ResolveMode::RipRelative, 14, 18},
 
-        // P2 -- function prologue + early-return path. The prologue is
-        // shared with one templated clone (`sub_1430C4880`). When P1
-        // succeeds this is unused; when it fails this returns the FIRST
-        // linear-scan match which is `sub_140350910` on v1.05.01 (the
-        // canonical lookup primitive lives in the lower .text band). The
-        // `48 83 EC 20` direct alloc + `83 79 04 00` field-zero compare
-        // pin this function shape against unrelated functions.
-        {"PrefabWrapperSwap_ApptInnerLookup_P2_FullPrologueEarlyExit",
-         "4C 89 74 24 20 41 57 48 83 EC 20 "
-         "83 79 04 00 4C 8B FA 4C 8B F1 75 0E "
-         "33 C0 4C 8B 74 24 ?? 48 83 C4 20 41 5F C3",
-         ResolveMode::Direct, 0, 0},
-
-        // P3 -- prologue + post-early-exit field load. Walks one more
-        // basic block past P2 into the `mov [rsp+arg_0], rbx ; mov rbx,
-        // [rdx] ; mov [rsp+arg_10], rdi ; mov edi, [rbx+0xC]` shape. The
-        // first `?? ` is the rsp disp8 of the saved-r14 spill (compiler-
-        // owned). Same multi-hit caveat as P2 (clone shares this body).
-        {"PrefabWrapperSwap_ApptInnerLookup_P3_PrologueBodyChain",
-         "4C 89 74 24 20 41 57 48 83 EC 20 "
-         "83 79 04 00 4C 8B FA 4C 8B F1 75 0E "
-         "33 C0 4C 8B 74 24 ?? 48 83 C4 20 41 5F C3 "
-         "48 89 5C 24 30 48 8B 1A 48 89 7C 24 40 8B 7B 0C",
-         ResolveMode::Direct, 0, 0},
+        // Note: no body / prologue fallback tier here. The function
+        // shares a byte-identical prologue and body with its templated
+        // clone `sub_1430C4880`, so any non-call-site anchor multi-hits.
+        // The strict-uniqueness contract requires P1 (the RipRelative
+        // call-site anchor in sub_140347BB0) to resolve cleanly; an
+        // ambiguous fallback would risk picking the clone if P1 ever
+        // broke.
     };
 
     /**
@@ -953,18 +872,14 @@ namespace Transmog
          "48 8B 02 48 89 01 48 8D 05 ?? ?? ?? ?? 48 89 02",
          ResolveMode::Direct, 0, 0},
 
-        // P2 -- truncated prologue (no RIP-rel). Stops at `48 89 29`
-        // (the `mov [rcx], rbp` zeroing of dst+0). Survives a future
-        // build that moves the vtable lea later in the function. WARNING:
-        // pattern fragment also matches `sub_140355210` (sibling). Hit
-        // count is 1 on the canonical target only when the cascade
-        // proceeds past P1 first; otherwise relies on
-        // `sanity_check_function_prologue` post-resolve.
-        {"PrefabWrapperSwap_StructCopy_P2_PrologueNoVtable",
-         "48 89 5C 24 18 48 89 6C 24 20 48 89 4C 24 08 "
-         "56 57 41 56 48 83 EC 20 "
-         "4C 8B F2 48 8B F1 33 ED 48 89 29",
-         ResolveMode::Direct, 0, 0},
+        // Note: no middle (truncated-prologue) tier here. A prologue
+        // anchor without the vtable lea matches the sibling
+        // `sub_140355210` and several byte-identical prologue copies
+        // in kernel DLL .text sections, so any short-prologue tier
+        // multi-hits. The cascade dispatches via P1 (full prologue
+        // + vtable lea, unique) or P3 (byte-transfer body, also
+        // unique); a discriminator that beats sub_140355210 from a
+        // short prologue alone is not feasible.
 
         // P3 -- byte-transfer body anchor. The unique 4-byte payload
         // copy (`movzx eax, byte ptr [rdx+8/9/A] ; mov [rcx+8/9/A], al`

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -195,23 +195,27 @@ namespace Transmog
     // only {0x012F}) are classified as Generic -- the engine accepts
     // them on any humanoid body, so the picker shows them for every
     // character.
-    // Body-type classifier tokens on v1.04.00 (renumbered from v1.03.01
-    // when the engine's class-enum was re-keyed; each token shifted by
-    // +1 or +2). Verified live against the rule-classifier arrays of
-    // WellsKnight_PlateArmor_{Helm, Armor} (known male carriers) and
-    // Demian_Leather_Armor (known female carrier). Structure unchanged
-    // at +0x248/+0x250 (rule list), +0x20/+0x28 (classifier list per
-    // rule), 0x38 rule stride; only the enum values moved.
+    // Body-type classifier tokens. The engine's class-enum has been
+    // re-keyed across major versions; structure is unchanged at +0x248
+    // / +0x250 (rule list), +0x20 / +0x28 (classifier list per rule),
+    // 0x38 rule stride. Only the enum values move:
     //
     //   v1.03.01:  male   {0x0018, 0x0058, 0x02E3}
     //              female {0x0072, 0x0382, 0x0300}
-    //   v1.04.00:  male   {0x0019, 0x0059, 0x02E5}
+    //   v1.04.00:  male   {0x0019, 0x0059, 0x02E5}     (+1 / +2 from v1.03)
     //              female {0x0073, 0x0384, 0x0302}
+    //   v1.08.00:  male   {0x0012, 0x0052, 0x02DE}     (-7 from v1.04)
+    //              female {0x006C, 0x037D, 0x02FB}     (-7 from v1.04)
+    //
+    // Kliff-native helms additionally carry the female token 0x006C
+    // alongside the male set, which classifies them as BodyKind::Both
+    // (dual-compat carrier). This matches the engine's intent to let
+    // Damiane wear Kliff-native gear via the carrier mechanism.
     static constexpr std::uint16_t k_maleBodyTokens[] = {
-        0x0019, 0x0059, 0x02E5,
+        0x0012, 0x0052, 0x02DE,
     };
     static constexpr std::uint16_t k_femaleBodyTokens[] = {
-        0x0073, 0x0384, 0x0302,
+        0x006C, 0x037D, 0x02FB,
     };
     // Body bits are accumulated during the classifier scan:
     //   Male / Female  -- saw a token from the respective body set

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -28,20 +28,32 @@
 namespace Transmog
 {
     // SlotPopulator (sub_14076C960) maintains a dispatch cache on the
-    // component at (basePtr, count, cap). The triple shifted 0x20
-    // bytes higher between v1.03.01 and v1.04.00 as the component
-    // gained new fields lower in the struct:
+    // component at (basePtr, count, cap). The triple shifted 0x20 bytes
+    // higher between v1.03.01 and v1.04.00 as the component gained new
+    // fields lower in the struct; in v1.08.00 the same sub-struct moved
+    // another 8 bytes higher (an extra qword was inserted below it):
     //
     //   v1.03.01 -- basePtr @ +0x1B8, count @ +0x1C0, cap @ +0x1C4
     //   v1.04.00 -- basePtr @ +0x1D8, count @ +0x1E0, cap @ +0x1E4
+    //   v1.08.00 -- basePtr @ +0x1E0, count @ +0x1E8, cap @ +0x1EC
     //
     // Reading the old offsets on v1.04.00 returns zero for count (the
-    // u32 that lives there is always 0), which makes apply look like
-    // a no-op; writing the old offsets scribbles into adjacent fields
-    // and corrupts the component a slot at a time.
-    constexpr std::ptrdiff_t k_compSlotCacheBasePtrOffset = 0x1D8;
-    constexpr std::ptrdiff_t k_compSlotCacheCountOffset   = 0x1E0;
-    constexpr std::ptrdiff_t k_compSlotCacheCapOffset     = 0x1E4;
+    // u32 that lives there is always 0), which makes apply look like a
+    // no-op; writing the old offsets scribbles into adjacent fields and
+    // corrupts the component a slot at a time. On v1.08.00 the old
+    // count slot now overlaps the LOW 32 bits of the basePtr qword, so
+    // a stale read yields a wildly inflated value (e.g. 0xA8000000 =
+    // 2819141376 -- the low bits of a 0x000004??A8XXXXXX heap address)
+    // and any write to it would shred the dispatch-cache pointer.
+    //
+    // The v1.08 SlotPopulator body at 0x1407A5F60+0xDB confirms the new
+    // offsets directly:
+    //   lea  r15, [r13+0x1E0]    ; r13 = a1
+    //   mov  r8d, [r15+0x08]     ; count   = [a1+0x1E8]
+    //   mov  r9,  [r15]          ; basePtr = [a1+0x1E0]
+    constexpr std::ptrdiff_t k_compSlotCacheBasePtrOffset = 0x1E0;
+    constexpr std::ptrdiff_t k_compSlotCacheCountOffset   = 0x1E8;
+    constexpr std::ptrdiff_t k_compSlotCacheCapOffset     = 0x1EC;
 
     // Pointer to the PartDef/auth-table container on a1.
     //


### PR DESCRIPTION
## Summary

Brings LiveTransmog and the remaining EquipHide / Core surfaces forward to game version **1.08.00**, plus an SEH lock-leak fix that surfaced under v1.08 stress.

