### PR TITLE
fix(live-transmog): gate apply_all_transmog on actor readiness

### DIFF
--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -3,3 +3,4 @@
 - Upgraded DetourModKit dependency to v3.3.0.
 - More resilient internal checks against the game's loaded modules.
 - Reduced duplicated crash-protection code across modules.
+- Fixed first-apply errors after a cold load by waiting until the character is fully ready.

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -958,6 +958,30 @@ namespace Transmog
             return;
         }
 
+        // Engine-readiness gate. is_world_ready() observes the world
+        // singleton, which becomes non-null well before the per-actor
+        // sub-handler at CCC+0x130 is wired. When the dispatcher runs
+        // against an actor whose sub-handler is still null, the engine
+        // path under tear_down / tear_down_fake dereferences it as
+        // `v15 = *(v7 + 304); *v15;`, the per-slot SEH wrappers burst-
+        // catch the resulting faults, every slot exits early, and the
+        // carrier apply continues against a half-wired actor before
+        // raising out of the outer __try. Gating at this entry point
+        // covers every caller (manual_apply, the multi-protagonist
+        // worker path, any future trigger) without coupling them to
+        // LT-specific readiness semantics.
+        constexpr std::uint64_t k_applyReadyRetryMs = 1000;
+        if (!RealPartTearDown::is_actor_apply_ready(
+                reinterpret_cast<void *>(a1)))
+        {
+            logger.debug(
+                "apply_all_transmog: actor not ready (a1={:#018x}), "
+                "re-arming in {} ms",
+                static_cast<uint64_t>(a1), k_applyReadyRetryMs);
+            schedule_transmog_ms(k_applyReadyRetryMs);
+            return;
+        }
+
         // Suppress VEC hook for the entire operation.
         suppress_vec().store(true, std::memory_order_release);
 


### PR DESCRIPTION
## Summary

PR #84 added `RealPartTearDown::is_actor_apply_ready` and wired it into the multi-protagonist auto-apply path, but the boot-scan `manual_apply` route into `apply_all_transmog` was still ungated. On cold-load, `is_world_ready()` returns true before the per-actor sub-handler at `CCC+0x130` is wired, so the dispatcher's `tear_down` / `tear_down_fake` SEH wrappers burst-catch faults, every slot exits early, and the carrier apply continues against a half-wired actor before raising out of the outer `__try` ("Transmog apply exception (debounced)").

This moves the readiness gate to the top of `apply_all_transmog`, covering every caller (manual, worker, future) without coupling them to LT-specific readiness semantics. On a not-ready actor the dispatcher re-arms after 1000 ms and returns before engaging `suppress_vec`.

## Changes

- `transmog_apply.cpp`: probe `is_actor_apply_ready(a1)` immediately after the existing `a1+8` sanity check; re-arm via `schedule_transmog_ms(k_applyReadyRetryMs)` and bail if the sub-handler is still null.
