### PR TITLE
fix(live-transmog): gate apply on engine readiness during cold-load

### DIFF
--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -1,6 +1,7 @@
 #ifndef CDCORE_CONTROLLED_CHAR_HPP
 #define CDCORE_CONTROLLED_CHAR_HPP
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <string_view>
@@ -275,6 +276,84 @@ namespace CDCore
      *          is rarely required).
      */
     void invalidate_controlled_character() noexcept;
+
+    /**
+     * @brief Find a component instance inside a CCOIA component-pointer
+     *        table by its MSVC RTTI mangled type-descriptor name.
+     * @details Component slots in @p p1 are sparse and slot-drift across
+     *          early/late load (a class can sit at +0x40 in steady state
+     *          and +0x48 during cold load). Hardcoded slot offsets are
+     *          fragile; this scanner identifies the target by traversing
+     *          each non-null slot's vtable -> RTTICompleteObjectLocator
+     *          -> TypeDescriptor and exact-comparing the mangled name.
+     *
+     *          The vtable address of the first match is cached via the
+     *          caller-supplied @p vtableCache so subsequent calls fast-
+     *          path on a single qword compare per slot. The cache lives
+     *          for process lifetime (image-resident vtables); the caller
+     *          declares one `std::atomic<std::uintptr_t>` static per
+     *          component class.
+     *
+     *          SEH-guarded. Returns 0 on torn reads, missing class, or
+     *          when @p p1 / @p rttiName is invalid.
+     *
+     * @param p1            Component-pointer table base
+     *                      (CCOIA + 0x68 typically).
+     * @param rttiName      MSVC-mangled type-descriptor name, e.g.
+     *                      ".?AVClientCharacterControlActorComponent@pa@@".
+     * @param vtableCache   Caller-owned cache slot. Must be initialised
+     *                      to 0 and dedicated to one @p rttiName.
+     * @returns Slot pointer (the component instance) or 0.
+     */
+    [[nodiscard]] std::uintptr_t find_component_in_table(
+        std::uintptr_t p1,
+        std::string_view rttiName,
+        std::atomic<std::uintptr_t> &vtableCache) noexcept;
+
+    /**
+     * @brief Convenience: locate a component on the currently-controlled
+     *        actor by its RTTI type-descriptor name.
+     * @details Equivalent to:
+     *
+     *              ccoia = current_controlled_ccoia();
+     *              p1    = *(ccoia + 0x68);
+     *              return find_component_in_table(p1, rttiName, cache);
+     *
+     *          ...but keeps the component-table offset encapsulated
+     *          inside CDCore so callers carry no hardcoded engine
+     *          offsets. SEH-guarded end-to-end; returns 0 on a torn
+     *          chain or missing component.
+     *
+     *          Intended for readiness probes: a component that
+     *          resolves by RTTI is fully wired in the engine's
+     *          component graph. Cold-load returns 0 for at least one
+     *          component until the table finishes registering all
+     *          classes.
+     */
+    [[nodiscard]] std::uintptr_t find_component_in_controlled_actor(
+        std::string_view rttiName,
+        std::atomic<std::uintptr_t> &vtableCache) noexcept;
+
+    /**
+     * @brief Locate a component on the actor whose
+     *        ClientEquipSlotActorComponent is @p equipSlot.
+     * @details Walks the equip-slot's CCOIA back-pointer and the
+     *          CCOIA's component-pointer table internally, then
+     *          RTTI-matches @p rttiName. Encapsulates the
+     *          a1->CCOIA->p1 chain offsets inside CDCore so callers
+     *          carry no engine offsets. SEH-guarded end-to-end.
+     *          Used by readiness probes that need to inspect a
+     *          specific sibling component of any protagonist (not
+     *          just the controlled character).
+     * @param equipSlot ClientEquipSlotActorComponent pointer (the
+     *                  same a1 the SlotPopulator pipeline carries).
+     * @param rttiName  MSVC-mangled type-descriptor name.
+     * @param vtableCache Caller-owned cache slot per rttiName.
+     */
+    [[nodiscard]] std::uintptr_t find_component_for_equipslot(
+        std::uintptr_t equipSlot,
+        std::string_view rttiName,
+        std::atomic<std::uintptr_t> &vtableCache) noexcept;
 
 } // namespace CDCore
 

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -121,21 +121,41 @@ namespace CDCore
         //       p1 +0x40 -> pa::ClientCharacterControlActorComponent
         //       p1 +0x48 -> pa::ClientVehicleActorComponent
         //
