### PR TITLE
fix(live-transmog): hide real Mask/Necklace on preset switch to all-none

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Fix: real Mask/Necklace (and other accessory slots) now hide correctly when switching to a preset with all slots set to (none). Previously only the manual transmog→none path worked; preset switches left the real mesh visible on first-claim hide.

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -1354,7 +1354,34 @@ namespace Transmog
                 const auto prevId = prevIds[idx];
                 const auto prevCarrier = last_applied_carrier_ids()[idx];
                 if (prevId == 0)
+                {
+                    // First-claim hide: active-none slot LT never owned
+                    // (prevIds==0, no carrier history). Phase B alone
+                    // calls the scene-graph tear-down once; empirically
+                    // that's insufficient for slots where LT hasn't
+                    // previously placed a carrier (e.g. Mask/Necklace
+                    // when switching to an all-none preset on first
+                    // apply). Doubling the call here matches the
+                    // working manual path (transmog-something → none),
+                    // which fires Phase A on the prior carrier + Phase
+                    // B on the real entry -- same hash, same slot tag,
+                    // twice.
+                    const auto &m = mappings[idx];
+                    if (m.active && m.targetItemId == 0 &&
+                        liveRealIds[idx] != 0)
+                    {
+                        logger.trace(
+                            "[dispatch] tear_down_fake slot={:#06x} "
+                            "itemId={:#06x} (first-claim hide)",
+                            td.gameTag,
+                            static_cast<std::uint16_t>(liveRealIds[idx]));
+                        RealPartTearDown::tear_down_by_item_id(
+                            reinterpret_cast<void *>(a1),
+                            liveRealIds[idx],
+                            td.gameTag);
+                    }
                     continue;
+                }
                 // Phase A runs unconditionally: fake and real are
                 // treated equally, so even when the previous fake
                 // matched the live real item we still tear it down.


### PR DESCRIPTION
## Summary
Switching to a preset where Mask/Necklace (and other accessory slots LT had never owned) are set to "active none" left the real mesh visible. Manually picking transmog → none on the same slot worked, exposing the asymmetry.

## Root cause
Phase A teardown in `apply_all_transmog` is gated by `prevIds[idx] != 0`, so a slot LT had never previously owned only got the scene-graph tear-down (`sub_14075FE60`) once via Phase B. Empirically a single call isn't enough,the working manual path fires it twice (Phase A on the just-placed carrier, Phase B on the real entry, same hash, same slot tag).