### PR TITLE
revert(live-transmog): drop matinst probe is_readable gating

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -3,3 +3,4 @@
 - Fixed a burst of transient errors that could appear in the log during the first few seconds after loading a save.
 - Transmog now waits for the game to finish setting up your character before applying, instead of retrying through errors.
 - Internal refactor: identify character components by class name so the mod keeps working if the game shuffles their order.
+- Fixed an FPS drop when applying transmog while Color Override is enabled.

--- a/CrimsonDesertLiveTransmog/src/color_override/matinst_probe.cpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/matinst_probe.cpp
@@ -1,41 +1,6 @@
 #include "matinst_probe.hpp"
 
-#include <DetourModKit.hpp>
 #include <Windows.h>
-
-#include <cstring>
-
-namespace
-{
-    namespace DMK = DetourModKit;
-
-    // Predicate-validated POD read (silent filter).
-    //
-    // Validates the source page via DMK's cached VirtualQuery probe
-    // (`DMK::Memory::is_readable`) before reading. On success copies
-    // `sizeof(T)` bytes via `memcpy`. The predicate filters the
-    // common stale-pointer cases (NULL, low addresses, uncommitted
-    // pages, PAGE_NOACCESS, PAGE_GUARD, short regions) without
-    // firing an AV, so no first-chance exception lands on an
-    // attached debugger for those cases.
-    //
-    // Deliberately contains no SEH. MSVC forbids `__try/__except`
-    // in a function that has objects requiring unwind, and mixing
-    // SEH with templated code is fragile under that rule. The
-    // residual TOCTOU race window between predicate and `memcpy`
-    // (page freed between the two, or a stale cache entry) is
-    // caught by the outer `__try/__except` in each caller, so this
-    // helper stays SEH-free.
-    template <typename T>
-    inline bool safe_read(std::uintptr_t src, T &out) noexcept
-    {
-        if (!DMK::Memory::is_readable(
-                reinterpret_cast<const void *>(src), sizeof(T)))
-            return false;
-        std::memcpy(&out, reinterpret_cast<const void *>(src), sizeof(T));
-        return true;
-    }
-}
 
 namespace Transmog::ColorOverride::MatInstProbe
 {
@@ -46,33 +11,18 @@ namespace Transmog::ColorOverride::MatInstProbe
             return false;
         __try
         {
-            // Stale-pointer gate: vtable @ +0 must be module-
-            // resident. The predicate inside `safe_read` rejects
-            // freed / unmapped pages silently; the surrounding SEH
-            // boundary catches the residual race where the page is
-            // freed between predicate and read.
-            std::uintptr_t vtbl = 0;
-            if (!safe_read(mi, vtbl))
-                return false;
-            if (!is_module_resident(vtbl))
-                return false;
-
-            out.mi     = mi;
-            out.vtable = vtbl;
-
-            if (!safe_read(mi + k_offMi_TemplateId, out.template_id))
-                return false;
-            if (!safe_read(mi + k_offMi_StableId, out.stable_id))
-                return false;
-
-            std::uintptr_t arec = 0;
-            if (!safe_read(mi + k_offMi_ArecBackref, arec))
-                return false;
+            out.mi = mi;
+            out.vtable = *reinterpret_cast<const std::uintptr_t *>(mi);
+            out.template_id = *reinterpret_cast<const std::uint16_t *>(
+                mi + k_offMi_TemplateId);
+            out.stable_id = *reinterpret_cast<const std::uint64_t *>(
+                mi + k_offMi_StableId);
+            const auto arec = *reinterpret_cast<const std::uintptr_t *>(
+                mi + k_offMi_ArecBackref);
             if (!is_likely_heap(arec))
                 return false;
-            if (!safe_read(arec + k_offArec_ContentHash, out.content_hash))
-                return false;
-
+            out.content_hash = *reinterpret_cast<const std::uint32_t *>(
+                arec + k_offArec_ContentHash);
             return true;
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
@@ -90,8 +40,8 @@ namespace Transmog::ColorOverride::MatInstProbe
         std::uintptr_t mi = 0;
         __try
         {
-            if (!safe_read(wrapper + k_offMat_WrapperBackref, mi))
-                return false;
+            mi = *reinterpret_cast<const std::uintptr_t *>(
+                wrapper + k_offMat_WrapperBackref);
         }
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
@@ -111,50 +61,36 @@ namespace Transmog::ColorOverride::MatInstProbe
         __try
         {
             // Back-pointer to parent SkinnedMeshMaterialWrapper.
-            std::uintptr_t wrapper = 0;
-            if (!safe_read(material + k_offMat_WrapperBackref, wrapper))
-                return false;
+            const auto wrapper = *reinterpret_cast<const std::uintptr_t *>(
+                material + k_offMat_WrapperBackref);
             if (!is_likely_heap(wrapper))
                 return false;
 
-            // Stale-pointer gate on the wrapper: vtable @ +0 must
-            // be module-resident. Catches reads into reallocated
-            // heap garbage that survived the readability predicate.
-            std::uintptr_t wrapperVtbl = 0;
-            if (!safe_read(wrapper, wrapperVtbl))
-                return false;
-            if (!is_module_resident(wrapperVtbl))
+            // Hardening: the wrapper's vtable pointer (at +0) must be
+            // module-resident. Catches the stale-pointer case where
+            // wrapper memory was freed and overwritten with non-
+            // vtable garbage that still happens to be mapped.
+            const auto wrapper_vtbl =
+                *reinterpret_cast<const std::uintptr_t *>(wrapper);
+            if (!is_module_resident(wrapper_vtbl))
                 return false;
 
-            // Wrapper's `_subMeshName` string-wrapper field. Engine
+            // Wrapper's _subMeshName string-wrapper field. Engine
             // uses a module-resident empty-string sentinel vtable
-            // instance when unset -- the inline buffer on that
-            // sentinel would read into module .rdata, so require
-            // the string-wrapper to be heap-resident.
-            std::uintptr_t sw = 0;
-            if (!safe_read(wrapper + k_offWrapper_SubMeshNameSw, sw))
-                return false;
+            // instance when unset -- reject those.
+            const auto sw = *reinterpret_cast<const std::uintptr_t *>(
+                wrapper + k_offWrapper_SubMeshNameSw);
             if (!is_likely_heap(sw))
                 return false;
 
-            // Validate the inline string buffer in one shot before
-            // the char-walk. `out_cap` bounds the walk, so one
-            // readability check covers every read in the loop. The
-            // residual race during the walk is still caught by the
-            // surrounding `__try`.
-            const auto str_addr = sw + k_offStringWrapper_Inline;
-            if (!DMK::Memory::is_readable(
-                    reinterpret_cast<const void *>(str_addr), out_cap))
-                return false;
-
-            const char *src = reinterpret_cast<const char *>(str_addr);
+            const char *src = reinterpret_cast<const char *>(
+                sw + k_offStringWrapper_Inline);
             std::size_t n = 0;
             while (n < out_cap - 1 && src[n] != '\0')
             {
-                // Printable-ASCII sanity: submesh names are
-                // `[a-zA-Z0-9_]+`. Anything else is garbage from a
-                // reallocated heap object that raced past the
-                // readability check.
+                // ASCII-only sanity: submesh names are
+                // `[a-zA-Z0-9_]+`. Anything else likely means we read
+                // garbage from a reallocated heap object.
                 const auto c = static_cast<unsigned char>(src[n]);
                 if (c < 0x20 || c > 0x7E)
                     break;

--- a/CrimsonDesertLiveTransmog/src/color_override/matinst_probe.hpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/matinst_probe.hpp
@@ -8,24 +8,8 @@
 // submesh name off its wrapper. Centralised here so the v1.06 struct
 // offsets + heap-floor sanity live in one place.
 //
-// Stale-pointer model (two-layer defence):
-//
-//   1. Each read first validates its source page via
-//      `DMK::Memory::is_readable` (cached VirtualQuery). The common
-//      stale-pointer cases -- NULL, low addresses, uncommitted
-//      pages, PAGE_NOACCESS, PAGE_GUARD, short regions -- are
-//      filtered silently. No AV fires, so no first-chance exception
-//      lands on an attached debugger for typical filtered calls.
-//
-//   2. Each function body is wrapped in `__try/__except` so the
-//      residual TOCTOU race (page freed between predicate and read,
-//      or stale predicate cache) cannot crash the process. That
-//      race is rare in practice; the SEH boundary keeps it sound.
-//      Debugger noise is therefore proportional to the race rate,
-//      not the bad-pointer rate.
-//
-// All readers remain `noexcept`. Bad pointers / freed memory return
-// `false`; no exception escapes.
+// All readers are SEH-guarded and `noexcept`. Bad pointers / freed
+// memory return `false`; no exception escapes.
 
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
## Summary

Reverts #74. The per-read `DMK::Memory::is_readable` predicate inside `matinst_probe` ran on the Color Override apply hot path and caused a visible FPS drop when applying transmog with Color Override enabled. This restores the prior SEH-only fast path.

## Why this is safe

- All probe entry points stay wrapped in `__try/__except (EXCEPTION_EXECUTE_HANDLER)`, so any stale read still returns `false` instead of crashing.
- Heap-floor / module-resident range checks remain in place to reject the obvious bad-pointer cases.
- No public API or call-site signature changed.
