### PR TITLE
chore: add editor config and reflow INI comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # IDE / editor
 00_idea
-.vscode/*
 
 # Build artifacts
 CrimsonDesert*/build/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-vscode.cpptools",
+    "ms-vscode.cmake-tools",
+    "EditorConfig.EditorConfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,13 +5,16 @@
     "editor.wordWrapColumn": 120
   },
   // Per-module build trees are large and the external/ submodules are never
-  // edited here; keep both out of search results and the file watcher.
+  // edited here; keep both out of search results and the file watcher. The
+  // build/template/ config templates are tracked sources, so re-include them.
   "search.exclude": {
     "**/build/**": true,
+    "**/build/template/**": false,
     "**/external/**": true
   },
   "files.watcherExclude": {
     "**/build/**": true,
+    "**/build/template/**": false,
     "**/external/**": true
   },
   "cmake.sourceDirectory": "D:/Workspace/CrimsonDesertTools/CrimsonDesertLiveTransmog"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0.0",
+  // CMake resolves through the Visual Studio 2022 toolchain. EquipHide and
+  // LiveTransmog each own a CMakePresets.json, so tasks run from the module
+  // directory; CrimsonDesertCore is a shared library compiled as part of each.
+  // The msvc-dev preset builds the two-DLL hot-reload configuration (loader +
+  // logic); msvc-release builds the single production module.
+  "tasks": [
+    {
+      "label": "EquipHide: configure (msvc-dev)",
+      "type": "shell",
+      "command": "cmake --preset msvc-dev",
+      "options": { "cwd": "${workspaceFolder}/CrimsonDesertEquipHide" },
+      "problemMatcher": []
+    },
+    {
+      "label": "EquipHide: build (msvc-dev)",
+      "type": "shell",
+      "command": "cmake --build --preset msvc-dev",
+      "options": { "cwd": "${workspaceFolder}/CrimsonDesertEquipHide" },
+      "group": "build",
+      "problemMatcher": ["$msCompile"]
+    },
+    {
+      "label": "LiveTransmog: configure (msvc-dev)",
+      "type": "shell",
+      "command": "cmake --preset msvc-dev",
+      "options": { "cwd": "${workspaceFolder}/CrimsonDesertLiveTransmog" },
+      "problemMatcher": []
+    },
+    {
+      "label": "LiveTransmog: build (msvc-dev)",
+      "type": "shell",
+      "command": "cmake --build --preset msvc-dev",
+      "options": { "cwd": "${workspaceFolder}/CrimsonDesertLiveTransmog" },
+      "group": { "kind": "build", "isDefault": true },
+      "problemMatcher": ["$msCompile"]
+    }
+  ]
+}

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -116,8 +116,7 @@ OongkaCodename  = cd_phm_oongka
 ; Default: 512
 SelfHealWindow = 512
 
-; ── Weapons
-; ──────────────────────────────────────────────────────────
+; == Weapons ==========================================================
 
 [OneHandWeapons]
 Enabled = false
@@ -249,8 +248,7 @@ HideHotkey =
 DefaultHidden = false
 Parts = CD_Tool_Hyperspace_RemoteControl, CD_Lantern, CD_Lantern_Ring
 
-; ── Armor
-; ────────────────────────────────────────────────────────────
+; == Armor ============================================================
 
 [Helm]
 Enabled = true
@@ -336,8 +334,7 @@ HideHotkey =
 DefaultHidden = false
 Parts = CD_Glasses
 
-; ── Accessories
-; ──────────────────────────────────────────────────────
+; == Accessories ======================================================
 
 [Earrings]
 Enabled = false
@@ -376,8 +373,7 @@ DefaultHidden = false
 ;   CD_Bag_For_Dock
 Parts = CD_Belt, CD_Acc, CD_Bag, CD_Bag_Rocket, CD_Bag_Belt_For_Dock, CD_Additional_For_Dock, CD_Bag_Small, CD_Bag_Acc, CD_Bag_Belt, CD_Bag_Lantern, CD_Bag_Rack
 
-; ── User Presets
-; ─────────────────────────────────────────────────────
+; == User Presets =====================================================
 ; Custom part groups with independent visibility control. When a preset is enabled, it takes full control of its parts
 ; -- built-in category toggles (like V for Shields/Helm/Mask) will NOT affect parts owned by an active preset. Only the
 ; preset's own hotkey controls them.

