### PR TITLE
refactor: adopt DetourModKit 3.3.0 and consolidate SEH read primitives

### DIFF
--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -121,23 +121,16 @@ namespace CDCore
         //       p1 +0x40 -> pa::ClientCharacterControlActorComponent
         //       p1 +0x48 -> pa::ClientVehicleActorComponent
         //
-        // Step 2 (locate the CCC inside p1) now walks the table by
+        // Step 2 (locate the CCC inside p1) walks the table by
         // RTTI/vtable rather than fixed offset, so the chain is
         // session-stable regardless of how many components have
-        // registered. See find_ccc_in_component_table() below.
-        // Steps 3 (+0x40) and 4 (+0x38) dereference fixed members of
-        // the resolved CCC and are structurally stable.
+        // registered. The walk runs through `DMKRtti::find_in_pointer_table`
+        // against `k_cccTypeDescriptorName`. Steps 3 (+0x40) and 4 (+0x38)
+        // dereference fixed members of the resolved CCC and are
+        // structurally stable.
         constexpr std::ptrdiff_t k_offAppearChain1 = 0x68;
         constexpr std::ptrdiff_t k_offAppearChain3 = 0x40;
         constexpr std::ptrdiff_t k_offAppearChain4 = 0x38;
-
-        // MSVC RTTI traversal. The vtable's RTTICompleteObjectLocator
-        // (COL) sits at `vtbl - 8` (qword); the COL stores the type
-        // descriptor as an RVA at `col + 0x0C`; the type descriptor's
-        // mangled-name C-string lives at `td + 0x10`.
-        constexpr std::ptrdiff_t k_offColInVtable      = -8;
-        constexpr std::ptrdiff_t k_offTdRvaInCol       = 0x0C;
-        constexpr std::ptrdiff_t k_offNameInDescriptor = 0x10;
 
         // RTTI mangled-name string of the target component class.
         // MSVC encodes class types as `.?AV<name>@<scope>@@`. The
@@ -218,38 +211,6 @@ namespace CDCore
         std::string  s_codenameDamiane{k_defaultCodenameDamiane};
         std::string  s_codenameOongka{k_defaultCodenameOongka};
 
