### PR TITLE
fix(live-transmog): instant apply works cross-character for prefab picks

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,3 +1,4 @@
-## [Title for next release]
+## Instant Apply and preset-hide fixes
 
 - Fix: real Mask/Necklace (and other accessory slots) now hide correctly when switching to a preset with all slots set to (none). Previously only the manual transmog→none path worked; preset switches left the real mesh visible on first-claim hide.
+- Fix: Instant Apply now works correctly for body-mesh prefab picks on Damiane and Oongka. Previously, Instant Apply only affected the controlled character, so editing another character's outfit reverted to their original armor.

--- a/CrimsonDesertLiveTransmog/src/overlay_ui.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui.cpp
@@ -415,7 +415,23 @@ static void draw_overlay_content()
                         {
                             flag_enabled().store(
                                 true, std::memory_order_relaxed);
-                            manual_apply_slot(i);
+                            // Body-mesh picks require the natpipe-hook
+                            // to substitute the source wrapper for the
+                            // editing character's body. That hook reads
+                            // s_swapMapPerChar[s_activeCharIdx-1] at
+                            // entry, and only the full multi-actor apply
+                            // path drives s_activeCharIdx per CCOIA
+                            // (PresetManager::apply_to_state binds it
+                            // for each character in the sweep). The
+                            // single-slot path runs against the
+                            // controlled actor only -- when the user
+                            // edits Damiane/Oongka while controlling
+                            // Kliff, the slot path byte-patches Kliff
+                            // and never triggers a body re-bind for the
+                            // editing character, so the substitution
+                            // never fires and the carrier renders
+                            // natural (e.g. Demenisian Uniform).
+                            manual_apply();
                         }
                         DMK::Logger::get_instance().info(
                             "[picker] slot={} BODY-MESH "


### PR DESCRIPTION
## What broke
With Instant Apply checked, a body-mesh prefab pick fired `manual_apply_slot(i)`, a single-slot apply against the controlled actor only. When the picker dropdown was on Damiane/Oongka but the controlled actor was Kliff, only Kliff's slot got patched. The edited character's body never re-bound, the natpipe-hook never fired her source wrapper, and the carrier rendered natural (e.g. Demenisian Uniform Leather Armor regardless of which prefab was picked).

The Apply button worked because it calls `manual_apply()`, which drives the multi-apply scheduler and sets `s_activeCharIdx` per CCOIA before each apply pass, exactly what the natpipe-hook needs.

## Fix
In the body-mesh Instant Apply branch in `overlay_ui.cpp`, call `manual_apply()` instead of `manual_apply_slot(i)`.