-        // The +0x40 offset is correct in the steady state where every
-        // expected component has registered; during cold load it can
-        // transiently miss, and current callers retry-on-failure to
-        // ride that out. Steps 3 (+0x40) and 4 (+0x38) dereference
-        // fixed members of the resolved component and are
-        // structurally stable.
-        //
-        // TODO: walk p1 by RTTI/vtable to land on
-        // pa::ClientCharacterControlActorComponent regardless of slot
-        // so the chain becomes session-stable; the vtable is in image
-        // and can be cached at startup.
+        // Step 2 (locate the CCC inside p1) now walks the table by
+        // RTTI/vtable rather than fixed offset, so the chain is
+        // session-stable regardless of how many components have
+        // registered. See find_ccc_in_component_table() below.
+        // Steps 3 (+0x40) and 4 (+0x38) dereference fixed members of
+        // the resolved CCC and are structurally stable.
         constexpr std::ptrdiff_t k_offAppearChain1 = 0x68;
-        constexpr std::ptrdiff_t k_offAppearChain2 = 0x40;
         constexpr std::ptrdiff_t k_offAppearChain3 = 0x40;
         constexpr std::ptrdiff_t k_offAppearChain4 = 0x38;
+
+        // MSVC RTTI traversal. The vtable's RTTICompleteObjectLocator
+        // (COL) sits at `vtbl - 8` (qword); the COL stores the type
+        // descriptor as an RVA at `col + 0x0C`; the type descriptor's
+        // mangled-name C-string lives at `td + 0x10`.
+        constexpr std::ptrdiff_t k_offColInVtable      = -8;
+        constexpr std::ptrdiff_t k_offTdRvaInCol       = 0x0C;
+        constexpr std::ptrdiff_t k_offNameInDescriptor = 0x10;
+
+        // RTTI mangled-name string of the target component class.
+        // MSVC encodes class types as `.?AV<name>@<scope>@@`. The
+        // engine consistently namespaces gameplay components in
+        // `pa::`, so this name is stable across patches that do not
+        // rename or move the class. Matched as an exact byte-equal
+        // compare (no substring scan) to avoid colliding with derived
+        // or sibling classes that share a prefix.
+        constexpr std::string_view k_cccTypeDescriptorName =
+            ".?AVClientCharacterControlActorComponent@pa@@";
+
+        // Maximum number of component-pointer slots to scan inside
+        // the p1 table. The table is component-type-id indexed and
+        // therefore sparse; a typical protagonist populates roughly
+        // 30 slots inside a 64-slot window. Scanning 64 slots covers
+        // any realistic engine expansion while keeping the cold-path
+        // RTTI scan bounded to a single page read.
+        constexpr std::size_t k_componentTableSlots = 64;
 
         // MSVC std::string: when content >= 16 chars the heap-buffer
         // pointer lives at +0x00 of the struct; smaller strings keep
@@ -411,23 +431,159 @@ namespace CDCore
             }
         }
 