--- a/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
+++ b/CrimsonDesertEquipHide/build/template/CrimsonDesertEquipHide.ini
@@ -29,14 +29,12 @@
 ; for the full list of supported input names.
 ;
 ; --- Parts ---
-; Comma-separated part names. Move items between categories by cut/paste.
-; Raw hex IDs (e.g. 0xAE1E) also accepted for unlisted/gap parts.
+; Comma-separated part names. Move items between categories by cut/paste. Raw hex IDs (e.g. 0xAE1E) also accepted for
+; unlisted/gap parts.
 ;
 ; --- Per-character Parts overrides ---
-; You can override the Parts list for a specific protagonist by creating a
-; section named [CategoryName:CharacterName]. Supported names: Kliff, Damiane,
-; Oongka. The override replaces the base Parts list when that character is
-; controlled.
+; You can override the Parts list for a specific protagonist by creating a section named [CategoryName:CharacterName].
+; Supported names: Kliff, Damiane, Oongka. The override replaces the base Parts list when that character is controlled.
 ;
 ; Three ways to set a per-character Parts value:
 ;   1. Section absent OR Parts = (empty)  -> inherit the base [CategoryName]
@@ -44,14 +42,14 @@
 ;   3. Parts = NONE                       -> disable this category for this character
 ;                                            (nothing hidden even when the base is enabled)
 ;
-; Example -- hide axes/maces only when playing Damiane (Kliff leaves them
-; alone because they have no sheath mesh on his body):
+; Example -- hide axes/maces only when playing Damiane (Kliff leaves them alone because they have no sheath mesh on his
+; body):
 ;
 ;   [OneHandWeapons]
 ;   Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ...
 ;
 ;   [OneHandWeapons:Damiane]
-;   Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, CD_MainWeapon_Axe_L, CD_MainWeapon_Mace_R, CD_MainWeapon_Mace_L
+;   Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_L, ..., CD_MainWeapon_Axe_R, CD_MainWeapon_Mace_R, ...
 ;
 ; Example -- hide the lantern on Kliff but leave it visible on Damiane:
 ;
@@ -63,65 +61,63 @@
 ;   [Lanterns:Damiane]
 ;   Parts = NONE
 ;
-; Only the Parts key is per-character. Enabled / DefaultHidden / hotkeys
-; remain global to the base [CategoryName] section.
+; Only the Parts key is per-character. Enabled / DefaultHidden / hotkeys remain global to the base [CategoryName]
+; section.
 ;
 ; --- Other ---
