### PR TITLE
ci: pin release workflows to windows-2022

### DIFF
--- a/.github/workflows/release-equiphide.yml
+++ b/.github/workflows/release-equiphide.yml
@@ -28,7 +28,9 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: windows-latest
+    # Pinned: windows-latest now images windows-2025-vs2026 (VS 2026, no VS 2022),
+    # which breaks the "Visual Studio 17 2022" CMake generator used below.
+    runs-on: windows-2022
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-livetransmog.yml
+++ b/.github/workflows/release-livetransmog.yml
@@ -28,7 +28,9 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: windows-latest
+    # Pinned: windows-latest now images windows-2025-vs2026 (VS 2026, no VS 2022),
+    # which breaks the "Visual Studio 17 2022" CMake generator used below.
+    runs-on: windows-2022
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
windows-latest now images Windows Server 2025 with Visual Studio 2026, which has no VS 2022, so the "Visual Studio 17 2022" CMake generator in the release builds fails to find an instance. Pin both release workflows (Live Transmog and Equip Hide) to windows-2022 to restore the known-good toolchain.