-        // ---- SEH-guarded primitives -------------------------------------
-
-        std::uintptr_t safe_read_qword(std::uintptr_t addr) noexcept
-        {
-            if (addr < k_minValidPtr)
-                return 0;
-            __try
-            {
-                return *reinterpret_cast<
-                    const volatile std::uintptr_t *>(addr);
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
-        }
-
-        std::uint32_t safe_read_dword(std::uintptr_t addr) noexcept
-        {
-            if (addr < k_minValidPtr)
-                return 0;
-            __try
-            {
-                return *reinterpret_cast<
-                    const volatile std::uint32_t *>(addr);
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
-        }
-
         // ---- Player base resolution -------------------------------------
 
         std::uintptr_t resolve_player_base_address() noexcept
@@ -275,6 +236,16 @@ namespace CDCore
         }
 
         // ---- Chain walks (SEH-guarded, single __try per call) -----------
+        //
+        // Each chain walk bundles every dereference along its path under a
+        // single SEH frame. Splitting the dereferences into individual
+        // `DMKMemory::seh_read<T>` calls would pay N SEH-frame costs in
+        // place of one and would lose the "any fault aborts the walk"
+        // property that mid-teardown windows rely on (a torn intermediate
+        // pointer must short-circuit the whole walk, not just one leaf).
+        //
+        // Single-deref reads outside these chains use
+        // `DMKMemory::seh_read<T>(addr).value_or(0)` inline at the call site.
 
         struct ChainAnchors
         {
@@ -439,132 +410,6 @@ namespace CDCore
         // once via RTTI scan on the first successful chain walk.
         std::atomic<std::uintptr_t> s_cccVtable{0};
 
-        // Compare a bounded ASCII string in memory against @p ref.
-        // Returns true only when the first ref.size() bytes match
-        // exactly and the byte at ref.size() is the NUL terminator
-        // (so a longer mangled name that begins with @p ref does
-        // not falsely match).
-        bool ascii_equals(std::uintptr_t addr,
-                          std::string_view ref) noexcept
-        {
-            if (addr < k_minValidPtr || ref.empty())
-                return false;
-            __try
-            {
-                for (std::size_t i = 0; i < ref.size(); ++i)
-                {
-                    const auto b = *reinterpret_cast<
-                        const volatile std::uint8_t *>(addr + i);
-                    if (b != static_cast<std::uint8_t>(ref[i]))
-                        return false;
-                }
-                const auto term = *reinterpret_cast<
-                    const volatile std::uint8_t *>(addr + ref.size());
-                return term == 0;
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return false;
-            }
-        }
-
-        // Returns true when the MSVC RTTI type-descriptor name for
-        // the class whose vtable is @p vtbl equals @p ref.
-        bool vtbl_matches_rtti_name(std::uintptr_t vtbl,
-                                    std::string_view ref) noexcept
-        {
-            const auto col =
-                safe_read_qword(vtbl + k_offColInVtable);
-            if (col < k_minValidPtr)
-                return false;
-            const auto tdRva =
-                safe_read_dword(col + k_offTdRvaInCol);
-            if (tdRva == 0)
-                return false;
-            // GetModuleHandle(nullptr) returns the game EXE's load
-            // address straight out of the PEB -- effectively a
-            // constant, so no caching needed.
-            const auto imgBase = reinterpret_cast<std::uintptr_t>(
-                GetModuleHandleW(nullptr));
-            if (imgBase < k_minValidPtr)
-                return false;
-            const auto td = imgBase + tdRva;
-            return ascii_equals(td + k_offNameInDescriptor, ref);
-        }
-
-        // Generic RTTI-keyed component finder. Generalises the legacy
-        // CCC-specific walker -- see `find_component_in_table` below
-        // for the public entry point. The cache slot is caller-owned
-        // (one atomic per RTTI name) so this function carries no
-        // global state and lets each consumer name its own component.
-        //
-        // Fast path (vtable cache warm): scans up to
-        // k_componentTableSlots qwords looking for a slot whose first
-        // qword equals the cached vtable. Cost is one qword read per
-        // slot plus one indirection per non-null candidate -- two
-        // page touches at worst.
-        //
-        // Cold path (cache empty, or fast-path miss): RTTI-validates
-        // each non-null slot against @p rttiName until it finds a
-        // match, then caches that slot's vtable for all subsequent
-        // walks in this process. A fast-path miss with a populated
-        // cache normally means the table got reallocated in a
-        // save-load transient -- the next walk picks it back up. The
-        // cache itself never needs invalidation because the vtable
-        // is image-resident.
-        std::uintptr_t find_component_impl(
-            std::uintptr_t p1,
-            std::string_view rttiName,
-            std::atomic<std::uintptr_t> &vtableCache) noexcept
-        {
-            if (p1 < k_minValidPtr || rttiName.empty())
-                return 0;
-            const auto cached =
-                vtableCache.load(std::memory_order_acquire);
-            if (cached >= k_minValidPtr)
-            {
-                for (std::size_t i = 0; i < k_componentTableSlots; ++i)
-                {
-                    const auto slot =
-                        safe_read_qword(p1 + i * sizeof(std::uintptr_t));
-                    if (slot < k_minValidPtr)
-                        continue;
-                    const auto vt = safe_read_qword(slot);
-                    if (vt == cached)
-                        return slot;
-                }
-                // Fast-path missed; fall through to RTTI rescan.
-            }
-            for (std::size_t i = 0; i < k_componentTableSlots; ++i)
-            {
-                const auto slot =
-                    safe_read_qword(p1 + i * sizeof(std::uintptr_t));
-                if (slot < k_minValidPtr)
-                    continue;
-                const auto vt = safe_read_qword(slot);
-                if (vt < k_minValidPtr)
-                    continue;
-                if (!vtbl_matches_rtti_name(vt, rttiName))
-                    continue;
-                std::uintptr_t expected = 0;
-                vtableCache.compare_exchange_strong(
-                    expected, vt,
-                    std::memory_order_acq_rel,
-                    std::memory_order_acquire);
-                return slot;
-            }
-            return 0;
-        }
-
-        // Internal CCC-specific walker. Used by the appearance-path
-        // resolver; thin wrapper over the generic finder.
-        std::uintptr_t find_ccc_in_component_table(
-            std::uintptr_t p1) noexcept
-        {
-            return find_component_impl(
-                p1, k_cccTypeDescriptorName, s_cccVtable);
-        }
-
         // Walk CCOIA +0x68 -> [CCC via RTTI] -> +0x40 -> +0x38 to
         // reach the appearance-config std::string. Resolves
         // heap-buffer vs inline layout and returns the start
@@ -574,19 +419,26 @@ namespace CDCore
         {
             if (ccoia < k_minValidPtr)
                 return 0;
-            const auto p1 =
-                safe_read_qword(ccoia + k_offAppearChain1);
+            const auto p1 = DMKMemory::seh_read<std::uintptr_t>(
+                                ccoia + k_offAppearChain1)
+                                .value_or(0);
             if (p1 < k_minValidPtr) return 0;
-            const auto ccc = find_ccc_in_component_table(p1);
+            const auto ccc = DMKRtti::find_in_pointer_table(
+                p1, k_componentTableSlots,
+                k_cccTypeDescriptorName, &s_cccVtable)
+                .value_or(0);
             if (ccc < k_minValidPtr) return 0;
-            const auto p3 =
-                safe_read_qword(ccc + k_offAppearChain3);
+            const auto p3 = DMKMemory::seh_read<std::uintptr_t>(
+                                ccc + k_offAppearChain3)
+                                .value_or(0);
             if (p3 < k_minValidPtr) return 0;
-            const auto strStruct =
-                safe_read_qword(p3 + k_offAppearChain4);
+            const auto strStruct = DMKMemory::seh_read<std::uintptr_t>(
+                                       p3 + k_offAppearChain4)
+                                       .value_or(0);
             if (strStruct < k_minValidPtr) return 0;
-            const auto bufPtr =
-                safe_read_qword(strStruct + k_offStringBufPtr);
+            const auto bufPtr = DMKMemory::seh_read<std::uintptr_t>(
+                                    strStruct + k_offStringBufPtr)
+                                    .value_or(0);
             if (bufPtr >= k_minValidPtr &&
                 bufPtr < k_canonicalUpperPtr)
                 return bufPtr;
@@ -663,8 +515,9 @@ namespace CDCore
             const auto byAppearance = classify_by_appearance(ccoia);
             if (byAppearance != 0)
                 return byAppearance;
-            const auto packed =
-                safe_read_dword(ccoia + k_offCcoiaIdentity);
+            const auto packed = DMKMemory::seh_read<std::uint32_t>(
+                                    ccoia + k_offCcoiaIdentity)
+                                    .value_or(0);
             const auto highByte =
                 static_cast<std::uint8_t>((packed >> 24) & 0xFFu);
             if (highByte == k_kliffHighByte)
@@ -775,7 +628,8 @@ namespace CDCore
         // or `cd_phm_oongka`), so the loop emits at most one
         // Damiane and one Oongka entry.
         const auto actorArray =
-            safe_read_qword(chain.mgr + k_offMgrActorArray);
+            DMKMemory::seh_read<std::uintptr_t>(chain.mgr + k_offMgrActorArray)
+                .value_or(0);
         if (actorArray < k_minValidPtr)
             return written;
 
@@ -785,8 +639,9 @@ namespace CDCore
              i < k_actorListCapacity && written < cap;
              ++i)
         {
-            const auto candidate = safe_read_qword(
-                actorArray + i * sizeof(std::uintptr_t));
+            const auto candidate = DMKMemory::seh_read<std::uintptr_t>(
+                                       actorArray + i * sizeof(std::uintptr_t))
+                                       .value_or(0);
             if (candidate < k_minValidPtr ||
                 candidate == chain.kliffCcoia)
                 continue;
@@ -849,7 +704,9 @@ namespace CDCore
                     continue;
                 std::uint32_t ident = 0;
                 if (ccoia >= k_minValidPtr)
-                    ident = safe_read_dword(ccoia + k_offCcoiaIdentity);
+                    ident = DMKMemory::seh_read<std::uint32_t>(
+                                ccoia + k_offCcoiaIdentity)
+                                .value_or(0);
                 out[n].ccoia    = ccoia;
                 out[n].flag     = flag;
                 out[n].identity = ident;
@@ -895,7 +752,9 @@ namespace CDCore
         std::string_view rttiName,
         std::atomic<std::uintptr_t> &vtableCache) noexcept
     {
-        return find_component_impl(p1, rttiName, vtableCache);
+        return DMKRtti::find_in_pointer_table(
+                   p1, k_componentTableSlots, rttiName, &vtableCache)
+            .value_or(0);
     }
 
     std::uintptr_t find_component_in_controlled_actor(
@@ -905,10 +764,14 @@ namespace CDCore
         const auto ccoia = current_controlled_ccoia();
         if (ccoia < k_minValidPtr)
             return 0;
-        const auto p1 = safe_read_qword(ccoia + k_offAppearChain1);
+        const auto p1 = DMKMemory::seh_read<std::uintptr_t>(
+                            ccoia + k_offAppearChain1)
+                            .value_or(0);
         if (p1 < k_minValidPtr)
             return 0;
-        return find_component_impl(p1, rttiName, vtableCache);
+        return DMKRtti::find_in_pointer_table(
+                   p1, k_componentTableSlots, rttiName, &vtableCache)
+            .value_or(0);
     }
 
     std::uintptr_t find_component_for_equipslot(
@@ -923,14 +786,19 @@ namespace CDCore
         // standard CCOIA + k_offAppearChain1 hop to the component
         // table.
         constexpr std::ptrdiff_t k_offEquipSlotCcoiaBackref = 0x08;
-        const auto ccoia =
-            safe_read_qword(equipSlot + k_offEquipSlotCcoiaBackref);
+        const auto ccoia = DMKMemory::seh_read<std::uintptr_t>(
+                               equipSlot + k_offEquipSlotCcoiaBackref)
+                               .value_or(0);
         if (ccoia < k_minValidPtr)
             return 0;
-        const auto p1 = safe_read_qword(ccoia + k_offAppearChain1);
+        const auto p1 = DMKMemory::seh_read<std::uintptr_t>(
+                            ccoia + k_offAppearChain1)
+                            .value_or(0);
         if (p1 < k_minValidPtr)
             return 0;
-        return find_component_impl(p1, rttiName, vtableCache);
+        return DMKRtti::find_in_pointer_table(
+                   p1, k_componentTableSlots, rttiName, &vtableCache)
+            .value_or(0);
     }
 
 } // namespace CDCore

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,4 +1,5 @@
-## [Title for next release]
+## Maintenance and reliability
 
-- Upgraded DetourModKit dependency from v3.2.3 to v3.2.4.
+- Upgraded DetourModKit dependency from v3.2.3 to v3.3.0.
+- More resilient internal checks against the game's loaded modules.
 - Demoted some verbose logs.

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Title for next release]
+## Maintenance and reliability
 
