### PR TITLE
feat(equip-hide): add Oongka default hidden weapon and tool parts

### DIFF
--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -160,12 +160,21 @@ Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, 
 [OneHandWeapons:Damiane]
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L, CD_MainWeapon_Gauntlet, CD_MainWeapon_Gauntlet_L
 
-; Oongka's vanilla-hidden set has not been verified. Leaving Parts empty
-; (or omitting the section entirely) inherits the conservative base list
-; defined in [OneHandWeapons] above; fill in once you confirm his sheath
-; meshes.
+; Oongka can additionally hide: left-hand daggers (CD_MainWeapon_Dagger_L,
+;   CD_MainWeapon_Dagger_IN_L), left gauntlet (CD_MainWeapon_Gauntlet_L),
+;   bola (CD_MainWeapon_Bola).
+; Vanilla-hidden for him (omitted from his override): right-hand daggers
+;   (CD_MainWeapon_Dagger_R, CD_MainWeapon_Dagger_IN_R), 1H axes
+;   (CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L), 1H maces
+;   (CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L), right gauntlet
+;   (CD_MainWeapon_Gauntlet), left fist (CD_MainWeapon_Fist_L), handcannon
+;   (CD_MainWeapon_HandCannon).
+; (Mirrors Kliff: Oongka shares the male phm rig -- their player-description
+;   PartInOutSocketInfo lists identical tool stow sockets and Oongka is a
+;   superset of Kliff's stowed-weapon sockets -- so the rig's 1H sheath meshes
+;   match Kliff's.)
 [OneHandWeapons:Oongka]
-Parts =
+Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux, CD_MainWeapon_Dagger_L, CD_MainWeapon_Dagger_IN_L, CD_MainWeapon_Gauntlet_L, CD_MainWeapon_Bola
 
 [TwoHandWeapons]
 Enabled = false
@@ -230,11 +239,14 @@ Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Too
 [Tools:Damiane]
 Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book, CD_Tool_Saw, CD_Tool_Pan, CD_Tool_Shooter
 
-; Oongka's vanilla-hidden tool set has not been verified. Leaving Parts
-; empty (or omitting the section entirely) inherits the conservative base
-; list defined in [Tools] above.
+; Oongka can additionally hide: fire can (CD_Tool_FireCan).
+; Vanilla-hidden for him (omitted from his override): torch (CD_Tool_Torch),
+;   flute (CD_Tool_Flute), pan (CD_Tool_Pan), pipe (CD_Tool_Pipe),
+;   saw (CD_Tool_Saw), shooter (CD_Tool_Shooter), sprayer (CD_Tool_Sprayer).
+; (Mirrors Kliff: Oongka shares the male phm rig -- their player-description
+;   PartInOutSocketInfo lists identical tool stow sockets.)
 [Tools:Oongka]
-Parts =
+Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book, CD_Tool_FireCan
 
 [Lanterns]
 Enabled = false

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
 ## [Title for next release]
 
-- New feature
-- Bug fix
-- Improvement
+- Oongka now hides the same one-handed weapons and tools as Kliff by default.


### PR DESCRIPTION
## Summary

- Fill the previously-empty `[OneHandWeapons:Oongka]` and `[Tools:Oongka]` per-character overrides in the shipped INI template with Kliff's verified set, so Oongka hides the same one-handed weapons and tools as Kliff by default instead of falling back to the conservative base list.

