### PR TITLE
feat: self-healing offsets and DetourModKit 3.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ __pycache__/
 docs/live-transmog/catalog.html
 docs/catalog-src/node_modules/
 docs/catalog-src/.vite/
+**/analysis

--- a/CrimsonDesertCore/CMakeLists.txt
+++ b/CrimsonDesertCore/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.28)
 
 project(CrimsonDesertCore VERSION 0.1.0 LANGUAGES CXX)
 

--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -108,6 +108,23 @@ namespace CDCore
     } // namespace ActorChainOffsets
 
     /**
+     * @brief INI-tunable search radius (bytes, per side) for the rtti_dissect
+     *        self-heal that recovers the manager->userActor offset after a patch
+     *        shifts the struct layout.
+     * @details Returns the atomic a consumer binds with
+     *          DMK::Config::register_atomic("Advanced", "SelfHealWindow", ...).
+     *          The heal reads it once per attempt (not a hot path) and clamps it
+     *          to DMK::Rtti::MAX_HEAL_WINDOW; a non-positive value falls back to
+     *          the built-in default. A wider window reaches a larger insertion
+     *          before the userActor slot; this is a single independent landmark,
+     *          but the manager references pa::ClientUserActor exactly once (the
+     *          next pointer to it is megabytes away), so the 0x200 default is
+     *          decoy-free across the whole heal range. Raise it via the INI only
+     *          if a real patch shifts the field further.
+     */
+    [[nodiscard]] std::atomic<int> &heal_window_setting() noexcept;
+
+    /**
      * @brief Identifies one of the three controlled playable characters.
      * @details Unknown is returned when the static chain has not yet
      *          been populated (cold-load), when it is mid-teardown

--- a/CrimsonDesertCore/include/cdcore/dmk_glue.hpp
+++ b/CrimsonDesertCore/include/cdcore/dmk_glue.hpp
@@ -29,12 +29,14 @@ namespace CDCore::Glue
      * @brief Resolves the first matching candidate from a cascade and
      *        returns the absolute address, or 0 on failure.
      * @details Thin wrapper around
-     *          DetourModKit::Scanner::resolve_cascade_with_prologue_fallback
+     *          DetourModKit::Scanner::resolve_cascade_in_host_module_with_prologue_fallback
      *          that flattens the std::expected return into the legacy
-     *          uintptr_t-or-zero shape used pervasively in CD mods. The
-     *          underlying cascade already logs the success line; on
-     *          failure this wrapper emits a single Warning so caller code
-     *          can stay focused on conditional feature wiring.
+     *          uintptr_t-or-zero shape used pervasively in CD mods. The scan is
+     *          scoped to the host executable because every Crimson Desert
+     *          hook/scan target lives in CrimsonDesert.exe. The underlying
+     *          cascade already logs the success line; on failure this wrapper
+     *          emits a single Warning so caller code can stay focused on
+     *          conditional feature wiring.
      *
      *          Use this for "look up an address, install a hook if it
      *          resolved, otherwise log a warning and continue without the
@@ -47,8 +49,12 @@ namespace CDCore::Glue
         std::span<const DetourModKit::Scanner::AddrCandidate> candidates,
         std::string_view label)
     {
-        auto hit = DetourModKit::Scanner::resolve_cascade_with_prologue_fallback(
-            candidates, label);
+        // Every Crimson Desert hook/scan target lives in the host EXE, so scope
+        // the scan to that image: faster than a whole-process walk and immune to
+        // a coincidental byte match in another injected module.
+        auto hit =
+            DetourModKit::Scanner::resolve_cascade_in_host_module_with_prologue_fallback(
+                candidates, label);
         if (hit.has_value())
             return hit->address;
 
@@ -58,6 +64,51 @@ namespace CDCore::Glue
             DetourModKit::Scanner::resolve_error_to_string(hit.error()));
         return 0;
     }
+
+    /**
+     * @struct BatchRequest
+     * @brief One target for @ref resolve_address_batch: a candidate cascade plus
+     *        the label echoed in log lines. Caller-owned; the candidate span and
+     *        the label must outlive the batch call.
+     */
+    struct BatchRequest
+    {
+        std::span<const DetourModKit::Scanner::AddrCandidate> candidates;
+        std::string_view label;
+    };
+
+    /**
+     * @brief Resolves several independent cascades concurrently, writing each
+     *        absolute address (or 0 on failure) into @p out, parallel to
+     *        @p requests.
+     * @details Fork-join counterpart to @ref resolve_address. Builds one
+     *          host-EXE-scoped, prologue-fallback
+     *          DetourModKit::Scanner::CascadeRequest per entry and resolves the
+     *          whole set in a single DetourModKit::Scanner::resolve_cascade_batch
+     *          pass, so the wall-clock collapses from the sum of the scans to the
+     *          slowest single scan. Per-request resolution is byte-identical to
+     *          resolve_address: same host range, same prologue recovery for a
+     *          sibling-stomped target, same require_unique discipline. Only the
+     *          timing changes, so it is correct only for targets whose resolution
+     *          does not depend on another request's result.
+     *
+     *          Setup/control-plane only. resolve_cascade_batch allocates and
+     *          spins a transient worker pool, so unlike the noexcept single-shot
+     *          resolvers it can throw. This wrapper is noexcept and, on any
+     *          exception, falls back to a serial resolve_address per request, so
+     *          a pool/allocation failure costs only the concurrency and never
+     *          aborts init. Never call it under the loader lock, where worker
+     *          threads cannot start.
+     *
+     *          Each unresolved request is reported as 0 and a single Warning,
+     *          matching resolve_address, so call sites keep the same
+     *          "address-or-zero, gate the feature" shape. Writes
+     *          min(requests.size(), out.size()) entries; any remaining @p out
+     *          slots are left zeroed.
+     */
+    void resolve_address_batch(
+        std::span<const BatchRequest> requests,
+        std::span<std::uintptr_t> out) noexcept;
 
     /**
      * @brief Returns true if any module whose name contains @p needle is

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -34,6 +34,23 @@
 
 namespace CDCore
 {
+    // INI-tunable self-heal landmark window (search radius per side, bytes),
+    // bound to [Advanced] SelfHealWindow by each consumer. 0x200 covers ~10x the
+    // worst historical manager drift (+0x30) with margin. The manager references
+    // pa::ClientUserActor exactly once (every neighbouring slot is a different
+    // actor/container type or non-polymorphic, and the next pointer to the user
+    // actor lives megabytes away), so the window is decoy-free across its whole
+    // range -- the size is a realistic-re-layout-reach choice, not a decoy bound.
+    // Raise it via the INI toward MAX_HEAL_WINDOW only if a patch shifts
+    // pa::ClientUserActor further from the nominal slot than this.
+    inline constexpr int k_healWindowDefault = 0x200;
+
+    std::atomic<int> &heal_window_setting() noexcept
+    {
+        static std::atomic<int> s_healWindow{k_healWindowDefault};
+        return s_healWindow;
+    }
+
     namespace
     {
         // Lower bound for "looks like a heap pointer". Catches both real
@@ -50,11 +67,115 @@ namespace CDCore
         // ChildContainer slot, the 100-entry actor-list capacity,
         // the 16-byte ptr+flag stride, and the live-flag value
         // 0x0101 round out the layout.
-        // mgr -> userActor. The canonical offset lives in
-        // controlled_char.hpp (CDCore::ActorChainOffsets), shared with
-        // the LT/EH WorldSystem-rooted resolvers.
-        constexpr std::ptrdiff_t k_offUserActor      =
+        // mgr -> userActor offset plus the sibling actor-array offsets, with
+        // runtime self-heal. The seeds come from controlled_char.hpp / the
+        // layout below; rtti_dissect re-resolves mgr->userActor from the live
+        // pa::ClientActorManager on the first walk, so a future manager
+        // re-layout self-corrects. heal_landmark checks the nominal slot first,
+        // so an unshifted binary short-circuits and the seeds stay (current
+        // behaviour byte-for-byte). The array/cap offsets sit in the same
+        // post-header region and shift by the same delta, so they are derived
+        // from the one healed delta rather than healed independently.
+        constexpr std::ptrdiff_t k_offUserActorNominal =
             ActorChainOffsets::k_actorManagerToUserActor;
+        constexpr std::ptrdiff_t k_offMgrActorArrayNominal    = 0x130;
+        constexpr std::ptrdiff_t k_offMgrActorArrayCapNominal = 0x13C;
+        constexpr std::string_view k_userActorMangled = ".?AVClientUserActor@pa@@";
+
+        std::atomic<std::ptrdiff_t> s_offUserActor{k_offUserActorNominal};
+        std::atomic<std::ptrdiff_t> s_mgrHeaderDelta{0};
+        std::atomic<bool> s_chainOffsetsHealed{false};
+        std::atomic<int> s_chainHealAttempts{0};
+
+        // Resolved self-heal window: the [Advanced] SelfHealWindow value clamped
+        // to the DMK maximum; a non-positive (unset) value falls back to the
+        // default. Read once per heal attempt, never on a hot path.
+        [[nodiscard]] std::size_t heal_window() noexcept
+        {
+            const int configured = heal_window_setting().load(std::memory_order_relaxed);
+            if (configured <= 0)
+                return static_cast<std::size_t>(k_healWindowDefault);
+            const auto w = static_cast<std::size_t>(configured);
+            return w > DMKRtti::MAX_HEAL_WINDOW ? DMKRtti::MAX_HEAL_WINDOW : w;
+        }
+
+        [[nodiscard]] std::ptrdiff_t off_user_actor() noexcept
+        {
+            return s_offUserActor.load(std::memory_order_acquire);
+        }
+
+        [[nodiscard]] std::ptrdiff_t off_mgr_actor_array() noexcept
+        {
+            return k_offMgrActorArrayNominal + s_mgrHeaderDelta.load(std::memory_order_acquire);
+        }
+
+        [[nodiscard]] std::ptrdiff_t off_mgr_actor_array_cap() noexcept
+        {
+            return k_offMgrActorArrayCapNominal + s_mgrHeaderDelta.load(std::memory_order_acquire);
+        }
+
+        // Re-entrant offset self-heal. Latches only on success (or the no-drift
+        // short-circuit inside heal_landmark). Until the player chain is wired the
+        // heal legitimately finds nothing: a user can sit at the main menu, where
+        // no pa::ClientUserActor exists yet, for any length of time. So it NEVER
+        // gives up and NEVER latches on failure -- every walk retries until the
+        // fully-wired chain heals (this also avoids the interner-hook cold-load
+        // latch bug). The nominal seeds carry the meantime, and the walk's own
+        // < k_minValidPtr gate rejects a garbage dereference, so an unhealed state
+        // can never mis-walk -- there is no reason (and it would be wrong) to cap
+        // the attempts.
+        void heal_chain_offsets(std::uintptr_t mgrBase) noexcept
+        {
+            if (s_chainOffsetsHealed.load(std::memory_order_acquire))
+                return;
+
+            DMKRtti::Landmark lm{};
+            lm.base = mgrBase;
+            lm.nominal_offset = k_offUserActorNominal;
+            lm.window = heal_window();
+            lm.expected_mangled = k_userActorMangled;
+            // mgr+0x58 is a qword POINTER to a single-COL pa::ClientUserActor
+            // (COL offset 0, no multiple inheritance), so PointerToObject is the
+            // exact slot shape.
+            lm.indirection = DMKRtti::Indirection::PointerToObject;
+
+            const auto hit = DMKRtti::heal_landmark(lm);
+            if (!hit.has_value())
+            {
+                // NoMatch / Ambiguous / BadDescriptor: keep the nominal seeds and
+                // retry on the next walk. NoMatch is expected and benign before a
+                // save is loaded. Never publish a guessed offset. Surface a
+                // persistent failure only on a geometric schedule (every
+                // power-of-two walk) at DEBUG, so a real patch-day drift stays
+                // diagnosable without spamming the per-walk path or alarming on the
+                // normal main-menu wait.
+                const int n = s_chainHealAttempts.fetch_add(1, std::memory_order_acq_rel) + 1;
+                if ((n & (n - 1)) == 0)
+                    DetourModKit::Logger::get_instance().debug(
+                        "ActorChainOffsets not healed yet after {} walk(s) ({}); using nominal "
+                        "offsets, will keep retrying",
+                        n, DMKRtti::heal_error_to_string(hit.error()));
+                return;
+            }
+
+            const std::ptrdiff_t healed = hit->healed_offset;
+            const std::ptrdiff_t drift = healed - k_offUserActorNominal;
+            s_offUserActor.store(healed, std::memory_order_release);
+            s_mgrHeaderDelta.store(drift, std::memory_order_release);
+            s_chainOffsetsHealed.store(true, std::memory_order_release);
+            // One-shot confirmation that the rtti_dissect path engaged and the
+            // mgr->userActor slot reverse-resolved to pa::ClientUserActor. A
+            // nonzero drift is a manager re-layout that self-corrected on a
+            // patch; surface it as a WARNING so the offset change is easy to spot.
+            if (drift != 0)
+                DetourModKit::Logger::get_instance().warning(
+                    "ActorChainOffsets DRIFTED: mgr->userActor {:#x} nominal {:#x} drift {} -- "
+                    "self-healed (manager layout changed)",
+                    healed, k_offUserActorNominal, drift);
+            else
+                DetourModKit::Logger::get_instance().info(
+                    "ActorChainOffsets self-heal OK: mgr->userActor {:#x} (matches nominal)", healed);
+        }
         constexpr std::ptrdiff_t k_offSubManager     = 0x08; // user +0x08
         constexpr std::ptrdiff_t k_offSubMgrKliff    = 0x30; // sub +0x30
         constexpr std::ptrdiff_t k_offSubMgrCtrl     = 0x38; // sub +0x38
@@ -80,7 +201,8 @@ namespace CDCore
         //   - +0x13C: u32 element capacity of that array (order 1000).
         // These sit in the same post-header region as the userActor
         // field, so a manager re-layout shifts them by the same delta;
-        // keep them in step with k_offUserActor when re-deriving.
+        // off_mgr_actor_array()/_cap() derive that delta from the one
+        // healed mgr->userActor offset above (single source of truth).
         // The array is a DENSE actor vector: every loaded character
         // -- protagonists, companions, AND every humanoid NPC -- is
         // appended here in spawn order. Protagonists do NOT cluster at
@@ -92,8 +214,6 @@ namespace CDCore
         // Non-protagonist entries are rejected by the appearance-config
         // classifier (their path carries no protagonist codename).
         constexpr std::ptrdiff_t k_offCcoiaIdentity    = 0x60;
-        constexpr std::ptrdiff_t k_offMgrActorArray    = 0x130;
-        constexpr std::ptrdiff_t k_offMgrActorArrayCap = 0x13C;
         constexpr std::uint8_t   k_kliffHighByte       = 0xA0;
 
         // Scan bound for the ClientActorManager+0x130 array. We read
@@ -292,8 +412,9 @@ namespace CDCore
                     const volatile std::uintptr_t *>(playerBase);
                 if (mgr < k_minValidPtr)
                     return out;
+                heal_chain_offsets(mgr);
                 const auto userActor = *reinterpret_cast<
-                    const volatile std::uintptr_t *>(mgr + k_offUserActor);
+                    const volatile std::uintptr_t *>(mgr + off_user_actor());
                 if (userActor < k_minValidPtr)
                     return out;
                 const auto subMgr = *reinterpret_cast<
@@ -688,13 +809,13 @@ namespace CDCore
         // below halts the walk as soon as both companions are found,
         // so the full sweep only runs when one is genuinely absent.
         const auto actorArray =
-            DMKMemory::seh_read<std::uintptr_t>(chain.mgr + k_offMgrActorArray)
+            DMKMemory::seh_read<std::uintptr_t>(chain.mgr + off_mgr_actor_array())
                 .value_or(0);
         if (actorArray < k_minValidPtr)
             return written;
 
         const auto rawCap = DMKMemory::seh_read<std::uint32_t>(
-                                chain.mgr + k_offMgrActorArrayCap)
+                                chain.mgr + off_mgr_actor_array_cap())
                                 .value_or(0);
         const std::size_t scanCap =
             (rawCap < k_mgrArrayCapMin)

--- a/CrimsonDesertCore/src/dmk_glue.cpp
+++ b/CrimsonDesertCore/src/dmk_glue.cpp
@@ -95,6 +95,60 @@ namespace CDCore::Glue
         }
     } // namespace
 
+    void resolve_address_batch(
+        std::span<const BatchRequest> requests,
+        std::span<std::uintptr_t> out) noexcept
+    {
+        // Honour the address-or-zero contract even on an early bail.
+        for (auto &slot : out)
+            slot = 0;
+
+        const std::size_t count = std::min(requests.size(), out.size());
+        if (count == 0)
+            return;
+
+        try
+        {
+            // Each request resolves exactly as resolve_address would: host-EXE
+            // scope (every target lives in CrimsonDesert.exe) plus prologue
+            // fallback (re-match a sibling-stomped prologue). resolve_cascade_batch
+            // dispatches each request to its own worker, so the host-module scans
+            // run concurrently instead of one after another.
+            std::vector<DetourModKit::Scanner::CascadeRequest> batch;
+            batch.reserve(count);
+            for (std::size_t i = 0; i < count; ++i)
+            {
+                DetourModKit::Scanner::CascadeRequest req{};
+                req.candidates = requests[i].candidates;
+                req.label = requests[i].label;
+                req.range = DetourModKit::Memory::host_module_range();
+                req.prologue_fallback = true;
+                batch.push_back(req);
+            }
+
+            const auto results = DetourModKit::Scanner::resolve_cascade_batch(batch);
+            for (std::size_t i = 0; i < count && i < results.size(); ++i)
+            {
+                if (results[i].has_value())
+                {
+                    out[i] = results[i]->address;
+                    continue;
+                }
+                DetourModKit::Logger::get_instance().warning(
+                    "{} resolve cascade failed: {}", requests[i].label,
+                    DetourModKit::Scanner::resolve_error_to_string(results[i].error()));
+            }
+        }
+        catch (...)
+        {
+            // resolve_cascade_batch can throw bad_alloc: it allocates the result
+            // vector and spins a worker pool. Degrade to the serial resolver so a
+            // transient failure loses only the concurrency, never the feature.
+            for (std::size_t i = 0; i < count; ++i)
+                out[i] = resolve_address(requests[i].candidates, requests[i].label);
+        }
+    }
+
     bool is_sibling_mod_loaded(std::string_view needle) noexcept
     {
         if (needle.empty())

--- a/CrimsonDesertEquipHide/CMakeLists.txt
+++ b/CrimsonDesertEquipHide/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.28)
 
 project(CrimsonDesertEquipHide VERSION 0.2.3 LANGUAGES CXX)
 

--- a/CrimsonDesertEquipHide/README.md
+++ b/CrimsonDesertEquipHide/README.md
@@ -139,6 +139,12 @@ ShowHotkey =
 HideHotkey =
 DefaultHidden = false
 Parts =
+
+[Advanced]
+; Self-heal search radius (bytes) used to recover an internal game offset
+; after a patch shifts it. Leave at the default; only raise it if a future
+; game update breaks the mod and a maintainer asks you to. Not for normal users.
+SelfHealWindow = 512
 ```
 
 ### Hotkey Types

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,3 +1,5 @@
-## Updated for 1.12.00
+## Stability and framework update
 
-- Updated for 1.12.00
+- Updated the underlying framework (DetourModKit) to 3.9.0 for better stability and future compatibility
+- More resilient to future game updates: some internal addresses now self-correct after a patch
+- Added an advanced INI setting (SelfHealWindow) to help the mod recover after a game update

--- a/CrimsonDesertEquipHide/src/aob_resolver.hpp
+++ b/CrimsonDesertEquipHide/src/aob_resolver.hpp
@@ -60,8 +60,16 @@ namespace EquipHide
             std::span<const AddrCandidate> candidates,
             std::string_view label)
         {
+            // Host-EXE scope: every target resolves inside CrimsonDesert.exe,
+            // so bounding the scan (and the require_unique count) to
+            // Memory::host_module_range() stops a generic-shaped candidate from
+            // first-matching inside a sibling mod or overlay elsewhere in the
+            // process image. The prologue-fallback variant is retained -- it
+            // re-matches a sibling-stomped prologue, and its rebuilt jump
+            // destination stays unbounded, so a trampoline outside the EXE is
+            // still recovered.
             auto hit =
-                DetourModKit::Scanner::resolve_cascade_with_prologue_fallback(
+                DetourModKit::Scanner::resolve_cascade_in_host_module_with_prologue_fallback(
                     candidates, label);
             if (hit.has_value())
                 return hit->address;
@@ -98,10 +106,13 @@ namespace EquipHide
     // --- EquipHide-only candidate tables ---------------------------------
 
     /**
-     * @brief ChildActor vtable -- static data pointer resolved via three
-     *        nearby RIP-relative loads. All three candidates resolve to the
-     *        same lea rax, [rip+disp32] that loads the vtable base; the
-     *        cascade picks whichever anchor shape survives the current build.
+     * @brief ChildActor (pa::ClientChildOnlyInGameActor) vtable. Resolved by
+     *        RTTI mangled name first (patch-stable, self-healing), with three
+     *        nearby RIP-relative byte loads as fallback. Each byte candidate
+     *        resolves to the lea rax, [rip+disp32] that loads the vtable base,
+     *        which is also the primary (COL.offset == 0) vtable that
+     *        vtable_for_type returns for that class; the cascade picks whichever
+     *        tier survives the current build.
      *
      * Branch-encoding caveat (aob-signatures.md section 8):
      *       P2 anchors on the trailing EB 03 (jmp-over-fallback) that
@@ -115,6 +126,17 @@ namespace EquipHide
      *       rel8 opcode literal.
      */
     inline constexpr AddrCandidate k_childActorVtblCandidates[] = {
+        // Primary -- resolve the vtable by its RTTI mangled name. The
+        // AllocCtor stores ClientChildOnlyInGameActor's primary vtable into
+        // the new object, so vtable_for_type on that class name yields the
+        // exact pointer the byte tiers below recover. The mangled name is
+        // patch-stable, so this tier self-heals across the vtable relocations
+        // and jmp-encoding flips the byte anchors are sensitive to.
+        // require_unique does not apply: the RTTI backend is unique-only and
+        // fails closed on an ambiguous name, falling through to the byte tiers.
+        {"ChildActorVtbl_RTTI", ".?AVClientChildOnlyInGameActor@pa@@",
+         ResolveMode::RttiVtable},
+
         // P1 -- truncated: ends at the mov [rsi], rax that stores the
         // vtable. Does NOT cross the trailing EB 03 jmp, so it survives
         // a Jcc-encoding flip.
@@ -184,12 +206,13 @@ namespace EquipHide
      *   [RBP+0x67] = a4 (transition type byte, saved from R9B at prologue)
      *   [RBP+0x4F] = a1 context pointer
      *
-     * Register layout at hook point (v1.08.00):
-     *   v1.08 spills the visibility byte itself to a stack arg slot
-     *   (default `[rsp+0x20]`) before the cmp; the `mov r8b, 1` that
-     *   sets the exclusion-list flag still precedes the read. The
-     *   PartInOutSocket struct is no longer dereferenced inline at the
-     *   hook point, only by the surrounding code that fed the spill.
+     * Register layout at hook point (v1.08.00 and later):
+     *   The visibility byte is read directly as `movzx eax, byte
+     *   [r12+disp8]; cmp al, 3`. The `44 24` SIB reads as `[rsp]`, but
+     *   the leading `41` REX.B prefix extends the base to R12, so this
+     *   is a struct field load (R12 holds the PartInOut decision
+     *   struct), not a stack-slot spill. The `mov r8b, 1` that sets the
+     *   exclusion-list flag still precedes the read.
      *
      * Cascade contract: 1-hit-only on the current target build.
      * Re-adding a legacy tier requires per-version CE verification of
@@ -202,13 +225,15 @@ namespace EquipHide
         // PN1 -- v1.08.00. The PartInOutSocket arg-passing convention
         // changed: the visibility byte is no longer fetched through
         // `mov rax, [rbp+0x5F] ; movzx eax, byte [rax+0x1C]` (which
-        // anchored P0..P3). The compiler now spills the byte itself to
-        // a stack arg slot and reads it directly: `movzx eax, byte
-        // [rsp+0x20] ; cmp al, 3`. The `mov r8b, 1` (set-exclusion-
+        // anchored P0..P3). The byte is now read directly from the
+        // decision struct: `movzx eax, byte [r12+0x20] ; cmp al, 3`.
+        // The `44 24` SIB reads as `[rsp]`, but the leading `41` REX.B
+        // extends the base to R12, so the disp8 is a struct field
+        // offset, not a stack slot. The `mov r8b, 1` (set-exclusion-
         // list flag) idiom that precedes the load is retained, so we
-        // anchor on the pair: `41 B0 01 41 0F B6 44 24 ?? 3C 03`.
-        // The stack disp8 is wildcarded -- the slot can drift across
-        // builds. Hook lands on the movzx at match + 3 (skip the
+        // anchor on the pair: `41 B0 01 41 0F B6 44 24 ?? 3C 03`. The
+        // struct disp8 is wildcarded so a future re-layout still
+        // matches. Hook lands on the movzx at match + 3 (skip the
         // `41 B0 01`). 1 hit on v1.08.00, 0 on v1.04.00 / v1.05.00.
         {"PartInOut_PN1_v108_StackArgVisRead",
          "41 B0 01 41 0F B6 44 24 ?? 3C 03",
@@ -227,9 +252,11 @@ namespace EquipHide
     /**
      * @brief AOB candidates for the Postfix rule evaluator.
      *
-     * Virtual function at vtable[4] of objects with vtable 0x144CC8248.
-     * Evaluates whether a postfix rule matches currently equipped items.
-     * Returns 1 = rule matches (hide hair), 0 = no match (keep hair).
+     * Evaluates whether a postfix rule matches the currently equipped items.
+     * Returns 1 = rule matches (hide hair), 0 = no match (keep hair). The
+     * engine reaches it through a named method-binding table rather than a
+     * COL-tagged C++ vtable, so there is no RTTI identity to name-resolve --
+     * the prologue cascade below is the strongest available anchor.
      */
     inline constexpr AddrCandidate k_postfixEvalCandidates[] = {
         // P1 -- tight. Full prologue (4 shadow-space saves + 3 pushes +

--- a/CrimsonDesertEquipHide/src/armor_injection.cpp
+++ b/CrimsonDesertEquipHide/src/armor_injection.cpp
@@ -336,6 +336,19 @@ namespace EquipHide
                     continue;
                 }
                 auto mapBase = *descNode + 0x20;
+
+                // Reject a non-faulting garbage mapBase from a drifted +0x58 /
+                // +0x218 chain (the SEH read only traps an actual fault, not a
+                // wrong-but-mapped pointer). Skip this vis-controller rather than
+                // inject into a wrong map.
+                if (!DMKMemory::plausible_userspace_ptr(mapBase))
+                {
+                    logger.trace("ArmorInject [{}]: vc=0x{:X} implausible mapBase=0x{:X} "
+                                 "(+0x58 -> +0x218 -> +0x20)",
+                                 i, vc, mapBase);
+                    continue;
+                }
+
                 logger.trace("ArmorInject [{}]: vc=0x{:X} descNode=0x{:X} "
                              "mapBase=0x{:X} char_idx={}",
                              i, vc, *descNode, mapBase, charIdx);

--- a/CrimsonDesertEquipHide/src/cascade_suppress.cpp
+++ b/CrimsonDesertEquipHide/src/cascade_suppress.cpp
@@ -16,11 +16,82 @@ namespace EquipHide
     static constexpr uint16_t k_chestSlot = 4;
 
     // BatchEquip dispatch-entry layout used to read the per-entry slot id.
-    // NOTE: cdcore/anchors.hpp documents a different (216-byte) BatchEquip
-    // entry layout. These literal values must be confirmed against the
-    // shipping build via live CE/x64dbg before being changed.
-    static constexpr std::size_t k_equipSwapEntryStride = 232;
-    static constexpr std::size_t k_equipSwapSlotOffset = 208;
+    // Decoded live from the dispatch code so a future entry re-widening
+    // self-corrects, with the last-known 240/216 layout as a validated
+    // fallback. An earlier build hardcoded the pre-widening 232/208 layout,
+    // which silently mis-read the slot id after the engine grew the entry.
+    //
+    // Stride: the entry array is indexed by `imul rsi, rax, imm32`. The AOB
+    // anchors on `mov rbx,[rcx]; mov eax,[rcx+8]; imul rsi,rax,imm32` and lands
+    // (+6) on the imul; its imm32 operand is the 240-byte entry stride. The
+    // pattern stops before the imm32 so it stays value-agnostic (self-heals).
+    static constexpr DMK::Scanner::AddrCandidate k_equipSwapStrideSite[] = {
+        {"BatchEquipStride", "48 8B 19 8B 41 08 48 69 F0", DMK::Scanner::ResolveMode::Direct, 6, 0, true},
+    };
+    // Slot: the per-entry slot id is the word read by
+    // `movzx eax, word ptr [rbx+disp32]` immediately before
+    // `cmp word ptr [rdx+disp32], ax`. The AOB wildcards the displacement (so a
+    // shifted slot still matches) and anchors on the trailing cmp opcode; it
+    // lands (+0) on the movzx, whose [rbx+disp32] displacement is the +216 slot.
+    static constexpr DMK::Scanner::AddrCandidate k_equipSwapSlotSite[] = {
+        {"BatchEquipSlot", "0F B7 83 ?? ?? ?? ?? 66 39 82", DMK::Scanner::ResolveMode::Direct, 0, 0, true},
+    };
+
+    // Decode an instruction operand to a layout constant, validated to a
+    // plausible range. On any miss, out-of-range value, or decode exception the
+    // nominal is kept, so a wrong anchor or operand index can never mis-read the
+    // dispatch entry; the decoded value is logged once for verification.
+    [[nodiscard]] static std::size_t decode_layout_constant(
+        std::span<const DMK::Scanner::AddrCandidate> site, DMK::Scanner::OperandKind kind,
+        std::uint8_t operandIndex, std::int64_t lo, std::int64_t hi, std::size_t nominal,
+        const char *label) noexcept
+    {
+        try
+        {
+            DMK::Scanner::CodeConstant cc{};
+            cc.site = site;
+            cc.kind = kind;
+            cc.operand_index = operandIndex;
+            cc.nominal = static_cast<std::int64_t>(nominal);
+            cc.has_nominal = true;
+            const auto decoded = DMK::Scanner::read_code_constant(cc);
+            if (decoded.has_value() && *decoded >= lo && *decoded <= hi)
+            {
+                const auto value = static_cast<std::size_t>(*decoded);
+                // A live value != nominal means the engine layout drifted on a
+                // patch; the decode self-healed it, but surface it as a WARNING
+                // so the offset change is easy to spot in the log.
+                if (value != nominal)
+                    DMK::Logger::get_instance().warning(
+                        "BatchEquip {} DRIFTED: live={} nominal={} -- self-healed (engine layout changed)",
+                        label, value, nominal);
+                else
+                    DMK::Logger::get_instance().info(
+                        "BatchEquip {} decoded live: {} (matches nominal)", label, value);
+                return value;
+            }
+            DMK::Logger::get_instance().warning(
+                "BatchEquip {} live-decode out of range/unavailable; using nominal {}", label, nominal);
+        }
+        catch (...)
+        {
+        }
+        return nominal;
+    }
+
+    [[nodiscard]] static std::size_t equip_swap_entry_stride() noexcept
+    {
+        static const std::size_t value = decode_layout_constant(
+            k_equipSwapStrideSite, DMK::Scanner::OperandKind::Immediate, 2, 216, 256, 240, "stride");
+        return value;
+    }
+
+    [[nodiscard]] static std::size_t equip_swap_slot_offset() noexcept
+    {
+        static const std::size_t value = decode_layout_constant(
+            k_equipSwapSlotSite, DMK::Scanner::OperandKind::MemoryDisplacement, 1, 192, 224, 216, "slot");
+        return value;
+    }
 
     // --- VisualEquipChange hook (equip/unequip) ---
 
@@ -64,6 +135,11 @@ namespace EquipHide
     void set_visual_equip_swap_trampoline(VisualEquipSwapFn original)
     {
         s_originalVisualEquipSwap = original;
+        // Warm the layout self-heal at install (setup/control-plane) so the
+        // dispatch-entry stride/slot are decoded and cached before the first
+        // swap, keeping the hot path free of the one-time AOB scan.
+        (void)equip_swap_entry_stride();
+        (void)equip_swap_slot_offset();
     }
 
     __int64 __fastcall on_visual_equip_swap(
@@ -83,8 +159,8 @@ namespace EquipHide
                 for (uint32_t i = 0; i < count && i < 16; ++i)
                 {
                     auto slot = *reinterpret_cast<const uint16_t *>(
-                        base + k_equipSwapEntryStride * i +
-                        k_equipSwapSlotOffset);
+                        base + equip_swap_entry_stride() * i +
+                        equip_swap_slot_offset());
                     logger.trace("EquipSwap: slot={}", slot);
                     if (slot == k_chestSlot)
                         hasChest = true;

--- a/CrimsonDesertEquipHide/src/equip_hide.cpp
+++ b/CrimsonDesertEquipHide/src/equip_hide.cpp
@@ -14,6 +14,7 @@
 #include "visibility_write.hpp"
 
 #include <cdcore/controlled_char.hpp>
+#include <cdcore/dmk_glue.hpp>
 
 #include <DetourModKit.hpp>
 
@@ -55,6 +56,14 @@ namespace EquipHide
             flag_independent_toggle(), false);
         DMK::Config::register_atomic<bool>(
             "General", "CascadeFix", "Cascade Fix", flag_cascade_fix(), false);
+
+        // Advanced: rtti_dissect self-heal search radius (bytes, per side) for
+        // the manager->userActor offset recovery in CDCore. Default 0x200 (~10x
+        // the worst historical drift); raise toward MAX_HEAL_WINDOW only if a game
+        // patch shifts the field further. Not for normal users.
+        DMK::Config::register_atomic<int>(
+            "Advanced", "SelfHealWindow", "Self Heal Window",
+            CDCore::heal_window_setting(), 0x200);
 
         // Protagonist codename overrides for CDCore's appearance-config
         // classifier. Each codename is a substring search target inside
@@ -287,7 +296,7 @@ namespace EquipHide
             s_hideLocked[hashIdx] &&
             is_any_category_hidden(mask))
         {
-            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x20);
+            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + vis_byte_offset());
             if (s_hideLocked[hashIdx] == 2)
             {
                 *visPtr = 0;
@@ -345,7 +354,7 @@ namespace EquipHide
 
         if (is_any_category_hidden_for(charMask, charIdx))
         {
-            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + 0x20);
+            auto *visPtr = reinterpret_cast<uint8_t *>(partInOut + vis_byte_offset());
             *visPtr = 2;
             if (cascadeOn && isChest)
             {
@@ -399,21 +408,24 @@ namespace EquipHide
         // resolution. CDCore::controlled_char uses the independent
         // static-chain [moduleBase + 0x5FA0430] anchor and does not
         // need a published holder.
-        addrs.worldSystem = resolve_address(
-            k_worldSystemCandidates, std::size(k_worldSystemCandidates),
-            "WorldSystem");
-
-        addrs.childActorVtbl = resolve_address(
-            k_childActorVtblCandidates, std::size(k_childActorVtblCandidates),
-            "ChildActorVtbl");
-
-        addrs.mapLookup = resolve_address(
-            k_mapLookupCandidates, std::size(k_mapLookupCandidates),
-            "MapLookup");
-
-        addrs.mapInsert = resolve_address(
-            k_mapInsertCandidates, std::size(k_mapInsertCandidates),
-            "MapInsert");
+        // These four targets are independent (no resolution reads another's
+        // result) and all live in the host EXE, so resolve them in one
+        // fork-join batch rather than four serial host-module scans. Each
+        // request keeps the host-scope + prologue-fallback semantics of the
+        // single resolve_address; only the wall-clock collapses to the slowest
+        // single scan. initAddrs is parallel to the request-array order.
+        const CDCore::Glue::BatchRequest initBatch[] = {
+            {k_worldSystemCandidates, "WorldSystem"},
+            {k_childActorVtblCandidates, "ChildActorVtbl"},
+            {k_mapLookupCandidates, "MapLookup"},
+            {k_mapInsertCandidates, "MapInsert"},
+        };
+        std::uintptr_t initAddrs[std::size(initBatch)] = {};
+        CDCore::Glue::resolve_address_batch(initBatch, initAddrs);
+        addrs.worldSystem = initAddrs[0];
+        addrs.childActorVtbl = initAddrs[1];
+        addrs.mapLookup = initAddrs[2];
+        addrs.mapInsert = initAddrs[3];
 
         // Resolve IndexedStringA global from MapLookup: mov rax, [rip+disp] at +20
         if (addrs.mapLookup)
@@ -492,15 +504,19 @@ namespace EquipHide
                 rebuild_part_lookup();
         }
 
-        // Mid-body scan with the shared cascade resolver. The
-        // prologue-fallback variant survives dev hot-reload: when a
-        // prior Logic-DLL load left a SafetyHook detour-jump in place
-        // at this site, every original-bytes candidate fails on rescan,
-        // and the resolver retries each Direct candidate with the first
-        // five byte-tokens replaced by the near-JMP signature
-        // E9 ?? ?? ?? ??. The candidate's disp_offset is preserved, so
-        // the returned address still lands on the original cmp instr.
-        auto hookHit = DMK::Scanner::resolve_cascade_with_prologue_fallback(
+        // Mid-body scan with the host-EXE-scoped, prologue-fallback cascade
+        // resolver. Host scope bounds this safety-critical match -- its
+        // callback writes engine structs (visPtr, ctx.r8) -- to
+        // CrimsonDesert.exe, where the real target provably lives, so a
+        // generic-shaped candidate cannot first-match elsewhere in the
+        // process image. The prologue-fallback variant survives dev
+        // hot-reload: when a prior Logic-DLL load left a SafetyHook
+        // detour-jump in place at this site, every original-bytes candidate
+        // fails on rescan, and the resolver retries each Direct candidate
+        // with the first five byte-tokens replaced by the near-JMP signature
+        // E9 ?? ?? ?? ??. The candidate's disp_offset is preserved, so the
+        // returned address still lands on the original cmp instr.
+        auto hookHit = DMK::Scanner::resolve_cascade_in_host_module_with_prologue_fallback(
             std::span<const AddrCandidate>{k_hookSiteCandidates,
                                            std::size(k_hookSiteCandidates)},
             "EquipVisCheckHookSite");
@@ -512,6 +528,11 @@ namespace EquipHide
         }
 
         const auto hookAddr = hookHit->address;
+
+        // Warm the self-healing vis-byte offset BEFORE installing the mid-hook:
+        // the decode re-resolves the EquipVisCheck instruction by AOB, and the
+        // SafetyHook install about to happen overwrites those bytes with a jmp.
+        (void)vis_byte_offset();
 
         auto &hookMgr = DMK::HookManager::get_instance();
         auto hookResult = hookMgr.create_mid_hook("EquipVisCheck", hookAddr, on_vis_check);
@@ -679,6 +700,14 @@ namespace EquipHide
         else
             logger.info("Equip hide fully initialized ({} parts resolved)",
                         total_part_count());
+
+        // One-shot DMK health snapshot for at-a-glance per-launch diagnostics:
+        // hook population plus any intentional loader-lock leak/detach events.
+        const auto health = DMK::Diagnostics::collect(DMK::HookManager::get_instance());
+        logger.info("DMK health: hooks total={} active={} disabled={}, intentional-leaks={}",
+                    health.hooks_total, health.hooks_active, health.hooks_disabled,
+                    health.total_intentional_leaks);
+
         return true;
     }
 