-        // Walk CCOIA +0x68 -> +0x40 -> +0x40 -> +0x38 to reach the
-        // appearance-config std::string. Resolves heap-buffer vs
-        // inline layout and returns the start address of ASCII
-        // content; returns 0 on any torn link.
+        // ---- RTTI-based component-table walker --------------------------
+
+        // Cached vtable address of the target component class
+        // (.?AVClientCharacterControlActorComponent@pa@@). Image-
+        // resident and stable for the process lifetime; learned
+        // once via RTTI scan on the first successful chain walk.
+        std::atomic<std::uintptr_t> s_cccVtable{0};
+
+        // Compare a bounded ASCII string in memory against @p ref.
+        // Returns true only when the first ref.size() bytes match
+        // exactly and the byte at ref.size() is the NUL terminator
+        // (so a longer mangled name that begins with @p ref does
+        // not falsely match).
+        bool ascii_equals(std::uintptr_t addr,
+                          std::string_view ref) noexcept
+        {
+            if (addr < k_minValidPtr || ref.empty())
+                return false;
+            __try
+            {
+                for (std::size_t i = 0; i < ref.size(); ++i)
+                {
+                    const auto b = *reinterpret_cast<
+                        const volatile std::uint8_t *>(addr + i);
+                    if (b != static_cast<std::uint8_t>(ref[i]))
+                        return false;
+                }
+                const auto term = *reinterpret_cast<
+                    const volatile std::uint8_t *>(addr + ref.size());
+                return term == 0;
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return false;
+            }
+        }
+
+        // Returns true when the MSVC RTTI type-descriptor name for
+        // the class whose vtable is @p vtbl equals @p ref.
+        bool vtbl_matches_rtti_name(std::uintptr_t vtbl,
+                                    std::string_view ref) noexcept
+        {
+            const auto col =
+                safe_read_qword(vtbl + k_offColInVtable);
+            if (col < k_minValidPtr)
+                return false;
+            const auto tdRva =
+                safe_read_dword(col + k_offTdRvaInCol);
+            if (tdRva == 0)
+                return false;
+            // GetModuleHandle(nullptr) returns the game EXE's load
+            // address straight out of the PEB -- effectively a
+            // constant, so no caching needed.
+            const auto imgBase = reinterpret_cast<std::uintptr_t>(
+                GetModuleHandleW(nullptr));
+            if (imgBase < k_minValidPtr)
+                return false;
+            const auto td = imgBase + tdRva;
+            return ascii_equals(td + k_offNameInDescriptor, ref);
+        }
+
+        // Generic RTTI-keyed component finder. Generalises the legacy
+        // CCC-specific walker -- see `find_component_in_table` below
+        // for the public entry point. The cache slot is caller-owned
+        // (one atomic per RTTI name) so this function carries no
+        // global state and lets each consumer name its own component.
+        //
+        // Fast path (vtable cache warm): scans up to
+        // k_componentTableSlots qwords looking for a slot whose first
+        // qword equals the cached vtable. Cost is one qword read per
+        // slot plus one indirection per non-null candidate -- two
+        // page touches at worst.
+        //
+        // Cold path (cache empty, or fast-path miss): RTTI-validates
+        // each non-null slot against @p rttiName until it finds a
+        // match, then caches that slot's vtable for all subsequent
+        // walks in this process. A fast-path miss with a populated
+        // cache normally means the table got reallocated in a
+        // save-load transient -- the next walk picks it back up. The
+        // cache itself never needs invalidation because the vtable
+        // is image-resident.
+        std::uintptr_t find_component_impl(
+            std::uintptr_t p1,
+            std::string_view rttiName,
+            std::atomic<std::uintptr_t> &vtableCache) noexcept
+        {
+            if (p1 < k_minValidPtr || rttiName.empty())
+                return 0;
+            const auto cached =
+                vtableCache.load(std::memory_order_acquire);
+            if (cached >= k_minValidPtr)
+            {
+                for (std::size_t i = 0; i < k_componentTableSlots; ++i)
+                {
+                    const auto slot =
+                        safe_read_qword(p1 + i * sizeof(std::uintptr_t));
+                    if (slot < k_minValidPtr)
+                        continue;
+                    const auto vt = safe_read_qword(slot);
+                    if (vt == cached)
+                        return slot;
+                }
+                // Fast-path missed; fall through to RTTI rescan.
+            }
+            for (std::size_t i = 0; i < k_componentTableSlots; ++i)
+            {
+                const auto slot =
+                    safe_read_qword(p1 + i * sizeof(std::uintptr_t));
+                if (slot < k_minValidPtr)
+                    continue;
+                const auto vt = safe_read_qword(slot);
+                if (vt < k_minValidPtr)
+                    continue;
+                if (!vtbl_matches_rtti_name(vt, rttiName))
+                    continue;
+                std::uintptr_t expected = 0;
+                vtableCache.compare_exchange_strong(
+                    expected, vt,
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire);
+                return slot;
+            }
+            return 0;
+        }
+
+        // Internal CCC-specific walker. Used by the appearance-path
+        // resolver; thin wrapper over the generic finder.
+        std::uintptr_t find_ccc_in_component_table(
+            std::uintptr_t p1) noexcept
+        {
+            return find_component_impl(
+                p1, k_cccTypeDescriptorName, s_cccVtable);
+        }
+
+        // Walk CCOIA +0x68 -> [CCC via RTTI] -> +0x40 -> +0x38 to
+        // reach the appearance-config std::string. Resolves
+        // heap-buffer vs inline layout and returns the start
+        // address of ASCII content; returns 0 on any torn link.
         std::uintptr_t resolve_appearance_path_buffer(
             std::uintptr_t ccoia) noexcept
         {
             if (ccoia < k_minValidPtr)
                 return 0;
-            auto p = safe_read_qword(ccoia + k_offAppearChain1);
-            if (p < k_minValidPtr) return 0;
-            p = safe_read_qword(p + k_offAppearChain2);
-            if (p < k_minValidPtr) return 0;
-            p = safe_read_qword(p + k_offAppearChain3);
-            if (p < k_minValidPtr) return 0;
+            const auto p1 =
+                safe_read_qword(ccoia + k_offAppearChain1);
+            if (p1 < k_minValidPtr) return 0;
+            const auto ccc = find_ccc_in_component_table(p1);
+            if (ccc < k_minValidPtr) return 0;
+            const auto p3 =
+                safe_read_qword(ccc + k_offAppearChain3);
+            if (p3 < k_minValidPtr) return 0;
             const auto strStruct =
-                safe_read_qword(p + k_offAppearChain4);
+                safe_read_qword(p3 + k_offAppearChain4);
             if (strStruct < k_minValidPtr) return 0;
             const auto bufPtr =
                 safe_read_qword(strStruct + k_offStringBufPtr);
@@ -732,6 +888,49 @@ namespace CDCore
         if (!kliff.empty())   s_codenameKliff   = kliff;
         if (!damiane.empty()) s_codenameDamiane = damiane;
         if (!oongka.empty())  s_codenameOongka  = oongka;
+    }
+
+    std::uintptr_t find_component_in_table(
+        std::uintptr_t p1,
+        std::string_view rttiName,
+        std::atomic<std::uintptr_t> &vtableCache) noexcept
+    {
+        return find_component_impl(p1, rttiName, vtableCache);
+    }
+
+    std::uintptr_t find_component_in_controlled_actor(
+        std::string_view rttiName,
+        std::atomic<std::uintptr_t> &vtableCache) noexcept
+    {
+        const auto ccoia = current_controlled_ccoia();
+        if (ccoia < k_minValidPtr)
+            return 0;
+        const auto p1 = safe_read_qword(ccoia + k_offAppearChain1);
+        if (p1 < k_minValidPtr)
+            return 0;
+        return find_component_impl(p1, rttiName, vtableCache);
+    }
+
+    std::uintptr_t find_component_for_equipslot(
+        std::uintptr_t equipSlot,
+        std::string_view rttiName,
+        std::atomic<std::uintptr_t> &vtableCache) noexcept
+    {
+        if (equipSlot < k_minValidPtr)
+            return 0;
+        // ClientEquipSlotActorComponent + 0x08 = back-pointer to
+        // pa::ClientChildOnlyInGameActor (the CCOIA). Then the
+        // standard CCOIA + k_offAppearChain1 hop to the component
+        // table.
+        constexpr std::ptrdiff_t k_offEquipSlotCcoiaBackref = 0x08;
+        const auto ccoia =
+            safe_read_qword(equipSlot + k_offEquipSlotCcoiaBackref);
+        if (ccoia < k_minValidPtr)
+            return 0;
+        const auto p1 = safe_read_qword(ccoia + k_offAppearChain1);
+        if (p1 < k_minValidPtr)
+            return 0;
+        return find_component_impl(p1, rttiName, vtableCache);
     }
 
 } // namespace CDCore

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed a burst of transient errors that could appear in the log during the first few seconds after loading a save.
+- Transmog now waits for the game to finish setting up your character before applying, instead of retrying through errors.
+- Internal refactor: identify character components by class name so the mod keeps working if the game shuffles their order.

