### PR TITLE
fix(live-transmog): apply body-mesh prefab picks without a saved preset

### DIFF
--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -153,6 +153,23 @@ namespace CDCore
         ControlledCharacter ch) noexcept;
 
     /**
+     * @brief Inverse of controlled_character_name: resolve a short
+     *        codename ("Kliff" / "Damiane" / "Oongka") back to its enum.
+     * @return Unknown for any other string.
+     */
+    [[nodiscard]] ControlledCharacter character_from_name(
+        std::string_view name) noexcept;
+
+    /**
+     * @brief One-based index for a character codename.
+     * @return 1 Kliff, 2 Damiane, 3 Oongka, 0 otherwise. Matches the
+     *         sentinel of current_controlled_character_idx() so name- and
+     *         live-derived indices are interchangeable.
+     */
+    [[nodiscard]] std::uint32_t character_idx_from_name(
+        std::string_view name) noexcept;
+
+    /**
      * @brief Convenience wrapper that returns the live name.
      * @return Short name of the controlled character, or an empty view if
      *         unknown.

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -564,6 +564,25 @@ namespace CDCore
         }
     }
 
+    ControlledCharacter character_from_name(std::string_view name) noexcept
+    {
+        if (name == "Kliff")   return ControlledCharacter::Kliff;
+        if (name == "Damiane") return ControlledCharacter::Damiane;
+        if (name == "Oongka")  return ControlledCharacter::Oongka;
+        return ControlledCharacter::Unknown;
+    }
+
+    std::uint32_t character_idx_from_name(std::string_view name) noexcept
+    {
+        switch (character_from_name(name))
+        {
+        case ControlledCharacter::Kliff:   return 1;
+        case ControlledCharacter::Damiane: return 2;
+        case ControlledCharacter::Oongka:  return 3;
+        default:                           return 0;
+        }
+    }
+
     std::string_view current_controlled_character_name() noexcept
     {
         return controlled_character_name(current_controlled_character());

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Title for next release]
+## Reliable body-mesh prefab picks
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed body-mesh prefab picks not applying when the character had no saved preset

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -12,6 +12,8 @@
 #include "transmog_apply.hpp"
 #include "transmog_map.hpp"
 
+#include <cdcore/controlled_char.hpp>
+
 #include <DetourModKit.hpp>
 #include <nlohmann/json.hpp>
 
@@ -1483,6 +1485,22 @@ namespace Transmog
 
     void PresetManager::apply_to_state() const
     {
+        namespace PWS = Transmog::PrefabWrapperSwap;
+
+        // Bind the editing character into PWS before the active_preset()
+        // early-out below. Only apply_to_state() binds s_activeCharIdx;
+        // the picker's body-mesh path (set_selection plus the Instant-
+        // Apply manual_apply) never does. For a character with no saved
+        // preset (active_preset() == nullptr) the bind therefore has to
+        // happen here, ahead of the early return -- otherwise the
+        // prefab-swap map stays unbound, apply_selections_to_swap_map()
+        // bails at its activeIdx < 1 guard, and the picked body mesh
+        // renders as the bare carrier instead of the chosen prefab. The
+        // bind is independent of the preset, so set_selection can still
+        // mirror picks into the correct per-char row and the swap arms.
+        PWS::set_active_char_idx(
+            CDCore::character_idx_from_name(m_editingCharacter));
+
         const auto *p = active_preset();
         if (!p)
             return;
@@ -1552,23 +1570,6 @@ namespace Transmog
         // resolution silently misses; the boot thread re-runs
         // apply_to_state when populate_slot_catalogs finishes so the
         // selection lands as soon as the data is available.
-        namespace PWS = Transmog::PrefabWrapperSwap;
-
-        // Bind the editing character into PWS first so subsequent
-        // set_selection calls mirror into the correct per-char row
-        // and the active-editing-view globals reflect that
-        // character's previously-saved selections. Without this
-        // binding the writes would leak into whatever bucket was
-        // last bound, and switching the editing character would
-        // silently drop the outgoing character's body-mesh picks.
-        {
-            std::uint32_t editIdx = 0;
-            if (m_editingCharacter == "Kliff")   editIdx = 1;
-            else if (m_editingCharacter == "Damiane") editIdx = 2;
-            else if (m_editingCharacter == "Oongka")  editIdx = 3;
-            PWS::set_active_char_idx(editIdx);
-        }
-
         for (std::size_t i = 0; i < k_slotCount; ++i)
         {
             const auto tslot = static_cast<TransmogSlot>(i);

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -237,22 +237,6 @@ namespace Transmog
 
     namespace
     {
-        // Map PresetManager character names to the 1-based char-idx
-        // CDCore::snapshot_body_cache emits (1=Kliff, 2=Damiane,
-        // 3=Oongka). Returns 0 for unknown names so the targeted-apply
-        // path can refuse to schedule rather than guess.
-        std::uint32_t char_idx_for_preset_name(
-            const std::string &name) noexcept
-        {
-            if (name == "Kliff")
-                return 1;
-            if (name == "Damiane")
-                return 2;
-            if (name == "Oongka")
-                return 3;
-            return 0;
-        }
-
         // Editing-target gate consulted by every overlay-UI entry point
         // (manual_apply, manual_apply_slot, manual_clear). Returns
         // true if the caller should proceed with `schedule_transmog_*`;
@@ -276,7 +260,7 @@ namespace Transmog
                 return true;
 
             const std::string editName{pm.editing_character()};
-            const auto idx = char_idx_for_preset_name(editName);
+            const auto idx = CDCore::character_idx_from_name(editName);
             if (idx == 0)
                 return true; // Unknown character name; fall back to default.
 

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -26,22 +26,6 @@
 
 namespace Transmog
 {
-    namespace
-    {
-        // Map PresetManager character names to the 1-based char-idx
-        // CDCore::snapshot_body_cache emits (1=Kliff, 2=Damiane,
-        // 3=Oongka). Returns 0 for unknown names so the per-body
-        // hydrate/capture helpers no-op safely on caller mistakes.
-        std::uint32_t char_idx_for_preset_name(
-            const std::string &name) noexcept
-        {
-            if (name == "Kliff")   return 1;
-            if (name == "Damiane") return 2;
-            if (name == "Oongka")  return 3;
-            return 0;
-        }
-    } // namespace
-
     // --- Deferred item-name catalog scan ---
     //
     // The game populates the iteminfo global (`qword_145CEF370`) some
@@ -601,7 +585,7 @@ namespace Transmog
         // fill(0)-style wipe. Mid-session re-applies (e.g., roster-
         // grew on follower summon) preserve the prior installed-state
         // so Phase A teardown still functions across iterations.
-        const auto idx = char_idx_for_preset_name(name);
+        const auto idx = CDCore::character_idx_from_name(name);
         rehydrate_applied_state_for_char(idx);
 
         bool faulted = false;
@@ -723,7 +707,7 @@ namespace Transmog
             m.targetItemId = 0;
         }
         pm.apply_to_state();
-        const auto idx = char_idx_for_preset_name(controlledName);
+        const auto idx = CDCore::character_idx_from_name(controlledName);
         rehydrate_applied_state_for_char(idx);
     }
 


### PR DESCRIPTION
## Summary
Fixes body-mesh prefab picks not applying when the active character has no saved preset. The prefab-swap map was only bound to the editing character once a preset was applied, so a character with no preset fell back to the bare carrier instead of the picked mesh. Also centralizes the character-name to index mapping in CrimsonDesertCore and removes the duplicated local copies.

## Changes
- Bind the editing character before the no-preset early-out so prefab picks always apply.
- Add shared character-name to index helpers in CrimsonDesertCore and route existing call sites through them.
- Add changelog entry for the next release.