--- a/CrimsonDesertEquipHide/src/visibility_write.cpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.cpp
@@ -1,4 +1,5 @@
 #include "visibility_write.hpp"
+#include "aob_resolver.hpp"
 #include "categories.hpp"
 #include "shared_state.hpp"
 
@@ -43,6 +44,57 @@ namespace EquipHide
         if (a.visCtrl != b.visCtrl)
             return a.visCtrl < b.visCtrl;
         return a.addr < b.addr;
+    }
+
+    /* Self-healing PartInOut vis-byte offset. The hooked EquipVisCheck
+       instruction reads the vis byte as `movzx eax, byte [r12+0x20]`, and the
+       engine builds the decision struct that instruction sees by copying the
+       IndexedString map entry field-for-field (the +0x20 vis byte included), so
+       the displacement in that one instruction is the vis-byte offset shared by
+       both the mid-hook write (partInOut) and the direct-write path (map entry).
+       Decoding it value-agnostically lets a future PartInOut re-layout
+       self-correct; 0x20 is the validated nominal kept on any miss. Mirrors the
+       BatchEquip stride/slot self-heal in cascade_suppress.cpp. */
+    std::size_t vis_byte_offset() noexcept
+    {
+        static const std::size_t value = []() noexcept -> std::size_t
+        {
+            constexpr std::size_t k_nominal = 0x20;
+            try
+            {
+                DMK::Scanner::CodeConstant cc{};
+                cc.site = k_hookSiteCandidates;
+                cc.kind = DMK::Scanner::OperandKind::MemoryDisplacement;
+                cc.operand_index = 1; // movzx eax, byte [r12+disp]: the memory operand
+                cc.nominal = static_cast<std::int64_t>(k_nominal);
+                cc.has_nominal = true;
+                const auto decoded = DMK::Scanner::read_code_constant(cc);
+                if (decoded.has_value() && *decoded >= 0x10 && *decoded <= 0x40)
+                {
+                    const auto off = static_cast<std::size_t>(*decoded);
+                    // A live value != nominal means the PartInOut layout drifted
+                    // on a patch; the decode self-healed it, but surface it as a
+                    // WARNING so the offset change is easy to spot in the log.
+                    if (off != k_nominal)
+                        DMK::Logger::get_instance().warning(
+                            "PartInOut vis-byte offset DRIFTED: live={:#x} nominal={:#x} -- self-healed "
+                            "(engine layout changed)",
+                            off, k_nominal);
+                    else
+                        DMK::Logger::get_instance().info(
+                            "PartInOut vis-byte offset decoded live: {:#x} (matches nominal)", off);
+                    return off;
+                }
+                DMK::Logger::get_instance().warning(
+                    "PartInOut vis-byte offset live-decode out of range/unavailable; using nominal {:#x}",
+                    k_nominal);
+            }
+            catch (...)
+            {
+            }
+            return k_nominal;
+        }();
+        return value;
     }
 
     /* Implementation body extracted out of the SEH-wrapped public entry
@@ -91,6 +143,20 @@ namespace EquipHide
             }
             auto mapBase = *descNode + 0x20;
 
+            // A drifted +0x58 / +0x218 chain offset can yield a non-faulting
+            // garbage mapBase (the SEH chain read only traps an actual fault, not
+            // a wrong-but-mapped pointer). Reject an implausible base so a future
+            // layout shift skips just this vis-controller instead of letting the
+            // per-part lookup walk a wrong map -- or fault and abort the whole
+            // pass for every character.
+            if (!DMKMemory::plausible_userspace_ptr(mapBase))
+            {
+                logger.trace("DirectWrite [{}]: vc=0x{:X} implausible mapBase=0x{:X} "
+                             "(+0x58 -> +0x218 -> +0x20)",
+                             i, vc, mapBase);
+                continue;
+            }
+
             /* Choose the character-specific map for the iteration.
                charIdx == -1 routes to the active-character map so a
                slot we could not identify still cycles through the
@@ -118,7 +184,7 @@ namespace EquipHide
                 if (!entry)
                     continue;
 
-                const auto visAddr = entry + 0x20;
+                const auto visAddr = entry + vis_byte_offset();
                 const VisKey key{vc, visAddr};
                 s_touchedVisKeys.push_back(key);
                 auto *visPtr = reinterpret_cast<uint8_t *>(visAddr);

--- a/CrimsonDesertEquipHide/src/visibility_write.hpp
+++ b/CrimsonDesertEquipHide/src/visibility_write.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 namespace EquipHide
 {
     /** @brief Write vis-byte modifications for all tracked parts across all protagonists. */