--- a/CrimsonDesertLiveTransmog/src/color_override/matinst_probe.hpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/matinst_probe.hpp
@@ -50,12 +50,16 @@ namespace Transmog::ColorOverride::MatInstProbe
 
     // ---- Address range sanity ----------------------------------------
     //
-    // Engine heap pool is typically `0x300000000`+; module image is
-    // `0x140000000..0x150000000` on v1.06 (no ASLR shift observed).
+    // Engine heap pool sits above `0x200000000`; the EXE image is
+    // mapped at `0x140000000` with no ASLR shift in shipped builds.
+    // The upper module bound is set to `0x160000000` to cover the
+    // shipped image (~410 MB) plus headroom for future patches that
+    // grow the module without forcing every dependent check to
+    // update.
     inline constexpr std::uintptr_t k_heapFloor   = 0x200000000ULL;
     inline constexpr std::uintptr_t k_heapCeiling = 0x800000000000ULL;
     inline constexpr std::uintptr_t k_moduleLow   = 0x140000000ULL;
-    inline constexpr std::uintptr_t k_moduleHigh  = 0x150000000ULL;
+    inline constexpr std::uintptr_t k_moduleHigh  = 0x160000000ULL;
 
     inline bool is_likely_heap(std::uintptr_t p) noexcept
     {

--- a/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
+++ b/CrimsonDesertLiveTransmog/src/real_part_tear_down.cpp
@@ -5,6 +5,8 @@
 #include "slot_metadata.hpp"
 #include "transmog_map.hpp"
 
+#include <cdcore/controlled_char.hpp>
+
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
@@ -21,14 +23,18 @@ namespace Transmog::RealPartTearDown
         // Helper function pointer types. Addresses come from
         // Transmog::resolved_addrs() (populated elsewhere in init()):
         //
-        // sub_14075FE60 -- Safe scene-graph tear-down.
-        //   Calls sub_1425EBAE0 internally. Does NOT mutate the
-        //   authoritative equip table at *(a1+0x78).
+        // SafeTearDown -- engine scene-graph tear-down. Calls
+        //   sub_1425EBAE0 internally. Does NOT mutate the
+        //   authoritative equip table at a1+k_containerPtrOffset.
+        //   AOB-resolved -- the v1.05 build name was sub_14075FE60
+        //   and the current v1.06 build resolves to sub_1407990E0;
+        //   readers comparing to the live IDA db should use the AOB
+        //   pattern in k_safeTearDownCandidates, not these names.
         //
-        // sub_1402D75D0 -- IndexedStringA short->hash lookup. Takes the
-        //   address of a uint16_t slot id; returns a pointer whose
-        //   first DWORD is the descriptor hash used by the rest of the
-        //   equip pipeline.
+        // IndexedStringLookup (sub_1402D75D0) -- short->hash lookup.
+        //   Takes the address of a uint16_t slot id; returns a
+        //   pointer whose first DWORD is the descriptor hash used
+        //   by the rest of the equip pipeline.
 
         using SafeTearDownFn =
             std::int64_t(__fastcall *)(std::int64_t a1,
@@ -104,6 +110,7 @@ namespace Transmog::RealPartTearDown
         constexpr std::uintptr_t k_containerPtrOffset       = 0x88;
         constexpr std::uintptr_t k_containerArrayBaseOffset = 0x08;
         constexpr std::uintptr_t k_containerCountOffset     = 0x10;
+
         constexpr std::uintptr_t k_entryStride              = 0xD0;
         constexpr std::uintptr_t k_entryPrimaryWordOffset   = 0x08;
         constexpr std::uintptr_t k_entrySlotTagOffset       = 0xC8;
@@ -364,12 +371,9 @@ namespace Transmog::RealPartTearDown
         if (a1 < 0x10000)
             return false;
 
-        // Mirrors the preamble of `tear_down_real_part` exactly. Layout
-        // constants are file-scope (not exported), so the probe lives in
-        // this TU and is exposed via the namespace function only. SEH-
-        // wrapped because the placeholder wrapper that the engine parks
-        // user+0xD8 on during world load faults at the container deref --
-        // that fault is the primary signal we are filtering on.
+        // Stage 1: structural reads under SEH (POD locals only).
+        std::uintptr_t arrayBase = 0;
+        std::uint32_t  count     = 0;
         __try
         {
             const auto container =
@@ -378,43 +382,68 @@ namespace Transmog::RealPartTearDown
             if (container < 0x10000)
                 return false;
 
-            const auto arrayBase =
+            arrayBase =
                 *reinterpret_cast<volatile std::uintptr_t *>(
                     container + k_containerArrayBaseOffset);
             if (arrayBase < 0x10000)
                 return false;
 
-            const auto count =
+            count =
                 *reinterpret_cast<volatile std::uint32_t *>(
                     container + k_containerCountOffset);
-
-            // count is the slot-entry count, not the equipped-item count
-            // (the iteration in tear_down_real_part visits all indices
-            // 0..count and skips empty slots via primary==0xFFFF and
-            // gate==0 inside the loop). A naked character still reports
-            // a full slot count -- empty slots persist as 0xFFFF
-            // sentinels. Therefore count==0 with a readable container
-            // signals an actor whose container struct is allocated but
-            // whose slot entries are not yet populated -- placeholder or
-            // mid-wiring. The upper bound rejects torn reads that would
-            // otherwise pass the lower bound by accident.
-            const bool ready =
-                count >= 1 && count <= k_maxPlausibleEntries;
-
-            // Passive slot-discovery: dump the auth table the moment a
-            // ready actor first appears (and again whenever a1 or count
-            // changes -- character swap, table resize). Fires before any
-            // tear-down call lands, so we get visibility even if the
-            // user never toggles LT for a given character.
-            if (ready)
-                dump_full_auth_table_if_changed(a1, arrayBase, count);
-
-            return ready;
+            if (count < 1 || count > k_maxPlausibleEntries)
+                return false;
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
             return false;
         }
+
+        // Stage 2: engine readiness. SafeTearDown's deep dereference
+        // reads
+        //     v15 = *(CCC + 0x130);
+        //     ... *v15 ...
+        // During cold-load the field at `CCC + 0x130` is null; once
+        // the engine wires up the actor's scene graph it becomes a
+        // heap-allocated sub-handler pointer. SafeTearDown's own
+        // null-check (`if (v7)`) only guards against a null CCC and
+        // not this deeper field, so calling it before the field is
+        // populated fault-trips inside the engine. Probing this one
+        // pointer is both necessary (SafeTearDown faults when it is
+        // null) and sufficient empirically (the transition coincides
+        // with the end of the cold-load fault burst window).
+        //
+        // The CCC instance is located by MSVC RTTI mangled name
+        // rather than fixed slot offset so the slot drift documented
+        // in CDCore controlled_char does not affect this probe. Only
+        // the +0x130 sub-handler offset lives in LT; the a1->CCOIA->
+        // p1 chain offsets live inside CDCore.
+        constexpr std::ptrdiff_t k_offCccSubHandler = 0x130;
+        static std::atomic<std::uintptr_t> s_cccVt{0};
+        static constexpr std::string_view k_cccName =
+            ".?AVClientCharacterControlActorComponent@pa@@";
+
+        const auto cccAddr = CDCore::find_component_for_equipslot(
+            a1, k_cccName, s_cccVt);
+        if (cccAddr < 0x10000)
+            return false;
+
+        std::uintptr_t subHandler = 0;
+        __try
+        {
+            subHandler =
+                *reinterpret_cast<volatile std::uintptr_t *>(
+                    cccAddr + k_offCccSubHandler);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return false;
+        }
+        if (subHandler < 0x10000)
+            return false;
+
+        dump_full_auth_table_if_changed(a1, arrayBase, count);
+        return true;
     }
 
     bool resolve_helpers() noexcept
@@ -492,6 +521,7 @@ namespace Transmog::RealPartTearDown
         g_indexedStringLookup.store(
             reinterpret_cast<IndexedStringLookupFn>(lookupAddr),
             std::memory_order_release);
+
         g_ready.store(true, std::memory_order_release);
 
         logger.info(

--- a/CrimsonDesertLiveTransmog/src/real_part_tear_down.hpp
+++ b/CrimsonDesertLiveTransmog/src/real_part_tear_down.hpp
@@ -13,30 +13,31 @@ namespace Transmog::RealPartTearDown
     // that case.
     bool resolve_helpers() noexcept;
 
-    // Walks the authoritative equip table at *(a1+0x78), locates the entry
-    // whose slotTag matches `gameSlotTag` (helm = 0x0003), extracts its
-    // item descriptor hash via IndexedStringA, then calls the safe
-    // scene-graph tear-down (sub_14075FE60). Does NOT touch the auth table.
-    // SEH-guarded; returns false on any failure.
+    // Walks the authoritative equip table at *(a1+k_containerPtrOffset),
+    // locates the entry whose slotTag matches `gameSlotTag` (helm = 0x0003),
+    // extracts its item descriptor hash via IndexedStringA, then calls the
+    // AOB-resolved SafeTearDown engine helper. Does NOT touch the auth
+    // table. SEH-guarded; returns false on any failure.
     //
-    // Thread affinity: sub_14075FE60 eventually walks the scene graph via
+    // Thread affinity: SafeTearDown eventually walks the scene graph via
     // sub_1425EBAE0. The game normally invokes this from its equip/render
-    // thread. This POC calls it from whatever thread apply_all_transmog is
-    // running on (currently the deferred-apply worker). Accepted risk for POC.
+    // thread; we call it from whatever thread apply_all_transmog is
+    // running on (currently the deferred-apply worker). Accepted risk.
     bool tear_down_real_part(void *a1, std::uint16_t gameSlotTag) noexcept;
 
-    // Same scene-graph tear-down as `tear_down_real_part`, but bypasses the
-    // auth-table walk and uses an explicit itemId. Intended for removing
-    // previously-applied fake transmog meshes whose itemId we tracked in
-    // lastIds but which never appeared in the auth table.
+    // Same scene-graph tear-down as `tear_down_real_part`, but bypasses
+    // the auth-table walk and uses an explicit itemId. Intended for
+    // removing previously-applied fake transmog meshes whose itemId we
+    // tracked in lastIds but which never appeared in the auth table.
     //
-    // Pipeline: itemId -> sub_1402D75D0 (IndexedStringA lookup) -> DWORD hash
-    // -> sub_14075FE60(a1, hash, slotTag). SEH-guarded; returns false on any
-    // failure (including hash lookup miss).
+    // Pipeline: itemId -> IndexedStringLookup -> DWORD hash ->
+    // SafeTearDown(a1, hash, slotTag). SEH-guarded; returns false on
+    // any failure (including hash lookup miss).
     bool tear_down_by_item_id(void *a1, std::uint16_t itemId,
                               std::uint16_t gameSlotTag) noexcept;
 
-    // Walks the authoritative equip table at *(a1+0x78) and returns the raw
+    // Walks the authoritative equip table at *(a1+k_containerPtrOffset)
+    // and returns the raw
     // item word (not the hash-transformed value) for the given gameSlotTag.
     // Returns 0 if no entry for the slot or on any failure. Used by callers
     // to detect "fake transmog itemId equals real equipped itemId" and skip
@@ -48,34 +49,42 @@ namespace Transmog::RealPartTearDown
     // feature without re-checking individual function pointers.
     bool is_ready() noexcept;
 
-    /** @brief Cheap read-only probe for "is this actor ready to receive
+    /** @brief Read-only probe for "is this actor ready to receive
      *         tear_down/apply".
-     *  @details Walks the same container chain that `tear_down_real_part`
-     *           dereferences, but issues no engine calls and writes
-     *           nothing -- just verifies that `*(a1+0x78) -> container`,
-     *           `container+0x08 -> arrayBase`, and `container+0x10 ->
-     *           count` all read cleanly under SEH and that `count` is in
-     *           a plausible range (`[1, k_maxPlausibleEntries]`).
+     *  @details Two-stage check, both SEH-guarded. Designed for the
+     *           load-detect retry loop -- during world load the
+     *           engine briefly parks the equip-slot component on a
+     *           placeholder whose downstream sub-handlers are not
+     *           yet wired. Calling `apply_all_transmog` in that
+     *           window consistently SEH-faults inside `SafeTearDown`'s
+     *           deep dereferences and produces dozens of log lines
+     *           per attempt. Probing readiness first lets the retry
+     *           loop skip those attempts at microsecond cost without
+     *           shrinking the overall retry budget.
      *
-     *           Designed for the load-detect retry loop. During world
-     *           load the engine briefly parks `user+0xD8` on a placeholder
-     *           wrapper whose actor part-registry is not yet wired; on
-     *           low-end PCs that placeholder can persist for 90+ seconds.
-     *           Calling `apply_all_transmog` against a placeholder
-     *           consistently SEH-faults inside engine calls and produces
-     *           dozens of log lines per attempt. Probing readiness first
-     *           lets the retry loop skip those attempts at microsecond
-     *           cost without shrinking the overall retry budget.
+     *           Stage 1 -- structural. Walks the same container
+     *           chain that `tear_down_real_part` dereferences
+     *           (`*(a1+k_containerPtrOffset) -> container`,
+     *           `container+0x08 -> arrayBase`, `container+0x10 ->
+     *           count`) and verifies each link reads cleanly and
+     *           `count` is in `[1, k_maxPlausibleEntries]`.
      *
-     *           A real actor's container has a non-empty entry array
-     *           (the protagonist always has at least one equipped slot in
-     *           practice; a hypothetical naked save would be filtered
-     *           briefly until the engine swaps the wrapper). A placeholder
-     *           either faults on container deref or returns sentinel
-     *           garbage that fails the count sanity check.
+     *           Stage 2 -- engine readiness. Locates the
+     *           `pa::ClientCharacterControlActorComponent` (CCC)
+     *           for this actor via RTTI (so component slot drift in
+     *           the CCOIA component table does not affect the
+     *           probe), then checks the sub-handler pointer at
+     *           `CCC + 0x130` is non-null. That is precisely the
+     *           field `SafeTearDown` dereferences as
+     *           `v15 = *(v7 + 304)` and unconditionally
+     *           re-dereferences as `*v15`. The field is null during
+     *           cold-load and becomes a heap-allocated sub-object
+     *           pointer at the moment `SafeTearDown` stops faulting,
+     *           making it both a necessary and empirically
+     *           sufficient readiness gate.
      *
-     *  @param a1 Player wrapper pointer (`*(actor+0x68)+0x38` shape, the
-     *            same value the apply pipeline accepts as `a1`).
-     *  @returns true if the chain reads cleanly and count is plausible. */
+     *  @param a1 ClientEquipSlotActorComponent pointer -- the same
+     *            value the SlotPopulator pipeline carries.
+     *  @returns true when both stages pass; false otherwise. */
     bool is_actor_apply_ready(void *a1) noexcept;
 }


### PR DESCRIPTION
## Summary
- Defer `apply_all_transmog` until the engine's CCC sub-handler pointer (`CCC + 0x130`) is wired. This is the exact field `SafeTearDown` dereferences as `v15 = *(v7 + 304)`, so probing it eliminates the SEH-fault burst inside engine code that fired in the first ~10s after a save load.
- Add a generic RTTI-keyed component walker in CDCore (`find_component_in_table`, `find_component_in_controlled_actor`, `find_component_for_equipslot`). The CCC is resolved by mangled class name, so component-slot drift between early and late load no longer affects the probe. The existing appearance-path resolver is refactored on top of the new walker.
- Inline the short-lived `engine_image_range.hpp` constants back into `matinst_probe.hpp` (single consumer) and correct `k_moduleHigh` from `0x150000000` to `0x160000000` so the shipped image fits with headroom.

## Test plan
- [x] Build clean (RelWithDebInfo, dev-msvc preset).
- [x] Cold-load capture: 0 `SEH caught fault` lines, 10 clean `body not yet ready` defers at 1 Hz, first apply succeeds without faults, `Transmog applied (debounced)` lands within ~10s of `World generation 0 -> 1`.
- [x] Multi-character verification (Kliff/Damiane/Oongka) all defer and admit correctly.