-- New feature
-- Bug fix
-- Improvement
+- Upgraded DetourModKit dependency to v3.3.0.
+- More resilient internal checks against the game's loaded modules.
+- Reduced duplicated crash-protection code across modules.

--- a/CrimsonDesertLiveTransmog/src/color_override/color_token_discovery.cpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/color_token_discovery.cpp
@@ -6,7 +6,6 @@
 #include <DetourModKit/scanner.hpp>
 
 #include <Windows.h>
-#include <Psapi.h>
 
 #include <array>
 #include <atomic>
@@ -162,27 +161,20 @@ namespace Transmog::ColorOverride::TokenSlotDiscovery
             using clock = std::chrono::steady_clock;
             const auto t0 = clock::now();
 
-            // Get module base + image size.
-            const auto hmod = GetModuleHandleW(nullptr);
-            if (hmod == nullptr)
+            // Get module base + image size from DMK's cached
+            // host-module range (single atomic load on the warm path).
+            const auto range = DMKMemory::host_module_range();
+            if (!range.valid())
             {
                 DMK::Logger::get_instance().warning(
-                    "[token-discovery] GetModuleHandle failed");
-                g_complete.store(true, std::memory_order_release);
-                return;
-            }
-            MODULEINFO mi{};
-            if (!GetModuleInformation(GetCurrentProcess(), hmod,
-                                      &mi, sizeof(mi)))
-            {
-                DMK::Logger::get_instance().warning(
-                    "[token-discovery] GetModuleInformation failed");
+                    "[token-discovery] host_module_range unavailable");
                 g_complete.store(true, std::memory_order_release);
                 return;
             }
             const auto *base =
-                reinterpret_cast<const std::byte *>(mi.lpBaseOfDll);
-            const auto size = mi.SizeOfImage;
+                reinterpret_cast<const std::byte *>(range.base);
+            const auto size =
+                static_cast<std::size_t>(range.end - range.base);
 
             // Walk every property-registration call site emitted by
             // the two TLS-guarded registrars (sub_14274A3C0 and

--- a/CrimsonDesertLiveTransmog/src/color_override/color_token_interner_hook.cpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/color_token_interner_hook.cpp
@@ -5,7 +5,6 @@
 #include <DetourModKit.hpp>
 
 #include <Windows.h>
-#include <Psapi.h>
 
 #include <array>
 #include <atomic>
@@ -62,29 +61,6 @@ namespace Transmog::ColorOverride::InternerHook
         std::atomic<std::uintptr_t> g_lastEntriesBase{0};
         std::atomic<std::size_t>    g_lastEntriesIdx{0};
 