@@ -11,5 +13,19 @@ namespace EquipHide
      *          entries (including injected zero-bone armor entries) are left as-is.
      */
     void cleanup_vis_bytes() noexcept;
+
+    /**
+     * @brief Offset of the vis byte within the engine's PartInOut struct.
+     * @details Self-heals: decoded once from the resolved EquipVisCheck
+     *          instruction (`movzx eax, byte [r12+disp]`) so a future PartInOut
+     *          re-layout self-corrects, with 0x20 as the validated nominal. The
+     *          decision struct EquipVisCheck reads and the IndexedString map
+     *          entry the direct-write path mutates are the same PartInOut layout
+     *          -- the engine fills the decision struct by copying the map entry
+     *          field-for-field -- so this single offset is correct for every
+     *          vis-byte access. Warmed at hook install; the hot path then only
+     *          reads the cached value.
+     */
+    [[nodiscard]] std::size_t vis_byte_offset() noexcept;
 
 } // namespace EquipHide

--- a/CrimsonDesertLiveTransmog/CMakeLists.txt
+++ b/CrimsonDesertLiveTransmog/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.28)
 
 project(CrimsonDesertLiveTransmog VERSION 0.4.0 LANGUAGES CXX)
 

--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -206,6 +206,12 @@ ColorOverride = false
 ; voices keep their vanilla muffle. Off by default; set to true to remove
 ; the muffle. Toggle changes take effect on the next game launch.
 UnmuffleHelmVoice = false