-; DefaultHidden = true to start hidden on game load.
-; Enabled = false to disable a category entirely (parts won't be tracked).
+; DefaultHidden = true to start hidden on game load. Enabled = false to disable a category entirely (parts won't be
+; tracked).
 
 [General]
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
-; Re-load this INI automatically on save without restarting the game
-; (filesystem-watcher driven). Set false to opt out.
+; Re-load this INI automatically on save without restarting the game (filesystem-watcher driven). Set false to opt out.
 AutoReloadConfig = true
-; Prevents baldness when hiding helmets/cloaks/masks.
-; The game normally hides hair when a helmet is equipped -- this fix keeps
-; hair visible when the mod hides the helmet mesh.
-; Note: Hair/beard may occasionally disappear; re-toggling the helmet
-; (show then hide) restores it.
+; Prevents baldness when hiding helmets/cloaks/masks. The game normally hides hair when a helmet is equipped -- this fix
+; keeps hair visible when the mod hides the helmet mesh. Note: Hair/beard may occasionally disappear; re-toggling the
+; helmet (show then hide) restores it.
 BaldFix = true
-; Prevents hidden equipment from briefly flashing during state transitions
-; (e.g. exiting gliding, cutscene transitions). Safe to leave enabled.
+; Prevents hidden equipment from briefly flashing during state transitions (e.g. exiting gliding, cutscene transitions).
+; Safe to leave enabled.
 GlidingFix = true
-; [Experimental] Reduces pants flickering when hiding chest armor.
-; Allows running around bare-chested without pants flashing.
-; Weapon/shield/accessory changes no longer trigger flicker.
-; Armor-to-armor swaps auto re-hide.
-; Known limitations:
+; [Experimental] Reduces pants flickering when hiding chest armor. Allows running around bare-chested without pants
+; flashing. Weapon/shield/accessory changes no longer trigger flicker. Armor-to-armor swaps auto re-hide. Known
+; limitations:
 ;   - Equipping chest armor from barechest requires a manual re-toggle
 ;     (show then hide) to re-apply hiding.
 ;   - Some armor (e.g. Bandit Cloth) may show invisible torso or missing
 ;     upper body parts when hiding chest with legs visible.
 ;   - Reloading a save may briefly show armor during the loading screen.
 CascadeFix = false
-; Reserved. Kept for backwards compatibility; current behaviour is
-; "each Toggle binding flips its own category's state" regardless of
-; this value. Bind the same combo to ShowAllHotkey / HideAllHotkey
-; below for a synchronised whole-loadout toggle.
+; Reserved. Kept for backwards compatibility; current behaviour is "each Toggle binding flips its own category's state"
+; regardless of this value. Bind the same combo to ShowAllHotkey / HideAllHotkey below for a synchronised whole-loadout
+; toggle.
 IndependentToggle = false
 ; Force all categories visible / hidden at once (empty = disabled)
 ShowAllHotkey =
 HideAllHotkey =
 
 ; --- Protagonist subfolder substrings ---
-; Each protagonist is identified by a substring of their appearance-config
-; asset path. Shipped engine paths:
+; Each protagonist is identified by a substring of their appearance-config asset path. Shipped engine paths:
 ;   Kliff   -> character/appearance/1_pc/1_phm/cd_phm_macduff/cd_phm_macduff_00000.app_xml
 ;   Damiane -> character/appearance/1_pc/2_phw/cd_phw_damian/cd_phw_damian_00000.app_xml
 ;   Oongka  -> character/appearance/1_pc/1_phm/cd_phm_oongka/cd_phm_oongka_00000.app_xml
 ;
-; The mod searches for the substring inside the path. Defaults pin the
-; full character-subfolder name (cd_<archetype>_<codename>) to avoid any
-; coincidental match. Override ONLY if a future patch or a local mod
-; renames a protagonist's appearance subfolder; otherwise leave alone.
-; Empty value = keep the built-in default.
+; The mod searches for the substring inside the path. Defaults pin the full character-subfolder name
+; (cd_<archetype>_<codename>) to avoid any coincidental match. Override ONLY if a future patch or a local mod renames a
+; protagonist's appearance subfolder; otherwise leave alone. Empty value = keep the built-in default.
 KliffCodename   = cd_phm_macduff
 DamianeCodename = cd_phw_damian
 OongkaCodename  = cd_phm_oongka
 
-; ── Weapons ──────────────────────────────────────────────────────────
+[Advanced]
+; Internal tuning. Leave at the default unless instructed otherwise. SelfHealWindow: byte radius the mod scans to
+; re-locate its internal offsets after a game update; raise only if a patch moves things further than the default.
+; Default: 512
+SelfHealWindow = 512
+
+; ── Weapons
+; ──────────────────────────────────────────────────────────
 
 [OneHandWeapons]
 Enabled = false
@@ -129,10 +125,9 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-; Base list = parts that have a sheath mesh on every protagonist. Per-character
-; sections below extend this with parts that only some characters can safely
-; hide. Parts lacking a sheath mesh on a specific character are omitted from
-; that character's override to avoid floating-mesh clipping when toggled visible.
+; Base list = parts that have a sheath mesh on every protagonist. Per-character sections below extend this with parts
+; that only some characters can safely hide. Parts lacking a sheath mesh on a specific character are omitted from that
+; character's override to avoid floating-mesh clipping when toggled visible.
 Parts = CD_MainWeapon_Sword_R, CD_MainWeapon_Sword_IN_R, CD_MainWeapon_Sword_L, CD_MainWeapon_Sword_IN_L, CD_MainWeapon_Hammer_R, CD_MainWeapon_Flail_R, CD_MainWeapon_Wand_R, CD_MainWeapon_Fist_R, CD_MainWeapon_Fist_Hand, CD_MainWeapon_Fist_Foot, CD_MainWeapon_Lance, CD_MainWeapon_Sword_R_Aux, CD_MainWeapon_Sword_IN_R_Aux
 
 ; Kliff can additionally hide: left-hand daggers (CD_MainWeapon_Dagger_L,
@@ -206,10 +201,9 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-; CD_MainWeapon_Fan is vanilla-hidden on both Kliff and Damiane (no sheath
-; mesh -- it only appears while drawn). Kept out of the base list to avoid
-; floating-mesh clipping when toggled visible. If you want to experiment with
-; showing it, paste into a [UserPresetN]:
+; CD_MainWeapon_Fan is vanilla-hidden on both Kliff and Damiane (no sheath mesh -- it only appears while drawn). Kept
+; out of the base list to avoid floating-mesh clipping when toggled visible. If you want to experiment with showing it,
+; paste into a [UserPresetN]:
 ;   CD_MainWeapon_Fan
 Parts = CD_MainWeapon_ArwHead, CD_MainWeapon_CrossBow, CD_MainWeapon_Pistol_R, CD_MainWeapon_Pistol_L, CD_MainWeapon_Musket, CD_MainWeapon_Trap, CD_MainWeapon_Bomb, CD_MainWeapon_ThrownSpear_R, CD_MainWeapon_ThrownSpear_L, CD_MainWeapon_Whip_R, CD_MainWeapon_Parachute
 
@@ -219,13 +213,12 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-; Base list = tools with a stowed mesh on every protagonist. Per-character
-; sections below add tools that specific characters can safely hide. Tools
-; without a stowed mesh on a given character are omitted from their override.
+; Base list = tools with a stowed mesh on every protagonist. Per-character sections below add tools that specific
+; characters can safely hide. Tools without a stowed mesh on a given character are omitted from their override.
 Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book
 
-; Kliff can additionally hide: fire can (CD_Tool_FireCan).
-; Vanilla-hidden for him (omitted from his override): torch (CD_Tool_Torch),
+; Kliff can additionally hide: fire can (CD_Tool_FireCan). Vanilla-hidden for him (omitted from his override): torch
+; (CD_Tool_Torch),
 ;   flute (CD_Tool_Flute), pan (CD_Tool_Pan), pipe (CD_Tool_Pipe),
 ;   saw (CD_Tool_Saw), shooter (CD_Tool_Shooter), sprayer (CD_Tool_Sprayer).
 [Tools:Kliff]
@@ -239,8 +232,8 @@ Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Too
 [Tools:Damiane]
 Parts = CD_Tool_FishingRod, CD_Tool, CD_Tool_01, CD_Tool_02, CD_Tool_Axe, CD_Tool_Hammer, CD_Tool_Hoe, CD_Tool_Broom, CD_Tool_FarmScythe, CD_Tool_Hayfork, CD_Tool_Pickaxe, CD_Tool_Rake, CD_Tool_Shovel, CD_Tool_Crutch, CD_Tool_FishingRod_Sub, CD_Tool_Cigarette, CD_Tool_HandDrum, CD_Tool_DrumStick_R, CD_Tool_DrumStick_L, CD_Tool_Trumpet, CD_Tool_Book, CD_Tool_Saw, CD_Tool_Pan, CD_Tool_Shooter
 
-; Oongka can additionally hide: fire can (CD_Tool_FireCan).
-; Vanilla-hidden for him (omitted from his override): torch (CD_Tool_Torch),
+; Oongka can additionally hide: fire can (CD_Tool_FireCan). Vanilla-hidden for him (omitted from his override): torch
+; (CD_Tool_Torch),
 ;   flute (CD_Tool_Flute), pan (CD_Tool_Pan), pipe (CD_Tool_Pipe),
 ;   saw (CD_Tool_Saw), shooter (CD_Tool_Shooter), sprayer (CD_Tool_Sprayer).
 ; (Mirrors Kliff: Oongka shares the male phm rig -- their player-description
@@ -256,7 +249,8 @@ HideHotkey =
 DefaultHidden = false
 Parts = CD_Tool_Hyperspace_RemoteControl, CD_Lantern, CD_Lantern_Ring
 
-; ── Armor ────────────────────────────────────────────────────────────
+; ── Armor
+; ────────────────────────────────────────────────────────────
 
 [Helm]
 Enabled = true
@@ -313,9 +307,8 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-; Known issue: CD_Cloak_Flight parts cause visual artifacts and squished hair
-; when toggling cloak visibility.
-; To re-enable at your own risk, append to Parts:
+; Known issue: CD_Cloak_Flight parts cause visual artifacts and squished hair when toggling cloak visibility. To
+; re-enable at your own risk, append to Parts:
 ;   CD_Cloak_Flight, CD_Cloak_Flight_01, CD_Cloak_Flight_02, CD_Cloak_Flight_03
 Parts = CD_Cloak, CD_Cloak_Acc, CD_Cloak_Acc_01, CD_Cloak_Acc_02, CD_Cloak_Shoulder
 
@@ -343,7 +336,8 @@ HideHotkey =
 DefaultHidden = false
 Parts = CD_Glasses
 
-; ── Accessories ──────────────────────────────────────────────────────
+; ── Accessories
+; ──────────────────────────────────────────────────────
 
 [Earrings]
 Enabled = false
@@ -375,24 +369,21 @@ ToggleHotkey =
 ShowHotkey =
 HideHotkey =
 DefaultHidden = false
-; CD_Bag_For_Dock is a dock-transition attachment (wooden frame), not a normal
-; equipped bag. It's absent from the player's <PartInOutSocketInfo> on both
-; Kliff and Damiane in vanilla, so forcing it visible via ShowAll/ShowHotkey
-; triggers a wooden-frame attachment that overrides KukuPack/weapon meshes on
-; the back. Kept out of the base list to avoid that regression.
-; If you want to toggle it anyway, paste into a [UserPresetN]:
+; CD_Bag_For_Dock is a dock-transition attachment (wooden frame), not a normal equipped bag. It's absent from the
+; player's <PartInOutSocketInfo> on both Kliff and Damiane in vanilla, so forcing it visible via ShowAll/ShowHotkey
+; triggers a wooden-frame attachment that overrides KukuPack/weapon meshes on the back. Kept out of the base list to
+; avoid that regression. If you want to toggle it anyway, paste into a [UserPresetN]:
 ;   CD_Bag_For_Dock
 Parts = CD_Belt, CD_Acc, CD_Bag, CD_Bag_Rocket, CD_Bag_Belt_For_Dock, CD_Additional_For_Dock, CD_Bag_Small, CD_Bag_Acc, CD_Bag_Belt, CD_Bag_Lantern, CD_Bag_Rack
 
-; ── User Presets ─────────────────────────────────────────────────────
-; Custom part groups with independent visibility control.
-; When a preset is enabled, it takes full control of its parts --
-; built-in category toggles (like V for Shields/Helm/Mask) will NOT
-; affect parts owned by an active preset. Only the preset's own
-; hotkey controls them.
+; ── User Presets
+; ─────────────────────────────────────────────────────
+; Custom part groups with independent visibility control. When a preset is enabled, it takes full control of its parts
+; -- built-in category toggles (like V for Shields/Helm/Mask) will NOT affect parts owned by an active preset. Only the
+; preset's own hotkey controls them.
 ;
-; Tip: Set DefaultHidden = true if you want preset parts hidden on startup.
-; Disabled by default -- set Enabled = true and add parts to use.
+; Tip: Set DefaultHidden = true if you want preset parts hidden on startup. Disabled by default -- set Enabled = true
+; and add parts to use.
 
 [UserPreset1]
 Enabled = false

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog.ini
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog.ini
@@ -2,18 +2,16 @@
 ; Runtime visual armor swap (transmog) for Crimson Desert.
 ;
 ; --- How it works ---
-; Transmog swaps are managed through presets stored in the companion
-; JSON file (CrimsonDesertLiveTransmog_presets.json). Use the in-game
-; overlay to browse items, build presets, and apply them.
-; This INI controls global settings and optional hotkey bindings.
+; Transmog swaps are managed through presets stored in the companion JSON file (CrimsonDesertLiveTransmog_presets.json).
+; Use the in-game overlay to browse items, build presets, and apply them. This INI controls global settings and optional
+; hotkey bindings.
 ;
 ; --- Overlay ---
-; The mod includes a built-in overlay (toggle with Home key by
-; default). No external tools required.
+; The mod includes a built-in overlay (toggle with Home key by default). No external tools required.
 ;
 ; --- Hotkeys ---
-; Most hotkeys are DISABLED by default. The overlay is the primary
-; interface; hotkeys are optional shortcuts for keyboard-driven users.
+; Most hotkeys are DISABLED by default. The overlay is the primary interface; hotkeys are optional shortcuts for
+; keyboard-driven users.
 ;
 ; Format: modifier+trigger (modifiers joined with +, last = trigger)
 ;   - Named keys: T, F3, Numpad1, Mouse4, Gamepad_A, etc.
@@ -27,42 +25,34 @@
 [General]
 ; Log level: Trace, Debug, Info, Warning, Error
 LogLevel = Info
-; Re-load this INI automatically on save without restarting the game
-; (filesystem-watcher driven). Set false to opt out.
+; Re-load this INI automatically on save without restarting the game (filesystem-watcher driven). Set false to opt out.
 AutoReloadConfig = true
 ; Master toggle for all transmog swaps
 Enabled = true
 
-; When the character dropdown is pinned to a non-controlled character,
-; route overlay-UI edits (dropdown switch, picker change, slot toggle,
-; preset cycle, manual buttons) onto that character's body instead of
-; cross-applying onto whoever you control. Engine-triggered equip
-; events still target the controlled body so the controlled
-; character's transmog stays consistent across their own gear
-; changes. Set false to restore the legacy cross-body behaviour where
-; the controlled body wears the selected character's preset items.
+; When the character dropdown is pinned to a non-controlled character, route overlay-UI edits (dropdown switch, picker
+; change, slot toggle, preset cycle, manual buttons) onto that character's body instead of cross-applying onto whoever
+; you control. Engine-triggered equip events still target the controlled body so the controlled character's transmog
+; stays consistent across their own gear changes. Set false to restore the legacy cross-body behaviour where the
+; controlled body wears the selected character's preset items.
 ApplyToSelectedCharacter = true
 
-; Skip ReShade addon registration and use the standalone overlay
-; window even when ReShade is installed. Leave false to register as a
-; ReShade addon when ReShade is present; the standalone window only
-; opens when ReShade is unavailable or this is set to true.
+; Skip ReShade addon registration and use the standalone overlay window even when ReShade is installed. Leave false to
+; register as a ReShade addon when ReShade is present; the standalone window only opens when ReShade is unavailable or
+; this is set to true.
 ForceStandaloneOverlay = false
 ; Toggle the overlay GUI. Default: Home
 OverlayToggleHotkey = Home
 
 ; --- Protagonist subfolder substrings ---
-; Each protagonist is identified by a substring of their appearance-config
-; asset path. Shipped engine paths:
+; Each protagonist is identified by a substring of their appearance-config asset path. Shipped engine paths:
 ;   Kliff   -> character/appearance/1_pc/1_phm/cd_phm_macduff/cd_phm_macduff_00000.app_xml
 ;   Damiane -> character/appearance/1_pc/2_phw/cd_phw_damian/cd_phw_damian_00000.app_xml
 ;   Oongka  -> character/appearance/1_pc/1_phm/cd_phm_oongka/cd_phm_oongka_00000.app_xml
 ;
-; The mod searches for the substring inside the path. Defaults pin the
-; full character-subfolder name (cd_<archetype>_<codename>) to avoid any
-; coincidental match. Override ONLY if a future patch or a local mod
-; renames a protagonist's appearance subfolder; otherwise leave alone.
-; Empty value = keep the built-in default.
+; The mod searches for the substring inside the path. Defaults pin the full character-subfolder name
+; (cd_<archetype>_<codename>) to avoid any coincidental match. Override ONLY if a future patch or a local mod renames a
+; protagonist's appearance subfolder; otherwise leave alone. Empty value = keep the built-in default.
 KliffCodename   = cd_phm_macduff
 DamianeCodename = cd_phw_damian
 OongkaCodename  = cd_phm_oongka
@@ -76,6 +66,12 @@ ApplyHotkey =
 ClearHotkey =
 ; Snapshot currently equipped real gear into slot mappings
 CaptureHotkey =
+
+[Advanced]
+; Internal tuning. Leave at the default unless instructed otherwise. SelfHealWindow: byte radius the mod scans to
+; re-locate its internal offsets after a game update; raise only if a patch moves things further than the default.
+; Default: 512
+SelfHealWindow = 512
 
 [Presets]
 ; --- Preset Hotkeys (all disabled by default) ---
@@ -92,49 +88,37 @@ PrevHotkey =
 
 [Experimental]
 ; --- Color Override ---
-; Adds a "Color Override" tab to the per-slot popup that lets you pick
-; a custom colour for each visible material region on a transmogged
-; item, including outfits the in-game dye merchant would normally refuse.
+; Adds a "Color Override" tab to the per-slot popup that lets you pick a custom colour for each visible material region
+; on a transmogged item, including outfits the in-game dye merchant would normally refuse.
 ;
-; HIGHLY EXPERIMENTAL -- disabled by default. Toggle changes take
-; effect on the next game launch.
+; HIGHLY EXPERIMENTAL -- disabled by default. Toggle changes take effect on the next game launch.
 ColorOverride = false
 
 ; --- Unmuffle Helm Voice ---
-; Removes the plate/heavy-helmet voice muffle on protagonists
-; (Kliff, Damiane, Oongka). The filter catches every helm class the
-; engine marks as muffling. NPC voices keep their vanilla muffle
-; either way. Off by default; set to true to remove the muffle.
-; Toggle changes take effect on the next game launch.
+; Removes the plate/heavy-helmet voice muffle on protagonists (Kliff, Damiane, Oongka). The filter catches every helm
+; class the engine marks as muffling. NPC voices keep their vanilla muffle either way. Off by default; set to true to
+; remove the muffle. Toggle changes take effect on the next game launch.
 UnmuffleHelmVoice = false
 
 [Diagnostics]
-; One-shot TSV dumps written next to this plugin once the engine's
-; item catalog (iteminfo) finishes loading. Useful for cross-referencing
-; mod data, regression-checking after game patches, or feeding companion
-; tools. Both files are overwritten on every launch when enabled.
-; Toggle changes take effect on the next game launch.
+; One-shot TSV dumps written next to this plugin once the engine's item catalog (iteminfo) finishes loading. Useful for
+; cross-referencing mod data, regression-checking after game patches, or feeding companion tools. Both files are
+; overwritten on every launch when enabled. Toggle changes take effect on the next game launch.
 
 ; CrimsonDesertLiveTransmog_items.tsv -- one row per item:
 ;   ItemID, Slot, Variant, PlayerSafe, Name
-; Useful for: name-to-id lookup, slot taxonomy audits, variant-meta
-; flag verification. Roughly 6k rows, ~290 KB.
+; Useful for: name-to-id lookup, slot taxonomy audits, variant-meta flag verification. Roughly 6k rows, ~290 KB.
 DumpItemCatalogTsv = false
 
-; CrimsonDesertLiveTransmog_itemprefabs.tsv -- one row per mesh prefab
-; in the asset pool (joined against the item catalog), columns:
+; CrimsonDesertLiveTransmog_itemprefabs.tsv -- one row per mesh prefab in the asset pool (joined against the item
+; catalog), columns:
 ;   Prefab, Base, ExactItemId, ExactItemName, ExactIconSlot,
 ;   SiblingItemIds, SiblingItemNames, FullIconString, Orphan
-; ExactItem* columns are populated when a pool prefab has an item
-; whose iconPrefab matches it directly. SiblingItem* groups all items
-; sharing the same `_NNNN`-anchored base (covers _l/_r dual-wield,
-; _slim_c female variants, _index0N geo variants, etc.). Orphan = yes
-; when a pool prefab has neither an exact nor sibling item. Items
-; whose mesh-prefab string never appears in the pool are recovered
-; into a separate phantom block at the end of the file. UI-only icons
-; (quest/skill/stat and similar entries that resolve to no mesh
-; prefab) are not listed: this is a prefab dump, so use the item
-; catalog dump above for the complete item list.
-; Roughly 29k rows, ~3-4 MB. Adds ~2 minutes to startup (full
+; ExactItem* columns are populated when a pool prefab has an item whose iconPrefab matches it directly. SiblingItem*
+; groups all items sharing the same `_NNNN`-anchored base (covers _l/_r dual-wield, _slim_c female variants, _index0N
+; geo variants, etc.). Orphan = yes when a pool prefab has neither an exact nor sibling item. Items whose mesh-prefab
+; string never appears in the pool are recovered into a separate phantom block at the end of the file. UI-only icons
+; (quest/skill/stat and similar entries that resolve to no mesh prefab) are not listed: this is a prefab dump, so use
+; the item catalog dump above for the complete item list. Roughly 29k rows, ~3-4 MB. Adds ~2 minutes to startup (full
 ; user-mode VA asset-pool scan + targeted phantom recovery).
 DumpItemPrefabsTsv = false


### PR DESCRIPTION
## Summary

Repo tooling and template tidy-up. No mod behaviour changes.

- Search and file-watcher exclude all of build/ except build/template/, which holds the tracked, shipped config templates.
- Reflows the LiveTransmog and EquipHide INI template comments to fill the 120-column baseline. Comment text only; section headers, examples, dividers, and all key=value lists are unchanged.
