### PR TITLE
feat(live-transmog): add helm voice unmuffle filter

### DIFF
--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -145,6 +145,31 @@ namespace CDCore
         std::uintptr_t ccoia) noexcept;
 
     /**
+     * @brief Classify an appearance-config asset path into a
+     *        protagonist index using the codename set shared with the
+     *        CCOIA classifier.
+     * @details Locates the `/cd_` anchor in @p path and substring-
+     *          matches the suffix against the three configured
+     *          protagonist codenames (settable via
+     *          @ref set_protagonist_codenames). Returns the same
+     *          1-based indices @ref current_controlled_character_idx
+     *          uses: 1 for Kliff, 2 for Damiane, 3 for Oongka. Returns
+     *          0 for paths that don't contain a known codename (NPCs,
+     *          monsters, empty paths).
+     *
+     *          Exposed so callers that already hold an actor's
+     *          appearance / asset string (read from any source, not
+     *          necessarily the CCOIA chain) can classify it without
+     *          having to re-derive the chain walk used by
+     *          @ref current_controlled_character_idx.
+     *
+     * @param path ASCII appearance path or asset string.
+     * @return 1, 2, or 3 on a protagonist match; 0 otherwise.
+     */
+    [[nodiscard]] std::uint32_t classify_appearance_by_path(
+        std::string_view path) noexcept;
+
+    /**
      * @brief One entry in a live player-CCOIA snapshot.
      * @details charIdx uses the same 1-based encoding as
      *          current_controlled_character_idx(): 1 for Kliff, 2 for

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -471,33 +471,8 @@ namespace CDCore
             std::size_t len = 0;
             if (!safe_read_ascii(strStart, buf, sizeof(buf), len))
                 return 0;
-            const std::string_view path{buf, len};
-            const auto anchor = path.find(k_appearAnchor);
-            if (anchor == std::string_view::npos)
-                return 0;
-            const auto suffix = path.substr(anchor);
-
-            // Snapshot codenames under one lock, then release before
-            // doing the substring search. Empty codenames are treated
-            // as "skip this protagonist" rather than "match everything"
-            // (find("") returns 0 = always-hit).
-            std::string kliff, damiane, oongka;
-            {
-                std::lock_guard<std::mutex> lock(s_codenameMutex);
-                kliff   = s_codenameKliff;
-                damiane = s_codenameDamiane;
-                oongka  = s_codenameOongka;
-            }
-            if (!kliff.empty() &&
-                suffix.find(kliff) != std::string_view::npos)
-                return 1;
-            if (!damiane.empty() &&
-                suffix.find(damiane) != std::string_view::npos)
-                return 2;
-            if (!oongka.empty() &&
-                suffix.find(oongka) != std::string_view::npos)
-                return 3;
-            return 0;
+            return classify_appearance_by_path(
+                std::string_view{buf, len});
         }
 
         // Primary CCOIA classifier. Tries the appearance-config path
@@ -602,6 +577,39 @@ namespace CDCore
         {
             return 0;
         }
+    }
+
+    std::uint32_t classify_appearance_by_path(
+        std::string_view path) noexcept
+    {
+        if (path.empty())
+            return 0;
+        const auto anchor = path.find(k_appearAnchor);
+        if (anchor == std::string_view::npos)
+            return 0;
+        const auto suffix = path.substr(anchor);
+
+        // Snapshot codenames under one lock, then release before
+        // doing the substring search. Empty codenames are treated
+        // as "skip this protagonist" rather than "match everything"
+        // (find("") returns 0 = always-hit).
+        std::string kliff, damiane, oongka;
+        {
+            std::lock_guard<std::mutex> lock(s_codenameMutex);
+            kliff   = s_codenameKliff;
+            damiane = s_codenameDamiane;
+            oongka  = s_codenameOongka;
+        }
+        if (!kliff.empty() &&
+            suffix.find(kliff) != std::string_view::npos)
+            return 1;
+        if (!damiane.empty() &&
+            suffix.find(damiane) != std::string_view::npos)
+            return 2;
+        if (!oongka.empty() &&
+            suffix.find(oongka) != std::string_view::npos)
+            return 3;
+        return 0;
     }
 
     std::size_t snapshot_body_cache(BodyCacheEntry *out,

--- a/CrimsonDesertLiveTransmog/CMakeLists.txt
+++ b/CrimsonDesertLiveTransmog/CMakeLists.txt
@@ -100,6 +100,7 @@ set(COMMON_SOURCES
     src/part_show_suppress.cpp
     src/real_part_tear_down.cpp
     src/prefab_wrapper_swap.cpp
+    src/helm_audio_filter.cpp
     src/color_override/host_scope.cpp
     src/dye_record_inject.cpp
     src/color_override/setter_substitute.cpp

--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -177,9 +177,9 @@ ColorOverride = false
 
 ; --- Unmuffle Helm Voice ---
 ; Removes the plate/heavy-helmet voice muffle on protagonists. NPC
-; voices keep their vanilla muffle. Set to false to restore the engine's
-; stock behaviour. Toggle changes take effect on the next game launch.
-UnmuffleHelmVoice = true
+; voices keep their vanilla muffle. Off by default; set to true to remove
+; the muffle. Toggle changes take effect on the next game launch.
+UnmuffleHelmVoice = false
 ```
 
 Presets are stored in `CrimsonDesertLiveTransmog_presets.json` (auto-generated alongside the INI).
@@ -196,7 +196,7 @@ See the full list at the [Supported Input Names](https://github.com/tkhquang/Det
 ## Known Limitations
 
 - **[Experimental] Color Override** is off by default. Set `ColorOverride = true` in the `[Experimental]` INI section to enable a per-region color picker that paints transmog items (including outfits the in-game dye merchant refuses). Changes take effect on the next game launch. Expect rough edges.
-- **[Experimental] Unmuffle Helm Voice** is on by default. Plate and heavy helmets no longer muffle your protagonist's voice; NPC voices still muffle as in vanilla. Set `UnmuffleHelmVoice = false` in the `[Experimental]` INI section to restore the stock helm voice muffle. Changes take effect on the next game launch.
+- **[Experimental] Unmuffle Helm Voice** is off by default. Set `UnmuffleHelmVoice = true` in the `[Experimental]` INI section to stop plate and heavy helmets from muffling your protagonist's voice; NPC voices still muffle as in vanilla. Changes take effect on the next game launch.
 - **[Experimental] Dye support shipped as a rough POC/MVP**, please bear with the UX for now. Note that not every item is dyeable; applying a color to a non-dyeable slot will produce no visual change.
 - **Helm visibility setting is overridden** - the in-game helmet visibility setting is overridden while LT is active. Workaround: set the Helm slot in the LT picker to "(none)" to hide the helmet.
 - **Protagonist switch may leave the picker on the previous character** - when switching protagonists, the LT picker may continue to show the previous protagonist's name and presets, and the dropdown may not let you switch. This is a known bug under investigation.

--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -174,6 +174,12 @@ PrevHotkey =
 ; HIGHLY EXPERIMENTAL -- disabled by default. Toggle changes take
 ; effect on the next game launch.
 ColorOverride = false
+
+; --- Unmuffle Helm Voice ---
+; Removes the plate/heavy-helmet voice muffle on protagonists. NPC
+; voices keep their vanilla muffle. Set to false to restore the engine's
+; stock behaviour. Toggle changes take effect on the next game launch.
+UnmuffleHelmVoice = true
 ```
 
 Presets are stored in `CrimsonDesertLiveTransmog_presets.json` (auto-generated alongside the INI).
@@ -190,6 +196,7 @@ See the full list at the [Supported Input Names](https://github.com/tkhquang/Det
 ## Known Limitations
 
 - **[Experimental] Color Override** is off by default. Set `ColorOverride = true` in the `[Experimental]` INI section to enable a per-region color picker that paints transmog items (including outfits the in-game dye merchant refuses). Changes take effect on the next game launch. Expect rough edges.
+- **[Experimental] Unmuffle Helm Voice** is on by default. Plate and heavy helmets no longer muffle your protagonist's voice; NPC voices still muffle as in vanilla. Set `UnmuffleHelmVoice = false` in the `[Experimental]` INI section to restore the stock helm voice muffle. Changes take effect on the next game launch.
 - **[Experimental] Dye support shipped as a rough POC/MVP**, please bear with the UX for now. Note that not every item is dyeable; applying a color to a non-dyeable slot will produce no visual change.
 - **Helm visibility setting is overridden** - the in-game helmet visibility setting is overridden while LT is active. Workaround: set the Helm slot in the LT picker to "(none)" to hide the helmet.
 - **Protagonist switch may leave the picker on the previous character** - when switching protagonists, the LT picker may continue to show the previous protagonist's name and presets, and the dropdown may not let you switch. This is a known bug under investigation.

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog.ini
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog.ini
@@ -100,6 +100,14 @@ PrevHotkey =
 ; effect on the next game launch.
 ColorOverride = false
 
+; --- Unmuffle Helm Voice ---
+; Removes the plate/heavy-helmet voice muffle on protagonists
+; (Kliff, Damiane, Oongka). The filter catches every helm class the
+; engine marks as muffling. NPC voices keep their vanilla muffle
+; either way. Set to false to restore the engine's stock behaviour.
+; Toggle changes take effect on the next game launch.
+UnmuffleHelmVoice = true
+
 [Diagnostics]
 ; One-shot TSV dumps written next to this plugin once the engine's
 ; item catalog (iteminfo) finishes loading. Useful for cross-referencing

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog.ini
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog.ini
@@ -104,9 +104,9 @@ ColorOverride = false
 ; Removes the plate/heavy-helmet voice muffle on protagonists
 ; (Kliff, Damiane, Oongka). The filter catches every helm class the
 ; engine marks as muffling. NPC voices keep their vanilla muffle
-; either way. Set to false to restore the engine's stock behaviour.
+; either way. Off by default; set to true to remove the muffle.
 ; Toggle changes take effect on the next game launch.
-UnmuffleHelmVoice = true
+UnmuffleHelmVoice = false
 
 [Diagnostics]
 ; One-shot TSV dumps written next to this plugin once the engine's

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Helm voice unmuffle and reliability fixes
 
-- Plate and heavy helmets no longer muffle your protagonist's voice (opt out via the new `UnmuffleHelmVoice` setting; NPC voices still muffle as in vanilla).
+- Optional setting to stop plate and heavy helmets from muffling your protagonist's voice -- enable `UnmuffleHelmVoice` under `[Experimental]` (off by default; NPC voices still muffle as in vanilla).
 - Upgraded DetourModKit dependency to v3.3.0.
 - More resilient internal checks against the game's loaded modules.
 - Reduced duplicated crash-protection code across modules.

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,6 @@
-## Maintenance and reliability
+## Helm voice unmuffle and reliability fixes
 
+- Plate and heavy helmets no longer muffle your protagonist's voice (opt out via the new `UnmuffleHelmVoice` setting; NPC voices still muffle as in vanilla).
 - Upgraded DetourModKit dependency to v3.3.0.
 - More resilient internal checks against the game's loaded modules.
 - Reduced duplicated crash-protection code across modules.

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -196,6 +196,12 @@ PrevHotkey =
 ; HIGHLY EXPERIMENTAL -- disabled by default. Toggle changes take
 ; effect on the next game launch.
 ColorOverride = false
+
+; --- Unmuffle Helm Voice ---
+; Removes the plate/heavy-helmet voice muffle on protagonists. NPC
+; voices keep their vanilla muffle. Set to false to restore the engine's
+; stock behaviour. Toggle changes take effect on the next game launch.
+UnmuffleHelmVoice = true
 [/code]
 
 [size=4]Hotkey Format[/size]
@@ -214,6 +220,7 @@ See the full list at the [url=https://github.com/tkhquang/DetourModKit?tab=readm
 
 [list]
 [*][b][Experimental] Color Override[/b] is off by default. Set [b]ColorOverride = true[/b] in the [b][Experimental][/b] INI section to enable a per-region color picker that paints transmog items (including outfits the in-game dye merchant refuses). Changes take effect on the next game launch. Expect rough edges.
+[*][b][Experimental] Unmuffle Helm Voice[/b] is on by default. Plate and heavy helmets no longer muffle your protagonist's voice; NPC voices still muffle as in vanilla. Set [b]UnmuffleHelmVoice = false[/b] in the [b][Experimental][/b] INI section to restore the stock helm voice muffle. Changes take effect on the next game launch.
 [*][b][Experimental] Dye support shipped as a rough POC/MVP[/b], please bear with the UX for now. Note that not every item is dyeable; applying a color to a non-dyeable slot will produce no visual change.
 [*][b]Helm visibility setting is overridden[/b] -the in-game helmet visibility setting is overridden while LT is active. Workaround: set the Helm slot in the LT picker to [b](none)[/b] to hide the helmet.
 [*][b]Protagonist switch may leave the picker on the previous character[/b] -when switching protagonists, the LT picker may continue to show the previous protagonist's name and presets, and the dropdown may not let you switch. This is a known bug under investigation.

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -199,9 +199,9 @@ ColorOverride = false
 
 ; --- Unmuffle Helm Voice ---
 ; Removes the plate/heavy-helmet voice muffle on protagonists. NPC
-; voices keep their vanilla muffle. Set to false to restore the engine's
-; stock behaviour. Toggle changes take effect on the next game launch.
-UnmuffleHelmVoice = true
+; voices keep their vanilla muffle. Off by default; set to true to remove
+; the muffle. Toggle changes take effect on the next game launch.
+UnmuffleHelmVoice = false
 [/code]
 
 [size=4]Hotkey Format[/size]
@@ -220,7 +220,7 @@ See the full list at the [url=https://github.com/tkhquang/DetourModKit?tab=readm
 
 [list]
 [*][b][Experimental] Color Override[/b] is off by default. Set [b]ColorOverride = true[/b] in the [b][Experimental][/b] INI section to enable a per-region color picker that paints transmog items (including outfits the in-game dye merchant refuses). Changes take effect on the next game launch. Expect rough edges.
-[*][b][Experimental] Unmuffle Helm Voice[/b] is on by default. Plate and heavy helmets no longer muffle your protagonist's voice; NPC voices still muffle as in vanilla. Set [b]UnmuffleHelmVoice = false[/b] in the [b][Experimental][/b] INI section to restore the stock helm voice muffle. Changes take effect on the next game launch.
+[*][b][Experimental] Unmuffle Helm Voice[/b] is off by default. Set [b]UnmuffleHelmVoice = true[/b] in the [b][Experimental][/b] INI section to stop plate and heavy helmets from muffling your protagonist's voice; NPC voices still muffle as in vanilla. Changes take effect on the next game launch.
 [*][b][Experimental] Dye support shipped as a rough POC/MVP[/b], please bear with the UX for now. Note that not every item is dyeable; applying a color to a non-dyeable slot will produce no visual change.
 [*][b]Helm visibility setting is overridden[/b] -the in-game helmet visibility setting is overridden while LT is active. Workaround: set the Helm slot in the LT picker to [b](none)[/b] to hide the helmet.
 [*][b]Protagonist switch may leave the picker on the previous character[/b] -when switching protagonists, the LT picker may continue to show the previous protagonist's name and presets, and the dropdown may not let you switch. This is a known bug under investigation.

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -1467,4 +1467,403 @@ namespace Transmog
     inline constexpr std::size_t k_colorTokenRegistrarCallAobCount =
         k_colorTokenRegistrarCallAobs.size();
 
+    /*
+     * sub_141C6CC90 -- per-tag passive-skill registrar. Invoked once
+     * per `{u16 tag, u32 lvl}` audio-classifier entry on the equipped
+     * item (iteminfo desc+0x100 vector). Reads the tag from `*r8`, the
+     * level from `r9`, and the character skill manager from `rcx`. The
+     * helm-audio filter hooks the function entry inline and short-
+     * circuits the call (zero the status int, return) when the call
+     * matches the audio-classifier code path (a7==0, 8-byte
+     * {u16 tag, u16 0, u16 lvl, u16 0} buffer at `a3`) AND the
+     * resolved skill's first per-level entry classifies as
+     * `pa::GameAudioEffectBuffData` AND the host actor classifies as
+     * a configured protagonist. Deriving muffle-class membership from
+     * the engine's own RTTI (rather than a hardcoded tag-id set) means
+     * any future tag backed by the same class is admitted
+     * automatically. See helm_audio_filter.{cpp,hpp} for the gate
+     * rationale and the bypass-safety analysis on the single virtual
+     * call SUPPRESS bypasses.
+     *
+     * Prologue (v1.08.00 .text @ 0x141C6CC90):
+     *   44 89 4C 24 20             mov  [rsp+20h], r9d   ; home a3
+     *   48 89 54 24 10             mov  [rsp+10h], rdx   ; home a1
+     *   55 53 56 57                push rbp/rbx/rsi/rdi
+     *   41 54 41 56 41 57          push r12/r14/r15
+     *   48 8D AC 24 B0 FE FF FF    lea  rbp, [rsp-150h]
+     *   48 81 EC 60 02 00 00       sub  rsp, 260h
+     *
+     * The 7-register save list together with the specific lea / sub
+     * immediates (-0x150, +0x260) pin this prologue uniquely in the
+     * v1.08.00 .text -- 1 match in the whole module. The two leading
+     * argument-home stores anchor the entry; the 7 pushes give a
+     * compact callee-save fingerprint; the lea/sub pair encodes the
+     * function's specific 0x4B0-byte frame.
+     */
+    /**
+     * @brief sub_1402FB2C0 -- engine's u16-tag -> skill record
+     *        resolver. Used by the helm-audio chain walk to map an
+     *        audio-classifier tag to its `pa::SkillInfo` record so
+     *        the per-level entry's class can be inspected without
+     *        hardcoded tag tokens.
+     *
+     * Function signature: `pa::SkillInfo* (*)(uint16_t* tag_ptr)`.
+     * Reads `*tag_ptr` as a u16 index into the SkillInfoManager's
+     * pointer array at `manager + 0x50`, returns the record pointer
+     * (or `MEMORY[0x145F34258]`, the manager's `default skill`
+     * sentinel, on out-of-range / unbound tags).
+     *
+     * Prologue (v1.08.00 .text @ 0x1402FB2C0):
+     *   48 89 5C 24 10           mov  [rsp+10], rbx       ; save callee
+     *   48 89 6C 24 18           mov  [rsp+18], rbp
+     *   56 57                    push rsi/rdi
+     *   41 56                    push r14
+     *   48 83 EC 40              sub  rsp, 40             ; frame
+     *   0F B7 39                 movzx edi, word ptr [rcx]; *a1 (u16 tag)
+     *   48 8B 1D ?? ?? ?? ??     mov  rbx, [rip+disp]     ; SkillInfoMgr
+     *   3B 7B 08                 cmp  edi, [rbx+8]        ; bound check
+     *
+     * Many sibling resolvers (ItemInfo, ParticleInfo, etc.) share
+     * the same prologue; what pins THIS function as the SkillInfo
+     * resolver is the specific RIP-rel offset to MEMORY[0x145F9B878].
+     * Every candidate keeps the `48 8B 1D 9C 05 CA 05` mov literal
+     * (baked disp32 to SkillInfoMgr) -- wildcarding that disp32 would
+     * collide with all 111 sibling `pa::*InfoManager` resolvers.
+     *
+     * P1 bakes the disp32 inside the function prologue (entry anchor).
+     * P2 anchors at entry+0x12 on the body sequence (movzx + mov +
+     * cmp + jnb + lea + table load) so the cascade still resolves when
+     * a future build reshapes the prologue. P3 extends P2 forward
+     * through the table-lookup tail (test + jnz + cmp + jnz + lea on
+     * the manager's `+0x88` default-skill sentinel) for maximum anti-
+     * collision while keeping the baked disp anchor.
+     */
+    inline constexpr AddrCandidate k_skillTagResolverCandidates[] = {
+        // P1 -- entry-anchored, RIP-rel to SkillInfoManager baked in.
+        // 1 unique match in v1.08.00 .text.
+        {"SkillTagResolver_P1_PrologueWithMgr",
+         "48 89 5C 24 10 "
+         "48 89 6C 24 18 "
+         "56 57 41 56 "
+         "48 83 EC 40 "
+         "0F B7 39 "
+         "48 8B 1D 9C 05 CA 05 "
+         "3B 7B 08",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- body anchor at entry+0x12, past the 5-byte SafetyHook
+        // prologue-overwrite window. Sequence:
+        //   0F B7 39                  movzx edi, word ptr [rcx]   ; *tag
+        //   48 8B 1D 9C 05 CA 05      mov   rbx, cs:_SkillInfoMgr ; baked disp32
+        //   3B 7B 08                  cmp   edi, [rbx+8]          ; bound check
+        //   0F 83 ?? ?? ?? ??         jnb   <oob_branch>          ; rel32 wildcarded
+        //   4C 8D 34 FD 00 00 00 00   lea   r14, ds:[rdi*8 + 0]   ; index scale
+        //   48 8B 43 50               mov   rax, [rbx+0x50]       ; entry array
+        //   49 8B 04 06               mov   rax, [r14+rax]        ; entry load
+        // The baked SkillInfoMgr disp32 is the discriminator vs. the
+        // sibling resolvers; the `4C 8D 34 FD 00 00 00 00` (scaled-
+        // index lea with zero base) shape is the unique table walk.
+        // dispOffset = -0x12 walks back to the entry.
+        {"SkillTagResolver_P2_BodyBoundCheck",
+         "0F B7 39 "
+         "48 8B 1D 9C 05 CA 05 "
+         "3B 7B 08 "
+         "0F 83 ?? ?? ?? ?? "
+         "4C 8D 34 FD 00 00 00 00 "
+         "48 8B 43 50 "
+         "49 8B 04 06",
+         ResolveMode::Direct, -0x12, 0},
+
+        // P3 -- deeper body anchor: extends P2 through the entry-found
+        // arm and the `mgr + 0x88` default-skill sentinel check:
+        //   ... (P2 body) ...
+        //   48 85 C0                  test  rax, rax
+        //   0F 85 ?? ?? ?? ??         jnz   <found_branch>      ; rel32 wildcarded
+        //   48 39 83 88 00 00 00      cmp   [rbx+0x88], rax     ; sentinel cmp
+        //   75 ??                     jnz   short <skip>        ; rel8 wildcarded
+        //   4C 8D 8B 88 00 00 00      lea   r9, [rbx+0x88]
+        // The rel8 jnz IS wildcarded (would normally violate
+        // aob-signatures DOs/DONTs section 9 on encoding-flip risk),
+        // but the surrounding baked SkillInfoMgr disp + the literal
+        // `+0x88` sentinel offset keep the pattern unique even with
+        // the rel8 free. dispOffset = -0x12 walks back to the entry.
+        {"SkillTagResolver_P3_BodyTableTail",
+         "0F B7 39 "
+         "48 8B 1D 9C 05 CA 05 "
+         "3B 7B 08 "
+         "0F 83 ?? ?? ?? ?? "
+         "4C 8D 34 FD 00 00 00 00 "
+         "48 8B 43 50 "
+         "49 8B 04 06 "
+         "48 85 C0 "
+         "0F 85 ?? ?? ?? ?? "
+         "48 39 83 88 00 00 00 "
+         "75 ?? "
+         "4C 8D 8B 88 00 00 00",
+         ResolveMode::Direct, -0x12, 0},
+    };
+
+    /**
+     * @brief `pa::GameAudioEffectBuffData` vtable -- the class
+     *        marker we compare buff-instance vtable pointers against
+     *        to identify muffle-class skills.
+     *
+     * Each `pa::GameAudioEffectBuffData` instance stores the address
+     * of vfunc[0] (= vtable + 8 bytes past the RTTI metadata ptr) in
+     * its first qword. The chain walk in helm_audio_filter.cpp
+     * resolves a tag's skill record -> per-level entry array -> first
+     * entry, then reads `*entry` and compares against the value
+     * resolved here.
+     *
+     * Resolution strategy: AOB on the class's CONSTRUCTOR's final
+     * vtable assignment (which lives in `.text`), then use
+     * RipRelative mode to read the constructor's RIP-rel disp32 to
+     * compute the absolute vtable address. Direct AOB scan on the
+     * vtable bytes themselves cannot work because DetourModKit's
+     * `scan_executable_regions` filters by READABLE_EXEC_FLAGS only
+     * (scanner.cpp:669) and `.rdata` (PAGE_READONLY) is skipped.
+     *
+     * Constructor tail at v1.08.00 .text @ 0x141A09500:
+     *   48 89 91 88 00 00 00         mov [rcx+88h], rdx        ; parent ctor fill
+     *   48 8D 05 ?? ?? ?? ??         lea rax, [rip+disp32]     ; load vtable addr
+     *   48 89 01                     mov [rcx], rax            ; store at obj[0]
+     *   C6 81 90 00 00 00 03         mov byte ptr [rcx+90h], 3 ; init audio_class byte
+     *   48 8B C1                     mov rax, rcx              ; this-return
+     *   C3                           ret
+     *
+     * The 28-byte signature is unique across v1.08.00 .text (1 match);
+     * the disp32 is wildcarded for build-portability. RipRelative
+     * decode:
+     *   - disp_offset    = 10  (offset of disp32 from match start;
+     *                          the LEA is at match+7, opcode `48 8D 05`
+     *                          is 3 bytes, disp32 starts at match+10)
+     *   - instr_end_offset = 14 (next instruction begins 7 bytes after
+     *                            the LEA start; LEA = 7 bytes; match+7+7
+     *                            = match+14)
+     * Resolved address = match + 14 + sign_extend(disp32). The 0x90-
+     * byte audio_class init right after the vtable store anchors the
+     * pattern specifically to GameAudioEffectBuffData -- other ctors
+     * that do similar vtable assignments have different post-vtable
+     * field initialization shapes.
+     *
+     * P2 extends the anchor one instruction earlier (the parent ctor's
+     * +0x84 state-init byte write) to add a stable 7-byte discriminator
+     * upstream of the vtable LEA; disp_offset shifts to 17 and
+     * instr_end_offset to 21 to follow the LEA's new position within
+     * the window. P3 walks back another 17 bytes to also include the
+     * `[rcx+0x78]` qword fill and `[rcx+0x80]` dword fill that
+     * GameAudioEffectBuffData's parent ctor performs immediately
+     * before the +0x84 byte; this gives the widest sub-frame-shaped
+     * fingerprint without dragging in calls that vary across builds.
+     */
+    inline constexpr AddrCandidate
+        k_gameAudioEffectVtableCandidates[] = {
+            // P1 -- constructor tail with RIP-rel LEA. 1 unique match
+            // in v1.08.00 .text. Resolved disp32 = 0x032CE5FA ->
+            // match+14+disp = 0x144CD7B08 (= vfunc[0] address, what
+            // objects store in their first qword).
+            {"GameAudioEffectVtable_P1_CtorLea",
+             "48 89 91 88 00 00 00 "
+             "48 8D 05 ?? ?? ?? ?? "
+             "48 89 01 "
+             "C6 81 90 00 00 00 03 "
+             "48 8B C1 "
+             "C3",
+             ResolveMode::RipRelative, 10, 14},
+
+            // P2 -- extend P1 backwards by the parent ctor's +0x84
+            // state-init byte:
+            //   C6 81 84 00 00 00 03   mov  byte ptr [rcx+0x84], 3
+            //   48 89 91 88 00 00 00   mov  [rcx+0x88], rdx
+            //   48 8D 05 ?? ?? ?? ??   lea  rax, [rip+disp32]  ; vtable
+            //   48 89 01               mov  [rcx], rax
+            //   C6 81 90 00 00 00 03   mov  byte ptr [rcx+0x90], 3
+            //   48 8B C1               mov  rax, rcx
+            //   C3                     ret
+            // The dual `byte ptr [..0x84]=3` + `byte ptr [..0x90]=3`
+            // state-byte pair flanks the LEA and pins this ctor against
+            // sibling effect-buff ctors that init only one of the two
+            // bytes. LEA now sits 7 bytes deeper into the pattern, so
+            // disp_offset = 10 + 7 = 17, instr_end_offset = 14 + 7 = 21.
+            {"GameAudioEffectVtable_P2_CtorStatePair",
+             "C6 81 84 00 00 00 03 "
+             "48 89 91 88 00 00 00 "
+             "48 8D 05 ?? ?? ?? ?? "
+             "48 89 01 "
+             "C6 81 90 00 00 00 03 "
+             "48 8B C1 "
+             "C3",
+             ResolveMode::RipRelative, 17, 21},
+
+            // P3 -- extend P2 backwards by the parent ctor's earlier
+            // payload writes at [rcx+0x78] (qword) and [rcx+0x80]
+            // (dword):
+            //   48 89 51 78            mov  [rcx+0x78], rdx
+            //   89 91 80 00 00 00      mov  [rcx+0x80], edx
+            //   ... (P2 body) ...
+            // These two writes capture the parent ctor's signature
+            // packing of `rdx` into three sequential fields (qword at
+            // 0x78, dword at 0x80, byte at 0x84) -- a layout shape
+            // specific to this effect-buff family. LEA shifts a further
+            // 10 bytes (P2 backward extension was 7; P3 adds 10), so
+            // disp_offset = 17 + 10 = 27, instr_end_offset = 21 + 10 = 31.
+            {"GameAudioEffectVtable_P3_CtorFullPayload",
+             "48 89 51 78 "
+             "89 91 80 00 00 00 "
+             "C6 81 84 00 00 00 03 "
+             "48 89 91 88 00 00 00 "
+             "48 8D 05 ?? ?? ?? ?? "
+             "48 89 01 "
+             "C6 81 90 00 00 00 03 "
+             "48 8B C1 "
+             "C3",
+             ResolveMode::RipRelative, 27, 31},
+        };
+
+    // -----------------------------------------------------------------------
+    // PlayerStatic -- engine global whose chain reaches the currently-
+    // controlled protagonist's pa::ServerChildOnlyInGameActor.
+    //
+    // Used by helm_audio_filter.cpp for the Kliff init-race fallback:
+    // when the actor's CharacterAssets vector has not yet been wired
+    // up (the first muffle event after world load), the asset-string
+    // scan returns Unknown. If the chain leaf here equals the host
+    // we are classifying, we attribute the host to Kliff (he is
+    // always the first-spawned protagonist and the controlled actor
+    // at world load).
+    //
+    // Walk (runtime, v1.08):
+    //   *(static)         -> root container
+    //   *(root  + 0x18)   -> pa::NwVirtualAsyncSession
+    //   *(nwSes + 0xA0)   -> pa::ServerUserActor
+    //   *(srvUA + 0xD0)   -> pa::ServerChildOnlyInGameActor (controlled)
+    //
+    // P1 anchors on the writer site inside sub_142104390. P2 extends
+    // that same writer forward through the TLS-guarded null-check
+    // (jz + gs:0x58 TIB load + compare against `[r12+rdx]`) so the
+    // cascade still resolves if a future compiler reshuffles the
+    // `mov r12d, 0x204` immediate within the same writer. P3 anchors
+    // on an unrelated reader site inside sub_14080E8E0 (SafeLaunch /
+    // pre-character-spawn path) -- a completely different call graph
+    // that loads PlayerStatic as the first argument to sub_1421062F0.
+    // P3 keeps the cascade alive even if the entire writer function
+    // around P1/P2 is reshaped by a future patch.
+    // -----------------------------------------------------------------------
+    inline constexpr AddrCandidate k_playerStaticCandidates[] = {
+        // P1 -- unique writer site at sub_1420D0470. Carries the
+        // distinctive `mov r12d, 0x204` initialisation tag immediately
+        // after the writer, plus a follow-on load from [rdi+0xF8].
+        // Both the SEMANTIC constant 0x204 and the +0xF8 ABI offset
+        // are kept literal; the rel8 of the trailing jcc is wildcarded.
+        {"PlayerStatic_P1_WriterSite",
+         "4C 89 3D ?? ?? ?? ?? 48 8B 8F F8 00 00 00 "
+         "41 BC 04 02 00 00 48 85 C9 ??",
+         ResolveMode::RipRelative, 3, 7},
+
+        // P2 -- writer site extended through the TLS-guard tail. Same
+        // store as P1 (`mov [rip+disp32], r15`) followed by the
+        // [rdi+0xF8] field load and the 0x204 init tag, then continues
+        // past the `74 ??` short-jz into the TIB load and the per-
+        // thread flag-byte compare:
+        //   74 ??                          jz   short <skip>          ; rel8 wildcarded
+        //   65 48 8B 04 25 58 00 00 00     mov  rax, gs:0x58          ; TIB
+        //   48 8B 10                       mov  rdx, [rax]            ; TLS block
+        //   45 38 3C 14                    cmp  [r12+rdx], r15b       ; flag test
+        // The rel8 jz byte is wildcarded for encoding-flip safety.
+        // The trailing TLS+compare shape is unique-text in v1.08.00
+        // .text and pins the writer even if the 0x204 immediate ever
+        // shifts.
+        // RipRelative offsets are unchanged from P1 (disp_offset = 3,
+        // instr_end_offset = 7) because the store is still the first
+        // instruction in the window.
+        {"PlayerStatic_P2_WriterSiteTlsTail",
+         "4C 89 3D ?? ?? ?? ?? 48 8B 8F F8 00 00 00 "
+         "41 BC 04 02 00 00 48 85 C9 74 ?? "
+         "65 48 8B 04 25 58 00 00 00 "
+         "48 8B 10 "
+         "45 38 3C 14",
+         ResolveMode::RipRelative, 3, 7},
+
+        // P3 -- reader site at sub_14080E8E0+0x144. Orthogonal call
+        // graph (SafeLaunch / pre-character-spawn path): loads
+        // PlayerStatic into rcx as the first argument to
+        // sub_1421062F0, with the remaining args being two xor-zeroed
+        // dwords and an `lea rdx, [rsp+0x64]` out-pointer.
+        //   45 33 C9                   xor  r9d, r9d              ; arg4 = 0
+        //   45 33 C0                   xor  r8d, r8d              ; arg3 = 0
+        //   48 8D 54 24 64             lea  rdx, [rsp+0x64]       ; out int*
+        //   48 8B 0D ?? ?? ?? ??       mov  rcx, cs:_PlayerStatic ; baked disp32
+        //   E8 ?? ?? ?? ??             call sub_1421062F0
+        // `mov rcx, [rip+disp32]` is 7 bytes (`48 8B 0D` + disp32);
+        // the load starts at pattern offset 11, so disp32 starts at
+        // offset 14 and the next instruction begins at offset 18.
+        // RIP-rel target = match + 18 + sign_extend(disp32) =
+        // cs:0x145F9B380. Genuinely independent from P1/P2 -- a patch
+        // that shuffles only sub_142104390 leaves this anchor intact.
+        {"PlayerStatic_P3_SafeLaunchReader",
+         "45 33 C9 45 33 C0 "
+         "48 8D 54 24 64 "
+         "48 8B 0D ?? ?? ?? ?? "
+         "E8 ?? ?? ?? ??",
+         ResolveMode::RipRelative, 14, 18},
+    };
+
+    inline constexpr AddrCandidate k_helmAudioRegistrarCandidates[] = {
+        // P1 -- full prologue, entry-anchored. dispOffset = 0 because
+        // the pattern starts exactly at the function entry.
+        {"HelmAudioRegistrar_P1_FullPrologue",
+         "44 89 4C 24 20 "
+         "48 89 54 24 10 "
+         "55 53 56 57 41 54 41 56 41 57 "
+         "48 8D AC 24 B0 FE FF FF "
+         "48 81 EC 60 02 00 00",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- post-prologue lea+sub+arg-stash chain at entry+0x14,
+        // past SafetyHook's 5-byte JMP window so the resolver still
+        // works after a sibling has inline-hooked the entry. The
+        // `48 8D AC 24 B0 FE FF FF 48 81 EC 60 02 00 00` lea/sub pair
+        // followed by `48 8B 41 08 4C 8B F9 48 89 45 90 48 8B FA`
+        // (mov rax,[rcx+8] / mov r15,rcx / mov [rbp-0x90],rax /
+        //  mov rdi,rdx) gives a 27-byte uniquely-pinned anchor.
+        // dispOffset = -0x14 walks back to the entry.
+        {"HelmAudioRegistrar_P2_PostPrologue",
+         "48 8D AC 24 B0 FE FF FF "
+         "48 81 EC 60 02 00 00 "
+         "48 8B 41 08 4C 8B F9 "
+         "48 89 45 90 48 8B FA",
+         ResolveMode::Direct, -0x14, 0},
+
+        // P3 -- deep TLS-gate anchor at entry+0x4D. Lands well past
+        // both the 5-byte SafetyHook JMP window AND the post-prologue
+        // P2 anchor, so it still resolves even when a sibling mod has
+        // installed a long mid-function detour over the prologue tail.
+        //
+        // The body shape at this offset is the function's thread-
+        // local-flag preamble:
+        //   65 48 8B 04 25 58 00 00 00   mov  rax, gs:58h         ; TIB->ThreadLocalStoragePointer
+        //   33 F6                         xor  esi, esi
+        //   48 8B 1D ?? ?? ?? ??         mov  rbx, cs:_someGlobal ; RIP-rel, disp32 wildcarded
+        //   4C 8B 00                      mov  r8, [rax]           ; TLS block base
+        //   B8 F2 01 00 00                mov  eax, 1F2h           ; TLS slot index 498
+        //   42 38 34 00                   cmp  [rax+r8], sil       ; flag byte == 0?
+        //   48 0F 45 DE                   cmovnz rbx, rsi          ; conditionally zero rbx
+        //
+        // The combination of a TIB load with the specific TLS slot
+        // 0x1F2 and a cmovnz on (rbx, rsi) is a single-occurrence
+        // fingerprint in v1.08.00 .text. The TLS slot index is a build-
+        // stable per-binary constant; the global RIP-disp32 and the
+        // SIB byte of the RIP-rel mov are wildcarded.
+        // dispOffset = -0x4D walks back to the entry.
+        {"HelmAudioRegistrar_P3_TlsGate",
+         "65 48 8B 04 25 58 00 00 00 "
+         "33 F6 "
+         "48 8B 1D ?? ?? ?? ?? "
+         "4C 8B 00 "
+         "B8 F2 01 00 00 "
+         "42 38 34 00 "
+         "48 0F 45 DE",
+         ResolveMode::Direct, -0x4D, 0},
+    };
+
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/helm_audio_filter.cpp
+++ b/CrimsonDesertLiveTransmog/src/helm_audio_filter.cpp
@@ -1,0 +1,758 @@
+#include "helm_audio_filter.hpp"
+
+#include "aob_resolver.hpp"
+
+#include <cdcore/controlled_char.hpp>
+
+#include <DetourModKit.hpp>
+
+#include <Windows.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <string_view>
+#include <unordered_map>
+
+namespace DMK = DetourModKit;
+
+namespace Transmog::HelmAudioFilter
+{
+    namespace
+    {
+        // 12-arg signature for sub_141C6CC90, the per-tag passive-skill
+        // registrar. a1 is the actor's skill registry, a2 a status
+        // int*, a3 a u16 tag pointer, a4 the level, a5..a12 carry
+        // per-call context (descriptors, scope, etc.). The function
+        // body returns `a2` and zeroes `*a2` on its natural exit; the
+        // suppress path replicates exactly that tail so callers
+        // cannot distinguish a SUPPRESS from a no-op registration.
+        using PassiveSkillRegistrarFn = std::int32_t * (*)(
+            std::int64_t, std::int32_t *, std::uint16_t *,
+            std::int32_t, std::int64_t, std::int64_t,
+            char, std::int32_t, std::int64_t,
+            std::int64_t, char, std::int64_t);
+
+        // Engine's u16-tag -> skill record resolver (sub_1402FB2C0).
+        // Reads a3 as `*(u16*)a3`, indexes into the SkillInfoManager
+        // pointer array at manager+0x50, returns the record pointer
+        // (or the manager's `default record` at MEMORY[0x145F34258] if
+        // the tag is out of range / unbound). The returned record
+        // carries the per-level entry table at +0x18 and a level-count
+        // vector at +0xF8.
+        using SkillTagResolverFn = std::int64_t (*)(std::uint16_t *);
+
+        PassiveSkillRegistrarFn g_trampoline = nullptr;
+        SkillTagResolverFn g_skillTagResolver = nullptr;
+        // The value stored in the first qword of every
+        // `pa::GameAudioEffectBuffData` instance: i.e. the address of
+        // vfunc[0]. We compare buff_instance[0] against this value to
+        // determine class membership without RTTI walks. Resolved at
+        // init via AOB on the vtable header (RTTI metadata ptr + first
+        // few vfuncs).
+        std::uintptr_t g_gameAudioEffectVtable = 0;
+
+        // Engine player static -- root of the chain that reaches the
+        // currently-controlled protagonist's Server CCOIA. Used as a
+        // Kliff identity fallback during the save-load init race
+        // window where Kliff's CharacterAssets struct isn't wired up
+        // yet but he IS the controlled actor at that moment (Kliff
+        // is always the first-spawned protagonist).
+        std::uintptr_t g_playerStatic = 0;
+
+        std::atomic<bool> g_initDone{false};
+
+        // Chain from a pa::ServerChildOnlyInGameActor host to the
+        // CharacterAssets std::vector<std::string>:
+        //
+        //   host
+        //     + 0x68 -> component table (64 packed pointer slots)
+        //     + 0x40 -> slot[8] = pa::ServerCharacterControlActor*
+        //     + 0x40 -> (struct, no RTTI vtable in image)
+        //     + 0x38 -> CharacterAssets vector base
+        //
+        // CharacterAssets is a packed array of MSVC-style std::string
+        // entries (0x40-byte stride). Slot content per protagonist:
+        //
+        //   Kliff (when armor-wearing, e.g. macduff):
+        //     [0] 'character/appearance/.../cd_phm_macduff_00000.app_xml'
+        //     [1] 'character/model/.../phm_01.pab'
+        //     [2] 'character/binary/skeletonvariation/.../cd_phm_00_nude_*.pabc'
+        //     [3] 'cd_portraitimage_Knowledge_Kliff'
+        //     [4] 'player_1'
+        //
+        //   Oongka (no armor):
+        //     [0] 'character/appearance/.../cd_phm_oongka_00000.app_xml'
+        //     [1] 'character/binary/skeletonvariation/.../cd_pom_00_nude_*.pabc'
+        //     [2] 'cd_portraitimage_Knowledge_Oongka'
+        //     [3] 'player_3'
+        //
+        // Slot indices for the portrait / `player_N` strings differ
+        // between protagonists because armor-wearing actors carry an
+        // extra `model` slot. The scan therefore walks all entries up
+        // to a small bound and short-circuits on the first codename
+        // hit. Slot[0] (the .app_xml path) is the canonical match
+        // target for unarmored protagonists; the portrait string at
+        // the slot whose index varies provides the fallback codename
+        // when armor renames slot[0].
+        constexpr std::ptrdiff_t k_offComponentTable = 0x68;
+        constexpr std::ptrdiff_t k_offCharCtlSlot = 0x40;
+        constexpr std::ptrdiff_t k_offCharCtlToInner = 0x40;
+        constexpr std::ptrdiff_t k_offInnerToAssets = 0x38;
+        constexpr std::ptrdiff_t k_assetStride = 0x40;
+        constexpr std::size_t k_assetMaxScan = 8;
+
+        // Persistent per-host classification cache. Once an actor's
+        // host pointer has been successfully identified via the
+        // CharacterAssets scan, store the result so later muffle
+        // events for the same actor don't have to re-walk the chain.
+        // The cache also covers the save-load init race: Kliff's
+        // first muffle events arrive before his CharacterAssets
+        // struct has been populated, so the chain returns empty and
+        // the gate falls through. Subsequent events for the same
+        // host succeed once the struct is wired and stay cached
+        // afterwards.
+        std::mutex g_hostCacheMutex;
+        std::unordered_map<std::uintptr_t,
+                           CDCore::ControlledCharacter>
+            g_hostCache;
+
+        // Per-entry std::string layout (MSVC SSO):
+        //   +0x00 -> ptr (heap buffer when len>=16, else points into
+        //            the entry's inline buffer at +0x10)
+        //   +0x08  size_t length
+        //   +0x10  inline buffer (16 bytes)
+        //   +0x18  size_t capacity
+        constexpr std::ptrdiff_t k_offEntryPtr = 0x00;
+        constexpr std::ptrdiff_t k_offEntryLen = 0x08;
+        constexpr std::ptrdiff_t k_offEntryInline = 0x10;
+        constexpr std::size_t k_maxStringRead = 96;
+
+        // Chain-walk reads route through DMK's SEH-guarded primitives
+        // (`DMKMemory::seh_read<T>` / `seh_read_bytes`). They handle
+        // the low-address sentinel (<0x10000) internally and report a
+        // fault as an empty optional / `false` return. The chain
+        // collapses to "not muffle" on any intermediate fault because
+        // each step propagates the empty optional via `value_or(0)`,
+        // and a 0 base terminates the next step at the sentinel
+        // check. The audio-classifier tag pointer (`a3`) is a heap-
+        // allocated 8-byte record from the engine's iteminfo /
+        // skillinfo metadata; in theory always live for the duration
+        // of the call, but the SEH guard keeps the feature alive on
+        // torn reads.
+
+        // Structural identification of an audio-classifier registration
+        // call (a7 == 0 AND a3 in the {u16 tag, u16 0, u16 lvl, u16 0}
+        // 8-byte-stride buffer layout the equip dispatcher uses). This
+        // cleanly separates the audio-classifier code path from the
+        // other ~45 callers of sub_141C6CC90 (combat passives, teardown
+        // nulls, vehicle skills, etc.) regardless of skill class.
+        bool is_audio_classifier_call(std::uint16_t *a3,
+                                      std::int32_t a4,
+                                      char a7) noexcept
+        {
+            if (a7 != 0)
+                return false;
+            if (a3 == nullptr)
+                return false;
+            const auto a3Addr = reinterpret_cast<std::uintptr_t>(a3);
+            const auto lvlEcho =
+                DMKMemory::seh_read<std::uint16_t>(a3Addr + 4);
+            if (!lvlEcho)
+                return false;
+            const auto padHi =
+                DMKMemory::seh_read<std::uint16_t>(a3Addr + 2);
+            if (!padHi || *padHi != 0u)
+                return false;
+            const auto padLo =
+                DMKMemory::seh_read<std::uint16_t>(a3Addr + 6);
+            if (!padLo || *padLo != 0u)
+                return false;
+            return *lvlEcho == static_cast<std::uint16_t>(a4);
+        }
+
+        // Chain walk that resolves the u16 tag at `*a3` to its skill
+        // record, walks to the first per-level entry, reads the
+        // entry's vtable, and returns true iff the entry's class is
+        // `pa::GameAudioEffectBuffData`.
+        //
+        // Chain:
+        //   record       = sub_1402FB2C0(a3)                  // engine resolver
+        //   level_table  = *(record + 0x18)                    // per-level table
+        //   inner_arr    = *(level_table + 0x00)               // first inner ptr
+        //   first_entry  = *(inner_arr + 0x00)                 // level 1 entry #1
+        //   vtable       = *(first_entry + 0x00)               // class vtable
+        //   return vtable == g_gameAudioEffectVtable
+        //
+        // Tag mapping observed in the live skillinfo catalog: only
+        // 0x64B (skill 91000, "PlateHelm_Audio") and 0x64C (skill
+        // 91001, "PlateHelm_Audio_OpenableHelm") resolve to records
+        // whose per-level entry is `pa::GameAudioEffectBuffData` (the
+        // class with description "투구 착용 시 먹먹한 소리" / Muffled
+        // sound when wearing helmet). Other tags in the same
+        // neighbourhood (0x647 / 0x64A / 0x650) resolve to
+        // `pa::VoidPassiveBuffData` (item stat) or
+        // `pa::ImmuneBuffData` (sound-attack immunity) and pass
+        // through. Iteminfo dump cross-check: 124 helms equip skill
+        // 91000 / 91001; the chain walk identifies them universally
+        // without hardcoded tag tokens.
+        bool is_audio_muffle_class(std::uint16_t *a3) noexcept
+        {
+            if (g_skillTagResolver == nullptr
+                || g_gameAudioEffectVtable == 0
+                || a3 == nullptr)
+                return false;
+
+            // Resolver is engine code; in theory faultless given the
+            // tag pointer's heap origin, but a torn iteminfo refresh
+            // could publish a stale pointer mid-equip. The trampoline
+            // detour is reached from arbitrary equip threads, so
+            // wrapping the call in our own SEH frame is cheaper than
+            // proving the engine's invariants and means a fault here
+            // pass-throughs to the registrar instead of crashing.
+            std::int64_t record = 0;
+            __try
+            {
+                record = g_skillTagResolver(a3);
+            }
+            __except (EXCEPTION_EXECUTE_HANDLER)
+            {
+                return false;
+            }
+            if (record < 0x10000)
+                return false;
+
+            const auto levelTable =
+                DMKMemory::seh_read<std::uintptr_t>(
+                    static_cast<std::uintptr_t>(record) + 0x18)
+                    .value_or(0);
+            if (levelTable < 0x10000)
+                return false;
+
+            const auto innerArr =
+                DMKMemory::seh_read<std::uintptr_t>(levelTable)
+                    .value_or(0);
+            if (innerArr < 0x10000)
+                return false;
+
+            const auto firstEntry =
+                DMKMemory::seh_read<std::uintptr_t>(innerArr)
+                    .value_or(0);
+            if (firstEntry < 0x10000)
+                return false;
+
+            const auto vtable =
+                DMKMemory::seh_read<std::uintptr_t>(firstEntry)
+                    .value_or(0);
+            return vtable == g_gameAudioEffectVtable;
+        }
+
+        // ASCII copy with length cap. Walks the std::string entry's
+        // backing buffer in a single SEH-guarded bulk read; the
+        // backing-buffer length comes from the std::string's own
+        // size field (already validated by the caller for plausibility)
+        // so we trust it as the upper bound and then truncate on the
+        // first embedded NUL we encounter, mirroring the C-string
+        // semantics the asset-path classifier expects.
+        std::size_t copy_ascii_safe(std::uintptr_t src,
+                                    std::size_t len,
+                                    char *out,
+                                    std::size_t cap) noexcept
+        {
+            if (src < 0x10000 || out == nullptr || cap == 0)
+                return 0;
+            const std::size_t limit =
+                len < (cap - 1) ? len : (cap - 1);
+            if (limit == 0)
+            {
+                out[0] = '\0';
+                return 0;
+            }
+            if (!DMKMemory::seh_read_bytes(src, out, limit))
+            {
+                out[0] = '\0';
+                return 0;
+            }
+            std::size_t actual = limit;
+            for (std::size_t i = 0; i < limit; ++i)
+            {
+                if (out[i] == '\0')
+                {
+                    actual = i;
+                    break;
+                }
+            }
+            out[actual] = '\0';
+            return actual;
+        }
+
+        // Delegates to CDCore::classify_appearance_by_path which
+        // matches the appearance path against dynamically-maintained
+        // codenames ("cd_phm_macduff" -> Kliff, "cd_phw_damian" ->
+        // Damiane, "cd_phm_oongka" -> Oongka). Using CDCore's API
+        // here means the codename set stays consistent with the
+        // rest of LT/EH/CDCore -- including any runtime auto-update
+        // of codenames the engine might perform.
+        //
+        // The function expects a path containing "/cd_" as anchor;
+        // protagonist .app_xml paths from the Server CharacterAssets
+        // (slot 0) carry this anchor verbatim, e.g.
+        // "character/appearance/1_pc/1_phm/cd_phm_macduff/...".
+        // Returns 1/2/3 for Kliff/Damiane/Oongka, 0 (Unknown) else.
+        CDCore::ControlledCharacter classify_asset_string(
+            std::string_view sv) noexcept
+        {
+            const auto idx =
+                CDCore::classify_appearance_by_path(sv);
+            return static_cast<CDCore::ControlledCharacter>(idx);
+        }
+
+        // Reads one std::string entry from the CharacterAssets array.
+        // Handles both SSO (capacity <= 15, buffer inline at +0x10)
+        // and heap (capacity > 15, ptr at +0x00). Returns chars
+        // copied (0 on fault / empty / implausible length).
+        std::size_t read_asset_entry(std::uintptr_t entry,
+                                     char *out,
+                                     std::size_t cap) noexcept
+        {
+            const auto len = DMKMemory::seh_read<std::uint32_t>(
+                                 entry + k_offEntryLen)
+                                 .value_or(0);
+            if (len == 0 || len > 0x10000)
+                return 0;
+            const auto ptr = DMKMemory::seh_read<std::uintptr_t>(
+                                 entry + k_offEntryPtr)
+                                 .value_or(0);
+            // SSO heuristic: if `ptr` looks like a canonical heap
+            // pointer, follow it; otherwise read inline at +0x10.
+            const bool ptrLooksValid = ptr >= 0x10000000000ULL
+                                       && ptr < 0xF000000000000ULL;
+            const auto src = ptrLooksValid
+                                 ? ptr
+                                 : (entry + k_offEntryInline);
+            return copy_ascii_safe(src, len, out, cap);
+        }
+
+        // Walk a Server CCOIA host to its CharacterAssets vector and
+        // scan each entry (up to k_assetMaxScan) for a protagonist
+        // codename. Returns the matched character or Unknown on
+        // chain fault / no match. `outMatchedAsset` (if not null)
+        // receives the matched string for log diagnostics.
+        CDCore::ControlledCharacter classify_host_by_assets(
+            std::uintptr_t host,
+            char *outMatchedAsset,
+            std::size_t outCap) noexcept
+        {
+            if (outMatchedAsset != nullptr && outCap > 0)
+                outMatchedAsset[0] = '\0';
+            if (host < 0x10000)
+                return CDCore::ControlledCharacter::Unknown;
+            const auto tbl =
+                DMKMemory::seh_read<std::uintptr_t>(
+                    host + k_offComponentTable)
+                    .value_or(0);
+            if (tbl < 0x10000)
+                return CDCore::ControlledCharacter::Unknown;
+            const auto ctl =
+                DMKMemory::seh_read<std::uintptr_t>(
+                    tbl + k_offCharCtlSlot)
+                    .value_or(0);
+            if (ctl < 0x10000)
+                return CDCore::ControlledCharacter::Unknown;
+            const auto inner =
+                DMKMemory::seh_read<std::uintptr_t>(
+                    ctl + k_offCharCtlToInner)
+                    .value_or(0);
+            if (inner < 0x10000)
+                return CDCore::ControlledCharacter::Unknown;
+            const auto assets =
+                DMKMemory::seh_read<std::uintptr_t>(
+                    inner + k_offInnerToAssets)
+                    .value_or(0);
+            if (assets < 0x10000)
+                return CDCore::ControlledCharacter::Unknown;
+
+            // Capture slot[0] (the appearance .app_xml) as the
+            // canonical diagnostic asset, shown in logs for every
+            // hit regardless of which slot the codename match
+            // actually came from. This keeps log output consistent
+            // across actors:
+            //   Kliff (armored)  asset='cd_phm_macduff_*.app_xml'
+            //   Oongka (base)    asset='cd_phm_oongka_*.app_xml'
+            //   NPC              asset='character/appearance/.../<npc>.app_xml'
+            // For protagonists the match is found independently in a
+            // later slot (portrait or player_N) when slot[0] doesn't
+            // contain the codename (e.g. Kliff in custom armor).
+            CDCore::ControlledCharacter matched =
+                CDCore::ControlledCharacter::Unknown;
+            for (std::size_t i = 0; i < k_assetMaxScan; ++i)
+            {
+                const auto entry = assets + i * k_assetStride;
+                char buf[k_maxStringRead]{};
+                const auto copied = read_asset_entry(
+                    entry, buf, sizeof(buf));
+                if (copied == 0)
+                    continue;
+                if (i == 0 && outMatchedAsset != nullptr
+                    && outCap > 0)
+                {
+                    const auto wl = copied < (outCap - 1)
+                                        ? copied : (outCap - 1);
+                    std::memcpy(outMatchedAsset, buf, wl);
+                    outMatchedAsset[wl] = '\0';
+                }
+                if (matched == CDCore::ControlledCharacter::Unknown)
+                {
+                    const std::string_view sv{buf, copied};
+                    matched = classify_asset_string(sv);
+                }
+                if (matched != CDCore::ControlledCharacter::Unknown
+                    && outMatchedAsset != nullptr
+                    && outMatchedAsset[0] != '\0')
+                {
+                    // We have both a match and the slot[0] diag.
+                    // Can short-circuit.
+                    return matched;
+                }
+            }
+            return matched;
+        }
+
+        // Walk the engine player-static chain to the currently-
+        // controlled protagonist's pa::ServerChildOnlyInGameActor.
+        // Each step SEH-guarded via DMKMemory::seh_read; returns 0 on
+        // fault or pre-world.
+        //
+        //   *(g_playerStatic) -> root container
+        //   *(root + 0x18)    -> pa::NwVirtualAsyncSession
+        //   *(nwSes + 0xA0)   -> pa::ServerUserActor
+        //   *(srvUA + 0xD0)   -> controlled host
+        std::uintptr_t resolve_controlled_host() noexcept
+        {
+            if (g_playerStatic == 0)
+                return 0;
+            const auto root =
+                DMKMemory::seh_read<std::uintptr_t>(g_playerStatic)
+                    .value_or(0);
+            if (root < 0x10000)
+                return 0;
+            const auto nwSes =
+                DMKMemory::seh_read<std::uintptr_t>(root + 0x18)
+                    .value_or(0);
+            if (nwSes < 0x10000)
+                return 0;
+            const auto srvUA =
+                DMKMemory::seh_read<std::uintptr_t>(nwSes + 0xA0)
+                    .value_or(0);
+            if (srvUA < 0x10000)
+                return 0;
+            const auto host =
+                DMKMemory::seh_read<std::uintptr_t>(srvUA + 0xD0)
+                    .value_or(0);
+            if (host < 0x10000)
+                return 0;
+            return host;
+        }
+
+        // Cached wrapper with Kliff init-race fallback. Resolution
+        // order:
+        //   1. Per-host cache hit -> return cached identity.
+        //   2. Asset-string scan -> on match, cache + return.
+        //   3. Kliff fallback: if `host` equals the player-static
+        //      chain leaf (i.e. host IS the currently-controlled
+        //      actor) AND the asset scan returned Unknown, treat
+        //      this as Kliff. Justification: Kliff is always the
+        //      first-spawned protagonist and is the controlled
+        //      actor at world load; during that brief window his
+        //      CharacterAssets struct hasn't been wired up yet so
+        //      the scan returns empty. Damiane and Oongka spawn
+        //      later with assets fully wired so the scan succeeds
+        //      for them without needing this fallback.
+        //   4. Otherwise return Unknown.
+        //
+        // The cache stores ONLY successful identifications. The
+        // Kliff fallback caches its result too so subsequent muffle
+        // events on the same Kliff host hit instantly without
+        // re-walking the chain.
+        CDCore::ControlledCharacter classify_host_cached(
+            std::uintptr_t host,
+            char *outMatchedAsset,
+            std::size_t outCap) noexcept
+        {
+            if (outMatchedAsset != nullptr && outCap > 0)
+                outMatchedAsset[0] = '\0';
+            if (host < 0x10000)
+                return CDCore::ControlledCharacter::Unknown;
+            {
+                std::lock_guard<std::mutex> lk(g_hostCacheMutex);
+                const auto it = g_hostCache.find(host);
+                if (it != g_hostCache.end())
+                    return it->second;
+            }
+            const auto ch = classify_host_by_assets(
+                host, outMatchedAsset, outCap);
+            if (ch != CDCore::ControlledCharacter::Unknown)
+            {
+                std::lock_guard<std::mutex> lk(g_hostCacheMutex);
+                g_hostCache.emplace(host, ch);
+                return ch;
+            }
+            // Asset scan returned Unknown. Kliff init-race fallback:
+            // if the static chain reaches a host AND it equals the
+            // one we're classifying, attribute to Kliff.
+            const auto controlled = resolve_controlled_host();
+            if (controlled != 0 && controlled == host)
+            {
+                const auto fb = CDCore::ControlledCharacter::Kliff;
+                if (outMatchedAsset != nullptr && outCap > 0)
+                {
+                    constexpr std::string_view marker =
+                        "<kliff-init-race-fallback>";
+                    const auto wl = marker.size() < (outCap - 1)
+                                        ? marker.size()
+                                        : (outCap - 1);
+                    std::memcpy(outMatchedAsset, marker.data(), wl);
+                    outMatchedAsset[wl] = '\0';
+                }
+                std::lock_guard<std::mutex> lk(g_hostCacheMutex);
+                g_hostCache.emplace(host, fb);
+                return fb;
+            }
+            return CDCore::ControlledCharacter::Unknown;
+        }
+
+        // Inline detour for sub_141C6CC90, the per-tag passive-skill
+        // registrar. The call is suppressed when ALL three conditions
+        // hold:
+        //   (1) Structural: args identify the audio-classifier code
+        //       path (a7 == 0 AND a3 in the {tag, 0, lvl, 0} layout
+        //       the equip dispatcher uses).
+        //   (2) Class chain walk: the resolved skill's first per-level
+        //       entry has class `pa::GameAudioEffectBuffData`. This
+        //       derives muffle-class membership from the engine's own
+        //       RTTI without hardcoded tag tokens, so any future tag
+        //       backed by the same class is admitted automatically.
+        //   (3) Actor protagonist gate: the actor's CharacterAssets
+        //       vector contains one of the configured protagonist
+        //       codenames (Kliff, Damiane, or Oongka). The gate
+        //       matches by appearance string so a non-controlled
+        //       protagonist actor (e.g. sibling sitting next to the
+        //       player) also has its voice muffle stripped.
+        //
+        // The combined gates restrict the suppress universe to
+        // protagonist-owned `pa::GameAudioEffectBuffData` entries.
+        // Item-stat / sound-attack-immunity / generic combat
+        // passives all pass through.
+        //
+        // Log policy: SUPPRESS at INFO so an audible behaviour
+        // change is always present in the user log for triage; the
+        // non-muffle and non-protagonist audio-classifier branches
+        // log at TRACE so a user who flips `log_level = trace` can
+        // see why a tag did or did not suppress.
+        std::int32_t * __fastcall detour(
+            std::int64_t a1, std::int32_t *a2, std::uint16_t *a3,
+            std::int32_t a4, std::int64_t a5, std::int64_t a6,
+            char a7, std::int32_t a8, std::int64_t a9,
+            std::int64_t a10, char a11, std::int64_t a12) noexcept
+        {
+            // Fast reject: only the audio-classifier code path can
+            // ever trigger SUPPRESS. Every other call falls through
+            // to the trampoline immediately. The is_audio_classifier
+            // check is cheap (4 SEH-wrapped u16 reads), so adding it
+            // at the entry rather than after the protagonist walk
+            // keeps the unhooked-call cost minimal.
+            if (a3 == nullptr
+                || a1 < 0x10000
+                || !is_audio_classifier_call(a3, a4, a7))
+            {
+                return g_trampoline(
+                    a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+            }
+
+            // Class chain walk: skip non-audio-muffle classes entirely
+            // (VoidPassiveBuffData, ImmuneBuffData, etc.). Logged at
+            // TRACE because the audio-classifier path on a normal helm
+            // equip iterates 3-8 entries and most of them fall here.
+            const std::uint16_t tag =
+                DMKMemory::seh_read<std::uint16_t>(
+                    reinterpret_cast<std::uintptr_t>(a3))
+                    .value_or(0);
+            if (!is_audio_muffle_class(a3))
+            {
+                DMK::Logger::get_instance().trace(
+                    "[helm-audio] non-muffle tag=0x{:X} lvl={}",
+                    tag, a4);
+                return g_trampoline(
+                    a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+            }
+
+            // Muffle-class confirmed. Actor gate next: walk to the
+            // host's CharacterAssets std::vector<std::string> and
+            // scan its entries for a protagonist codename literal
+            // (Kliff, Damiane, or Oongka). Returns the matched
+            // character on first hit; pass-through otherwise.
+            //
+            // Why asset-string scan vs other actor-identity sources:
+            // the codename appears verbatim in the resource paths
+            // shipped with the game data, so the match is grounded
+            // in semantically meaningful content rather than a
+            // run-time-allocated handle or a build-specific byte
+            // offset on the host. The chain
+            //   host -> +0x68 (component table)
+            //        -> +0x40 (slot 8, CharacterControlActorComp)
+            //        -> +0x40 -> +0x38 (CharacterAssets vector)
+            // is populated once the CharacterControlActorComponent
+            // is wired, which precedes any audio-classifier
+            // registration on the actor's skill list. The init-race
+            // window where the assets vector is still empty is
+            // covered by the Kliff fallback inside
+            // classify_host_cached().
+            const auto host =
+                DMKMemory::seh_read<std::uintptr_t>(
+                    static_cast<std::uintptr_t>(a1) + 8)
+                    .value_or(0);
+            char matchedAsset[k_maxStringRead]{};
+            const auto actorChar = classify_host_cached(
+                host, matchedAsset, sizeof(matchedAsset));
+            const bool isProtagonist =
+                actorChar != CDCore::ControlledCharacter::Unknown;
+
+            const auto actorName =
+                CDCore::controlled_character_name(actorChar);
+            const std::string_view actorSv =
+                actorName.empty() ? std::string_view{"?"} : actorName;
+            const std::string_view assetSv{matchedAsset};
+
+            constexpr auto k_fmt =
+                "[helm-audio] {} tag=0x{:X} lvl={} a1=0x{:X} "
+                "host=0x{:X} actor='{}' asset='{}'";
+            auto &log = DMK::Logger::get_instance();
+
+            if (!isProtagonist)
+            {
+                // Muffle path but no protagonist codename was found
+                // in the actor's CharacterAssets entries. Pass
+                // through (NPCs, generic humanoids, pre-init).
+                log.trace(k_fmt, "non-protagonist", tag, a4,
+                          static_cast<std::uintptr_t>(a1), host,
+                          actorSv, assetSv);
+                return g_trampoline(
+                    a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+            }
+
+            // SUPPRESS. Tag never enters the actor's skill registry,
+            // so the audio dispatcher never finds it and no muffle
+            // gets published for the protagonist. The single virtual
+            // call that the trampoline-skip leaves un-invoked is
+            // rate-limited, role-gated, and refcount-balanced inside
+            // its own body (see header bypass-safety analysis), so
+            // the skip is a no-op for the only role the protagonist
+            // ever has.
+            log.info(k_fmt, "suppress", tag, a4,
+                     static_cast<std::uintptr_t>(a1), host,
+                     actorSv, assetSv);
+            if (a2 != nullptr)
+                *a2 = 0;
+            return a2;
+        }
+    } // namespace
+
+    bool init()
+    {
+        if (g_initDone.load(std::memory_order_acquire))
+            return true;
+
+        auto &log = DMK::Logger::get_instance();
+
+        // Resolve the registrar entry (sub_141C6CC90 in v1.08.00).
+        const auto target = ::Transmog::resolve_address(
+            ::Transmog::k_helmAudioRegistrarCandidates,
+            "HelmAudioFilter_PassiveSkillRegistrar");
+        if (target == 0)
+        {
+            log.warning(
+                "[helm-audio] registrar AOB resolve failed; "
+                "feature disabled");
+            return false;
+        }
+
+        // Resolve the engine's tag -> skill record resolver
+        // (sub_1402FB2C0). Required for the class chain walk; without
+        // it we cannot distinguish muffle-class buffs from other
+        // audio-classifier entries and the hook would have no safe
+        // way to suppress.
+        const auto resolverAddr = ::Transmog::resolve_address(
+            ::Transmog::k_skillTagResolverCandidates,
+            "HelmAudioFilter_SkillTagResolver");
+        if (resolverAddr == 0)
+        {
+            log.warning(
+                "[helm-audio] skill-tag resolver AOB resolve failed; "
+                "feature disabled");
+            return false;
+        }
+        g_skillTagResolver =
+            reinterpret_cast<SkillTagResolverFn>(resolverAddr);
+
+        // Resolve the pa::GameAudioEffectBuffData vtable's first vfunc
+        // address. Each instance of that class stores this exact value
+        // in its first qword, so we compare buff_instance[0] against
+        // this to identify muffle-class entries. The AOB anchors at
+        // the vtable header (RTTI metadata ptr + first 2 vfuncs);
+        // dispOffset=+8 advances past the RTTI ptr to vfunc[0]'s
+        // address, which is what objects actually store.
+        const auto vtableAddr = ::Transmog::resolve_address(
+            ::Transmog::k_gameAudioEffectVtableCandidates,
+            "HelmAudioFilter_GameAudioEffectVtable");
+        if (vtableAddr == 0)
+        {
+            log.warning(
+                "[helm-audio] GameAudioEffectBuffData vtable AOB "
+                "resolve failed; feature disabled");
+            return false;
+        }
+        g_gameAudioEffectVtable = vtableAddr;
+
+        // Engine player static -- needed by the Kliff init-race
+        // fallback. On AOB failure we still install the hook; the
+        // fallback simply won't fire (asset-string scan still works
+        // for Damiane/Oongka and for Kliff once his assets wire up).
+        const auto playerStatic = ::Transmog::resolve_address(
+            ::Transmog::k_playerStaticCandidates,
+            "HelmAudioFilter_PlayerStatic");
+        if (playerStatic != 0)
+            g_playerStatic = playerStatic;
+        else
+            log.warning(
+                "[helm-audio] player-static AOB resolve failed; "
+                "Kliff init-race fallback disabled (asset-string "
+                "scan still active)");
+
+        // Install the inline hook on the registrar.
+        auto &hookMgr = DMK::HookManager::get_instance();
+        auto res = hookMgr.create_inline_hook(
+            "HelmAudioFilterPassiveSkillRegistrar", target,
+            reinterpret_cast<void *>(&detour),
+            reinterpret_cast<void **>(&g_trampoline));
+        if (!res.has_value())
+        {
+            log.warning(
+                "[helm-audio] inline-hook install failed at 0x{:X}: "
+                "{}",
+                target,
+                DetourModKit::Hook::error_to_string(res.error()));
+            return false;
+        }
+
+        log.info(
+            "[helm-audio] inline-hook installed at 0x{:X} "
+            "(resolver=0x{:X}, audio-vtable=0x{:X}, "
+            "player-static=0x{:X})",
+            target, resolverAddr, vtableAddr, g_playerStatic);
+
+        g_initDone.store(true, std::memory_order_release);
+        return true;
+    }
+
+} // namespace Transmog::HelmAudioFilter

--- a/CrimsonDesertLiveTransmog/src/helm_audio_filter.hpp
+++ b/CrimsonDesertLiveTransmog/src/helm_audio_filter.hpp
@@ -1,0 +1,151 @@
+#pragma once
+
+/**
+ * @file helm_audio_filter.hpp
+ * @brief PlateHelm voice-muffle suppression at the passive-skill
+ *        registration boundary.
+ *
+ * The engine's helm-muffle path runs through this chain (v1.08.00):
+ *
+ *   iteminfo[idx].equip_passive_skill_list      // {skill_id, level} per item
+ *       |
+ *       v
+ *   per-skill iteminfo audio-classifier vector  // 8-byte stride
+ *                                               // {u16 tag, u16 0, u16 lvl, u16 0}
+ *       |
+ *       v
+ *   sub_141C6CC90   (THIS HOOK target -- per-tag passive-skill
+ *                    registrar; for each iteration writes a 224-byte
+ *                    descriptor and dispatches it via the registry's
+ *                    vtable[46] into the actor's skill manager. The
+ *                    audio dispatcher later reads the registered
+ *                    entries to decide voice muffling.)
+ *
+ * Structural identification of the audio-classifier call path:
+ *   - `a7` (7th positional arg, single byte) is 0 for every
+ *     audio-classifier registration and non-zero for every other
+ *     passive registrar caller observed across 46 xrefs.
+ *   - `a3` (the tag pointer) points into an 8-byte vector entry
+ *     `{ u16 tag, u16 0, u16 lvl, u16 0 }` ONLY for audio-classifier
+ *     calls; other passive paths use different `a3` layouts. The
+ *     `(u16)*(a3+4) == (u16)a4` equality is a deterministic
+ *     format-check that admits only the audio-classifier code path.
+ *
+ * Muffle-class identification (chain walk via engine RTTI):
+ *
+ *   record       = sub_1402FB2C0(a3)                  // engine resolver
+ *   level_table  = *(record + 0x18)                    // per-level table
+ *   inner_arr    = *(level_table + 0x00)               // first inner ptr
+ *   first_entry  = *(inner_arr + 0x00)                 // level 1 entry #1
+ *   vtable       = *(first_entry + 0x00)               // class vtable
+ *
+ * If `vtable` equals the resolved `pa::GameAudioEffectBuffData`
+ * vtable, the tag is a voice-muffle audio buff and qualifies for
+ * suppression. Other classes (`pa::VoidPassiveBuffData`,
+ * `pa::ImmuneBuffData`, etc.) pass through.
+ *
+ * Evidence basis:
+ *   - Tag 0x64B (skill 91000, internal name `"PlateHelm_Audio"`)
+ *     resolves to `pa::GameAudioEffectBuffData` with Korean
+ *     description `"투구 착용 시 먹먹한 소리"` (Muffled sound when
+ *     wearing helmet).
+ *   - Tag 0x64C (skill 91001, `"PlateHelm_Audio_OpenableHelm"`,
+ *     visor-closed variant) resolves to the same class with the
+ *     same description.
+ *   - Other tags in the same iteminfo vector (0x647 / 0x650)
+ *     resolve to non-audio classes (item stat / sound-attack
+ *     immunity) and must remain pass-through so helm-derived stats
+ *     and sound-attack resistance survive the filter.
+ *   - 108 helms carry skill 91000 and 16 carry skill 91001 (iteminfo
+ *     dump cross-check). The chain walk identifies all 124 muffle
+ *     helms universally, including any future content patch that
+ *     adds new tags backed by the same engine class.
+ *   - Footstep / armor-clank audio uses unrelated character-config
+ *     fields (`_footStepSoundEvent` etc.) and never reaches this
+ *     registrar; zero collateral risk on those systems.
+ *
+ * Per-actor scope (any-protagonist gate by appearance):
+ *
+ * The hook suppresses muffle for any actor whose appearance path
+ * classifies as one of the 3 protagonists (Kliff, Damiane, Oongka),
+ * regardless of which protagonist the player is currently driving.
+ *
+ *   appearance file (e.g. `cd_phm_macduff_00000.app_xml` for Kliff
+ *   in armor, or `cd_phm_oongka_00000.app_xml` for Oongka)
+ *      -> CDCore::classify_appearance_by_path()
+ *      -> {Kliff, Damiane, Oongka, Unknown}
+ *   isProtagonist = actor in {Kliff, Damiane, Oongka}
+ *
+ * Why protagonist-set, not controlled-only: all 3 protagonist
+ * voices must play unmuffled even when not driven. A Damiane body
+ * spawning as a roster NPC alongside a Kliff-driven player still
+ * needs her muffle stripped so the muffled-helmet effect does not
+ * leak onto her dialogue lines while the player walks past.
+ *
+ * Collateral safety: the chain-walk vtable check above restricts
+ * the suppress universe to `pa::GameAudioEffectBuffData` only. A
+ * protagonist-classified body has only its voice muffle stripped;
+ * item-stat / sound-attack-immunity / generic combat passives all
+ * pass through unchanged.
+ *
+ * Pre-world note: when the actor's appearance config has not yet
+ * been wired up, the path resolver returns an empty buffer and
+ * `classify_appearance_by_path` yields Unknown -- the gate
+ * rejects, the trampoline runs, the engine muffles as usual. The
+ * next equip cycle after the appearance is wired runs through the
+ * hook with the classifier resolving cleanly.
+ *
+ * Bypass-safety analysis.
+ *
+ * SUPPRESS returns before invoking the trampoline, so the entire body
+ * of sub_141C6CC90 is skipped. The only pre-branch side effect inside
+ * that body is one entry-block virtual call that resolves to
+ * `sub_142463190` on a `pa::ServerTransformSyncActorComponent`. That
+ * target is rate-limited (>=100-tick gate when arg2 == 0), role-gated
+ * (network branch only for roles {3,4,5,6}, so role=1 Kliff is a
+ * complete no-op), and refcount-balanced inside its own body. A
+ * skipped invocation has zero observable correctness impact and zero
+ * refcount delta; gating the feature behind an INI toggle keeps a
+ * runtime safety lever in case a future engine patch reshapes the
+ * call's contract.
+ *
+ * Alternative hook points considered and rejected:
+ *   - Consumer layer (sub_148FC9490 publisher / Wwise SetState):
+ *     attempts here mute the world bus because muffle state is
+ *     tightly coupled with RTPC voice attenuation + Switch routing.
+ *     v1.08.00 audio reader code additionally lives in obfuscated `.tls`
+ *     space (sub_14BA47B10 et al.), so static-RE is impractical.
+ *   - iteminfo desc+0x100 source mutation: persistent data change
+ *     that would affect NPC inventories, save serialization, and
+ *     network sync. Out of scope for a per-actor mod.
+ */
+
+namespace Transmog::HelmAudioFilter
+{
+    /**
+     * @brief Resolve dependencies and install the passive-skill
+     *        registrar inline hook.
+     *
+     * Idempotent. Resolves four AOBs:
+     *   1. sub_141C6CC90 (registrar entry; see
+     *      `k_helmAudioRegistrarCandidates`)
+     *   2. sub_1402FB2C0 (engine tag resolver for the chain walk;
+     *      see `k_skillTagResolverCandidates`)
+     *   3. `pa::GameAudioEffectBuffData` vtable (class marker for
+     *      muffle-class identification; see
+     *      `k_gameAudioEffectVtableCandidates`)
+     *   4. engine player static (root of the Kliff init-race
+     *      fallback chain; see `k_playerStaticCandidates`). On
+     *      AOB failure the hook still installs; only the
+     *      first-frame Kliff fallback is disabled.
+     *
+     * On any required AOB or hook install failure, logs a warning
+     * and leaves the feature disabled; the rest of LT continues to
+     * load.
+     *
+     * @return true if the hook is now installed (including a prior
+     *         successful install), false otherwise.
+     */
+    bool init();
+
+} // namespace Transmog::HelmAudioFilter

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -35,6 +35,7 @@ namespace Transmog
     static std::atomic<bool> s_enabled{true};
     static std::atomic<bool> s_shutdownRequested{false};
     static std::atomic<bool> s_colorOverride{false};
+    static std::atomic<bool> s_helmAudioUnmuffle{true};
     static std::atomic<bool> s_dumpItemPrefabs{false};
     static std::atomic<bool> s_dumpItemCatalog{false};
     static std::atomic<bool> s_applyToEditing{true};
@@ -77,6 +78,7 @@ namespace Transmog
     std::atomic<bool> &flag_enabled() { return s_enabled; }
     std::atomic<bool> &shutdown_requested() { return s_shutdownRequested; }
     std::atomic<bool> &flag_color_override() { return s_colorOverride; }
+    std::atomic<bool> &flag_helm_audio_unmuffle() { return s_helmAudioUnmuffle; }
     std::atomic<bool> &flag_dump_item_prefabs() { return s_dumpItemPrefabs; }
     std::atomic<bool> &flag_dump_item_catalog() { return s_dumpItemCatalog; }
     std::atomic<bool> &flag_apply_to_editing() { return s_applyToEditing; }

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -131,9 +131,9 @@ namespace Transmog
     /// it did before the ColorOverride port landed.
     std::atomic<bool> &flag_color_override();
 
-    /// Master gate for the helm voice-unmuffle filter. True by default;
-    /// disable via the `[Experimental] UnmuffleHelmVoice` INI key to
-    /// restore the engine's stock plate/heavy-helm voice muffle. When
+    /// Master gate for the helm voice-unmuffle filter. False by default;
+    /// enable via the `[Experimental] UnmuffleHelmVoice` INI key to
+    /// remove the engine's stock plate/heavy-helm voice muffle. When
     /// false, the passive-skill registrar inline hook is not installed
     /// and the muffle behaves as it does in vanilla. Toggle is read
     /// once at startup; takes effect on the next game launch.

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -131,6 +131,14 @@ namespace Transmog
     /// it did before the ColorOverride port landed.
     std::atomic<bool> &flag_color_override();
 
+    /// Master gate for the helm voice-unmuffle filter. True by default;
+    /// disable via the `[Experimental] UnmuffleHelmVoice` INI key to
+    /// restore the engine's stock plate/heavy-helm voice muffle. When
+    /// false, the passive-skill registrar inline hook is not installed
+    /// and the muffle behaves as it does in vanilla. Toggle is read
+    /// once at startup; takes effect on the next game launch.
+    std::atomic<bool> &flag_helm_audio_unmuffle();
+
     /// One-shot diagnostic dumps gated by `[Diagnostics]` INI section.
     /// Off by default. When true the corresponding TSV is written next
     /// to the plugin once ItemNameTable::build() returns Ok.

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -108,14 +108,14 @@ namespace Transmog
             "Experimental", "ColorOverride", "Color Override",
             flag_color_override(), false);
 
-        // Experimental: helm voice-unmuffle filter. Enabled by default;
-        // disable to restore the engine's stock plate/heavy-helm voice
+        // Experimental: helm voice-unmuffle filter. Disabled by default;
+        // enable to remove the engine's stock plate/heavy-helm voice
         // muffle on protagonists. The hook only installs at startup
         // when this is true, so toggle changes take effect on the next
         // game launch. NPC voice muffle is unaffected either way.
         DMK::Config::register_atomic<bool>(
             "Experimental", "UnmuffleHelmVoice", "Unmuffle Helm Voice",
-            flag_helm_audio_unmuffle(), true);
+            flag_helm_audio_unmuffle(), false);
 
         // One-shot diagnostic TSV dumps. Off by default; enable to
         // capture item-catalog / item->prefab snapshots once
@@ -1258,9 +1258,9 @@ namespace Transmog
         else
         {
             DMK::Logger::get_instance().info(
-                "[helm-audio] disabled via "
-                "`[Experimental] UnmuffleHelmVoice = false`; "
-                "stock plate/heavy-helm voice muffle preserved.");
+                "[helm-audio] disabled; set "
+                "`[Experimental] UnmuffleHelmVoice = true` to remove "
+                "the stock plate/heavy-helm voice muffle.");
         }
 
         // Per-slot dye-record injector. Hooks the engine's dye-copier

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -22,6 +22,7 @@
 #include "transmog_hooks.hpp"
 #include "transmog_map.hpp"
 #include "transmog_worker.hpp"
+#include "helm_audio_filter.hpp"
 
 #include <cdcore/controlled_char.hpp>
 #include <cdcore/dmk_glue.hpp>
@@ -106,6 +107,15 @@ namespace Transmog
         DMK::Config::register_atomic<bool>(
             "Experimental", "ColorOverride", "Color Override",
             flag_color_override(), false);
+
+        // Experimental: helm voice-unmuffle filter. Enabled by default;
+        // disable to restore the engine's stock plate/heavy-helm voice
+        // muffle on protagonists. The hook only installs at startup
+        // when this is true, so toggle changes take effect on the next
+        // game launch. NPC voice muffle is unaffected either way.
+        DMK::Config::register_atomic<bool>(
+            "Experimental", "UnmuffleHelmVoice", "Unmuffle Helm Voice",
+            flag_helm_audio_unmuffle(), true);
 
         // One-shot diagnostic TSV dumps. Off by default; enable to
         // capture item-catalog / item->prefab snapshots once
@@ -200,9 +210,9 @@ namespace Transmog
     // VALUES themselves are unchanged (Helm=0x03, Chest=0x04, Gloves=0x05,
     // Boots=0x06, Cloak=0x10); only the position within the entry shifted.
     // Mirrors k_entryStride / k_entrySlotTagOffset in real_part_tear_down.cpp.
-    constexpr std::ptrdiff_t k_compEntryStride         = 0xD0;
-    constexpr std::ptrdiff_t k_compEntryItemIdOffset   = 0x08;
-    constexpr std::ptrdiff_t k_compEntrySlotTagOffset  = 0xC8;
+    constexpr std::ptrdiff_t k_compEntryStride = 0xD0;
+    constexpr std::ptrdiff_t k_compEntryItemIdOffset = 0x08;
+    constexpr std::ptrdiff_t k_compEntrySlotTagOffset = 0xC8;
 
     // --- Public interface ---
 
@@ -234,9 +244,12 @@ namespace Transmog
         std::uint32_t char_idx_for_preset_name(
             const std::string &name) noexcept
         {
-            if (name == "Kliff")   return 1;
-            if (name == "Damiane") return 2;
-            if (name == "Oongka")  return 3;
+            if (name == "Kliff")
+                return 1;
+            if (name == "Damiane")
+                return 2;
+            if (name == "Oongka")
+                return 3;
             return 0;
         }
 
@@ -408,10 +421,10 @@ namespace Transmog
             if (src.group_hash == 0)
                 continue;
             auto &dst = slotPreset.dye[k];
-            dst.group_hash  = src.group_hash;
-            dst.r           = src.r;
-            dst.g           = src.g;
-            dst.b           = src.b;
+            dst.group_hash = src.group_hash;
+            dst.r = src.r;
+            dst.g = src.g;
+            dst.b = src.b;
             dst.material_id = src.material_id;
             dst.repair_byte = src.repair_byte;
             const auto *grp =
@@ -510,7 +523,11 @@ namespace Transmog
         __try
         {
             auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + k_compEntryTablePtrOffset);
-            if (entryDesc < 0x10000) { logger.warning("Capture: no entry table"); return; }
+            if (entryDesc < 0x10000)
+            {
+                logger.warning("Capture: no entry table");
+                return;
+            }
             auto entryArray = *reinterpret_cast<uintptr_t *>(entryDesc + 8);
             auto entryCount = *reinterpret_cast<uint32_t *>(entryDesc + 16);
 
@@ -623,7 +640,8 @@ namespace Transmog
         __try
         {
             auto entryDesc = *reinterpret_cast<uintptr_t *>(a1 + k_compEntryTablePtrOffset);
-            if (entryDesc < 0x10000) return;
+            if (entryDesc < 0x10000)
+                return;
             auto entryArray = *reinterpret_cast<uintptr_t *>(entryDesc + 8);
             auto entryCount = *reinterpret_cast<uint32_t *>(entryDesc + 16);
 
@@ -891,7 +909,9 @@ namespace Transmog
                     // init (hooks, color-override) doesn't block waiting
                     // for the TSV write -- nothing downstream depends on
                     // the dump.
-                    std::thread{[] { dump_itemmesh_tsv(); }}.detach();
+                    std::thread{[]
+                                { dump_itemmesh_tsv(); }}
+                        .detach();
                 }
             }
             else if (result == BR::Deferred)
@@ -977,9 +997,16 @@ namespace Transmog
             // Verify the resolved byte is 0x74 (jz). SEH-isolated via
             // noinline lambda (C++ objects in parent block unwinding).
             uint8_t probe = 0;
-            [&]() __declspec(noinline) {
-                __try { probe = *reinterpret_cast<volatile uint8_t *>(addrs.charClassBypass); }
-                __except (EXCEPTION_EXECUTE_HANDLER) { probe = 0; }
+            [&]() __declspec(noinline)
+            {
+                __try
+                {
+                    probe = *reinterpret_cast<volatile uint8_t *>(addrs.charClassBypass);
+                }
+                __except (EXCEPTION_EXECUTE_HANDLER)
+                {
+                    probe = 0;
+                }
             }();
             if (probe == 0x74)
                 logger.info("CharClassBypass at 0x{:X} (byte=0x{:02X} OK)",
@@ -1206,6 +1233,35 @@ namespace Transmog
         }
 
         PrefabWrapperSwap::init();
+
+        // Helm-audio filter -- intervenes at the passive-skill
+        // REGISTRATION boundary (sub_141C6CC90) BEFORE the muffle
+        // tag enters the character's skill registry, so no downstream
+        // Wwise / RTPC / Switch path ever observes it. The combined
+        // gates (audio-classifier call layout + RTTI chain walk to
+        // `pa::GameAudioEffectBuffData` + protagonist host) leave
+        // other passive-skill effects of the same item intact and
+        // keep NPC voices muffling as in vanilla. See
+        // helm_audio_filter.hpp for the full data-flow chain and
+        // bypass-safety analysis.
+        //
+        // Gated by `[Experimental] UnmuffleHelmVoice`. The flag is
+        // read once here at startup; runtime toggle is not supported
+        // because tearing down the inline detour would race the engine
+        // equip pipeline that calls it from arbitrary threads. The
+        // hook leaves a single virtual call un-invoked on SUPPRESS;
+        // letting users opt out is the safety lever for that bypass.
+        if (flag_helm_audio_unmuffle().load(std::memory_order_relaxed))
+        {
+            HelmAudioFilter::init();
+        }
+        else
+        {
+            DMK::Logger::get_instance().info(
+                "[helm-audio] disabled via "
+                "`[Experimental] UnmuffleHelmVoice = false`; "
+                "stock plate/heavy-helm voice muffle preserved.");
+        }
 
         // Per-slot dye-record injector. Hooks the engine's dye-copier
         // primitive and appends fabricated ARMOR_MOD records so fake


### PR DESCRIPTION
## Summary
- Adds opt-in `[Experimental] UnmuffleHelmVoice` setting (off by default) that suppresses plate/heavy-helm voice muffle on the player only; NPC voices remain vanilla.
- New `helm_audio_filter` module hooks the passive-skill registrar and filters muffle tags from iteminfo before they reach the character skill registry.
- Minor `controlled_char` / `shared_state` / `transmog` plumbing to support the strict per-actor gate.