-        // SEH-guarded reads.
-        std::uint64_t safe_read_qword(std::uintptr_t addr) noexcept
-        {
-            __try
-            {
-                return *reinterpret_cast<const std::uint64_t *>(addr);
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
-        }
-        std::uint32_t safe_read_dword(std::uintptr_t addr) noexcept
-        {
-            __try
-            {
-                return *reinterpret_cast<const std::uint32_t *>(addr);
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
-        }
         bool safe_is_property_name(const char *p) noexcept
         {
             if (p == nullptr) return false;
@@ -196,10 +172,12 @@ namespace Transmog::ColorOverride::InternerHook
             {
                 const auto entryAddr =
                     entriesBase + i * k_entryStride;
-                const auto namePtr = safe_read_qword(
-                    entryAddr + k_offName);
-                const auto token = safe_read_dword(
-                    entryAddr + k_offToken);
+                const auto namePtr = DMKMemory::seh_read<std::uint64_t>(
+                                         entryAddr + k_offName)
+                                         .value_or(0);
+                const auto token = DMKMemory::seh_read<std::uint32_t>(
+                                       entryAddr + k_offToken)
+                                       .value_or(0);
                 // Bail when we walk off the end -- consecutive
                 // entries with null/garbage indicate we've left the
                 // allocated array.
@@ -240,15 +218,11 @@ namespace Transmog::ColorOverride::InternerHook
         void do_init() noexcept
         {
             auto &logger = DMK::Logger::get_instance();
-            const auto hmod = GetModuleHandleW(nullptr);
-            if (hmod == nullptr) return;
-            MODULEINFO mi{};
-            if (!GetModuleInformation(GetCurrentProcess(), hmod,
-                                      &mi, sizeof(mi)))
-                return;
-            const auto modBase =
-                reinterpret_cast<std::uintptr_t>(mi.lpBaseOfDll);
-            const auto modSize = mi.SizeOfImage;
+            const auto range = DMKMemory::host_module_range();
+            if (!range.valid()) return;
+            const auto modBase = range.base;
+            const auto modSize =
+                static_cast<std::size_t>(range.end - range.base);
 
             const auto funcAddr = Transmog::resolve_address(
                 Transmog::k_colorTokenInternerCandidates,
@@ -269,7 +243,7 @@ namespace Transmog::ColorOverride::InternerHook
                     funcAddr);
                 return;
             }
-            const auto stateAddr = safe_read_qword(stateSlot);
+            const auto stateAddr = DMKMemory::seh_read<std::uint64_t>(stateSlot).value_or(0);
             if (stateAddr < 0x10000ULL)
             {
                 logger.warning(
@@ -295,8 +269,8 @@ namespace Transmog::ColorOverride::InternerHook
                 for (std::size_t i = 0; i < 256; ++i)
                 {
                     const auto e = base + i * 32;
-                    const auto np = safe_read_qword(e + 0x08);
-                    const auto tk = safe_read_dword(e + 0x18);
+                    const auto np = DMKMemory::seh_read<std::uint64_t>(e + 0x08).value_or(0);
+                    const auto tk = DMKMemory::seh_read<std::uint32_t>(e + 0x18).value_or(0);
                     if (np < 0x10000ULL || np > 0x7FFFFFFFFFFFULL)
                         continue;
                     if (tk == 0 || tk > 0x100000u) continue;
@@ -306,8 +280,8 @@ namespace Transmog::ColorOverride::InternerHook
                 }
                 return valid;
             };
-            const auto base40 = safe_read_qword(stateAddr + 0x40);
-            const auto base48 = safe_read_qword(stateAddr + 0x48);
+            const auto base40 = DMKMemory::seh_read<std::uint64_t>(stateAddr + 0x40).value_or(0);
+            const auto base48 = DMKMemory::seh_read<std::uint64_t>(stateAddr + 0x48).value_or(0);
             const auto v40 = probe(base40);
             const auto v48 = probe(base48);
             logger.info(
@@ -380,14 +354,15 @@ namespace Transmog::ColorOverride::InternerHook
                 expected, true, std::memory_order_acq_rel))
             return 0;
         s_lastMs.store(nowMs, std::memory_order_release);
-        const auto stateAddr = safe_read_qword(slot);
+        const auto stateAddr = DMKMemory::seh_read<std::uint64_t>(slot).value_or(0);
         std::size_t added = 0;
         if (stateAddr >= 0x10000ULL)
         {
             const auto entriesOff = g_offEntriesArray.load(
                 std::memory_order_acquire);
-            const auto entriesBase = safe_read_qword(
-                stateAddr + entriesOff);
+            const auto entriesBase = DMKMemory::seh_read<std::uint64_t>(
+                                         stateAddr + entriesOff)
+                                         .value_or(0);
             if (entriesBase >= 0x10000ULL)
             {
                 // Resume the walk where the previous one stopped if

--- a/CrimsonDesertLiveTransmog/src/color_override/host_scope.cpp
+++ b/CrimsonDesertLiveTransmog/src/color_override/host_scope.cpp
@@ -57,24 +57,14 @@ namespace Transmog::ColorOverride::HostScope
 
         std::atomic<bool> g_initDone{false};
 
-        // CrimsonDesert.exe is < 0x20000000 in size.
+        // Tests whether @p p lies inside the host EXE's mapped range.
+        // `host_module_range()` is magic-static cached, so the warm
+        // path is a single atomic load plus the constexpr point-in-
+        // range comparison performed by `contains`.
         bool ptr_in_text_or_rdata(std::uintptr_t p) noexcept
         {
-            const auto base = reinterpret_cast<std::uintptr_t>(
-                GetModuleHandleW(nullptr));
-            return p >= base && p < (base + 0x20000000ull);
-        }
-
-        std::uintptr_t safe_read_qword(std::uintptr_t addr) noexcept
-        {
-            __try
-            {
-                return *reinterpret_cast<const std::uintptr_t *>(addr);
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
+            return DMKMemory::contains(
+                DMKMemory::host_module_range(), p);
         }
 
         bool looks_like_live_host(std::uintptr_t parent) noexcept
@@ -86,7 +76,8 @@ namespace Transmog::ColorOverride::HostScope
             // either a small int or stack/junk -- reject.
             if (parent < 0x100000000ull)
                 return false;
-            const auto vtbl = safe_read_qword(parent);
+            const auto vtbl =
+                DMKMemory::seh_read<std::uintptr_t>(parent).value_or(0);
             return vtbl != 0 && ptr_in_text_or_rdata(vtbl);
         }
 

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -70,82 +70,48 @@ namespace Transmog
     // one) until the next build() populates it.
     static std::atomic<uintptr_t> s_variantMetaSentinel{0};
 
-    // --- Safe memory helpers (SEH-wrapped) ---
+    // --- Safe memory helpers ---
+    //
+    // The `(value, bool& ok)` shape distinguishes a faulted read from a
+    // legitimate zero result, which matters at call sites where 0 is a
+    // valid value (e.g. slot index 0 versus unread slot field).
+    // `DMKMemory::seh_read<T>` is the underlying SEH-protected primitive;
+    // these adapters fold its `std::optional<T>` return into the local
+    // shape used by the rest of this translation unit.
 
     static uint8_t read_u8_safe(uintptr_t addr, bool &ok) noexcept
     {
-        __try
-        {
-            uint8_t v = *reinterpret_cast<const uint8_t *>(addr);
-            ok = true;
-            return v;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            ok = false;
-            return 0;
-        }
+        const auto v = DMKMemory::seh_read<uint8_t>(addr);
+        ok = v.has_value();
+        return v.value_or(0);
     }
 
     static int32_t read_i32_safe(uintptr_t addr, bool &ok) noexcept
     {
-        __try
-        {
-            int32_t v = 0;
-            std::memcpy(&v, reinterpret_cast<const void *>(addr), sizeof(v));
-            ok = true;
-            return v;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            ok = false;
-            return 0;
-        }
+        const auto v = DMKMemory::seh_read<int32_t>(addr);
+        ok = v.has_value();
+        return v.value_or(0);
     }
 
     static uintptr_t read_qword_safe(uintptr_t addr, bool &ok) noexcept
     {
-        __try
-        {
-            uintptr_t v = *reinterpret_cast<const uintptr_t *>(addr);
-            ok = true;
-            return v;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            ok = false;
-            return 0;
-        }
+        const auto v = DMKMemory::seh_read<uintptr_t>(addr);
+        ok = v.has_value();
+        return v.value_or(0);
     }
 
     static uint32_t read_u32_safe(uintptr_t addr, bool &ok) noexcept
     {
-        __try
-        {
-            uint32_t v = *reinterpret_cast<const uint32_t *>(addr);
-            ok = true;
-            return v;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            ok = false;
-            return 0;
-        }
+        const auto v = DMKMemory::seh_read<uint32_t>(addr);
+        ok = v.has_value();
+        return v.value_or(0);
     }
 
     static uint16_t read_u16_safe(uintptr_t addr, bool &ok) noexcept
     {
-        __try
-        {
-            uint16_t v = *reinterpret_cast<const uint16_t *>(addr);
-            ok = true;
-            return v;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            ok = false;
-            return 0;
-        }
+        const auto v = DMKMemory::seh_read<uint16_t>(addr);
+        ok = v.has_value();
+        return v.value_or(0);
     }
 
     // --- Player-compatibility detection via rule-classifier tokens ---

--- a/CrimsonDesertLiveTransmog/src/itemmesh_dumper.cpp
+++ b/CrimsonDesertLiveTransmog/src/itemmesh_dumper.cpp
@@ -42,51 +42,34 @@ namespace Transmog
         constexpr ptrdiff_t kOffWrapLen = 0x28;
         constexpr uint32_t kSsoCap = 0x1F;
 
-        // ----- safe reads (SEH-wrapped) -----
+        // ----- safe reads -----
+        //
+        // The `(value, bool& ok)` shape distinguishes a faulted read from
+        // a legitimate zero result, which matters at call sites where 0
+        // is a valid value (e.g. a slot index of 0). `DMKMemory::seh_read`
+        // is the underlying SEH-protected primitive; these adapters fold
+        // its `std::optional<T>` return into the local shape used by the
+        // dumper's bounded walks.
 
         uintptr_t read_qword_safe(uintptr_t addr, bool &ok) noexcept
         {
-            ok = false;
-            __try
-            {
-                uintptr_t v = *reinterpret_cast<const uintptr_t *>(addr);
-                ok = true;
-                return v;
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
+            const auto v = DMKMemory::seh_read<uintptr_t>(addr);
+            ok = v.has_value();
+            return v.value_or(0);
         }
 
         uint32_t read_u32_safe(uintptr_t addr, bool &ok) noexcept
         {
-            ok = false;
-            __try
-            {
-                uint32_t v = *reinterpret_cast<const uint32_t *>(addr);
-                ok = true;
-                return v;
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
+            const auto v = DMKMemory::seh_read<uint32_t>(addr);
+            ok = v.has_value();
+            return v.value_or(0);
         }
 
         uint16_t read_u16_safe(uintptr_t addr, bool &ok) noexcept
         {
-            ok = false;
-            __try
-            {
-                uint16_t v = *reinterpret_cast<const uint16_t *>(addr);
-                ok = true;
-                return v;
-            }
-            __except (EXCEPTION_EXECUTE_HANDLER)
-            {
-                return 0;
-            }
+            const auto v = DMKMemory::seh_read<uint16_t>(addr);
+            ok = v.has_value();
+            return v.value_or(0);
         }
 
         size_t read_printable_into(const char *src, char *dst, size_t maxLen) noexcept

--- a/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
+++ b/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
@@ -252,25 +252,9 @@ namespace Transmog::PrefabWrapperSwap
 
     // --- SEH-isolated read/write helpers ---
 
-    static std::uint64_t read_qword_seh(const void *p) noexcept
-    {
-        std::uint64_t out = 0;
-        [&]() __declspec(noinline) {
-            __try { out = *static_cast<const volatile std::uint64_t *>(p); }
-            __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; }
-        }();
-        return out;
-    }
+    
 
-    static std::uint32_t read_dword_seh(const void *p) noexcept
-    {
-        std::uint32_t out = 0;
-        [&]() __declspec(noinline) {
-            __try { out = *static_cast<const volatile std::uint32_t *>(p); }
-            __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; }
-        }();
-        return out;
-    }
+    
 
     static bool write_qword_seh(void *p, std::uint64_t value) noexcept
     {
@@ -302,18 +286,7 @@ namespace Transmog::PrefabWrapperSwap
         return len;
     }
 
-    // Bulk SEH-wrapped memcpy. One exception frame for the whole copy
-    // instead of one per field -- collapses ~5 SEH-guarded per-entry reads
-    // into a single 128B local copy during the StringInfo walk.
-    static bool bulk_copy_seh(const void *src, void *dst, std::size_t size) noexcept
-    {
-        bool ok = false;
-        [&]() __declspec(noinline) {
-            __try { std::memcpy(dst, src, size); ok = true; }
-            __except (EXCEPTION_EXECUTE_HANDLER) { ok = false; }
-        }();
-        return ok;
-    }
+    
 
     // Bumps a wrapper's refcount via Interlocked, gated on the same
     // condition sub_14079DA20 uses (refcount field >= 0). No-op if
@@ -465,25 +438,20 @@ namespace Transmog::PrefabWrapperSwap
             s_loaderRegistrySingleton.load(std::memory_order_acquire);
         if (singletonAbs < 0x10000ULL)
             return;
-        const auto singletonPtr = read_qword_seh(
-            reinterpret_cast<const void *>(singletonAbs));
+        const auto singletonPtr = DMKMemory::seh_read<std::uint64_t>(singletonAbs).value_or(0);
         if (singletonPtr < 0x10000ULL)
             return;
         // singleton + 0x50 = table struct (matches internal
         // k_loaderRegistryTableOff defined later in this TU).
         const std::uintptr_t tableStruct = singletonPtr + 0x50;
-        const auto count = read_dword_seh(
-            reinterpret_cast<const void *>(tableStruct + 0x04));
-        const auto dataArrayPtr = read_qword_seh(
-            reinterpret_cast<const void *>(tableStruct + 0x18));
+        const auto count = DMKMemory::seh_read<std::uint32_t>(tableStruct + 0x04).value_or(0);
+        const auto dataArrayPtr = DMKMemory::seh_read<std::uint64_t>(tableStruct + 0x18).value_or(0);
         if (count == 0 || count > 100000 || dataArrayPtr < 0x10000ULL)
             return;
 
         std::vector<std::uintptr_t> entryPtrs;
         entryPtrs.resize(count);
-        const bool bulkOk = bulk_copy_seh(
-            reinterpret_cast<const void *>(dataArrayPtr),
-            entryPtrs.data(), count * sizeof(std::uintptr_t));
+        const bool bulkOk = DMKMemory::seh_read_bytes(dataArrayPtr, entryPtrs.data(), count * sizeof(std::uintptr_t));
 
         const auto vtableSentinel =
             s_stringInfoVtable.load(std::memory_order_acquire);
@@ -491,11 +459,9 @@ namespace Transmog::PrefabWrapperSwap
         for (std::uint32_t i = 0; i < count; ++i) {
             const std::uintptr_t entry = bulkOk
                 ? entryPtrs[i]
-                : read_qword_seh(reinterpret_cast<const void *>(
-                      dataArrayPtr + 8ULL * i));
+                : DMKMemory::seh_read<std::uint64_t>(dataArrayPtr + 8ULL * i).value_or(0);
             if (entry < 0x10000ULL) continue;
-            const auto wrapper = read_qword_seh(
-                reinterpret_cast<const void *>(entry + 0x08));
+            const auto wrapper = DMKMemory::seh_read<std::uint64_t>(entry + 0x08).value_or(0);
             if (wrapper < 0x10000ULL) continue;
             if (wrapper == vtableSentinel) continue;
             constexpr std::size_t k_loaderNameCap = 96;
@@ -632,12 +598,10 @@ namespace Transmog::PrefabWrapperSwap
             return 0;
         }
         const auto regAddr = reinterpret_cast<const void *>(regAbs);
-        const auto registryPtr = read_qword_seh(regAddr);
+        const auto registryPtr = DMKMemory::seh_read<std::uint64_t>(reinterpret_cast<std::uintptr_t>(regAddr)).value_or(0);
         if (registryPtr < 0x10000ULL) return 0;
-        const auto count = read_dword_seh(
-            reinterpret_cast<const void *>(registryPtr + 8));
-        const auto arrayPtr = read_qword_seh(
-            reinterpret_cast<const void *>(registryPtr + 80));
+        const auto count = DMKMemory::seh_read<std::uint32_t>(registryPtr + 8).value_or(0);
+        const auto arrayPtr = DMKMemory::seh_read<std::uint64_t>(registryPtr + 80).value_or(0);
         if (count < k_minPlausibleCount || count > k_maxPlausibleCount ||
             arrayPtr < 0x10000ULL)
             return 0;
@@ -651,9 +615,7 @@ namespace Transmog::PrefabWrapperSwap
         bool bulkOk = false;
         if (arrayBytes > 0) {
             entryPtrs.resize(count);
-            bulkOk = bulk_copy_seh(
-                reinterpret_cast<const void *>(arrayPtr),
-                entryPtrs.data(), arrayBytes);
+            bulkOk = DMKMemory::seh_read_bytes(arrayPtr, entryPtrs.data(), arrayBytes);
         }
 
         const auto walkStart = std::chrono::steady_clock::now();
@@ -671,11 +633,9 @@ namespace Transmog::PrefabWrapperSwap
         auto decode_long_name =
             [](std::uintptr_t entry, char *buf, std::size_t cap) -> bool
         {
-            const auto wrapperPtr = read_qword_seh(
-                reinterpret_cast<const void *>(entry + k_wrapperPtrOff));
+            const auto wrapperPtr = DMKMemory::seh_read<std::uint64_t>(entry + k_wrapperPtrOff).value_or(0);
             if (wrapperPtr < 0x10000ULL) return false;
-            const auto strPtr = read_qword_seh(
-                reinterpret_cast<const void *>(wrapperPtr));
+            const auto strPtr = DMKMemory::seh_read<std::uint64_t>(wrapperPtr).value_or(0);
             if (strPtr < 0x10000ULL) return false;
             const auto extLen = read_cstr_seh(
                 reinterpret_cast<const void *>(strPtr), buf, cap);
@@ -697,13 +657,11 @@ namespace Transmog::PrefabWrapperSwap
         for (std::uint32_t i = 0; i < count; ++i) {
             const std::uintptr_t entryPtr = bulkOk
                 ? entryPtrs[i]
-                : read_qword_seh(reinterpret_cast<const void *>(
-                      arrayPtr + 8ULL * i));
+                : DMKMemory::seh_read<std::uint64_t>(arrayPtr + 8ULL * i).value_or(0);
             if (entryPtr < 0x10000ULL) continue;
             ++scanned;
 
-            if (!bulk_copy_seh(reinterpret_cast<const void *>(entryPtr),
-                               header, k_headerBytes))
+            if (!DMKMemory::seh_read_bytes(entryPtr, header, k_headerBytes))
                 continue;
 
             const std::uintptr_t vtable =
@@ -828,11 +786,9 @@ namespace Transmog::PrefabWrapperSwap
             {
                 const auto end = regionBase + regionSize - 0x40;
                 for (std::uintptr_t p = regionBase; p < end; p += 8) {
-                    const auto v = read_qword_seh(
-                        reinterpret_cast<const void *>(p));
+                    const auto v = DMKMemory::seh_read<std::uint64_t>(p).value_or(0);
                     if (v != p + 0x18) continue;
-                    const auto len = read_dword_seh(
-                        reinterpret_cast<const void *>(p + 8));
+                    const auto len = DMKMemory::seh_read<std::uint32_t>(p + 8).value_or(0);
                     if (len == 0 || len >= k_extNameMax) continue;
                     char nameBuf[k_extNameMax + 1] = {0};
                     const auto rlen = read_cstr_seh(
@@ -1118,8 +1074,7 @@ namespace Transmog::PrefabWrapperSwap
                 "resolved -- skip enumeration");
             return 0;
         }
-        const auto singletonPtr = read_qword_seh(
-            reinterpret_cast<const void *>(singletonAbs));
+        const auto singletonPtr = DMKMemory::seh_read<std::uint64_t>(singletonAbs).value_or(0);
         if (singletonPtr < 0x10000ULL) {
             logger.warning(
                 "[prefab-swap] Loader registry singleton "
@@ -1131,10 +1086,8 @@ namespace Transmog::PrefabWrapperSwap
             singletonPtr + k_loaderRegistryTableOff;
 
         // Step 2: read count + data_array_ptr, sanity-check.
-        const auto count = read_dword_seh(
-            reinterpret_cast<const void *>(tableStruct + 0x04));
-        const auto dataArrayPtr = read_qword_seh(
-            reinterpret_cast<const void *>(tableStruct + 0x18));
+        const auto count = DMKMemory::seh_read<std::uint32_t>(tableStruct + 0x04).value_or(0);
+        const auto dataArrayPtr = DMKMemory::seh_read<std::uint64_t>(tableStruct + 0x18).value_or(0);
         if (count == 0 || count > 100000 || dataArrayPtr < 0x10000ULL) {
             logger.warning(
                 "[prefab-swap] Loader registry sanity failed: "
@@ -1153,9 +1106,7 @@ namespace Transmog::PrefabWrapperSwap
         bool bulkOk = false;
         if (arrayBytes > 0) {
             entryPtrs.resize(count);
-            bulkOk = bulk_copy_seh(
-                reinterpret_cast<const void *>(dataArrayPtr),
-                entryPtrs.data(), arrayBytes);
+            bulkOk = DMKMemory::seh_read_bytes(dataArrayPtr, entryPtrs.data(), arrayBytes);
         }
 
         // Step 4: walk entries, classify by slot tag, collect (name,
@@ -1176,8 +1127,7 @@ namespace Transmog::PrefabWrapperSwap
         for (std::uint32_t i = 0; i < count; ++i) {
             const std::uintptr_t entry = bulkOk
                 ? entryPtrs[i]
-                : read_qword_seh(reinterpret_cast<const void *>(
-                      dataArrayPtr + 8ULL * i));
+                : DMKMemory::seh_read<std::uint64_t>(dataArrayPtr + 8ULL * i).value_or(0);
             if (entry < 0x10000ULL) continue;
             ++scanned;
 
@@ -1188,8 +1138,7 @@ namespace Transmog::PrefabWrapperSwap
             // VALUE wrapper is a metadata struct (counts/IDs), not a
             // name-bearing wrapper, so reading +0x18 there gives junk
             // and the prefix gate filters everything out.
-            const auto wrapper = read_qword_seh(
-                reinterpret_cast<const void *>(entry + 0x08));
+            const auto wrapper = DMKMemory::seh_read<std::uint64_t>(entry + 0x08).value_or(0);
             if (wrapper < 0x10000ULL) continue;
             // Skip the StringInfo vtable sentinel (registry can hold
             // metadata-only entries that aren't partprefab wrappers).
@@ -1974,8 +1923,7 @@ namespace Transmog::PrefabWrapperSwap
 
         s_callCount.fetch_add(1, std::memory_order_relaxed);
 
-        const auto srcWrapper = read_qword_seh(
-            reinterpret_cast<const void *>(a2));
+        const auto srcWrapper = DMKMemory::seh_read<std::uint64_t>(a2).value_or(0);
         // Filter the StringInfo vtable sentinel: a2 sometimes points
         // at the entry's +0x08 vtable slot rather than its wrapper-ptr
         // slot, in which case srcWrapper would equal the sentinel
@@ -2086,10 +2034,9 @@ namespace Transmog::PrefabWrapperSwap
         std::uint64_t *listData = nullptr;
         std::uint32_t  listCount = 0;
         if (a2) {
-            const auto raw = read_qword_seh(a2);
+            const auto raw = DMKMemory::seh_read<std::uint64_t>(reinterpret_cast<std::uintptr_t>(a2)).value_or(0);
             listData = reinterpret_cast<std::uint64_t *>(raw);
-            listCount = read_dword_seh(
-                reinterpret_cast<const char *>(a2) + 8);
+            listCount = DMKMemory::seh_read<std::uint32_t>(reinterpret_cast<std::uintptr_t>(reinterpret_cast<const char *>(a2) + 8)).value_or(0);
         }
 
         s_natpipeListEntries.fetch_add(
@@ -2128,7 +2075,7 @@ namespace Transmog::PrefabWrapperSwap
         // unrelated wrappers and the noise drowns out the rare SUBST
         // events that matter for the body-mesh cleanup path.
         for (std::uint32_t i = 0; i < cnt; ++i) {
-            const auto orig = read_qword_seh(&listData[i * 2]);
+            const auto orig = DMKMemory::seh_read<std::uint64_t>(reinterpret_cast<std::uintptr_t>(&listData[i * 2])).value_or(0);
             saved[i] = orig;
             if (orig < 0x10000ULL)
                 continue;
@@ -2181,7 +2128,7 @@ namespace Transmog::PrefabWrapperSwap
         std::uint32_t restored = 0;
         for (std::uint32_t i = 0; i < cnt; ++i) {
             if (saved[i] == 0) continue;
-            const auto cur = read_qword_seh(&listData[i * 2]);
+            const auto cur = DMKMemory::seh_read<std::uint64_t>(reinterpret_cast<std::uintptr_t>(&listData[i * 2])).value_or(0);
             if (cur == saved[i]) continue; // not substituted
             if (write_qword_seh(&listData[i * 2], saved[i]))
                 ++restored;

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -367,32 +367,6 @@ namespace Transmog
         return needs_carrier(itemId, std::string("Kliff"));
     }
 
-    // SEH-safe memory helpers (MSVC: __try cannot coexist with C++
-    // object unwinding in the same function).
-    static uintptr_t read_qword_seh(uintptr_t addr) noexcept
-    {
-        __try
-        {
-            return *reinterpret_cast<volatile uintptr_t *>(addr);
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            return 0;
-        }
-    }
-    static bool memcpy_seh(void *dst, const void *src, size_t n) noexcept
-    {
-        __try
-        {
-            std::memcpy(dst, src, n);
-            return true;
-        }
-        __except (EXCEPTION_EXECUTE_HANDLER)
-        {
-            return false;
-        }
-    }
-
     // Descriptor size. Stride between consecutive descriptors observed
     // in CE on the live build:
     //
@@ -510,9 +484,11 @@ namespace Transmog
 
         const auto carrierSlotAddr =
             ci.ptrArray + static_cast<uint64_t>(carrierId) * 8;
-        const uintptr_t targetDesc = read_qword_seh(
-            ci.ptrArray + static_cast<uint64_t>(targetId) * 8);
-        const uintptr_t carrierDesc = read_qword_seh(carrierSlotAddr);
+        const uintptr_t targetDesc = DMKMemory::seh_read<uintptr_t>(
+                                         ci.ptrArray + static_cast<uint64_t>(targetId) * 8)
+                                         .value_or(0);
+        const uintptr_t carrierDesc =
+            DMKMemory::seh_read<uintptr_t>(carrierSlotAddr).value_or(0);
 
         if (targetDesc < 0x10000 || carrierDesc < 0x10000)
         {
@@ -537,8 +513,7 @@ namespace Transmog
             return;
         }
 
-        if (!memcpy_seh(hybrid, reinterpret_cast<const void *>(targetDesc),
-                        k_descBufSize))
+        if (!DMKMemory::seh_read_bytes(targetDesc, hybrid, k_descBufSize))
         {
             logger.warning("[carrier] fault copying target descriptor");
             VirtualFree(hybrid, 0, MEM_RELEASE);
@@ -552,9 +527,8 @@ namespace Transmog
         {
             if (p.off + p.len > k_descBufSize)
                 continue;
-            if (!memcpy_seh(hybrid + p.off,
-                            reinterpret_cast<const void *>(carrierDesc + p.off),
-                            p.len))
+            if (!DMKMemory::seh_read_bytes(carrierDesc + p.off,
+                                           hybrid + p.off, p.len))
             {
                 logger.warning("[carrier] fault patching carrier field "
                                "at +{:#x} len={}",


### PR DESCRIPTION
## Summary

- Bump `DetourModKit` submodule from v3.2.4 to v3.3.0 (purely additive: adds `Rtti::` walker + `Memory::ModuleRange` / `seh_read<T>`).
- Replace hand-rolled MSVC RTTI walk in `controlled_char.cpp` with `DMKRtti::find_in_pointer_table`; drop the vestigial `find_component_impl` / `find_ccc_in_component_table` forwarders.
- Replace `GetModuleHandle` + `GetModuleInformation` patterns in `host_scope.cpp`, `color_token_discovery.cpp`, `color_token_interner_hook.cpp` with `DMKMemory::host_module_range()`. Drops the `+0x20000000` sentinel that assumed the EXE never exceeds 512 MiB.
- Inline `DMKMemory::seh_read<T>(addr).value_or(0)` at call sites for the trivial single-deref SEH wrappers in `controlled_char.cpp`, `color_token_interner_hook.cpp`, `host_scope.cpp`, `prefab_wrapper_swap.cpp` (27 sites) and `transmog_apply.cpp`. Use `DMKMemory::seh_read_bytes` for the SEH-protected memcpy paths.
- Keep the `(T, bool& ok)` adapters in `item_name_table.cpp` and `itemmesh_dumper.cpp`: at those call sites 0 is a legitimate read result and the `bool` is the only fault signal.