+
+[Advanced]
+; Self-heal search radius (bytes) used to recover an internal game offset
+; after a patch shifts it. Leave at the default; only raise it if a future
+; game update breaks the mod and a maintainer asks you to. Not for normal users.
+SelfHealWindow = 512
 ```
 
 Presets are stored in `CrimsonDesertLiveTransmog_presets.json` (auto-generated alongside the INI).

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Title for next release]
+## Stability and framework update
 
-- New feature
-- Bug fix
-- Improvement
+- Updated the underlying framework (DetourModKit) to 3.9.0 for better stability and future compatibility
+- More resilient to future game updates: some internal addresses now self-correct after a patch
+- Added an advanced INI setting (SelfHealWindow) to help the mod recover after a game update

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -53,8 +53,16 @@ namespace Transmog
             std::span<const AddrCandidate> candidates,
             std::string_view label)
         {
+            // Host-EXE scope: every target resolves inside CrimsonDesert.exe,
+            // so bounding the scan (and the require_unique count) to
+            // Memory::host_module_range() stops a generic-shaped candidate from
+            // first-matching inside a sibling mod or overlay elsewhere in the
+            // process image. The prologue-fallback variant is retained -- it
+            // re-matches a sibling-stomped prologue, and its rebuilt jump
+            // destination stays unbounded, so a trampoline outside the EXE is
+            // still recovered.
             auto hit =
-                DetourModKit::Scanner::resolve_cascade_with_prologue_fallback(
+                DetourModKit::Scanner::resolve_cascade_in_host_module_with_prologue_fallback(
                     candidates, label);
             if (hit.has_value())
                 return hit->address;
@@ -286,7 +294,8 @@ namespace Transmog
     };
 
     /**
-     * @brief StringInfoVtable sentinel: 0x145BC4638.
+     * @brief StringInfoVtable sentinel (resolved at runtime; no hardcoded
+     *        address -- an absolute vtable value goes stale on every game build).
      *
      * Vtable pointer used as the +0x08 sentinel of every StringInfo
      * entry. PrefabWrapperSwap reads it to filter out non-StringInfo
@@ -1746,6 +1755,17 @@ namespace Transmog
      */
     inline constexpr AddrCandidate
         k_gameAudioEffectVtableCandidates[] = {
+            // Primary -- resolve by RTTI mangled name. Every
+            // pa::GameAudioEffectBuffData instance stores its primary
+            // (COL.offset == 0) vtable base in its first qword, which is
+            // exactly what the byte ctor-LEA tiers below recover. Resolving by
+            // the patch-stable mangled name self-heals across the vtable
+            // relocations that move those byte anchors between builds. The
+            // backend is unique-only and fails closed, so an absent name falls
+            // through to the byte tiers.
+            {"GameAudioEffectVtable_RTTI",
+             ".?AVGameAudioEffectBuffData@pa@@", ResolveMode::RttiVtable},
+
             // P1 -- constructor tail with RIP-rel LEA. 1 unique match
             // in v1.08.00 .text. Resolved disp32 = 0x032CE5FA ->
             // match+14+disp = 0x144CD7B08 (= vfunc[0] address, what

--- a/CrimsonDesertLiveTransmog/src/helm_audio_filter.cpp
+++ b/CrimsonDesertLiveTransmog/src/helm_audio_filter.cpp
@@ -844,21 +844,22 @@ namespace Transmog::HelmAudioFilter
         // only makes is_audio_muffle_class pass through, so it never blocks
         // hook installation. See ensure_skill_tag_resolver.
 
-        // Resolve the pa::GameAudioEffectBuffData vtable's first vfunc
-        // address. Each instance of that class stores this exact value
-        // in its first qword, so we compare buff_instance[0] against
-        // this to identify muffle-class entries. The AOB anchors at
-        // the vtable header (RTTI metadata ptr + first 2 vfuncs);
-        // dispOffset=+8 advances past the RTTI ptr to vfunc[0]'s
-        // address, which is what objects actually store.
+        // Resolve the pa::GameAudioEffectBuffData vtable. Each instance of
+        // that class stores its vtable base in its first qword, so the filter
+        // compares buff_instance[0] against g_gameAudioEffectVtable to identify
+        // muffle-class entries. The candidate cascade leads with a
+        // ResolveMode::RttiVtable tier (resolve by the patch-stable mangled
+        // name, which self-heals across the vtable relocations that move the
+        // byte ctor-LEA anchors), then falls back to those byte anchors; both
+        // yield the same vtable base.
         const auto vtableAddr = ::Transmog::resolve_address(
             ::Transmog::k_gameAudioEffectVtableCandidates,
             "HelmAudioFilter_GameAudioEffectVtable");
         if (vtableAddr == 0)
         {
             log.warning(
-                "[helm-audio] GameAudioEffectBuffData vtable AOB "
-                "resolve failed; feature disabled");
+                "[helm-audio] GameAudioEffectBuffData vtable resolve failed "
+                "(RTTI name + AOB); feature disabled");
             return false;
         }
         g_gameAudioEffectVtable = vtableAddr;

--- a/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
+++ b/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
@@ -2205,6 +2205,18 @@ namespace Transmog::PrefabWrapperSwap
                     "-- AppearanceTableLoader enumeration disabled.");
             }
 
+            // Resolve the part-prefab data container vtable by its RTTI name
+            // first: the class name is patch-stable while the vtable address and
+            // the ctor's lea layout move between builds, so reverse RTTI
+            // self-heals where the byte scan below would drift. The lea-walk
+            // fallback runs only when reverse RTTI is unavailable.
+            if (const auto rttiVt =
+                    DetourModKit::Rtti::vtable_for_type(
+                        ".?AV?$ThreadSafeRefCountedContainerBase@VstaticstringA@pa@@VAppearanceTableData@2@UDefaultUserData@2@@pa@@")
+                        .value_or(0)) {
+                s_apptContainerVtable.store(rttiVt, std::memory_order_release);
+                logger.debug("[prefab-swap] ApptContainerVtable via RTTI: 0x{:X}", rttiVt);
+            }
             // ApptContainerVtable: the cascade locates the
             // AppearanceTableLoader ctor (sub_141E2DBB0). Walk
             // forward inside its first 0x400 bytes for the SECOND
@@ -2218,7 +2230,8 @@ namespace Transmog::PrefabWrapperSwap
             const auto ctorAbs = resolve_address(
                 k_apptLoaderCtorCandidates,
                 "ApptLoaderCtor");
-            if (ctorAbs) {
+            if (ctorAbs
+                && s_apptContainerVtable.load(std::memory_order_acquire) == 0) {
                 const auto *body =
                     reinterpret_cast<const std::uint8_t *>(ctorAbs);
                 constexpr std::size_t k_scanLen = 0x400;
@@ -2257,7 +2270,7 @@ namespace Transmog::PrefabWrapperSwap
                         "in 0x{:X} bytes -- vtable filter disabled.",
                         ctorAbs, k_scanLen);
                 }
-            } else {
+            } else if (s_apptContainerVtable.load(std::memory_order_acquire) == 0) {
                 logger.warning(
                     "[prefab-swap] ApptContainerVtable cascade "
                     "FAILED -- container vtable filter disabled.");

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -66,6 +66,14 @@ namespace Transmog
             "Apply To Selected Character",
             flag_apply_to_editing(), true);
 
+        // Advanced: rtti_dissect self-heal search radius (bytes, per side) for
+        // the manager->userActor offset recovery in CDCore. Default 0x200 (~10x
+        // the worst historical drift); raise toward MAX_HEAL_WINDOW only if a game
+        // patch shifts the field further. Not for normal users.
+        DMK::Config::register_atomic<int>(
+            "Advanced", "SelfHealWindow", "Self Heal Window",
+            CDCore::heal_window_setting(), 0x200);
+
         // When true, always use the standalone transparent overlay window
         // instead of the ReShade addon tab. Useful if ReShade is installed
         // but the user prefers the standalone overlay.
@@ -813,18 +821,29 @@ namespace Transmog
 
         // --- Resolve AOB addresses ---
         //
-        // The game may restart its exe during shader compilation.  If
-        // we load before the code section is fully populated, all scans
-        // fail.  Retry up to 5 times with a 3-second delay if the
-        // critical SlotPopulator pattern isn't found.
+        // These six targets are independent: each scans a static candidate
+        // table and none reads another's resolved address. They all live in the
+        // host EXE, so resolve them in one fork-join batch rather than six serial
+        // host-module scans. Each per-target validation and side-effect block
+        // below is unchanged and runs in the same order; every block touches only
+        // its own address, so hoisting the scans ahead of them is
+        // behaviour-preserving. The initBatch order defines the initAddrs order.
 
         auto &addrs = resolved_addrs();
 
+        const CDCore::Glue::BatchRequest initBatch[] = {
+            {k_slotPopulatorCandidates, "SlotPopulator"},
+            {k_mapLookupCandidates, "MapLookup"},
+            {k_subTranslatorCandidates, "SubTranslator"},
+            {k_safeTearDownCandidates, "SafeTearDown"},
+            {k_initSwapEntryCandidates, "InitSwapEntry"},
+            {k_charClassBypassCandidates, "CharClassBypass"},
+        };
+        std::uintptr_t initAddrs[std::size(initBatch)] = {};
+        CDCore::Glue::resolve_address_batch(initBatch, initAddrs);
+
         // SlotPopulator: the KEY function for transmog.
-        addrs.slotPopulator = resolve_address(
-            k_slotPopulatorCandidates,
-            std::size(k_slotPopulatorCandidates),
-            "SlotPopulator");
+        addrs.slotPopulator = initAddrs[0];
 
         if (!addrs.slotPopulator)
             logger.warning("SlotPopulator AOB scan failed -- transmog will not work");
@@ -832,10 +851,7 @@ namespace Transmog
         // MapLookup: IndexedStringA::lookup. Not hooked -- RIP anchor for
         // scan_indexed_string_table(). Must be resolved before
         // PartShowSuppress::init_slot_hashes.
-        addrs.mapLookup = resolve_address(
-            k_mapLookupCandidates,
-            std::size(k_mapLookupCandidates),
-            "MapLookup");
+        addrs.mapLookup = initAddrs[1];
 
         if (addrs.mapLookup)
         {
@@ -859,10 +875,7 @@ namespace Transmog
         }
 
         // SubTranslator (sub_14076D950): anchor for the item-name catalog scan.
-        addrs.subTranslator = resolve_address(
-            k_subTranslatorCandidates,
-            std::size(k_subTranslatorCandidates),
-            "SubTranslator");
+        addrs.subTranslator = initAddrs[2];
 
         if (addrs.subTranslator)
         {
@@ -928,10 +941,7 @@ namespace Transmog
         }
 
         // SafeTearDown (sub_14075FE60): scene-graph tear-down.
-        addrs.safeTearDown = resolve_address(
-            k_safeTearDownCandidates,
-            std::size(k_safeTearDownCandidates),
-            "SafeTearDown");
+        addrs.safeTearDown = initAddrs[3];
         if (!addrs.safeTearDown)
         {
             logger.warning(
@@ -942,10 +952,7 @@ namespace Transmog
         // InitSwapEntry (sub_141D451B0): zero-init helper for the 0x80-byte
         // swap entry passed to SlotPopulator.
         {
-            auto iseAddr = resolve_address(
-                k_initSwapEntryCandidates,
-                std::size(k_initSwapEntryCandidates),
-                "InitSwapEntry");
+            auto iseAddr = initAddrs[4];
 
             if (iseAddr && !DMK::Scanner::is_likely_function_prologue(iseAddr))
             {
@@ -972,10 +979,7 @@ namespace Transmog
         // CharClassBypass: single-byte patch site in CondPrefab evaluator.
         // Toggled 0x74↔0xEB around each carrier apply so NPC items
         // pass the character-class hash check.
-        addrs.charClassBypass = resolve_address(
-            k_charClassBypassCandidates,
-            std::size(k_charClassBypassCandidates),
-            "CharClassBypass");
+        addrs.charClassBypass = initAddrs[5];
         if (addrs.charClassBypass)
         {
             // Verify the resolved byte is 0x74 (jz). SEH-isolated via
@@ -1291,6 +1295,13 @@ namespace Transmog
 
         logger.info("Transmog initialization complete -- SlotPopulator {}",
                     slot_populator_fn() ? "READY" : "UNAVAILABLE");
+
+        // One-shot DMK health snapshot for at-a-glance per-launch diagnostics:
+        // hook population plus any intentional loader-lock leak/detach events.
+        const auto health = DMK::Diagnostics::collect(DMK::HookManager::get_instance());
+        logger.info("DMK health: hooks total={} active={} disabled={}, intentional-leaks={}",
+                    health.hooks_total, health.hooks_active, health.hooks_disabled,
+                    health.total_intentional_leaks);
 
         return true;
     }


### PR DESCRIPTION
## Summary

- Upgrades the DetourModKit submodule to 3.9.0 and raises the CMake minimum to 3.28.
- Scopes every cascade scan to the host EXE and batches the independent startup resolves, so resolution is faster and cannot first-match inside a sibling mod.
- Self-heals the drift-prone offsets (manager to userActor, BatchEquip stride/slot, PartInOut vis-byte) by decoding them live, each with a validated nominal fallback so a miss never mis-reads.
- Leads the ChildActor, GameAudioEffect, and ApptContainer vtable lookups with patch-stable RTTI name resolution, keeping the byte signatures as fallback.
- Adds an advanced SelfHealWindow INI setting and a one-line per-launch DMK health log.
