### PR TITLE
docs(live-transmog): set next-release changelog title

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Title for next release]
+## Save-load and Color Override fixes
 
 - Fixed a burst of transient errors that could appear in the log during the first few seconds after loading a save.
 - Transmog now waits for the game to finish setting up your character before applying, instead of retrying through errors.


### PR DESCRIPTION
## Summary

Replaces the `[Title for next release]` placeholder in `NEXT_CHANGELOG.md` with a concise heading that reflects the entries already queued for the next release (cold-load save-load fixes and the Color Override apply-time perf revert).
