### PR TITLE
fix(live-transmog): render correct per-body armor variant on transmog

### DIFF
--- a/CrimsonDesertLiveTransmog/CMakeLists.txt
+++ b/CrimsonDesertLiveTransmog/CMakeLists.txt
@@ -92,6 +92,7 @@ set(COMMON_SOURCES
     src/input_handler.cpp
     src/transmog.cpp
     src/transmog_apply.cpp
+    src/body_variant_hook.cpp
     src/transmog_hooks.cpp
     src/transmog_worker.cpp
     src/dx_overlay.cpp
@@ -293,6 +294,17 @@ endif()
             -DSTAGING_PDB=${GAME_STAGING_DIR}/CrimsonDesertLiveTransmog_Logic.pdb
             -P "${CMAKE_CURRENT_BINARY_DIR}/deploy_logic.cmake"
         COMMENT "Deploying Logic DLL+PDB (falls back to staging if locked)"
+    )
+
+    # The display_names TSV (item names + the wearer-body "Male"/"Female" column filled by
+    # scripts/gen_item_body_table.py) is data the mod loads at runtime. Keep the deployed copy in
+    # sync so it never goes stale -- unlike the DLL it is never game-locked, so a direct
+    # copy_if_different is enough (no staging dance).
+    add_custom_command(TARGET transmog_logic POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/build/template/CrimsonDesertLiveTransmog_display_names.tsv"
+            "${GAME_BIN_DIR}/CrimsonDesertLiveTransmog_display_names.tsv"
+        COMMENT "Deploying display_names.tsv (item names + wearer-body column)"
     )
 
     target_compile_options(transmog_logic PRIVATE /W4 /Zi)

--- a/CrimsonDesertLiveTransmog/README.md
+++ b/CrimsonDesertLiveTransmog/README.md
@@ -16,7 +16,7 @@
 - Preset system: save, load, rename, and cycle through multiple transmog presets per character
 - Multi-character support: independent preset lists for Kliff, Damiane, and Oongka. Every visible protagonist's preset is applied automatically on world entry (and to followers as soon as they're summoned in-game), and the active preset follows whoever you control
 - NPC armor variants and damaged variants render via automatic carrier swap
-- Body-type picker filter: hides items whose body (male/female) does not match the active character so broken meshes stay out of the list. Per-character override available in the overlay for body-swap mod users. Temporarily disabled on game version 1.13.00 while it is reworked; all other picker filters work normally
+- Body-type picker filter: hides items whose body (male/female) does not match the active character so broken meshes stay out of the list. Per-character override available in the overlay for body-swap mod users
 - Per-slot control: enable/disable transmog independently for each equipment slot
 - Optional hotkeys: all disabled by default, configurable via INI
 - Open-source with full transparency

--- a/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_display_names.tsv
+++ b/CrimsonDesertLiveTransmog/build/template/CrimsonDesertLiveTransmog_display_names.tsv
@@ -1,18 +1,18 @@
-Aant_PlateArmor_Helm	Awrain Plate Helm
+Aant_PlateArmor_Helm	Awrain Plate Helm	Female
 Abacus	Abacus
-Abidon_Fabric_Helm	Pailunese Hat
-Abidon_Fabric_Helm_T5_QA	Abidon Fabric Helm T5 QA
+Abidon_Fabric_Helm	Pailunese Hat	Male
+Abidon_Fabric_Helm_T5_QA	Abidon Fabric Helm T5 QA	Male
 AbyssGear_Epistle	White Crow's Letter
 AbyssReward_Desert_OneHandMace	Desert Hammer
 AbyssReward_Dragon_TwoHandGiantHammer	Aeserion Greathammer
 AbyssReward_Drake_Metal_OneHandShield	Drake Shield
 AbyssReward_EastWitch_Ring	Witch's Ring
-AbyssReward_HolyEcho_OneHandBow	Divine Echoes Bow
+AbyssReward_HolyEcho_OneHandBow	Divine Echoes Bow	Male
 AbyssReward_Kutum_TowerShield	Kutum Shield
 AbyssReward_MarniMusket	Marni Musket
 AbyssReward_Mysterm_OneHandSword	Sword of the Lord
 AbyssReward_Peltree_OneHandSword	Peltree Sword
-AbyssReward_Reeddevil_OneHandSword	Hollow Visage
+AbyssReward_Reeddevil_OneHandSword	Hollow Visage	Male
 AbyssReward_Skull_Knight_TwoHandSword	Frozen Anguish
 AbyssReward_Titan_TwoHandSpear	Reckoning
 AbyssReward_WhiteHorn_Ring	White Horn's Ring
@@ -22,39 +22,39 @@ Abyss_Artifact	Abyss Artifact
 Abyss_InfiniteStat_Hp30	Vitality of the Abyss
 Abyss_InfiniteStat_Mp2	Spirit of the Abyss
 Abyss_InfiniteStat_Sp3	Breath of the Abyss
-Abyss_Surreal_Human_Fabric_Boots	Rabbit Cloth Boots
-Abyss_Surreal_Human_Leather_Armor	Rabbit Leather Coat
-Abyss_Surreal_Human_Leather_Helm	Rabbit Leather Mask
-Abyss_Surreal_Wolf_Leather_Armor	Jester Leather Coat
-Abyss_Surreal_Wolf_Leather_Cloak	Jester Leather Cloak
-Abyss_Surreal_Wolf_Leather_Gloves	Jester Leather Gloves
-Abyss_Surreal_Wolf_Leather_Helm	Jester Leather Mask
+Abyss_Surreal_Human_Fabric_Boots	Rabbit Cloth Boots	Male
+Abyss_Surreal_Human_Leather_Armor	Rabbit Leather Coat	Male
+Abyss_Surreal_Human_Leather_Helm	Rabbit Leather Mask	Male
+Abyss_Surreal_Wolf_Leather_Armor	Jester Leather Coat	Male
+Abyss_Surreal_Wolf_Leather_Cloak	Jester Leather Cloak	Male
+Abyss_Surreal_Wolf_Leather_Gloves	Jester Leather Gloves	Male
+Abyss_Surreal_Wolf_Leather_Helm	Jester Leather Mask	Male
 Abyss_Surreal_Wolf_Necklace	Surreal Necklace
-Acembel_Leather_Gloves	Essembel Leather Gloves
+Acembel_Leather_Gloves	Essembel Leather Gloves	Male
 Acid_Spider_Poison	Acid Spider Venom
 Acorn	Acorn
 Acquirs_Wood_OneHandShield	Rising Arrow Shield
-Adeion_Leather_Boots	Adeion Leather Boots
-Adeion_Leather_Gloves	Adeion Leather Gloves
+Adeion_Leather_Boots	Adeion Leather Boots	Female
+Adeion_Leather_Gloves	Adeion Leather Gloves	Male
 Aequor_OneHandMusket	Delesyian Musket
 Aggro_Backpack	Sonic Resonator
-Ahns_Fabric_Armor	Annis Cloth Armor
-Ahntutan_Fabric_Armor	Antutan Cloth Armor
-Air_OneHandCannon	Air Blaster
-Ajure_Leather_Armor	Ajure Leather Armor
-Akesti_Leather_Boots	Agstree Leather Boots
-Aklas_Fabric_Armor	Acklass Cloth Armor
-Albert_PlateArmor_Armor	Albert Plate Armor
+Ahns_Fabric_Armor	Annis Cloth Armor	Male
+Ahntutan_Fabric_Armor	Antutan Cloth Armor	Male
+Air_OneHandCannon	Air Blaster	Male
+Ajure_Leather_Armor	Ajure Leather Armor	Male
+Akesti_Leather_Boots	Agstree Leather Boots	Male
+Aklas_Fabric_Armor	Acklass Cloth Armor	Male
+Albert_PlateArmor_Armor	Albert Plate Armor	Male
 Alchemist_Key	Engraved Key
 Alchemist_Key_Proto	Shabby Wooden Key
-Ald_Leather_Armor	Auld Leather Armor
-Aldwin_Leather_Gloves	Aldwin Leather Gloves
+Ald_Leather_Armor	Auld Leather Armor	Male
+Aldwin_Leather_Gloves	Aldwin Leather Gloves	Male
 Alida_OneHandShotgun	Dewhaven Shotgun
 Alida_Restraint_OneHandPistol	Shadow of the Past Pistol
-Allbit_Leather_Boots	Alvitt Leather Boots
-Alpein_Fabric_Armor	Alphen Cloth Armor
+Allbit_Leather_Boots	Alvitt Leather Boots	Male
+Alpein_Fabric_Armor	Alphen Cloth Armor	Male
 AlpineIbex_Armor	Ibex Saddle
-Alsace_Fabric_Armor	Alsace Cloth Armor
+Alsace_Fabric_Armor	Alsace Cloth Armor	Male
 Alustin_Journal_Book_I	Archive Records: Vol. I
 Alustin_Journal_Book_II	Archive Records: Vol. II
 Alustin_Journal_Book_III	Archive Records: Vol. III
@@ -62,45 +62,45 @@ Alustin_Journal_Book_IV	Archive Records: Vol. IV
 Alustin_Journal_Book_V	Archive Records: Vol. V
 Alustin_Journal_Book_VI	Archive Records: Vol. VI
 Ama	Flax
-Amanas_ChainMail_Armor	Amanas Chain Mail
-Amanta_PlateArmor_Armor	Amanta Plate Armor
-Amantia_ChainMail_Armor	Amantia Chain Mail
-Amundule_Fabric_Armor	Amundule Cloth Armor
+Amanas_ChainMail_Armor	Amanas Chain Mail	Male
+Amanta_PlateArmor_Armor	Amanta Plate Armor	Male
+Amantia_ChainMail_Armor	Amantia Chain Mail	Male
+Amundule_Fabric_Armor	Amundule Cloth Armor	Male
 Anamorphic_Book	Constellation Research Journal
 Anamorphic_PlateArmor_Helm	Constellation Helm
-Ancient_Fabric_Armor	Primus's Cloth Armor
-Ancient_Fabric_Armor_I	Priscus's Cloth Armor
-Ancient_Fabric_Armor_II	Praevus's Cloth Armor
+Ancient_Fabric_Armor	Primus's Cloth Armor	Male
+Ancient_Fabric_Armor_I	Priscus's Cloth Armor	Male
+Ancient_Fabric_Armor_II	Praevus's Cloth Armor	Male
 Ancient_People_Earring	Ancient Earring
 Ancient_People_Necklace	Ancient's Necklace
 Ancient_People_Ring	Ancient Ring
 Ancient_Shield	Ancient Shield
-Andaran_Leather_Boots	Andaran Leather Boots
-Andre_ChainMail_Armor	Andre Chain Mail
-Andria_Leather_Gloves	Andria Leather Gloves
-Angry_Wave_Ring_Drill	Furious Waves Gauntlet
+Andaran_Leather_Boots	Andaran Leather Boots	Female
+Andre_ChainMail_Armor	Andre Chain Mail	Male
+Andria_Leather_Gloves	Andria Leather Gloves	Male
+Angry_Wave_Ring_Drill	Furious Waves Gauntlet	Male
 Animal_Bone	Small Bone
 Animal_Spirit	Animal Spirit
-Ankara_Fabric_Armor	Ancara Cloth Armor
-Ankrian_Fabric_Armor	Ankrian Cloth Armor
-Anruditz_Leather_Armor	Anderitz Leather Armor
-Anruditz_Leather_Boots	Anderitz Leather Boots
+Ankara_Fabric_Armor	Ancara Cloth Armor	Male
+Ankrian_Fabric_Armor	Ankrian Cloth Armor	Male
+Anruditz_Leather_Armor	Anderitz Leather Armor	Male
+Anruditz_Leather_Boots	Anderitz Leather Boots	Male
 Anti_Caliburn_Picket	Anti-Caliburn Signboard
-Anti_Demeniss_Crail_PlateArmor_Armor	Anti-Crail Plate Armor
-Anti_Demeniss_Mueo_PlateArmor_Armor	Anti-Meyer Plate Armor
-Antika_Leather_Armor	Antika Leather Armor
-Antony_PlateArmor_Armor	Antoni Plate Armor
-Antony_PlateArmor_Helm	Antoni Plate Helm
-Antra_PlateArmor_Helm	Antra Plate Helm
-Antuka_ChainMail_Armor	Antuka Chain Mail
-Antum_PlateArmor_Armor	Antum Plate Armor
+Anti_Demeniss_Crail_PlateArmor_Armor	Anti-Crail Plate Armor	Male
+Anti_Demeniss_Mueo_PlateArmor_Armor	Anti-Meyer Plate Armor	Male
+Antika_Leather_Armor	Antika Leather Armor	Male
+Antony_PlateArmor_Armor	Antoni Plate Armor	Male
+Antony_PlateArmor_Helm	Antoni Plate Helm	Male
+Antra_PlateArmor_Helm	Antra Plate Helm	Male
+Antuka_ChainMail_Armor	Antuka Chain Mail	Male
+Antum_PlateArmor_Armor	Antum Plate Armor	Male
 Antumbra_DarkDeacon_Earring	Oath of Darkness
 Antumbra_DarkDeacon_Necklace	Relic of Darkness
 Antumbra_DarkDeacon_Ring	Mark of Darkness
 Antumbra_Fabric_Armor	Antumbra Cloth Armor
 Antumbra_King_Ring	Seal of Pitch-Black Darkness
 Antumbra_Leather_Boots	Antumbra Leather Boots
-Antumbra_Leather_Gloves	Ator's Will Leather Gloves
+Antumbra_Leather_Gloves	Ator's Will Leather Gloves	Male
 Antumbra_Leather_Gloves_I	Antumbra Leather Gloves
 Antumbra_Picket	Antumbra Sign
 Anvil_Fort_Secret_Document	The Seal of House Serkis
@@ -110,89 +110,89 @@ Apothecary_BackPack_II	Apothecary's Pack
 Apple	Apple
 AppleTree_Seed	Apple Seed
 Apple_BackPack	Apple Pack
-Arandhal_Fabric_Armor	Arandhal Cloth Armor
-Arcalu_PlateArmor_Armor	Arcalu Plate Armor
+Arandhal_Fabric_Armor	Arandhal Cloth Armor	Male
+Arcalu_PlateArmor_Armor	Arcalu Plate Armor	Male
 Archaia_OneHandMace	Spine of the Earth
-Archen_Leather_Gloves	Archen Leather Gloves
-Archran_Fabric_Armor	Akran Cloth Armor
-Archria_ChainMail_Armor	Acria Chain Mail
-Archria_Fabric_Armor	Acria Cloth Armor
+Archen_Leather_Gloves	Archen Leather Gloves	Male
+Archran_Fabric_Armor	Akran Cloth Armor	Male
+Archria_ChainMail_Armor	Acria Chain Mail	Male
+Archria_Fabric_Armor	Acria Cloth Armor	Male
 Archria_OneHandSword	Acria Sword
 Archrika_OneHandSword	Legionary's Gladius
 Archsyan_OneHandMace	Odeck Wooden Club Mace
-Arcria_Leather_Gloves	Acria Leather Bracers
-Arcti_Leather_Gloves	Arsen Leather Gloves
-Arctotus_Leather_Armor	Acrodus Leather Armor
-Ardeah_Leather_Armor	Ardia Leather Armor
-Ardoratte_Leather_Armor_I	Adoratt Leather Armor
-Arendyer_Leather_Boots	Arrenya Leather Boots
-Argatah_Fabric_Helm	Agatha Cloth Cap
-Argatah_Leather_Helm	Agatha Leather Helm
+Arcria_Leather_Gloves	Acria Leather Bracers	Male
+Arcti_Leather_Gloves	Arsen Leather Gloves	Male
+Arctotus_Leather_Armor	Acrodus Leather Armor	Male
+Ardeah_Leather_Armor	Ardia Leather Armor	Male
+Ardoratte_Leather_Armor_I	Adoratt Leather Armor	Male
+Arendyer_Leather_Boots	Arrenya Leather Boots	Male
+Argatah_Fabric_Helm	Agatha Cloth Cap	Male
+Argatah_Leather_Helm	Agatha Leather Helm	Male
 Argatah_OneHandMusket	Pailunese Musket
-Argatah_PlateArmor_Gloves	Agatha's Plate Gloves
+Argatah_PlateArmor_Gloves	Agatha's Plate Gloves	Male
 Argen_OneHandMace	Lanford Hammer
-Arghai_Fabric_Armor	Arghai Cloth Armor
-Arghai_Leather_Boots	Arghai Leather Boots
-Arghai_PlateArmor_Helm	The Faceless's Plate Helm
+Arghai_Fabric_Armor	Arghai Cloth Armor	Male
+Arghai_Leather_Boots	Arghai Leather Boots	Male
+Arghai_PlateArmor_Helm	The Faceless's Plate Helm	Male
 Argtisan_TwoHandSpear	Cog Destroyer Spear
 Ariete_OneHandRapier	Fallen Noble's Rapier
-Arkhan_Fabric_Armor	Leddic Cloth Armor
-Arkhan_PlateArmor_Armor	Arkhan Plate Armor
-Arkhan_PlateArmor_Gloves	Arkhan Plate Gloves
-Arqus_Leather_Armor	Arqus Leather Armor
+Arkhan_Fabric_Armor	Leddic Cloth Armor	Male
+Arkhan_PlateArmor_Armor	Arkhan Plate Armor	Male
+Arkhan_PlateArmor_Gloves	Arkhan Plate Gloves	Male
+Arqus_Leather_Armor	Arqus Leather Armor	Male
 Arrow	Arrow
 Arrow_Flag_I	The Blinding Arrows Small Banner Pike
 Arrow_Flag_II	The Blinding Arrows Medium Banner Pike
-Arrow_Technique_Instructor_Leather_Armor	Arrow Skill Instructor Armor
+Arrow_Technique_Instructor_Leather_Armor	Arrow Skill Instructor Armor	Male
 Arsard_TwoHandedWarHammer	Bekker Warhammer
-Arti_Leather_Gloves	Arti Leather Bracers
-Artiree_Fabric_Helm	Artiree Cloth Cap
-Artisan_Leather_Armor	Arteyan Leather Armor
+Arti_Leather_Gloves	Arti Leather Bracers	Male
+Artiree_Fabric_Helm	Artiree Cloth Cap	Female
+Artisan_Leather_Armor	Arteyan Leather Armor	Male
 Artisan_Thorn_OneHandTowerShield	Thorny Warspike Large Shield
-Artnan_Fabric_Armor	Atnan Cloth Armor
-Arven_Giant_TwoHandGiantBastard	Arben Greatsword
-Ashad_PlateArmor_Armor	Ashad Plate Armor
-Ashad_PlateArmor_Boots	Ashad Plate Boots
-Ashad_PlateArmor_Cloak	Ashad Plate Cloak
-Ashad_PlateArmor_Gloves	Ashad Plate Gloves
-Ashad_PlateArmor_Helm	Ashad Plate Helm
-Ashiteu_Fabric_Gloves	Ashtu Cloth Gloves
-Aslan_ChainMail_Armor	Aslan Chain Mail
+Artnan_Fabric_Armor	Atnan Cloth Armor	Male
+Arven_Giant_TwoHandGiantBastard	Arben Greatsword	Female
+Ashad_PlateArmor_Armor	Ashad Plate Armor	Male
+Ashad_PlateArmor_Boots	Ashad Plate Boots	Male
+Ashad_PlateArmor_Cloak	Ashad Plate Cloak	Male
+Ashad_PlateArmor_Gloves	Ashad Plate Gloves	Male
+Ashad_PlateArmor_Helm	Ashad Plate Helm	Male
+Ashiteu_Fabric_Gloves	Ashtu Cloth Gloves	Male
+Aslan_ChainMail_Armor	Aslan Chain Mail	Male
 Asparagus	Asparagus
-Aspherd_PlateArmor_Helm	Ashford Plate Helm
-Astia_Fabric_Gloves	Astia Cloth Gloves
-Astin_PlateArmor_Helm	Austin Plate Helm
-Astti_Fabric_Gloves	Asty Cloth Gloves
-Atanti_Leather_Boots	Lauques Leather Boots
-Ataram_Fabric_Helm	Ataram Cloth Cap
-Aurellian_Leather_Boots	Aurelian Leather Greaves
-Aurellian_OneHandBow	Tardik Bow
+Aspherd_PlateArmor_Helm	Ashford Plate Helm	Male
+Astia_Fabric_Gloves	Astia Cloth Gloves	Male
+Astin_PlateArmor_Helm	Austin Plate Helm	Male
+Astti_Fabric_Gloves	Asty Cloth Gloves	Male
+Atanti_Leather_Boots	Lauques Leather Boots	Male
+Ataram_Fabric_Helm	Ataram Cloth Cap	Male
+Aurellian_Leather_Boots	Aurelian Leather Greaves	Male
+Aurellian_OneHandBow	Tardik Bow	Male
 Aurio_OneHandDagger	Pailunese Riteblade
-Auron_Fabric_Armor	Auron Cloth Armor
-Austia_Leather_Armor	Oustia Leather Armor
-Austphelt_Fabric_Armor	Austfeld Cloth Armor
-Austphelt_Leather_Gloves	Austfeld Leather Gloves
-Avignon_Fabric_Armor	Avignon Cloth Armor
+Auron_Fabric_Armor	Auron Cloth Armor	Male
+Austia_Leather_Armor	Oustia Leather Armor	Male
+Austphelt_Fabric_Armor	Austfeld Cloth Armor	Male
+Austphelt_Leather_Gloves	Austfeld Leather Gloves	Male
+Avignon_Fabric_Armor	Avignon Cloth Armor	Male
 Awaken_Caliburn_TwoHandSword	Twisted Verdict
 Badran_Leather_Boots	Badran Leather Boots
 Badran_Leather_Gloves	Badran Leather Gloves
-Baidan_Fabric_Helm	Baidan Cloth Headband
+Baidan_Fabric_Helm	Baidan Cloth Headband	Male
 Bailao_Fabric_Armor	Bailao Cloth Armor
-Bainian_Leather_Boots	Blackwing Leather Boots
-Bainian_Leather_Boots_T5_QA	Bainian Leather Boots T5 QA
+Bainian_Leather_Boots	Blackwing Leather Boots	Male
+Bainian_Leather_Boots_T5_QA	Bainian Leather Boots T5 QA	Male
 Baked_Egg	Smoked Egg
 Baked_Egg_Large	Satisfying Smoked Eggs
 Baked_Egg_Medium	Filling Smoked Eggs
 Baked_Egg_XLarge	Hearty Smoked Eggs
 Bakrao_Fabric_Armor	Barclao Cloth Armor
-Baku_Leather_Boots	Baku Leather Boots
-Balder_Leather_Armor	Bettert Leather Armor
-Balderinne_Fabric_Armor	Baldrin Cloth Armor
-Balindean_Leather_Armor	Baladean Leather Armor
-Balindeuri_Leather_Gloves	Bandellure Leather Gloves
-Ballet_Leather_Gloves	Barre Leather Gloves
+Baku_Leather_Boots	Baku Leather Boots	Female
+Balder_Leather_Armor	Bettert Leather Armor	Male
+Balderinne_Fabric_Armor	Baldrin Cloth Armor	Male
+Balindean_Leather_Armor	Baladean Leather Armor	Male
+Balindeuri_Leather_Gloves	Bandellure Leather Gloves	Male
+Ballet_Leather_Gloves	Barre Leather Gloves	Male
 Balthazar_BackPack	Wyvernflames Captain's Pack
-Baltimer_Leather_Armor	Baltimier Leather Armor
+Baltimer_Leather_Armor	Baltimier Leather Armor	Male
 Balton_OneHandMace	Balton Hammer
 Bamboo_Branch_01	Bamboo Stalk
 Bamboo_Branch_01_II	Bamboo Shoot
@@ -218,66 +218,66 @@ Bamboo_Branch_Hard_Usable	Rough and Sturdy Bamboo Stalk
 Bamboo_Branch_Usable	Rough Bamboo Stalk
 Bamboo_TwoHandSpear	Bamboo Spear
 Banana_Bread	Fruit Bread
-Bandit_Leather_Boots	Bandit's Leather Greaves
-Bandit_Leather_Boots_II	Bandit's Leather Boots
-Bandit_Leather_Gloves_I	Bandit's Leather Gloves
-Bandit_Leather_Gloves_II	Orc Bandit's Leather Gloves
-Bandit_Leather_Gloves_III	Bandit's Scale Leather Gloves
+Bandit_Leather_Boots	Bandit's Leather Greaves	Male
+Bandit_Leather_Boots_II	Bandit's Leather Boots	Male
+Bandit_Leather_Gloves_I	Bandit's Leather Gloves	Male
+Bandit_Leather_Gloves_II	Orc Bandit's Leather Gloves	Male
+Bandit_Leather_Gloves_III	Bandit's Scale Leather Gloves	Male
 Baraccuro_Fabric_Armor	Baraccuro Cloth Armor
 Baraoh_Fabric_Armor	Barrow Cloth Armor
 Baras_Fabric_Armor	Baras Cloth Armor
-Baratan_ChainMail_Armor	Baratan Chain Mail
+Baratan_ChainMail_Armor	Baratan Chain Mail	Male
 Baratum_Fabric_Armor	Baratum Cloth Armor
-Barbarian_Leather_Boots_II	Barbarian Leather Greaves
-Barbarian_Leather_Gloves_I	Barbarian Leather Gloves
-Barbaros_Leather_Armor	Barbaros Leather Armor
-Barbaroy_Fabric_Armor	Barbaroy Cloth Armor
-Barbaroy_Leather_Armor	Barbaroy Leather Armor
-Barch_Fabric_Armor	Barch Cloth Armor
-Barcy_Fabric_Armor	Barcy Cloth Armor
-Baredin_OneHandBow	Tommasoan Bow
-Bareuan_Fabric_Armor	Barian Cloth Armor
+Barbarian_Leather_Boots_II	Barbarian Leather Greaves	Male
+Barbarian_Leather_Gloves_I	Barbarian Leather Gloves	Male
+Barbaros_Leather_Armor	Barbaros Leather Armor	Male
+Barbaroy_Fabric_Armor	Barbaroy Cloth Armor	Male
+Barbaroy_Leather_Armor	Barbaroy Leather Armor	Male
+Barch_Fabric_Armor	Barch Cloth Armor	Male
+Barcy_Fabric_Armor	Barcy Cloth Armor	Male
+Baredin_OneHandBow	Tommasoan Bow	Male
+Bareuan_Fabric_Armor	Barian Cloth Armor	Male
 Barioca_Leather_Armor	Baorica Leather Armor
 Barisoka_Leather_Armor	Varsoka Leather Armor
 Baritum_Fabric_Armor	Baritum Cloth Armor
 Barley	Barley
-Barndid_Fabric_Armor	Bandide Cloth Armor
-Barnia_ChainMail_Boots	Varnian Chain Boots
-Barnia_Fabric_Armor	Varnia Cloth Armor
-Barnia_Fabric_Helm	Varnia Cloth Cap
-Barnia_Leather_Gloves	Varnian Leather Bracers
-Barnia_Soldier_General_Fabric_Armor	Varnian Guard Captain's Cloth Armor
-Barnia_Soldier_General_Fabric_Cloak	Varnian Guard Captain's Cloth Cloak
-Barnia_Soldier_General_PlateArmor_Helm	Varnian Guard Captain's Plate Helm
+Barndid_Fabric_Armor	Bandide Cloth Armor	Male
+Barnia_ChainMail_Boots	Varnian Chain Boots	Male
+Barnia_Fabric_Armor	Varnia Cloth Armor	Male
+Barnia_Fabric_Helm	Varnia Cloth Cap	Male
+Barnia_Leather_Gloves	Varnian Leather Bracers	Male
+Barnia_Soldier_General_Fabric_Armor	Varnian Guard Captain's Cloth Armor	Male
+Barnia_Soldier_General_Fabric_Cloak	Varnian Guard Captain's Cloth Cloak	Male
+Barnia_Soldier_General_PlateArmor_Helm	Varnian Guard Captain's Plate Helm	Male
 Barrette_Fabric_Boots	Barrette Cloth Boots
-Barrette_Leather_Armor	Barrette Leather Armor
+Barrette_Leather_Armor	Barrette Leather Armor	Male
 Bastion_OneHandMace	Mace of Ambition
 Bastion_OneHandShield	Black Sun
-Bastion_PlateArmor_Armor	Bastier Armor
-Bastion_PlateArmor_Cloak	Bastier Plate Cloak
-Batangka_Leather_Armor	Batangka Leather Armor
+Bastion_PlateArmor_Armor	Demenissian Grand General Plate Armor	Male
+Bastion_PlateArmor_Cloak	Demenissian Grand General Plate Cloak	Male
+Batangka_Leather_Armor	Batangka Leather Armor	Male
 BattleStickyBomb	Sticky Bomb
 BattleSticky_FlowerBomb	Sticky Flower Bomb
-Battmen_Fabric_Armor	Bartmun Cloth Armor
+Battmen_Fabric_Armor	Bartmun Cloth Armor	Male
 Batz_OneHandDagger	Kylus Dagger
-Batz_PlateArmor_Gloves	Batz Plate Gloves
-Batz_PlateArmor_Gloves_I	Batz Plate Gloves I
-Batz_Plate_Boots	Batz Plate Boots
-Bayur_Fabric_Armor	The Faceless's Cloth Armor
-Bayur_Leather_Boots	Bayer Leather Boots
+Batz_PlateArmor_Gloves	Batz Plate Gloves	Male
+Batz_PlateArmor_Gloves_I	Batz Plate Gloves I	Male
+Batz_Plate_Boots	Batz Plate Boots	Male
+Bayur_Fabric_Armor	The Faceless's Cloth Armor	Male
+Bayur_Leather_Boots	Bayer Leather Boots	Male
 Bayur_PlateArmor_Helm	Bayer Plate Helm
 Bean	Beans
 Bear_Armor	Bear Saddle
 Bear_BackPack	Bear Pack
 Bear_Bile	Bear's Gallbladder
-Bear_Chief_Leather_Helm	Boss Bear Hat
+Bear_Chief_Leather_Helm	Boss Bear Hat	Male
 Bear_Leather	Thick Hide
-Bear_Leather_cloak	Bear Hide Cloak
-Beastman_ChainMail_Gloves	Beastman Chain Gloves
-Beastman_Leather_Armor	Beastman Leather Armor
-Beastman_PlateArmor_Helm	Beastman Bone Helmet
+Bear_Leather_cloak	Bear Hide Cloak	Male
+Beastman_ChainMail_Gloves	Beastman Chain Gloves	Male
+Beastman_Leather_Armor	Beastman Leather Armor	Male
+Beastman_PlateArmor_Helm	Beastman Bone Helmet	Male
 Beastman_TwoHandSword	Savage Longsword
-Becur_PlateArmor_Armor	Bekur Plate Armor
+Becur_PlateArmor_Armor	Bekur Plate Armor	Male
 Beef_Bone_Soup	Meat Stew
 Beef_Bone_Soup_Large	Satisfying Meat Stew
 Beef_Bone_Soup_Medium	Filling Meat Stew
@@ -285,76 +285,77 @@ Beef_Bone_Soup_XLarge	Hearty Meat Stew
 Beekeeping_BackPack	Beekeeper's Pack
 Beer	Beer
 BeggarLeader_FindPotion	Plague Remedy
-Begill_Leather_Armor	Begill Leather Armor
-Begill_Leather_Boots	Begill Leather Boots
+Begill_Leather_Armor	Begill Leather Armor	Male
+Begill_Leather_Boots	Begill Leather Boots	Male
 Begonia	Begonia
 Bekker_OneHandAxe	Bekker Axe
 Bekker_OneHandSword	Alabaster Curved Sword
 Bell_BackPack	Bell Pack
 Bell_Flower	Lily of the Valley
 Bellac_HorseArmor_Helm	Velok Champron
+Bellania_Leather_Armor	Dark Executioner Leather Armor	Female
 Bellaon_OneHandMace	Bekker Hammer
-Beltran_PlateArmor_Helm	Beltran Plate Helm
-Belui_Leather_Boots	Belui Leather Boots
-Belui_PlateArmor_Gloves	Belui Plate Gloves
-Belui_PlateArmor_Helm	Belui Plate Helm
-Benberry_Leather_Boots	Benberry Leather Boots
-Benne_Leather_Armor	Benne Leather Armor
-Beoneck_Fabric_Helm	Beoneck Cloth Cap
-Beoneck_Leather_Helm	Black Bears' Leather Helm
-Beoratte_Fabric_Armor	Beralt Cloth Armor
-Berenzard_Leather_Armor	Berenzard Leather Armor
+Beltran_PlateArmor_Helm	Beltran Plate Helm	Male
+Belui_Leather_Boots	Belui Leather Boots	Male
+Belui_PlateArmor_Gloves	Belui Plate Gloves	Male
+Belui_PlateArmor_Helm	Belui Plate Helm	Male
+Benberry_Leather_Boots	Benberry Leather Boots	Male
+Benne_Leather_Armor	Benne Leather Armor	Male
+Beoneck_Fabric_Helm	Beoneck Cloth Cap	Male
+Beoneck_Leather_Helm	Black Bears' Leather Helm	Male
+Beoratte_Fabric_Armor	Beralt Cloth Armor	Male
+Berenzard_Leather_Armor	Berenzard Leather Armor	Male
 Bergam_OneHandMace	Rogue's Mace
-Berin_PlateArmor_Helm	Berin Plate Helm
+Berin_PlateArmor_Helm	Berin Plate Helm	Male
 Berkei_HorseArmor_Armor	Berkei Barding
 Berkei_HorseArmor_Helm	Berkei Champron
 Berkei_HorseArmor_Saddle	Berkei Saddle
 Berkei_HorseArmor_Stirrup	Berkei Stirrups
-Berker_Leather_Armor	Berker Leather Armor
-Berkhia_Fabric_Armor	Berkhia Cloth Armor
-Berkhia_Leather_Gloves	Berkhia Leather Gloves
-Berkhia_OneHandBow	Twilight Messengers' Bow
+Berker_Leather_Armor	Berker Leather Armor	Male
+Berkhia_Fabric_Armor	Berkhia Cloth Armor	Male
+Berkhia_Leather_Gloves	Berkhia Leather Gloves	Male
+Berkhia_OneHandBow	Twilight Messengers' Bow	Male
 Berkhia_OneHandTowerShield	Thalwynd Large Shield
-Berlublean_Leather_Armor	Berblin Leather Armor
-Bernold_Leather_Armor	Bennault Leather Armor
+Berlublean_Leather_Armor	Berblin Leather Armor	Male
+Bernold_Leather_Armor	Bennault Leather Armor	Male
 Berry_Juice	Fruit Juice
-Bessenette_Fabric_Armor	Besnet Cloth Armor
-Bessenette_Leather_Boots	Bessett Leather Boots
-Bessenette_PlateArmor_Gloves	Bessett Plate Gloves
-Bessenette_PlateArmor_Helm	Besnet Plate Helm
-Bethel_Leather_Boots	Bethel Leather Boots
-Betty_Leather_Boots	Bettie Leather Boots
-Betty_Leather_Gloves	Bettie Leather Gloves
-Beverly_PlateArmor_Armor	Beverly Plate Armor
+Bessenette_Fabric_Armor	Besnet Cloth Armor	Male
+Bessenette_Leather_Boots	Besnet Leather Boots	Male
+Bessenette_PlateArmor_Gloves	Besnet Plate Gloves	Male
+Bessenette_PlateArmor_Helm	Besnet Plate Helm	Male
+Bethel_Leather_Boots	Bethel Leather Boots	Male
+Betty_Leather_Boots	Bettie Leather Boots	Female
+Betty_Leather_Gloves	Bettie Leather Gloves	Female
+Beverly_PlateArmor_Armor	Beverly Plate Armor	Male
 Bhetert_TwoHandAxe	Fan-Blade Greataxe
 Bhran_TwoHandAxe	Tardik Greataxe
-Bicornio_PlateArmor_Helm	Biconio Plate Helm
-Bierny_Leather_Armor	Vierni Leather Armor
-Big_Horn_Tiger_OneHandAxe	Silverwolf Axe
-Bildain_Leather_Armor_I	Vildyne Leather Armor
+Bicornio_PlateArmor_Helm	Biconio Plate Helm	Male
+Bierny_Leather_Armor	Vierni Leather Armor	Male
+Big_Horn_Tiger_OneHandAxe	Silverwolf Axe	Male
+Bildain_Leather_Armor_I	Vildyne Leather Armor	Male
 Bilibili_Earring	Blue Scout Earring
-Bilibili_Fabric_Armor	Blue Scout Armor
-Bilibili_Fabric_Cloak	Blue Scout Cloak
+Bilibili_Fabric_Armor	Blue Scout Armor	Male
+Bilibili_Fabric_Cloak	Blue Scout Cloak	Male
 Bilibili_HorseArmor_Helm	Blue Scout Champron
 Bilibili_HorseArmor_Saddle	Blue Scout Saddle
 Bilibili_HorseArmor_Stirrup	Blue Scout Stirrups
 Bilibili_Lantern	Blue Scout Lantern
-Bilibili_Leather_Helm	Blue Scout Hat
+Bilibili_Leather_Helm	Blue Scout Hat	Male
 Bilibili_Necklace	Blue Scout Necklace
 Bilibili_OneHandShield	Blue Scout Shield
 Bilibili_Ring	Blue Scout Ring
-Binden_Leather_Armor	Binden Leather Armor
-Binder_PlateArmor_Helm	Binder's Plate Helm
+Binden_Leather_Armor	Binden Leather Armor	Male
+Binder_PlateArmor_Helm	Binder's Plate Helm	Male
 Bird_Meat	Lean Bird Meat
-Birdish_Leather_Armor	Verdesh Leather Armor
-Birdish_Leather_Gloves	Verdesh Leather Gloves
-Biryghton_Leather_Gloves	Viraiton Leather Gloves
+Birdish_Leather_Armor	Verdesh Leather Armor	Male
+Birdish_Leather_Gloves	Verdesh Leather Gloves	Male
+Biryghton_Leather_Gloves	Viraiton Leather Gloves	Male
 Biryghton_OneHandMace	Wells Mace
 BismuthOre	Bismuth Ore
 Bismuth_CannonBall_Errant	Crude Bismuth Cannonball
 Bismuth_TwoHandCannon_I	Bismuth Cannon
 Bismuth_TwoHandSpear	Bismuth Spear
-BlackBear_Leather_Gloves	Black Bear Leather Gloves
+BlackBear_Leather_Gloves	Black Bear Leather Gloves	Male
 BlackOath_OneHandShield	Black Oath Shield
 Black_Horse_Report	Sighting of Rokade
 Black_Lion_Earring	Black Lion Earring
@@ -362,37 +363,38 @@ Blackbear_Flag_I	Small Black Bears Banner Pike
 Blackbear_Flag_II	Medium Black Bears Banner Pike
 Blackbear_Flag_IV	Black Bears Banner Pike with Tassel
 Blackberry	Blackberry
-Blackburn_PlateArmor_Armor	Blackburn Plate Armor
-Blady_ChainMail_Armor	Blandry Chain Mail
+Blackburn_PlateArmor_Armor	Blackburn Plate Armor	Male
+Blacksmith_Leather_Armor	Blacksmith's Leather Armor	Male
+Blady_ChainMail_Armor	Blandry Chain Mail	Male
 Blank_Book	Empty Book
-Bleann_Leather_Armor	Blin Leather Armor
-Bleed_Alchemist_Fabric_Armor_I	Bleed Alchemist's Cloth Armor
-Bleed_Bandits_Fabric_Armor	Bleed Officer's Cloth Armor
-Bleed_Bandits_Fabric_Cloak_II	Bleed Officer's Cloth Cloak
-Bleed_Bandits_Leather_Armor	Bleed Officer's Leather Armor
-Bleed_Bandits_Leather_Gloves	Bleed Officer's Leather Gloves
+Bleann_Leather_Armor	Blin Leather Armor	Male
+Bleed_Alchemist_Fabric_Armor_I	Bleed Alchemist's Cloth Armor	Male
+Bleed_Bandits_Fabric_Armor	Bleed Officer's Cloth Armor	Male
+Bleed_Bandits_Fabric_Cloak_II	Bleed Officer's Cloth Cloak	Male
+Bleed_Bandits_Leather_Armor	Bleed Officer's Leather Armor	Male
+Bleed_Bandits_Leather_Gloves	Bleed Officer's Leather Gloves	Male
 Bleed_Bomb_BackPack	Bleed Bandits' Alchemy Explosive Pack
 Bleed_Flag_II	Small Bleed Bandits Banner Pike
 Bleed_Flag_III	Medium Bleed Bandits Banner Pike
-Bloatte_Leather_Armor	Blaine Leather Armor
+Bloatte_Leather_Armor	Blaine Leather Armor	Male
 BloodyFarmhouse_Book	Quarry Manager's Log
-Blowin_Leather_Armor	Bleawin Leather Armor
+Blowin_Leather_Armor	Bleawin Leather Armor	Male
 BlueStone	Azurite
 Blueberry	Blueberry
-Blyan_Leather_Gloves	Blyne Leather Bracers
+Blyan_Leather_Gloves	Blyne Leather Bracers	Male
 BoardPaperBundle	Posters
-Boboten_Leather_Boots	Bourveten Leather Boots
-Bodin_PlateArmor_Armor	Bodin Plate Armor
-Bohen_Leather_Gloves	Boggen Leather Gloves
+Boboten_Leather_Boots	Bourveten Leather Boots	Male
+Bodin_PlateArmor_Armor	Bodin Plate Armor	Male
+Bohen_Leather_Gloves	Boggen Leather Gloves	Male
 BoiledPork	Boiled Meat
 BoiledPork_Large	Satisfying Boiled Meat
 BoiledPork_Medium	Filling Boiled Meat
 BoiledPork_XLarge	Hearty Boiled Meat
-Bolson_Leather_Gloves	Bolson Leather Gloves
-Bolton_PlateArmor_Armor	Bolton Plate Armor
-Bolton_PlateArmor_Cloak	Bolton Plate Cloak
-Bolton_PlateArmor_Helm	Keredeg Plate Helm
-Bolzers_Leather_Armor	Bolzers Leather Armor
+Bolson_Leather_Gloves	Bolson Leather Gloves	Male
+Bolton_PlateArmor_Armor	Bolton Plate Armor	Male
+Bolton_PlateArmor_Cloak	Bolton Plate Cloak	Male
+Bolton_PlateArmor_Helm	Keredeg Plate Helm	Male
+Bolzers_Leather_Armor	Bolzers Leather Armor	Male
 BombSpider_CannonBall	Mine Spider Cannonball
 Bomb_Arrow	Explosive Arrow
 Bomb_Smoke	Smoke Bomb
@@ -417,12 +419,12 @@ Book_ScholarLibrary_Knowledge_Knowledge_PlateArmor_Helm	The Knowledge Helm
 Book_TruthontheSand	Investigative Log: Truth on the Sands
 Book_WeightOfKnowledge	Investigative Log: The Weight of Knowledge
 Book_WyvernJournal	Balthazar's Wyvern Observation Journal
-Bopet_PlateArmor_Helm	Bobfett Plate Helm
-Borman_Fabric_Armor	Borman Cloth Armor
-Borsehir_Fabric_Armor	Borsehir Cloth Armor
+Bopet_PlateArmor_Helm	Bobfett Plate Helm	Male
+Borman_Fabric_Armor	Borman Cloth Armor	Male
+Borsehir_Fabric_Armor	Borsehir Cloth Armor	Male
 Boss_Hyena_Skevald_Report	Sighting of Skevald, the Carrion King
-Boss_Ludvig_Awakening_Leahter_Armor	Awakened Jackal's Leather Armor
-Boss_Ludvig_Awakening_Leather_Boots	Awakened Jackal's Leather Boots
+Boss_Ludvig_Awakening_Leahter_Armor	Awakened Jackal's Leather Armor	Male
+Boss_Ludvig_Awakening_Leather_Boots	Awakened Jackal's Leather Boots	Male
 Boss_Reward_AutomatedIncome	Golden Piggy Bank
 Boss_Reward_BigMoney	Plunderer's Gold Chest
 Boss_Reward_BountyReduction	Shadow Contract
@@ -455,43 +457,43 @@ Boss_Reward_SuperWeapon	Axe of the Apocalypse
 Boss_Reward_Supercarrot	Giant Brown Sugar Cube
 Boss_Reward_Survivors	The Ivory Messenger
 Boss_Reward_Tracker	Leebur's Soul
-BountyHunter_Fabric_Armor	Bounty Hunter's Cloth Armor
-BountyHunter_Fabric_Armor_I	Bounty Hunter's Cloth Armor
-BountyHunter_Fabric_Armor_II	Bounty Hunter's Cloth Armor
-BountyHunter_Fabric_Armor_III	Bounty Hunter's Cloth Armor
-BountyHunter_Fabric_Armor_IV	Bounty Hunter's Cloth Armor
-BountyHunter_Fabric_Armor_V	Bounty Hunter's Cloth Armor
-BountyHunter_Fabric_Armor_VI	Bounty Hunter's Cloth Armor
-BountyHunter_Fabric_Boots_I	Bounty Hunter's Cloth Boots
-BountyHunter_Fabric_Gloves_I	Bounty Hunter's Cloth Gloves
-BountyHunter_Fabric_Helm_I	Bounty Hunter's Cloth Cap
-BountyHunter_Fabric_Helm_II	Bounty Hunter's Cloth Cap
-BountyHunter_Leather_Armor	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_I	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_II	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_III	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_IV	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_V	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_VI	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_VII	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Armor_VIII	Bounty Hunter's Leather Armor
-BountyHunter_Leather_Boots	Bounty Hunter's Leather Boots
-BountyHunter_Leather_Boots_I	Strapped Bounty Hunter's Leather Boots
-BountyHunter_Leather_Cloak	Bounty Hunter's Leather Cloak
-BountyHunter_Leather_Gloves	Ringed Leather Gloves
-BountyHunter_Leather_Gloves_I	Tough Hunter's Leather Gloves
-BountyHunter_Leather_Gloves_II	Thick Hunter's Leather Gloves
-BountyHunter_Leather_Helm_I	Bounty Hunter's Scale Hat
-BountyHunter_Leather_Helm_II	Bounty Hunter's Leather Cap
-BountyHunter_PlateArmor_Gloves_I	Bounty Hunter's Plate Gloves
-BountyHunter_PlateArmor_Helm	Horned Bounty Hunter's Plate Helm
-BountyHunter_PlateArmor_Helm_I	Bounty Hunter's Plate Helm
-BountyHunter_PlateArmor_Helm_II	Crow Bounty Plate Helm
-BountyHunter_Plate_Armor	Bounty Hunter's Plate Armor
-BountyHunter_Plate_Armor_I	Bounty Hunter's Plate Armor
-BountyHunter_Plate_Armor_II	Bounty Hunter's Plate Armor
-BountyHunter_Plate_Armor_III	Bounty Hunter's Plate Armor
-BountyHunter_Plate_Boots	Bounty Hunter's Plate Boots
+BountyHunter_Fabric_Armor	Bounty Hunter's Cloth Armor	Male
+BountyHunter_Fabric_Armor_I	Bounty Hunter's Cloth Armor	Male
+BountyHunter_Fabric_Armor_II	Bounty Hunter's Cloth Armor	Male
+BountyHunter_Fabric_Armor_III	Bounty Hunter's Cloth Armor	Male
+BountyHunter_Fabric_Armor_IV	Bounty Hunter's Cloth Armor	Male
+BountyHunter_Fabric_Armor_V	Bounty Hunter's Cloth Armor	Male
+BountyHunter_Fabric_Armor_VI	Bounty Hunter's Cloth Armor	Male
+BountyHunter_Fabric_Boots_I	Bounty Hunter's Cloth Boots	Male
+BountyHunter_Fabric_Gloves_I	Bounty Hunter's Cloth Gloves	Male
+BountyHunter_Fabric_Helm_I	Bounty Hunter's Cloth Cap	Male
+BountyHunter_Fabric_Helm_II	Bounty Hunter's Cloth Cap	Male
+BountyHunter_Leather_Armor	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_I	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_II	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_III	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_IV	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_V	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_VI	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_VII	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Armor_VIII	Bounty Hunter's Leather Armor	Male
+BountyHunter_Leather_Boots	Bounty Hunter's Leather Boots	Male
+BountyHunter_Leather_Boots_I	Strapped Bounty Hunter's Leather Boots	Male
+BountyHunter_Leather_Cloak	Bounty Hunter's Leather Cloak	Male
+BountyHunter_Leather_Gloves	Ringed Leather Gloves	Male
+BountyHunter_Leather_Gloves_I	Tough Hunter's Leather Gloves	Male
+BountyHunter_Leather_Gloves_II	Thick Hunter's Leather Gloves	Male
+BountyHunter_Leather_Helm_I	Bounty Hunter's Scale Hat	Male
+BountyHunter_Leather_Helm_II	Bounty Hunter's Leather Cap	Male
+BountyHunter_PlateArmor_Gloves_I	Bounty Hunter's Plate Gloves	Male
+BountyHunter_PlateArmor_Helm	Horned Bounty Hunter's Plate Helm	Male
+BountyHunter_PlateArmor_Helm_I	Bounty Hunter's Plate Helm	Male
+BountyHunter_PlateArmor_Helm_II	Crow Bounty Plate Helm	Male
+BountyHunter_Plate_Armor	Bounty Hunter's Plate Armor	Male
+BountyHunter_Plate_Armor_I	Bounty Hunter's Plate Armor	Male
+BountyHunter_Plate_Armor_II	Bounty Hunter's Plate Armor	Male
+BountyHunter_Plate_Armor_III	Bounty Hunter's Plate Armor	Male
+BountyHunter_Plate_Boots	Bounty Hunter's Plate Boots	Male
 Bourgogne_OneHandMace	Sorcerer's Massage Stick
 Braised_Fish	Braised Fish
 Braised_Fish_Large	Satisfying Braised Fish
@@ -518,107 +520,107 @@ Braised_Vegetable_Large	Satisfying Pickled Vegetables
 Braised_Vegetable_Medium	Filling Pickled Vegetables
 Braised_Vegetable_XLarge	Hearty Pickled Vegetables
 Branik_HorseArmor_Saddle	Branique Saddle
-Braxen_PlateArmor_Helm	Condemner's Plate Helm
+Braxen_PlateArmor_Helm	Condemner's Plate Helm	Male
 Bread	Bread
-Brejin_PlateArmor_Armor	Brejin Plate Armor
-Brejin_PlateArmor_Armor_I	Brejin Plate Armor
+Brejin_PlateArmor_Armor	Brejin Plate Armor	Male
+Brejin_PlateArmor_Armor_I	Brejin Plate Armor	Male
 Brimstone_Bomb	Brimstone Bomb
-Brimstone_Leather_Helm	Black Bear Gas Mask
-Brimstone_Leather_Helm_I	Demenissian Soldiers' Brimstone Gas Mask
-Brimstone_Leather_Helm_II	Demeniss Brimstone Gas Mask
-Brina_PlateArmor_Armor	Brina Plate Armor
-Brittle_Leather_Gloves	Bristel Leather Gloves
-Brizzle_Leather_Armor	Breitzle Leather Armor
-Brogue_Leather_Armor	Brogue Leather Armor
-Bromarty_Leather_Armor	Brometi Leather Armor
+Brimstone_Leather_Helm	Black Bear Gas Mask	Male
+Brimstone_Leather_Helm_I	Demenissian Soldiers' Brimstone Gas Mask	Male
+Brimstone_Leather_Helm_II	Demeniss Brimstone Gas Mask	Male
+Brina_PlateArmor_Armor	Brina Plate Armor	Male
+Brittle_Leather_Gloves	Bristel Leather Gloves	Male
+Brizzle_Leather_Armor	Breitzle Leather Armor	Male
+Brogue_Leather_Armor	Brogue Leather Armor	Male
+Bromarty_Leather_Armor	Brometi Leather Armor	Male
 Brudandi_TwoHandAxe	Kylus Greataxe
-Buchanan_Fabric_Armor	Buchanan Cloth Armor
+Buchanan_Fabric_Armor	Buchanan Cloth Armor	Male
 BucketHeavy	Heavy Bucket
 Buckwheat	Buckwheat
-Bulga_Leather_Armor	Bulga Leather Armor
+Bulga_Leather_Armor	Bulga Leather Armor	Male
 Bullet	Bullet
-Bunce_Leather_Gloves	Bunce Leather Gloves
-Burimen_PlateArmor_Armor	Breemen Plate Armor
-Bydan_Fabric_Gloves	Baidan Cloth Gloves
+Bunce_Leather_Gloves	Bunce Leather Gloves	Male
+Burimen_PlateArmor_Armor	Breemen Plate Armor	Male
+Bydan_Fabric_Gloves	Baidan Cloth Gloves	Male
 ByeorSeungja_Chongtong_TwoHandCannon_I	Gamma Barrel Cannon
 Cabbage	Cabbage
 CabinDeathMystery_Book	Journal at the Cabin
 Cacao	Cacao
-Cacheco_Leather_Boots	Catcheta Leather Boots
-Cadwallon_ChainMail_Helm	Kadallon Chain Coif
-Cadwallon_Leather_Boots	Kadallon's Leather Boots
-Cadwallon_Leather_Gloves	Kadallon Leather Gloves
+Cacheco_Leather_Boots	Catcheta Leather Boots	Male
+Cadwallon_ChainMail_Helm	Kadallon Chain Coif	Male
+Cadwallon_Leather_Boots	Kadallon's Leather Boots	Male
+Cadwallon_Leather_Gloves	Kadallon Leather Gloves	Male
 Cage_BackPack	Birdcage Pack
 Caisro_Leather_Boots	Cassrow Leather Boots
-Caliburn_Engineer_Fabric_Armor	Caliburn's Combat Engineer Cloth Armor
-Caliburn_Engineer_Fabric_Armor_I	Caliburn's Combat Engineer Cloth Armor
-Caliburn_Engineer_Fabric_Armor_II	Caliburn's Combat Engineer Cloth Armor
-Caliburn_Engineer_Fabric_Armor_III	Caliburn's Combat Engineer Cloth Armor
-Caliburn_Engineer_Fabric_Armor_IV	Caliburn's Combat Engineer Cloth Armor
-Caliburn_Engineer_Leather_Gloves	Caliburn's Combat Engineer Leather Gloves
+Caliburn_Engineer_Fabric_Armor	Caliburn's Combat Engineer Cloth Armor	Male
+Caliburn_Engineer_Fabric_Armor_I	Caliburn's Combat Engineer Cloth Armor	Male
+Caliburn_Engineer_Fabric_Armor_II	Caliburn's Combat Engineer Cloth Armor	Male
+Caliburn_Engineer_Fabric_Armor_III	Caliburn's Combat Engineer Cloth Armor	Male
+Caliburn_Engineer_Fabric_Armor_IV	Caliburn's Combat Engineer Cloth Armor	Male
+Caliburn_Engineer_Leather_Gloves	Caliburn's Combat Engineer Leather Gloves	Male
 Caliburn_Flag	Small Caliburn's Banner Pike
 Caliburn_Flag_I	Small Caliburn's Banner Pike
 Caliburn_Flag_II	Medium Caliburn's Banner Pike
-Caliburn_PlateArmor_Armor	Caliburn's Plate Armor
-Caliburn_PlateArmor_Gloves	Caliburn's Plate Gloves
-Caliburn_Plate_Boots	Caliburn's Plate Boots
+Caliburn_PlateArmor_Armor	Caliburn's Plate Armor	Male
+Caliburn_PlateArmor_Gloves	Caliburn's Plate Gloves	Male
+Caliburn_Plate_Boots	Caliburn's Plate Boots	Male
 Caliburn_Report	Investigative Report
 Caliburn_Tolerance_OneHandPistol	Caliburn's Mercy Pistol
 Caliburn_TwoHandSword	Righteous Verdict
-Calio_Leather_Gloves	Calio's Leather Gloves
-Calio_Leather_Gloves_I	Calio's Leather Gloves
-Calio_PlateArmor_Helm	Calio Plate Helm
-Calis_Fabric_Armor	Calis Cloth Armor
+Calio_Leather_Gloves	Calio's Leather Gloves	Male
+Calio_Leather_Gloves_I	Calio's Leather Gloves	Male
+Calio_PlateArmor_Helm	Calio Plate Helm	Male
+Calis_Fabric_Armor	Calis Cloth Armor	Female
 Calphade_Contribution_Flag	Calphadean Contribution Banner Pike
 Calphade_Flag_I	Small Calphadean Banner Pike
 Calphade_Flag_II	Medium Calphadean Banner Pike
-Calpris_Fabric_Helm	Calprise Cloth Cap
-Calto_Leather_Armor	Calto Leather Armor
+Calpris_Fabric_Helm	Calprise Cloth Cap	Male
+Calto_Leather_Armor	Calto Leather Armor	Male
 Caltrop_Bomb	Caltrop Explosive
 Camantti_Leather_Boots	Camantti Leather Boots
 Camel_Armor	Embroidered Camel Saddle
-Camouflage_Boar_Cloak	Boar Cloak
-Camouflage_Boar_Leather_Gloves	Boar Camouflage Leather Bracers
-Camouflage_Bull_Cloak	Cow Cloak
-Camouflage_Reindeer_Cloak	Reindeer Cloak
-Camouflage_Wolf_Cloak	Wolf Cloak
-Campbell_Leather_Gloves	Keimbel Leather Gloves
-Campo_Leather_Armor	Campo Leather Armor
+Camouflage_Boar_Cloak	Boar Cloak	Male
+Camouflage_Boar_Leather_Gloves	Boar Camouflage Leather Bracers	Male
+Camouflage_Bull_Cloak	Cow Cloak	Male
+Camouflage_Reindeer_Cloak	Reindeer Cloak	Male
+Camouflage_Wolf_Cloak	Wolf Cloak	Male
+Campbell_Leather_Gloves	Keimbel Leather Gloves	Male
+Campo_Leather_Armor	Campo Leather Armor	Male
 CannonBall	Small Cannonball
-Canta_PlateArmor_Armor	Canta Plate Armor
-Canta_PlateArmor_Cloak	Canta Plate Cloak
-Cantarts_Leather_Armor	Cantars Leather Armor
-Cantina_ChainMail_Armor	Cantina Chain Mail
-Cantu_Leather_Boots	Cantu Leather Boots
-Canusti_PlateArmor_Armor	Canusti Plate Armor
-Canusti_PlateArmor_Armor_I	Canusti Plate Armor
+Canta_PlateArmor_Armor	Canta Plate Armor	Male
+Canta_PlateArmor_Cloak	Canta Plate Cloak	Male
+Cantarts_Leather_Armor	Cantars Leather Armor	Male
+Cantina_ChainMail_Armor	Cantina Chain Mail	Male
+Cantu_Leather_Boots	Cantu Leather Boots	Female
+Canusti_PlateArmor_Armor	Canusti Plate Armor	Male
+Canusti_PlateArmor_Armor_I	Canusti Plate Armor	Male
 CapitalPatrol_OneHandShield	City Guard's Shield
-Carcon_Leather_Boots	Carcon Leather Boots
-Card_Vision_Helm	Deceiver's Fedora
-Cardion_Leather_Boots	Bolton Leather Boots
-Carious_Leather_Armor	Karius Leather Armor
-Carix_Leather_Gloves	Cains Leather Gloves
-Carphalen_Leather_Armor	Carphalen Leather Armor
-Carpinne_Leather_Armor	Carpine Leather Armor
+Carcon_Leather_Boots	Carcon Leather Boots	Male
+Card_Vision_Helm	Deceiver's Fedora	Male
+Cardion_Leather_Boots	Bolton Leather Boots	Male
+Carious_Leather_Armor	Karius Leather Armor	Male
+Carix_Leather_Gloves	Cains Leather Gloves	Male
+Carphalen_Leather_Armor	Carphalen Leather Armor	Male
+Carpinne_Leather_Armor	Carpine Leather Armor	Male
 Carrot	Carrot
-Carta_Leather_Gloves	Carta Leather Gloves
-Carta_PlateArmor_Armor	Carta Plate Armor
-Carta_PlateArmor_Helm	Carta Plate Helm
-Carta_Plated_Boots	Carta Plate Boots
-Carton_PlateArmor_Armor	Garten Plate Armor
-Casa_Fabric_Armor	Kassa Cloth Armor
+Carta_Leather_Gloves	Carta Leather Gloves	Male
+Carta_PlateArmor_Armor	Carta Plate Armor	Male
+Carta_PlateArmor_Helm	Carta Plate Helm	Male
+Carta_Plated_Boots	Carta Plate Boots	Male
+Carton_PlateArmor_Armor	Garten Plate Armor	Male
+Casa_Fabric_Armor	Kassa Cloth Armor	Male
 Casanta_Leather_Boots	Kassantra Leather Boots
 Casco_Leather_Boots	Cosgrove Leather Boots
-Casinian_PlateArmor_Helm	Casinian Plate Helm
-Cateine_Leather_Boots	Cateine Leather Boots
-Catfish_Helm	Catfish Plate Helm
-Caviden_Leather_Gloves	Caviden Leather Gloves
+Casinian_PlateArmor_Helm	Casinian Plate Helm	Female
+Cateine_Leather_Boots	Cateine Leather Boots	Male
+Catfish_Helm	Catfish Plate Helm	Male
+Caviden_Leather_Gloves	Caviden Leather Gloves	Male
 Caviden_Wood_OneHandShield	Sydmon Kite Shield
 Cebro_Fabric_Gloves	Serbello Cloth Gloves
 Cecilia_Kokes_OneHandMace	Acorn Mace
 Ceremonial_OneHandDagger	Ator's Finger
 Cernos_HorseArmor_Armor	Cernos Barding
-Ceruon_PlateArmor_Armor	Cerruan Plate Armor
+Ceruon_PlateArmor_Armor	Cerruan Plate Armor	Male
 Cetry_Fabric_Gloves	Setri Cloth Gloves
 CharacterCustomize_Damian_DefultHair	Damiane's Basic Hair Ticket
 CharacterCustomize_Damian_TieHair	Damiane's Ponytail Ticket
@@ -627,51 +629,51 @@ CharacterCustomize_Kliff_Deaging	Kliff Youthful Appearance Change Coupon
 CharacterCustomize_Kliff_Neck_Scar	Kliff's Neck Scar Change Coupon
 CharacterCustomize_Oongka_Arm_Aging	Oongka's Arms Aging Appearance Change Coupon
 Charphnir_OneHandDagger	Alabaster Dagger
-Chart_Leather_Gloves	Chent Leather Gloves
-Chartian_Fabric_Helm	Dark Ringleader's Cloth Helm
+Chart_Leather_Gloves	Chent Leather Gloves	Male
+Chartian_Fabric_Helm	Dark Ringleader's Cloth Helm	Male
 Chaya_seed	Chaya Seed
-Checia_PlateArmor_Helm	Chelcia Plate Helm
-Checia_PlateArmor_Helm_I	Wells Elite Plate Helm
+Checia_PlateArmor_Helm	Chelcia Plate Helm	Male
+Checia_PlateArmor_Helm_I	Wells Elite Plate Helm	Male
 Cheese	Cheese
-Chelcia_Plate_Boots	Chelcia Plate Boots
-Chelti_Leather_Boots	Chanti Leather Boots
-Cheon_Leather_Armor	Chayten Leather Armor
+Chelcia_Plate_Boots	Chelcia Plate Boots	Male
+Chelti_Leather_Boots	Chanti Leather Boots	Male
+Cheon_Leather_Armor	Chayten Leather Armor	Male
 Cheonja_Chongtong_TwoHandCannon_I	Alpha Barrel Cannon
-Cherke_Leather_Armor	Cherke Leather Armor
+Cherke_Leather_Armor	Cherke Leather Armor	Male
 Chickadee	False Hellebore
-Chicken_Helm	Herald of Six O'Clock
+Chicken_Helm	Herald of Six O'Clock	Male
 Chicken_Meat	Bird Meat
-Chijar_Fabric_Armor	Chizhar Cloth Armor
-Chijar_Fabric_Boots	Chizhar Cloth Boots
-Chijar_Fabric_Gloves	Chizhar Cloth Gloves
-Chile_Leather_Armor	Cherlay Leather Armor
-Chile_Leather_Boots	Cherlay Leather Boots
-Chile_Leather_Gloves	Cherlay Leather Gloves
+Chijar_Fabric_Armor	Chizhar Cloth Armor	Male
+Chijar_Fabric_Boots	Chizhar Cloth Boots	Male
+Chijar_Fabric_Gloves	Chizhar Cloth Gloves	Male
+Chile_Leather_Armor	Cherlay Leather Armor	Male
+Chile_Leather_Boots	Cherlay Leather Boots	Male
+Chile_Leather_Gloves	Cherlay Leather Gloves	Male
 Chocolate_Factory_BackPack	Gearmelt Confectionery Pack
-Ciburn_Leather_Gloves	Sivern Leather Gloves
-Cigar_Leather_Boots	Seiger Leather Boots
+Ciburn_Leather_Gloves	Sivern Leather Gloves	Male
+Cigar_Leather_Boots	Seiger Leather Boots	Male
 Cigar_OneHandSword	Grey Wolf's Sword
-Cigrymon_Plate_Boots	Sigremon Plate Boots
+Cigrymon_Plate_Boots	Unyielding Hero's Plate Boots	Male
 Cigrymon_TwoHandAxe	Sigremon Greataxe
-Cilantro_Leather_Boots	Sillau Leather Boots
+Cilantro_Leather_Boots	Sillau Leather Boots	Male
 CircusMachine_Sphere	Circus Machine Sphere
-ClaireHill_Leather_Boots	Clarille Leather Boots
-Claire_Leather_Gloves	Claire Leather Gloves
-Clays_Leather_Boots	Clays Leather Boots
-Clays_Leather_Boots_I	Desert Clays Leather Boots
-Clays_Leather_Boots_II	Large Clays Leather Boots
-Clays_Leather_Boots_III	Wetlands Clays Leather Boots
-Clays_Leather_Boots_IV	Gilded Clays Leather Boots
+ClaireHill_Leather_Boots	Clarille Leather Boots	Male
+Claire_Leather_Gloves	Claire Leather Gloves	Male
+Clays_Leather_Boots	Clays Leather Boots	Male
+Clays_Leather_Boots_I	Desert Clays Leather Boots	Male
+Clays_Leather_Boots_II	Large Clays Leather Boots	Male
+Clays_Leather_Boots_III	Wetlands Clays Leather Boots	Male
+Clays_Leather_Boots_IV	Gilded Clays Leather Boots	Male
 Clout	Cloth Piece
-Coby_Leather_Armor_I	Coby Leather Armor
-Cocotar_Fabric_Armor	Cocotar Cloth Armor
+Coby_Leather_Armor_I	Coby Leather Armor	Male
+Cocotar_Fabric_Armor	Cocotar Cloth Armor	Male
 Coffee	Coffee Cherry
 Coffee_Seed	Coffee Cherry Seed
 Cog	Cogwheel
 Cog_Pack	Cogwheel
-Colatte_Leather_Armor	Colatte Leather Armor
-Colbern_Leather_Boots	Colbern Leather Boots
-Colbill_Leather_Armor_I	Colbill Leather Armor
+Colatte_Leather_Armor	Colatte Leather Armor	Male
+Colbern_Leather_Boots	Colbern Leather Boots	Male
+Colbill_Leather_Armor_I	Colbill Leather Armor	Male
 Collection_Lamp_Candle_0001	Icy White Glass Lamp
 Collection_Lamp_Candle_0001_index01	Twilight Glass Lamp
 Collection_Lamp_Candle_0001_index02	Lilac Glass Lamp
@@ -729,11 +731,11 @@ Collection_Prop_Bottle_0039	Long Blue Water Bottle
 Collection_Prop_Bottle_0040	Silver-Decorated Water Bottle
 Collection_Prop_Bottle_0041	Wide-Mouthed Water Bottle
 Collection_Prop_Bottle_0042	Small Pot for Boiling
-Collection_Prop_Bottle_0043	Blue-Glazed Container
+Collection_Prop_Bottle_0043	White Iron Water Bottle
 Collection_Prop_Bottle_0044	Black Ceramic Water Bottle
 Collection_Prop_Bottle_0045	Travel Flask
 Collection_Prop_Bottle_0046	Yellow-Glazed Water Bottle
-Collection_Prop_Bottle_0047	Light Green-Glazed Water Bottle
+Collection_Prop_Bottle_0047	White-Glazed Water Bottle
 Collection_Prop_Bottle_0048	Clay-Handled Water Bottle
 Collection_Prop_Bottle_0049	Indigo Bottle
 Collection_Prop_Bottle_0050	Wide-Bottomed Water Bottle
@@ -1056,16 +1058,17 @@ Collection_gemstone_lamp_0001_index02	Lilac Processed Crystal
 Collection_gemstone_lamp_0002	Icy White Crystal
 Collection_gemstone_lamp_0002_index01	Twilight Crystal
 Collection_gemstone_lamp_0002_index02	Lilac Crystal
-Colossus_Boots	Giant's Boots
-Commander_PlateArmor_Gloves	Dulone Plate Gloves
+Colossus_Boots	Giant's Boots	Male
+Commander_PlateArmor_Gloves	Dulone Plate Gloves	Male
 Common_Flag_I	Double-Sided Banner Pike
 Common_Flag_II	Small Banner Pike
-Conally_Fabric_Armor	Conally Cloth Armor
-Concerta_Leather_Gloves	Conchetta Leather Gloves
+Common_Flag_III	Small Banner Pike
+Conally_Fabric_Armor	Conally Cloth Armor	Male
+Concerta_Leather_Gloves	Conchetta Leather Gloves	Male
 Condola	Contola
 Continuous_Supply_Bullet	Replenishing Bullets
 Continuous_Supply_CannonBall	Replenishing Cannonballs
-Contra_Leather_Gloves	Contra Leather Gloves
+Contra_Leather_Gloves	Contra Leather Gloves	Male
 Contribution_Delesyian	Delesyian Contribution
 Contribution_Demenissian	Demenissian Contribution
 Contribution_Graymane	Greymane Contribution
@@ -1075,18 +1078,18 @@ Contribution_Tashkalpan	Tashkalp Contribution
 Cooking_Oil	Cooking Oil
 CopperOre	Copper Ore
 Copper_Pack	Modest Copper Pouch
-Corey_Fabric_Armor	Corey Cloth Armor
+Corey_Fabric_Armor	Corey Cloth Armor	Male
 Corn	Corn
 Corn_seed	Corn Seed
-Cornia_Leather_Boots	Cornia Leather Boots
-Corvo_PlateArmor_Armor	Icewing Plate Armor
-Corvo_PlateArmor_Cloak	Icewing Plate Cloak
-Corvo_PlateArmor_Gloves	Icewing Plate Gloves
-Corvo_PlateArmor_Gloves_II	Corvo Plate Gloves
+Cornia_Leather_Boots	Cornia Leather Boots	Male
+Corvo_PlateArmor_Armor	Icewing Plate Armor	Male
+Corvo_PlateArmor_Cloak	Icewing Plate Cloak	Male
+Corvo_PlateArmor_Gloves	Icewing Plate Gloves	Male
+Corvo_PlateArmor_Gloves_II	Corvo Plate Gloves	Male
 Cotton	Cotton
-Cournantry_Fabric_Armor	Conentry Cloth Armor
-Cournantry_Leather_Boots	Conentry Leather Boots
-Cradbahn_Leather_Armor	Cradbahn Leather Armor
+Cournantry_Fabric_Armor	Conentry Cloth Armor	Male
+Cournantry_Leather_Boots	Conentry Leather Boots	Male
+Cradbahn_Leather_Armor	Cradbahn Leather Armor	Male
 CraftingRecipe_Demian_Leather_Armor_V	Elegant Carmine Armor Blueprint
 CraftingRecipe_Demian_Leather_Cloak_I	Elegant Carmine Cloak Blueprint
 CraftingRecipe_Demian_PlateArmor_Gloves_VI	Elegant Carmine Gloves Blueprint
@@ -1106,56 +1109,56 @@ CraftingRecipe_Oongka_PlateArmor_Gloves_III	Belkandor Plate Gloves Blueprint
 CraftingRecipe_Oongka_PlateArmor_Helm_III	Belkandor Plate Helm Blueprint
 Crafting_Blizzard_Necklace	Blizzard Crystal Necklace
 Crafting_WhiteHorn_OneHandShield	Frostbone Shield
-Crail_PlateArmor_Armor	Crail Plate Armor
-Crail_PlateArmor_Armor_I	Crail Plate Armor
+Crail_PlateArmor_Armor	Crail Plate Armor	Male
+Crail_PlateArmor_Armor_I	Crail Plate Armor	Male
 Criminal_DropItem	Note with a Suspicious Symbol
 Criminal_Urga_Book	Ursula's Journal
 CrimsonFlame_OneHandShield	Blazing Shield
 Crocodile_Skin	Sturdy Hide
-Croden_Leather_Armor	Croden Leather Armor
+Croden_Leather_Armor	Croden Leather Armor	Male
 Croton	Croton
 Croton_Red	Red Croton
-CrowMan_PlateArmor_Helm	Blackwing Mask
+CrowMan_PlateArmor_Helm	Blackwing Mask	Male
 Crow_Bell	Bells
 Crow_Bomb	Crow Bomb
 Crow_Charm	Talisman
-Crow_PlateArmor_Helm	Crow Plate Helm
+Crow_PlateArmor_Helm	Crow Plate Helm	Male
 Crow_Thurible	Censer
-Crude_Devil_Mask	Crude Devil Mask
+Crude_Devil_Mask	Crude Devil Mask	Male
 Crudell_OneHandAxe	Timberham Axe
-Crudil_Leather_Boots	Crudil Leather Boots
-Crudil_PlateArmor_Helm	Crudil Plate Helm
-Cruedil_Leather_Gloves	Crudil Leather Gloves
+Crudil_Leather_Boots	Crudil Leather Boots	Male
+Crudil_PlateArmor_Helm	Crudil Plate Helm	Male
+Cruedil_Leather_Gloves	Crudil Leather Gloves	Male
 Crutch	Crutch
 Cucumber	Cucumber
-Cueman_Fabric_Armor	Quandan Cloth Armor
-Cuenantta_Fabric_Armor	Qunanta Cloth Armor
-Cuetain_Fabric_Armor	Qutin Cloth Armor
-Cuthbertson_Leather_Armor	Cuthbertson Leather Armor
-Cuzerchin_Leather_Armor	Churrchen Leather Armor
-Cyton_Leather_Armor	Cyton Leather Armor
-Dadnion_PlateArmor_Armor	Dardnion Plate Armor
+Cueman_Fabric_Armor	Quandan Cloth Armor	Male
+Cuenantta_Fabric_Armor	Qunanta Cloth Armor	Male
+Cuetain_Fabric_Armor	Qutin Cloth Armor	Male
+Cuthbertson_Leather_Armor	Cuthbertson Leather Armor	Male
+Cuzerchin_Leather_Armor	Churrchen Leather Armor	Male
+Cyton_Leather_Armor	Cyton Leather Armor	Male
+Dadnion_PlateArmor_Armor	Dardnion Plate Armor	Male
 Daeil_Band	Axiom Bracelet
-Daibeads_Leather_Armor	Davis Leather Armor
-Daine_Leather_Boots	Daine Leather Boots
-Dakahbern_Fabric_Armor	Dahkavan Cloth Armor
-Dallaban_Leather_Gloves	Dallaban Leather Gloves
-Dallabici_PlateArmor_Armor	Demeniss Honor Armor
-Dallabici_PlateArmor_Armor_I	Dalbich Plate Armor
-Dalton_Leather_Gloves	Dalton Leather Gloves
-DamianOnly_Leather_Boots_II	Low-Heeled Leather Boots
-DamianOnly_Leather_Boots_III	White Bloodwind Leather Boots
-DamianOnly_Leather_Boots_IV	Autumn Banquet Leather Boots
-DamianOnly_Leather_Boots_V	Official Knight's Leather Boots
-DamianOnly_Leather_Boots_VI	Wanderer of Faith Leather Boots
-DamianOnly_Leather_Boots_VII	Leather Boots of Earth's Honor
+Daibeads_Leather_Armor	Davis Leather Armor	Male
+Daine_Leather_Boots	Daine Leather Boots	Male
+Dakahbern_Fabric_Armor	Dahkavan Cloth Armor	Male
+Dallaban_Leather_Gloves	Dallaban Leather Gloves	Male
+Dallabici_PlateArmor_Armor	Demeniss Honor Armor	Male
+Dallabici_PlateArmor_Armor_I	Dalbich Plate Armor	Male
+Dalton_Leather_Gloves	Dalton Leather Gloves	Male
+DamianOnly_Leather_Boots_II	Low-Heeled Leather Boots	Female
+DamianOnly_Leather_Boots_III	White Bloodwind Leather Boots	Female
+DamianOnly_Leather_Boots_IV	Autumn Banquet Leather Boots	Female
+DamianOnly_Leather_Boots_V	Official Knight's Leather Boots	Female
+DamianOnly_Leather_Boots_VI	Wanderer of Faith Leather Boots	Female
+DamianOnly_Leather_Boots_VII	Leather Boots of Earth's Honor	Female
 Damian_Daeil_Band	Damiane's Axiom Bracelet
-Damian_Demeniss_Elite_Uniform_Leather_Armor	Demenissian Elite Uniform Leather Armor
-Damian_Demeniss_Elite_Uniform_Leather_Boots	Demeniss Elite Uniform Leather Boots
-Damian_Demeniss_Uniform_Leather_Armor	Demenissian Uniform Leather Armor
-Damian_Demeniss_Uniform_Leather_Boots	Demenissian Uniform Leather Boots
-Damian_Demeniss_Uniform_Leather_Cloak	Demenissian Uniform Leather Cloak
-Damian_Demeniss_Uniform_Leather_Gloves	Demenissian Uniform Leather Gloves
+Damian_Demeniss_Elite_Uniform_Leather_Armor	Demenissian Elite Uniform Leather Armor	Female
+Damian_Demeniss_Elite_Uniform_Leather_Boots	Demeniss Elite Uniform Leather Boots	Female
+Damian_Demeniss_Uniform_Leather_Armor	Demenissian Uniform Leather Armor	Female
+Damian_Demeniss_Uniform_Leather_Boots	Demenissian Uniform Leather Boots	Female
+Damian_Demeniss_Uniform_Leather_Cloak	Demenissian Uniform Leather Cloak	Female
+Damian_Demeniss_Uniform_Leather_Gloves	Demenissian Uniform Leather Gloves	Female
 Damian_OneHandPistol	Spencer Pistol
 Damian_OneHandShield	Demenissian Gold-Decorated Shield
 Damian_OneHandShield_IV	Demenissian Silver-Decorated Shield
@@ -1165,42 +1168,42 @@ Damian_OneHandShield_VIII	Golden Kerria Shield
 Danda_ChainMail_Armor	Danda Chain Mail
 Danda_Fabric_Helm	Danda Cloth Cap
 Danda_Leather_Gloves	Danda Leather Bracers
-Danekoche_Leather_Boots	Dannoche Leather Boots
-Danid_PlateArmor_Helm	Deland Plate Helm
-Daraz_Fabric_Armor	Daraz Cloth Armor
-Darbaran_Leather_Armor	Darbaran Leather Armor
+Danekoche_Leather_Boots	Dannoche Leather Boots	Male
+Danid_PlateArmor_Helm	Deland Plate Helm	Male
+Daraz_Fabric_Armor	Daraz Cloth Armor	Male
+Darbaran_Leather_Armor	Darbaran Leather Armor	Male
 DarkLeader_OneHandDagger	Dagger of Dark Pursuit
 DarkLeader_TwoHandGiantSpear	Thorn of Dark Pursuit
 DarkLeader_TwoHandSword	Vessel of Dark Pursuit
 DarkLeader_TwoHandWarHammer	Guidance of Dark Pursuit
-Dark_King_Fabric_Armor	Antumbra Cloth Armor
+Dark_King_Fabric_Armor	Antumbra Cloth Armor	Male
 Dark_King_Metal_OneHandShield	Mirror of Night
-Dark_King_Plate_Boots	Antumbra Plate Greaves
-DarknessKing_PlateArmor_Armor	Plate Armor of the Shadows
-DarknessKing_PlateArmor_Boots	Plate Boots of the Shadows
-DarknessKing_PlateArmor_Cloak	Plate Cloak of the Shadows
-DarknessKing_PlateArmor_Gloves	Plate Gloves of the Shadows
-DarknessKing_PlateArmor_Helm	Plate Helm of the Shadows
+Dark_King_Plate_Boots	Antumbra Plate Greaves	Male
+DarknessKing_PlateArmor_Armor	Plate Armor of the Shadows	Male
+DarknessKing_PlateArmor_Boots	Plate Boots of the Shadows	Male
+DarknessKing_PlateArmor_Cloak	Plate Cloak of the Shadows	Male
+DarknessKing_PlateArmor_Gloves	Plate Gloves of the Shadows	Male
+DarknessKing_PlateArmor_Helm	Plate Helm of the Shadows	Male
 DarknessKing_TwoHandAlebard	Vow of the Dead King
-Darman_Leather_Boots	Darman Leather Boots
-Darren_ChainMail_Armor	Darren Chain Mail
-Darren_Fabric_Armor	Darren Cloth Armor
-Darren_Leather_Gloves	Darren Leather Gloves
+Darman_Leather_Boots	Darman Leather Boots	Male
+Darren_ChainMail_Armor	Darren Chain Mail	Male
+Darren_Fabric_Armor	Darren Cloth Armor	Male
+Darren_Leather_Gloves	Darren Leather Gloves	Male
 Dart	Dart
-Dartus_Leather_Armor	Dartus Leather Armor
-Dasasola_Leather_Armor	Dasala Leather Armor
-David_Leather_Boots	Daveed Leather Boots
-David_Leather_Gloves	Daveed Leather Gloves
-David_Leather_Helm	Daveed Leather Headband
-Daymonicon_Leather_Armor	Deimon Leather Armor
-Dayseorun_Leather_Armor	Derrison Leather Armor
-Dayseorun_Leather_Gloves	Derrison Leather Gloves
+Dartus_Leather_Armor	Dartus Leather Armor	Male
+Dasasola_Leather_Armor	Dasala Leather Armor	Male
+David_Leather_Boots	Daveed Leather Boots	Male
+David_Leather_Gloves	Daveed Leather Gloves	Male
+David_Leather_Helm	Daveed Leather Headband	Male
+Daymonicon_Leather_Armor	Deimon Leather Armor	Male
+Dayseorun_Leather_Armor	Derrison Leather Armor	Male
+Dayseorun_Leather_Gloves	Derrison Leather Gloves	Male
 Deactived_Abyss_Artifact	Faded Abyss Artifact
-Dealinger_Fabric_Armor	Dillinger Cloth Armor
+Dealinger_Fabric_Armor	Dillinger Cloth Armor	Male
 Dealinger_OneHandTowerShield	Mass-Produced Large Rekel Shield
-Deboros_Leather_Armor	Deboros Leather Armor
+Deboros_Leather_Armor	Deboros Leather Armor	Male
 Decoy_Human_I	Fake Silver Pouch
-Deekz_Fabric_Armor	Diggs Cloth Armor
+Deekz_Fabric_Armor	Diggs Cloth Armor	Male
 DeerAntler_Fruit_Tea	Antler Tea
 DeerAntler_Soup	Longhorn Soup
 DeerAntler_Soup_Large	Satisfying Longhorn Soup
@@ -1208,70 +1211,70 @@ DeerAntler_Soup_Medium	Filling Longhorn Soup
 DeerAntler_Soup_XLarge	Hearty Longhorn Soup
 DeerKing_Lantern	Fancy Flame-Patterned Lantern
 Deer_Antler	Long Horn
-Deer_King_Follower_Cloak_I	Yrkabel Cloth Cloak
-Deer_King_Follower_Leather_Armor	Staglord Acolyte's Leather Armor
-Deer_King_Follower_Leather_Armor_II	Staglord Acolyte's Leather Armor
-Deer_King_Follower_Leather_Armor_III	Staglord Acolyte's Leather Armor
-Deer_King_Follower_Leather_Armor_IV	Staglord Acolyte's Leather Armor
-Deer_King_Follower_Leather_Armor_V	Staglord Acolyte's Leather Armor
-Deer_King_Follower_Leather_Armor_VI	Yrkabel Leather Armor
-Deer_King_Follower_Leather_Helm	Deer Hat
-Deer_King_Leather_Helm	Leather Helm of the Fallen Kingdom
-Deer_King_Leather_Helm_T4_QA	Deer King Leather Helm T4 QA
+Deer_King_Follower_Cloak_I	Yrkabel Cloth Cloak	Male
+Deer_King_Follower_Leather_Armor	Staglord Acolyte's Leather Armor	Male
+Deer_King_Follower_Leather_Armor_II	Staglord Acolyte's Leather Armor	Male
+Deer_King_Follower_Leather_Armor_III	Staglord Acolyte's Leather Armor	Male
+Deer_King_Follower_Leather_Armor_IV	Staglord Acolyte's Leather Armor	Male
+Deer_King_Follower_Leather_Armor_V	Staglord Acolyte's Leather Armor	Male
+Deer_King_Follower_Leather_Armor_VI	Yrkabel Leather Armor	Male
+Deer_King_Follower_Leather_Helm	Deer Hat	Male
+Deer_King_Leather_Helm	Leather Helm of the Fallen Kingdom	Male
+Deer_King_Leather_Helm_T4_QA	Deer King Leather Helm T4 QA	Male
 Deer_King_Metal_OneHandShield	Staglord's Shield
 Deer_King_OneHandSword	Survivor's Solitude
 Deer_Leather	Short Hair Hide
 Deer_Porter_BackPack	Deer Pack
-Deerking_Leather_Armor	Leather Armor of the Fallen Kingdom
-Deerking_Leather_Armor_T4_QA	Deerking Leather Armor T4 QA
-Deerking_Leather_Cloak	Leather Cloak of the Fallen Kingdom
-Deerking_PlateArmor_Gloves	Plate Gloves of the Fallen Kingdom
-Deerking_Plate_Boots	Plate Boots of the Fallen Kingdom
-Deernil_Leather_Gloves	Delinell's Leather Gloves
-Deernil_Leather_Gloves_I	Delinell's Leather Gloves
-Deerprice_Leather_Armor	Dyrfrith Leather Armor
-Deerprice_Leather_Boots	Dyrfrith Leather Boots
+Deerking_Leather_Armor	Leather Armor of the Fallen Kingdom	Male
+Deerking_Leather_Armor_T4_QA	Deerking Leather Armor T4 QA	Male
+Deerking_Leather_Cloak	Leather Cloak of the Fallen Kingdom	Male
+Deerking_PlateArmor_Gloves	Plate Gloves of the Fallen Kingdom	Male
+Deerking_Plate_Boots	Plate Boots of the Fallen Kingdom	Male
+Deernil_Leather_Gloves	Delinell's Leather Gloves	Male
+Deernil_Leather_Gloves_I	Delinell's Leather Gloves	Male
+Deerprice_Leather_Armor	Dyrfrith Leather Armor	Male
+Deerprice_Leather_Boots	Dyrfrith Leather Boots	Male
 Deet_Leather_Boots	Deint Leather Boots
-Defelde_Leather_Gloves	Dimfeld Leather Gloves
-Degah_Fabric_Armor	Dega Cloth Armor
-Deidre_Leather_Boots	Deidre Leather Boots
+Defelde_Leather_Gloves	Dimfeld Leather Gloves	Male
+Degah_Fabric_Armor	Dega Cloth Armor	Male
+Deidre_Leather_Boots	Deidre Leather Boots	Female
 Dein_OneHandShotgun	Dane Shotgun
-Dekcher_Leather_Armor	Dekter Leather Armor
-Dekcher_Leather_Boots	Dekter Leather Boots
-Dekcher_Leather_Helm	Dekter Leather Cap
+Dekcher_Leather_Armor	Dekter Leather Armor	Female
+Dekcher_Leather_Boots	Dekter Leather Boots	Female
+Dekcher_Leather_Helm	Dekter Leather Cap	Female
 Del_Prison_Room_Key	Delesyia Prison Key
-Delegation_Leather_Helm	Delegation Leather Hat
+Delegation_Leather_Helm	Delegation Leather Hat	Male
 Delesian_Friend_Boss_TwoHandSword	Delesyian Longsword
-Delesian_Friend_PlateArmor_Armor	Armor of Loyal Friendship
-Delesian_Friend_PlateArmor_Cloak	Cloak of Loyal Friendship
+Delesian_Friend_PlateArmor_Armor	Armor of Loyal Friendship	Male
+Delesian_Friend_PlateArmor_Cloak	Cloak of Loyal Friendship	Male
 Delesian_HorseArmor_Armor	Delesyian Barding
 Delesian_HorseArmor_Helm	Delesyian Champron
 Delesian_HorseArmor_Saddle	Delesyian Saddle
 Delesian_HorseArmor_Stirrup	Delesyian Stirrups
-Delesian_Soldier_General_Fabric_Cloak	Delesyian Guard Captain's Cloth Cloak
-Delesian_Soldier_General_PlateArmor_Armor	Delesyian Guard Captain's Armor
+Delesian_Soldier_General_Fabric_Cloak	Delesyian Guard Captain's Cloth Cloak	Male
+Delesian_Soldier_General_PlateArmor_Armor	Delesyian Guard Captain's Armor	Male
 Delesian_Soldier_HorseArmor_Armor	Delesyian Soldier's Cloth Barding
-Delesyian_Cloak	Delesyian Noble's Cloak
+Delesyian_Cloak	Delesyian Noble's Cloak	Male
 Delesyian_Contribution_Flag	Delesyian Contribution Banner Pike
-Delesyian_Crown	Delesyian Circlet
+Delesyian_Crown	Delesyian Circlet	Male
 Delesyian_Flag	Small Delesyian Banner Pike
 Delesyian_Nobility_Degree_I	Delesyian Signet
-Delfrid_Leather_Armor	Delfreid Leather Armor
-Delicy_Leather_Gloves	Delise Leather Gloves
+Delfrid_Leather_Armor	Delfreid Leather Armor	Male
+Delicy_Leather_Gloves	Delise Leather Gloves	Male
 Dellesian_Flag_I	Small Delesyian Banner Pike
 Dellesian_Flag_II	Medium Delesyian Banner Pike
-Dellian_Leather_Armor	Dellian Leather Armor
+Dellian_Leather_Armor	Dellian Leather Armor	Male
 Delmar_HorseArmor_Saddle	Delmar Saddle
 Delonde_OneHandAxe	Delonde Axe
-Delphi_Leather_Boots	Delphi Leather Boots
+Delphi_Leather_Boots	Delphi Leather Boots	Male
 Delphoir_OneHandRapier	Lambert Rapier
-Deltlin_Leather_Armor	Deltin Leather Armor
+Deltlin_Leather_Armor	Deltin Leather Armor	Male
 Demeniss_Chainsaw	Demenissian Chainsaw
-Demeniss_Cloak	Demenissian Noble's Cloak
+Demeniss_Cloak	Demenissian Noble's Cloak	Male
 Demeniss_Contribution_Flag	Demenissian Contribution Banner Pike
 Demeniss_Cross_Necklace	Demeniss Cathedral Necklace
 Demeniss_Cross_Ring	Demeniss Cathedral Ring
-Demeniss_Crown	Demenissian Circlet
+Demeniss_Crown	Demenissian Circlet	Male
 Demeniss_Earring	Demeniss Earring
 Demeniss_Flag	Small Demenissian Banner Pike
 Demeniss_Flag_II	Small Demenissian Banner Pike
@@ -1282,8 +1285,8 @@ Demeniss_HorseArmor_Helm	Demenissian Champron
 Demeniss_HorseArmor_Saddle	Demenissian Saddle
 Demeniss_HorseArmor_Stirrup	Demenissian Stirrups
 Demeniss_Nobility_Degree_I	Demenissian Signet
-Demeniss_PlateArmor_Armor	Chelcia Plate Armor
-Demeniss_PlateArmor_Cloak	Chelcia Plate Cloak
+Demeniss_PlateArmor_Armor	Chelcia Plate Armor	Male
+Demeniss_PlateArmor_Cloak	Chelcia Plate Cloak	Male
 Demeniss_Revolutionary_Paper_I	Demenissian Rebel's Secret Letter
 Demeniss_Soldier_HorseArmor_Armor	Demenissian Soldier's Cloth Barding
 Demeniss_Soldier_Kitee_Metal_OneHandShield_I	Demenissian Shield of Valor
@@ -1291,91 +1294,91 @@ Demeniss_Soldier_Kitee_Metal_OneHandShield_II	Demenissian Shield of Loyalty
 Demeniss_Soldier_Kitee_Metal_OneHandShield_III	Demenissian Shield of Obedience
 Demeniss_Soldier_OneHandTowerShield	Demenissian Soldier's Large Shield
 Demian_Earring_I	Light of the Battlefield Earring
-Demian_Fabric_Cloak_I	Light of the Battlefield Cloth Cloak
-Demian_Fabric_Cloak_II	White Bloodwind Cloth Cloak
-Demian_Fabric_Cloak_III	Autumn Banquet Cloth Cloak
-Demian_Fabric_Cloak_IV	Official Knight's Cloth Cloak
-Demian_Fabric_Cloak_V	Demian Fabric Cloak V
-Demian_Greyfur_Fabric_Cloak	Grey Wolf Cloth Cloak
+Demian_Fabric_Cloak_I	Light of the Battlefield Cloth Cloak	Female
+Demian_Fabric_Cloak_II	White Bloodwind Cloth Cloak	Female
+Demian_Fabric_Cloak_III	Autumn Banquet Cloth Cloak	Female
+Demian_Fabric_Cloak_IV	Official Knight's Cloth Cloak	Female
+Demian_Fabric_Cloak_V	Demian Fabric Cloak V	Female
+Demian_Greyfur_Fabric_Cloak	Grey Wolf Cloth Cloak	Female
 Demian_Greyfur_Fabric_Cloak_I	Greymane Cloth Cloak
-Demian_Greyfur_Fabric_Gloves	Honorary Greymane Cloth Gloves
-Demian_Leather_Armor	Leather Armor of Earth's Honor
-Demian_Leather_Armor_III	White Bloodwind Leather Armor
-Demian_Leather_Armor_IV	Autumn Banquet Leather Armor
-Demian_Leather_Armor_V	Elegant Carmine Leather Armor
-Demian_Leather_Armor_VI	Wanderer of Faith Leather Armor
-Demian_Leather_Cloak	Leather Cloak of Earth's Honor
-Demian_Leather_Cloak_I	Elegant Carmine Leather Cloak
-Demian_Leather_Cloak_II	Wanderer of Faith Leather Cloak
-Demian_Leather_Gloves_I	Official Knight's Leather Gloves
-Demian_Leather_Gloves_II	Leather Gloves of Earth's Honor
-Demian_Leather_Gloves_III	Autumn Banquet Leather Gloves
-Demian_Leather_Gloves_IV	Wanderer of Faith Leather Gloves
+Demian_Greyfur_Fabric_Gloves	Honorary Greymane Cloth Gloves	Female
+Demian_Leather_Armor	Leather Armor of Earth's Honor	Female
+Demian_Leather_Armor_III	White Bloodwind Leather Armor	Female
+Demian_Leather_Armor_IV	Autumn Banquet Leather Armor	Female
+Demian_Leather_Armor_V	Elegant Carmine Leather Armor	Female
+Demian_Leather_Armor_VI	Wanderer of Faith Leather Armor	Female
+Demian_Leather_Cloak	Leather Cloak of Earth's Honor	Female
+Demian_Leather_Cloak_I	Elegant Carmine Leather Cloak	Female
+Demian_Leather_Cloak_II	Wanderer of Faith Leather Cloak	Female
+Demian_Leather_Gloves_I	Official Knight's Leather Gloves	Female
+Demian_Leather_Gloves_II	Leather Gloves of Earth's Honor	Female
+Demian_Leather_Gloves_III	Autumn Banquet Leather Gloves	Female
+Demian_Leather_Gloves_IV	Wanderer of Faith Leather Gloves	Female
 Demian_OneHandRapier	White Wind Rapier
-Demian_PlateArmor_Armor_II	Light of the Battlefield Plate Armor
-Demian_PlateArmor_Armor_VI	Official Knight's Plate Armor
-Demian_PlateArmor_Cloak_III	Goldlight Plate Cloak
-Demian_PlateArmor_Cloak_V	Executioner of Darkness Plate Cloak
-Demian_PlateArmor_Gloves_I	Fluttering Radiance Plate Gloves
-Demian_PlateArmor_Gloves_II	Light of the Battlefield Plate Gloves
-Demian_PlateArmor_Gloves_III	White Bloodwind Plate Gloves
-Demian_PlateArmor_Gloves_IV	Goldlight Plate Gloves
-Demian_PlateArmor_Gloves_V	Executioner of Darkness Plate Gloves
-Demian_PlateArmor_Gloves_VI	Elegant Carmine Plate Gloves
-Demian_PlateArmor_Helm_I	White Bloodwind Plate Helm
-Demian_PlateArmor_Helm_IV	Goldlight Plate Helm
-Demian_PlateArmor_Helm_V	Wanderer of Faith's Plate Helm
-Demian_PlateArmor_Helm_VI	Autumn Banquet Plate Helm
-Demian_PlateArmor_Helm_VII	Official Knight's Plate Helm
-Demian_PlateArmor_Helm_VIII	Light of the Battlefield Plate Helm
-Demian_PlateArmor_Helm_XI	Executioner of Darkness Plate Helm
-Demian_PlateArmor_Helm_XIII	Elegant Carmine Plate Helm
-Demian_Plate_Boots_III	Goldlight Plate Boots
-Demian_Plate_Boots_IV	Elegant Carmine Plate Boots
-Demian_Plate_Boots_V	Executioner of Darkness Plate Boots
-Demian_Plate_Boots_VI	Light of the Battlefield Plate Boots
-Demian_Pure_White_Plate_Boots_I	Radiant Plate Boots
-Demian_Pure_White_Plate_Boots_II	Fluttering Radiance Plate Boots
-Dendi_PlateArmor_Armor	Dundree Plate Armor
-Dendi_PlateArmor_Armor_I	Dundree Plate Armor
+Demian_PlateArmor_Armor_II	Light of the Battlefield Plate Armor	Female
+Demian_PlateArmor_Armor_VI	Official Knight's Plate Armor	Female
+Demian_PlateArmor_Cloak_III	Goldlight Plate Cloak	Female
+Demian_PlateArmor_Cloak_V	Executioner of Darkness Plate Cloak	Female
+Demian_PlateArmor_Gloves_I	Fluttering Radiance Plate Gloves	Female
+Demian_PlateArmor_Gloves_II	Light of the Battlefield Plate Gloves	Female
+Demian_PlateArmor_Gloves_III	White Bloodwind Plate Gloves	Female
+Demian_PlateArmor_Gloves_IV	Goldlight Plate Gloves	Female
+Demian_PlateArmor_Gloves_V	Executioner of Darkness Plate Gloves	Female
+Demian_PlateArmor_Gloves_VI	Elegant Carmine Plate Gloves	Female
+Demian_PlateArmor_Helm_I	White Bloodwind Plate Helm	Female
+Demian_PlateArmor_Helm_IV	Goldlight Plate Helm	Female
+Demian_PlateArmor_Helm_V	Wanderer of Faith's Plate Helm	Female
+Demian_PlateArmor_Helm_VI	Autumn Banquet Plate Helm	Female
+Demian_PlateArmor_Helm_VII	Official Knight's Plate Helm	Female
+Demian_PlateArmor_Helm_VIII	Light of the Battlefield Plate Helm	Female
+Demian_PlateArmor_Helm_XI	Executioner of Darkness Plate Helm	Female
+Demian_PlateArmor_Helm_XIII	Elegant Carmine Plate Helm	Female
+Demian_Plate_Boots_III	Goldlight Plate Boots	Female
+Demian_Plate_Boots_IV	Elegant Carmine Plate Boots	Female
+Demian_Plate_Boots_V	Executioner of Darkness Plate Boots	Female
+Demian_Plate_Boots_VI	Light of the Battlefield Plate Boots	Female
+Demian_Pure_White_Plate_Boots_I	Radiant Plate Boots	Female
+Demian_Pure_White_Plate_Boots_II	Fluttering Radiance Plate Boots	Female
+Dendi_PlateArmor_Armor	Dundree Plate Armor	Male
+Dendi_PlateArmor_Armor_I	Dundree Plate Armor	Male
 Dendrobium_Flower	Dendrobium Orchid
-Denill_Fabric_Armor	Denill Cloth Armor
-Denmore_Fabric_Armor	Denmore Cloth Armor
-Deole_Fabric_Helm	Dwelle Cloth Cap
-Deole_Leather_Boots	Dwelle Leather Boots
-Deole_Leather_Gloves	Dwelle Leather Gloves
+Denill_Fabric_Armor	Denill Cloth Armor	Male
+Denmore_Fabric_Armor	Denmore Cloth Armor	Male
+Deole_Fabric_Helm	Dwelle Cloth Cap	Female
+Deole_Leather_Boots	Dwelle Leather Boots	Male
+Deole_Leather_Gloves	Dwelle Leather Gloves	Male
 Derbid_Wood_OneHandShield	Tardik Shield
-Derish_Fabric_Helm	Drish Cloth Cap
-Dernat_Fabric_Armor	Dernat Cloth Armor
-Dernat_PlateArmor_Helm	Dernat Plate Helm
-Derovidine_Leather_Armor	Dellovian Leather Armor
-Derrison_Fabric_Gloves	Derrison Cloth Gloves
+Derish_Fabric_Helm	Drish Cloth Cap	Male
+Dernat_Fabric_Armor	Dernat Cloth Armor	Male
+Dernat_PlateArmor_Helm	Dernat Plate Helm	Male
+Derovidine_Leather_Armor	Dellovian Leather Armor	Male
+Derrison_Fabric_Gloves	Derrison Cloth Gloves	Male
 Desert_Abyss_Wraith_OneHandShield	Twisted Thorns
-Desert_BackPack_I	Desert Pack
-Desert_Harrier_Leather_Armor	Helms Leather Armor
-Desert_Harrier_Leather_Boots_I	Helms Leather Boots
-Desert_Harrier_Leather_Boots_II	Helms Leather Boots
-Desert_Harrier_PlateArmor_Armor_I	Desert Marauder's Plate Armor
-Desert_Harrier_PlateArmor_Armor_II	Desert Marauder's Plate Armor
-Desert_Harrier_PlateArmor_Armor_III	Desert Marauder's Plate Armor
-Desert_Harrier_PlateArmor_Cloak_I	Desert Marauder's Cloak
-Desert_Harrier_PlateArmor_Gloves	Helms Plate Gloves
-Desert_Harrier_PlateArmor_Helm_II	Helms Rhinoceros Beetle Helm
-Desert_Harrier_PlateArmor_Helm_III	Helms Stag Beetle Helm
-Desert_Harrier_PlateArmor_Helm_IV	Helms Beetle Helm
-Desert_Harrier_PlateArmor_Helm_V	Helms Hornet Helm
-Desert_Harrier_PlateArmor_Helm_VI	Helms Bull Helm
-Desert_Harrier_PlateArmor_Helm_VII	Helms Bull Helm
+Desert_BackPack_I	Desert Pack	Male
+Desert_Harrier_Leather_Armor	Helms Leather Armor	Male
+Desert_Harrier_Leather_Boots_I	Helms Leather Boots	Male
+Desert_Harrier_Leather_Boots_II	Helms Leather Boots	Male
+Desert_Harrier_PlateArmor_Armor_I	Desert Marauder's Plate Armor	Male
+Desert_Harrier_PlateArmor_Armor_II	Desert Marauder's Plate Armor	Male
+Desert_Harrier_PlateArmor_Armor_III	Desert Marauder's Plate Armor	Male
+Desert_Harrier_PlateArmor_Cloak_I	Desert Marauder's Cloak	Male
+Desert_Harrier_PlateArmor_Gloves	Helms Plate Gloves	Male
+Desert_Harrier_PlateArmor_Helm_II	Helms Rhinoceros Beetle Helm	Male
+Desert_Harrier_PlateArmor_Helm_III	Helms Stag Beetle Helm	Male
+Desert_Harrier_PlateArmor_Helm_IV	Helms Beetle Helm	Male
+Desert_Harrier_PlateArmor_Helm_V	Helms Hornet Helm	Male
+Desert_Harrier_PlateArmor_Helm_VI	Helms Bull Helm	Male
+Desert_Harrier_PlateArmor_Helm_VII	Helms Bull Helm	Male
 Desert_HorseArmor_Armor	Sahareum Barding
 Desert_HorseArmor_Helm	Sahareum Champron
 Desert_HorseArmor_Saddle	Sahareum Saddle
 Desert_HorseArmor_Stirrup	Sahareum Stirrups
 Desert_Watermelon	Desert Melon
 Deshret_Ceremonial_TwoHandedWarHammer	Ceremonial Warhammer
-Deshret_Fabric_Armor	Deshret Cloth Armor
-Deshret_Leather_Armor	Ziggurat Leather Armor
-Deshret_Leather_Boots	Deshret Leather Boots
-Deshret_Soldier_Fabric_Armor	Deshret Cloth Armor
+Deshret_Fabric_Armor	Deshret Cloth Armor	Male
+Deshret_Leather_Armor	Ziggurat Leather Armor	Male
+Deshret_Leather_Boots	Deshret Leather Boots	Male
+Deshret_Soldier_Fabric_Armor	Deshret Cloth Armor	Male
 Detail_Gold_Necklace	Finely Crafted Gold Necklace
 Detail_Gold_Ring	Finely Crafted Gold Ring
 Dev_Growth_Ring_I	Dev Growth Ring I
@@ -1403,195 +1406,197 @@ Dev_Red_Dragon_HorseArmor_Armor	Dev Red Dragon HorseArmor Armor
 Dev_Red_Dragon_HorseArmor_Helm	Dev Red Dragon HorseArmor Helm
 Dev_Red_Dragon_HorseArmor_Saddle	Dev Red Dragon HorseArmor Saddle
 Dev_Red_Dragon_HorseArmor_Stirrup	Dev Red Dragon HorseArmor Stirrup
-Dev_Red_Dragon_Kliff_Leather_Armor	Dev Red Dragon Kliff Leather Armor
-Dev_Red_Dragon_Oongka_Leather_Armor	Dev Red Dragon Oongka Leather Armor
+Dev_Red_Dragon_Kliff_Leather_Armor	Dev Red Dragon Kliff Leather Armor	Male
+Dev_Red_Dragon_Oongka_Leather_Armor	Dev Red Dragon Oongka Leather Armor	Male
 Dev_Red_Dragon_Ring_Def_HP	Dev Red Dragon Ring Def HP
 Dev_Red_Dragon_Ring_Immune	Dev Red Dragon Ring Immune
 Dev_Red_Dragon_Ring_MP_Stamina	Dev Red Dragon Ring MP Stamina
 Dev_Red_Dragon_Ring_Str_HP	Dev Red Dragon Ring Str HP
-Dev_Red_Dragon_Yann_Leather_Armor	Dev Red Dragon Yann Leather Armor
+Dev_Red_Dragon_Yann_Leather_Armor	Dev Red Dragon Yann Leather Armor	Male
 Dev_Specialty_Crudell_OneHandAxe	Dev Specialty Crudell OneHandAxe
 Dev_Speed_Ring	Dev Speed Ring
-Devarn_Fabric_Armor	Dvalin Cloth Armor
-Devidhe_Fabric_Helm	Duvidet Hoops
-Devinenne_PlateArmor_Gloves	Devinine Plate Gloves
-Devinion_PlateArmor_Helm	Devins Plate Helm
+Devarn_Fabric_Armor	Dvalin Cloth Armor	Male
+Devidhe_Fabric_Helm	Duvidet Hoops	Male
+Devinenne_PlateArmor_Gloves	Devinine Plate Gloves	Male
+Devinion_PlateArmor_Helm	Devins Plate Helm	Male
 Dewhaven_Flag_I	Small Dewhaven Banner Pike
 Dewhaven_Flag_II	Medium Dewhaven Banner Pike
-Dewhaven_PlateArmor_Helm	Dewhaven Standard Plate Helm
+Dewhaven_PlateArmor_Helm	Dewhaven Standard Plate Helm	Male
 Diamond	Diamond
 Diancia_OneHandAxe	Kylus Axe
-Dicari_Fabric_Helm	Dicari Laurel Headband
-Dicrian_PlateArmor_Helm	Digren Plate Helm
-Diencia_Fabric_Boots	Diencia Cloth Boots
+Dicari_Fabric_Helm	Dicari Laurel Headband	Female
+Dicrian_PlateArmor_Helm	Digren Plate Helm	Male
+Diencia_Fabric_Boots	Diencia Cloth Boots	Male
 Diencia_TwoHandAlebard	Lambert Halberd
 Diencia_TwoHandAxe	Iris Greataxe
 Diencia_TwoHandedWarHammer	Arlem Warhammer
-Dikkahn_Fabric_Helm	Deccain Cloth Headband
-Diknanteu_Fabric_Armor	Decanteau Cloth Armor
-Dimfeld_Leather_Boots	Dimfeld Leather Boots
-Dimfeld_Leather_Helm	Dimfeld Leather Hat
-Dimfeld_PlateArmor_Gloves	Dimfeld Plate Gloves
+Dikkahn_Fabric_Helm	Deccain Cloth Headband	Male
+Diknanteu_Fabric_Armor	Decanteau Cloth Armor	Male
+Dimfeld_Leather_Boots	Dimfeld Leather Boots	Male
+Dimfeld_Leather_Helm	Dimfeld Leather Hat	Male
+Dimfeld_PlateArmor_Gloves	Dimfeld Plate Gloves	Male
 Dimphelt_Wood_OneHandShield	Dewhaven Shield
-Dinon_Leather_Armor	Dannon Leather Armor
-Dioburn_Leather_Boots	Diovern Leather Boots
-Dior_Fabric_Armor	Deorre Cloth Armor
-Diorness_Leather_Armor	Dorness Leather Armor
-Diorness_Leather_Boots	Ferman Leather Boots
-Dirmall_Leather_Armor	Dremel Leather Armor
+Dinon_Leather_Armor	Dannon Leather Armor	Male
+Dioburn_Leather_Boots	Diovern Leather Boots	Male
+Dior_Fabric_Armor	Deorre Cloth Armor	Male
+Diorness_Leather_Armor	Dorness Leather Armor	Male
+Diorness_Leather_Boots	Ferman Leather Boots	Male
+Dirmall_Leather_Armor	Dremel Leather Armor	Male
 Discao_PlateArmor_Helm_I	Descao Plate Helm
 Discao_PlateArmor_Helm_II	Blacksteel Descao Plate Helm
-Diskio_Leather_Gloves	Deskio Leather Gloves
+Diskio_Leather_Gloves	Deskio Leather Gloves	Male
 Diskio_Metal_OneHandShield	Sydmon Round Shield
-Ditter_Fabric_Armor	Ditter Cloth Armor
+Ditter_Fabric_Armor	Ditter Cloth Armor	Male
 Diver_Steel_Drill	Diver's Machine Knuckledrill
-Dohahn_Fabric_Armor	Dohann Cloth Armor
-Dollette_Fabric_Armor	Dollette Cloth Armor
-Dolters_Leather_Boots	Dolters Leather Boots
-Donaf_Leather_Boots	Donaff Leather Boots
-Dongdegobi_Fabric_Armor	Dondegobi Cloth Armor
-Dongdegobi_Leather_Gloves	Dondegobi Leather Gloves
-Dongdegobi_PlateArmor_Helm	Dondegobi Plate Helm
-Douglas_Leather_Armor	Blackwing Leather Armor
-Douglas_Leather_Armor_T5_QA	Douglas Leather Armor T5 QA
-Douglas_Leather_Cloak	Blackwing Leather Cloak
-Douglas_Leather_Gloves	Blackwing Leather Gloves
-Douglas_Leather_Gloves_T5_QA	Douglas Leather Gloves T5 QA
-Doventry_Leather_Armor	Doventry Leather Armor
-Dowsampton_Leather_Armor	Dowsampton Leather Armor
-DragonSlayerLeader_OneHandCannon	Wyvern Blaster
+Dohahn_Fabric_Armor	Dohann Cloth Armor	Male
+Dollette_Fabric_Armor	Dollette Cloth Armor	Male
+Dolters_Leather_Boots	Dolters Leather Boots	Male
+Donaf_Leather_Boots	Donaff Leather Boots	Male
+Dongdegobi_Fabric_Armor	Dondegobi Cloth Armor	Male
+Dongdegobi_Leather_Gloves	Dondegobi Leather Gloves	Male
+Dongdegobi_PlateArmor_Helm	Dondegobi Plate Helm	Male
+Douglas_Leather_Armor	Blackwing Leather Armor	Male
+Douglas_Leather_Armor_T5_QA	Douglas Leather Armor T5 QA	Male
+Douglas_Leather_Cloak	Blackwing Leather Cloak	Male
+Douglas_Leather_Gloves	Blackwing Leather Gloves	Male
+Douglas_Leather_Gloves_T5_QA	Douglas Leather Gloves T5 QA	Male
+Doventry_Leather_Armor	Doventry Leather Armor	Male
+Dowsampton_Leather_Armor	Dowsampton Leather Armor	Male
+DragonSlayerLeader_OneHandCannon	Wyvern Blaster	Male
 Dragon_Armor_01	Abyssal Dragon Armor
 Dragon_Armor_Material	Abyssal Fusion
-Dragon_Knight_Archer_PlateArmor_Gloves	Dragon Knight Archer's Plate Gloves
-Dragon_Knight_ChainMail_Armor	Dragon Knight Chain Mail
-Dragon_Knight_Commander_ChainMail_Armor	Dragon Flame Armor
-Dragon_Knight_Commander_ChainMail_Cloak	Dragon Flame Cloak
-Dragon_Knight_Commander_PlateArmor_Helm	Dragon Flame Helm
-Dragon_Knight_PlateArmor_Helm	Dragon Knight's Helm
-Dragon_Knight_Warrior_PlateArmor_Armor	Dragon Knight Warrior's Plate Armor
-Dragon_Knight_Warrior_PlateArmor_Gloves	Dragon Knight Warrior's Plate Gloves
-Dragon_OneHandBow	Aeserion Bow
+Dragon_Knight_Archer_PlateArmor_Gloves	Dragon Knight Archer's Plate Gloves	Male
+Dragon_Knight_ChainMail_Armor	Dragon Knight Chain Mail	Male
+Dragon_Knight_Commander_ChainMail_Armor	Dragon Flame Armor	Male
+Dragon_Knight_Commander_ChainMail_Cloak	Dragon Flame Cloak	Male
+Dragon_Knight_Commander_PlateArmor_Helm	Dragon Flame Helm	Male
+Dragon_Knight_PlateArmor_Helm	Dragon Knight's Helm	Male
+Dragon_Knight_Warrior_PlateArmor_Armor	Dragon Knight Warrior's Plate Armor	Male
+Dragon_Knight_Warrior_PlateArmor_Gloves	Dragon Knight Warrior's Plate Gloves	Male
+Dragon_OneHandBow	Aeserion Bow	Male
 Dragon_OneHandDagger	Aeserion Dagger
 Dragon_OneHandMace	Aeserion Mace
-Dragon_Slayer_Leather_Boots	Flame Knights Leather Boots
-Dragon_Slayer_Ohyoon_PlateArmor_Helm	Cassius Morten's Plate Helm
+Dragon_Slayer_Leather_Boots	Flame Knights Leather Boots	Male
+Dragon_Slayer_Ohyoon_PlateArmor_Helm	Unyielding Hero's Plate Helm	Male
 Dragon_TwoHandAlebard	Aeserion Halberd
 Dragon_TwoHandAxe	Aeserion Greataxe
 Dragon_TwoHandSword	Aeserion Longsword
 Dragon_TwoHandedWarHammer	Aeserion Warhammer
-Draiga_PlateArmor_Gloves	Draiga Plate Gloves
+Draiga_PlateArmor_Gloves	Draiga Plate Gloves	Male
 Drakhan_OneHandMace	Drakhan Hammer
-Dreenah_Fabric_Helm	Drina Cloth Cap
-Drheebahn_Leather_Armor	Dreban Leather Armor
-Dria_PlateArmor_Helm	Drea Plate Helm
-Drimnarrow_Fabric_Armor	Drimrow Cloth Armor
-Drivon_ChainMail_Armor	Drivon Chain Mail
+Dreenah_Fabric_Helm	Drina Cloth Cap	Male
+Drheebahn_Leather_Armor	Dreban Leather Armor	Male
+Dria_PlateArmor_Helm	Drea Plate Helm	Male
+Drimnarrow_Fabric_Armor	Drimrow Cloth Armor	Male
+Drivon_ChainMail_Armor	Drivon Chain Mail	Male
 Drone_Backpack	Sandwatcher Watcher Pack
 Drottesel_Leather_Armor	Drossel Leather Armor
-Drug_Leather_Helm	Scarlet Blades Gas Mask
-Drug_Leather_Helm_I	Bleed Bandits' Gas Mask
-Drug_Leather_Helm_II	Bleed Bandits' Makeshift Gas Mask
-Drumard_Leather_Gloves	Drumard Leather Gloves
-Drumfin_Fabric_Armor	Drumfin Cloth Armor
-Drunk_BlackBears_Elite_Leather_Armor	Black Bear Officer's Leather Armor
-Drunk_BlackBears_Elite_Leather_Gloves	Black Bear Officer's Leather Gloves
+Drug_Leather_Helm	Scarlet Blades Gas Mask	Male
+Drug_Leather_Helm_I	Bleed Bandits' Gas Mask	Male
+Drug_Leather_Helm_II	Bleed Bandits' Makeshift Gas Mask	Male
+Drumard_Leather_Gloves	Drumard Leather Gloves	Female
+Drumfin_Fabric_Armor	Drumfin Cloth Armor	Male
+Drunk_BlackBears_Elite_Leather_Armor	Black Bear Officer's Leather Armor	Male
+Drunk_BlackBears_Elite_Leather_Gloves	Black Bear Officer's Leather Gloves	Male
 Drunk_BlackBears_Flag	Small Black Bears Banner Pike
-Drunk_BlackBears_Leather_Armor	Black Bear Leather Armor
-Drunk_BlackBears_Leather_Boots	Black Bear Leather Boots
-Drunk_BlackBears_Leather_Gloves	Black Bear Leather Gloves
+Drunk_BlackBears_Leather_Armor	Black Bear Leather Armor	Male
+Drunk_BlackBears_Leather_Boots	Black Bear Leather Boots	Male
+Drunk_BlackBears_Leather_Gloves	Black Bear Leather Gloves	Male
 Drunk_BlackBears_TwoHandedWarHamme	Roar of the Black Bear
-Dublin_Leather_Boots	Derting Leather Boots
-Ducca_Leather_Armor	Ducca Leather Armor
+Dublin_Leather_Boots	Derting Leather Boots	Male
+Ducca_Leather_Armor	Ducca Leather Armor	Male
 Duebell_Leather_Armor	Duvelle Leather Armor
-Dueblone_Plated_Boots	Dulone Plate Boots
-Duemeniss_Fabric_Armor	Dumenis Cloth Armor
-Duemeniss_Leather_Boots	Dumenis Leather Boots
-Duemeniss_PlateArmor_Gloves	Dumenis Plate Gloves
-Duemeniss_PlateArmor_Helm	Demenissian Soldier Plate Helm
-Duemeniss_PlateArmor_Helm_I	Dumenis Plate Helm
-Duemeniss_Plate_Boots	Dumenis Plate Boots
-Duemeniss_Plate_Boots_I	Blacksteel Dumenis Plate Boots
-Duemeniss_Plate_Boots_II	Dumenis Plate Boots II
+Dueblone_Plated_Boots	Dulone Plate Boots	Male
+Duemeniss_Fabric_Armor	Dumenis Cloth Armor	Male
+Duemeniss_Leather_Boots	Dumenis Leather Boots	Male
+Duemeniss_PlateArmor_Gloves	Dumenis Plate Gloves	Male
+Duemeniss_PlateArmor_Helm	Demenissian Soldier Plate Helm	Male
+Duemeniss_PlateArmor_Helm_I	Dumenis Plate Helm	Male
+Duemeniss_Plate_Boots	Dumenis Plate Boots	Male
+Duemeniss_Plate_Boots_I	Blacksteel Dumenis Plate Boots	Male
+Duemeniss_Plate_Boots_II	Dumenis Plate Boots II	Male
 Dueroin_Fabric_Gloves	Duroin Cloth Gloves
-Duilker_Fabric_Armor	Dwelker Cloth Armor
+Duilker_Fabric_Armor	Dwelker Cloth Armor	Male
 Dukesan_OneHandDagger	Delesyian Dagger
-Dukris_Fabric_Helm	Ducriss Conical Cap
-Duncan_Leather_Armor	Dunqane Leather Armor
-Dunfermline_PlateArmor_Armor	Dunverline Plate Armor
-Dunfermline_PlateArmor_Armor_I	Dunverline Plate Armor
-Dunion_ChainMail_Armor	Dunion Chain Mail
-Dunion_Leather_Gloves	Dunion Leather Gloves
-Dunion_PlateArmor_Armor	Dunion Plate Armor
-Dunis_Leather_Gloves	Dherri Leather Gloves
-Duratti_PlateArmor_Helm	Schtump Plate Helm
-Durion_ChainMail_Armor	Durain Chain Mail
+Dukris_Fabric_Helm	Ducriss Conical Cap	Male
+Duncan_Leather_Armor	Dunqane Leather Armor	Male
+Dunfermline_PlateArmor_Armor	Dunverline Plate Armor	Male
+Dunfermline_PlateArmor_Armor_I	Dunverline Plate Armor	Male
+Dunion_ChainMail_Armor	Dunion Chain Mail	Male
+Dunion_Leather_Gloves	Dunion Leather Gloves	Male
+Dunion_PlateArmor_Armor	Dunion Plate Armor	Male
+Dunis_Leather_Gloves	Dherri Leather Gloves	Male
+Duratti_PlateArmor_Helm	Schtump Plate Helm	Male
+Durion_ChainMail_Armor	Durain Chain Mail	Male
 Durion_OneHandDagger	Crow Brothers Dagger
-Duroar_PlateArmor_Armor	Dreer Plate Armor
-Duroar_PlateArmor_Armor_I	Dreer Plate Armor
-Dursus_Leather_Armor	Dursus Leather Armor
-Dutian_ChainMail_Armor	Dutian Chain Mail
-Dutinaan_ChainMail_Armor	Dutinan Chain Mail
-Dutinion_PlateArmor_Armor	Dutinion Plate Armor
-Dutrat_Leather_Boots	Dutrat Leather Boots
-Dutyluon_PlateArmor_Armor	Dutiron Plate Armor
-Dux_Leather_Armor	Dux Leather Armor
-Duzje_Fabric_Armor	Duizeh Cloth Armor
+Duroar_PlateArmor_Armor	Dreer Plate Armor	Male
+Duroar_PlateArmor_Armor_I	Dreer Plate Armor	Male
+Dursus_Leather_Armor	Dursus Leather Armor	Male
+Duskmoon_Fabric_Armor	Duskmoon Cloth Armor	Female
+Duskmoon_Fabric_Cloak	Duskmoon Cloth Cloak	Female
+Dutian_ChainMail_Armor	Dutian Chain Mail	Male
+Dutinaan_ChainMail_Armor	Dutinan Chain Mail	Male
+Dutinion_PlateArmor_Armor	Dutinion Plate Armor	Male
+Dutrat_Leather_Boots	Dutrat Leather Boots	Male
+Dutyluon_PlateArmor_Armor	Dutiron Plate Armor	Male
+Dux_Leather_Armor	Dux Leather Armor	Female
+Duzje_Fabric_Armor	Duizeh Cloth Armor	Male
 Dwarf_Necklace	Dwarf Necklace
-Dweyi_Leather_Armor	Dewey Leather Armor
-Dylanka_Fabric_Armor	Dilanka Cloth Armor
+Dweyi_Leather_Armor	Dewey Leather Armor	Male
+Dylanka_Fabric_Armor	Dilanka Cloth Armor	Male
 Dyran_Fabric_Armor	Dyran Cloth Armor
 Dyrania_Fabric_Armor	Direnya Cloth Armor
-Dyrill_Leather_Armor	Dyrel Leather Armor
+Dyrill_Leather_Armor	Dyrel Leather Armor	Male
 EMP_BackPack	Disruptor
 EMP_TwoHandSpear	Disruptor Spear
 Earring_Tier1_I	Worn Earring
 Earring_Tier2_I	Tarnished Earring
 Earring_Tier3_I	Green Coral Reef Earring
 EasternWanderer_OneHandShield	Eastern Wanderer's Shield
-Ebenezer_Leather_Gloves	Ebenezer Leather Gloves
-Eccanta_PlateArmor_Armor	Eccanta Plate Armor
-Echebern_Fabric_Armor	Echebern Cloth Armor
-Eclan_PlateArmor_Armor	Eclaon Plate Armor
-Eclis_PlateArmor_Armor	Egliss Plate Armor
-Eclman_PlateArmor_Armor	Ekklemen Plate Armor
-Ecyrune_Fabric_Armor	Eshrun Cloth Armor
-Edzel_PlateArmor_Armor	Edzel Plate Armor
-Edzel_PlateArmor_Armor_I	Edzel Plate Armor
+Ebenezer_Leather_Gloves	Ebenezer Leather Gloves	Male
+Eccanta_PlateArmor_Armor	Eccanta Plate Armor	Male
+Echebern_Fabric_Armor	Echebern Cloth Armor	Male
+Eclan_PlateArmor_Armor	Eclaon Plate Armor	Male
+Eclis_PlateArmor_Armor	Egliss Plate Armor	Male
+Eclman_PlateArmor_Armor	Ekklemen Plate Armor	Male
+Ecyrune_Fabric_Armor	Eshrun Cloth Armor	Male
+Edzel_PlateArmor_Armor	Edzel Plate Armor	Male
+Edzel_PlateArmor_Armor_I	Edzel Plate Armor	Male
 Eestyon_TwoHandHammer	Golden Dragon's Claw
 Egg	Egg
-Ehshian_Leather_Boots	Eshian Leather Boots
+Ehshian_Leather_Boots	Eshian Leather Boots	Male
 Ehshian_OneHandSword	Fallen Kingdom's Sword
-Einz_Leather_Armor	Einz Leather Armor
-Eirun_PlateArmor_Armor	Aeron Plate Armor
-Ekeny_Fabric_Boots	Eckney Cloth Boots
-Elai_Leather_Armor	Eli's Attire
+Einz_Leather_Armor	Einz Leather Armor	Male
+Eirun_PlateArmor_Armor	Aeron Plate Armor	Male
+Ekeny_Fabric_Boots	Eckney Cloth Boots	Male
+Elai_Leather_Armor	Eli's Attire	Female
 Elderberry	Elderberry
-Eldruan_Leather_Gloves	Eldruan Leather Gloves
-Eleven_Leather_Gloves	Eplern Leather Gloves
-Elish_Leather_Boots	Elish Leather Boots
-Ellachic_Leather_Gloves	Elashe Leather Gloves
-Elliot_Leather_Armor	Elliot Leather Armor
-Elsiguo_Leather_Gloves	Ellisco Leather Bracers
-Emil_PlateArmor_Armor	Emil Plate Armor
+Eldruan_Leather_Gloves	Eldruan Leather Gloves	Male
+Eleven_Leather_Gloves	Eplern Leather Gloves	Male
+Elish_Leather_Boots	Elish Leather Boots	Male
+Ellachic_Leather_Gloves	Elashe Leather Gloves	Male
+Elliot_Leather_Armor	Elliot Leather Armor	Male
+Elsiguo_Leather_Gloves	Ellisco Leather Bracers	Male
+Emil_PlateArmor_Armor	Emil Plate Armor	Male
 Empty_BackPack	Empty Pack
 Empty_Bottle	Empty Bottle
-Endnion_PlateArmor_Armor	Endnion Plate Armor
-Endoron_Leather_Boots	Endoron Leather Boots
-Endour_PlateArmor_Helm	Goldbranch Plate Crown
+Endnion_PlateArmor_Armor	Endnion Plate Armor	Male
+Endoron_Leather_Boots	Endoron Leather Boots	Male
+Endour_PlateArmor_Helm	Goldbranch Plate Crown	Male
 Enge_Leather_Armor	Enge Leather Armor
 EngineerWorkLog_Book	An Engineer's Work Log
-Enratte_PlateArmor_Helm	Enratte Plate Helm
-Enratte_PlateArmor_Helm_I	Large Enratte Plate Helm
+Enratte_PlateArmor_Helm	Enratte Plate Helm	Male
+Enratte_PlateArmor_Helm_I	Large Enratte Plate Helm	Male
 Ensete_seed	Enset Seed
-EntHunter_Leather_Armor	Shadowleaf Leather Armor
-EntHunter_Leather_Cloak	Shadowleaf Leather Cloak
-EntHunter_OneHandBow	Shadowleaf Bow
-Entom_PlateArmor_Armor	Entom Plate Armor
-Entrian_Fabric_Armor	Attrean Cloth Armor
+EntHunter_Leather_Armor	Shadowleaf Leather Armor	Male
+EntHunter_Leather_Cloak	Shadowleaf Leather Cloak	Male
+EntHunter_OneHandBow	Shadowleaf Bow	Male
+Entom_PlateArmor_Armor	Entom Plate Armor	Male
+Entrian_Fabric_Armor	Attrean Cloth Armor	Male
 Entuka_Fabric_Armor	Entuka Cloth Armor
-Entura_PlateArmor_Helm	Icewing Plate Helm
-Enus_PlateArmor_Armor	Enus Plate Armor
-Ephesus_Fabric_Armor	Esbeth Cloth Armor
+Entura_PlateArmor_Helm	Icewing Plate Helm	Male
+Enus_PlateArmor_Armor	Enus Plate Armor	Male
+Ephesus_Fabric_Armor	Esbeth Cloth Armor	Female
 Epistle	Mysterious Letter
 Equip_Broom	Broom
 Equip_Drum	Small Drum
@@ -1615,26 +1620,26 @@ Equip_TriRake	Wooden Pitchfork
 Equip_Trumpet	Trumpet
 Equip_WoodRake	Wooden Rake
 Equip_Work_Hammer	Mallet
-Erday_Leather_Armor	Erday Leather Armor
-Erin_Fabric_Helm	Eryn Cloth Cap
-Erkeney_Fabric_Armor	Eckney Cloth Armor
+Erday_Leather_Armor	Erday Leather Armor	Male
+Erin_Fabric_Helm	Eryn Cloth Cap	Male
+Erkeney_Fabric_Armor	Eckney Cloth Armor	Male
 Erkeney_OneHandAxe	Lanford Axe
-Ernst_ChainMail_Armor	Ernst Chain Mail
-Erphy_Leather_Boots	Erphy Leather Boots
-Esahah_Leather_Boots	Esha Leather Boots
-Esahah_Leather_Gloves	Esha Leather Bracers
-Esirun_Leather_Armor	Eshrun Leather Armor
-Esleague_Leather_Armor	Islekk Leather Armor
-Estir_Leather_Boots	Estelle Leather Boots
+Ernst_ChainMail_Armor	Ernst Chain Mail	Male
+Erphy_Leather_Boots	Erphy Leather Boots	Male
+Esahah_Leather_Boots	Esha Leather Boots	Male
+Esahah_Leather_Gloves	Esha Leather Bracers	Male
+Esirun_Leather_Armor	Eshrun Leather Armor	Male
+Esleague_Leather_Armor	Islekk Leather Armor	Male
+Estir_Leather_Boots	Estelle Leather Boots	Female
 Euler_OneHandRapier	Elenore Rapier
-Eustis_Leather_Boots	Eustice Leather Boots
-Evanizer_Leather_Boots	Ebenezer Leather Boots
+Eustis_Leather_Boots	Eustice Leather Boots	Male
+Evanizer_Leather_Boots	Ebenezer Leather Boots	Male
 Ewen_Fabric_Armor	Ewen Cloth Armor
 Faded_Necklace	Tarnished Necklace
 Faded_Ring	Tarnished Ring
-Faience_Fabric_Armor	Faians Cloth Armor
+Faience_Fabric_Armor	Faians Cloth Armor	Male
 Falcone_OneHandPistol	Falconne Pistol
-Falstaff_Fabric_Helm	Falstaff's Cloth Cap
+Falstaff_Fabric_Helm	Falstaff's Cloth Cap	Male
 Fang	Fang
 FarmSlot_Expansion_1	Small Livestock Capacity Increase
 FarmSlot_Expansion_2	Medium Livestock Capacity Increase
@@ -1649,18 +1654,19 @@ Fiburrou_TwoHandedWarHammer	Iris Warhammer
 FieldBattle_BackPack_I	Field Pack
 FieldBattle_BackPack_II	Field Pack
 FieldBattle_BackPack_III	Field Pack
+Fighter_Fabric_Armor	Martial Artist's Cloth Garb	Male
 Figs	Fig
 Figs_Seed	Fig Seed
 Fine_Stone	Fine Stone
 Fine_Wood	Fine Timber
-Finraysen_Leather_Armor	Finneron Leather Armor
-Fiore_Fabric_Armor	Fiore Cloth Armor
-Fiore_Fabric_Helm	Fiore Cloth Cap
-Fiore_Leather_Boots	Fiore Leather Boots
+Finraysen_Leather_Armor	Finneron Leather Armor	Male
+Fiore_Fabric_Armor	Fiore Cloth Armor	Male
+Fiore_Fabric_Helm	Fiore Cloth Cap	Male
+Fiore_Leather_Boots	Fiore Leather Boots	Male
 FireFly_Lantern	Firefly Lantern
 Fire_Arrow	Fire Arrow
 Fire_Bomb	Bomb
-Fire_Boots	Fire Walk Boots
+Fire_Boots	Fire Walk Boots	Male
 Fire_staff_spear_TwoHandSpear	Flame Spear
 First_Artifact	The First Artifact
 Fish_BackPack_I	Angler's Pack
@@ -1697,22 +1703,22 @@ FishingRod	Fishing Rod
 FishingRod_II	Fine Fishing Rod
 FishingRod_III	Pororin Fishing Rod
 FlameThrower	Electromagnetic Flamespitter
-Flame_Knights_PlateArmor_Helm	Elite Flame Knights Plate Helm
-Flame_Knights_PlateArmor_Helm_I	Flame Knights Plate Helm
-Flame_SwordMan_PlateArmor_Gloves	Flame Swordsman Plate Gloves
+Flame_Knights_PlateArmor_Helm	Elite Flame Knights Plate Helm	Male
+Flame_Knights_PlateArmor_Helm_I	Flame Knights Plate Helm	Male
+Flame_SwordMan_PlateArmor_Gloves	Flame Swordsman Plate Gloves	Male
 Flame_SwordMan_TwoHandHammer	Greathammer of Fire
 Flame_staff_spear_TwoHandSpear	Blazing Spear
 FlatBasket	Wide Basket
 Flolin_BackPack	Pororin Pack
 Flolin_BackPack_FlowerDrone_I	Florindale Flower Bomb Pack
 Flolin_BackPack_II	Florindale Empty Pack
-Flordanus_Leather_Armor	Flordanus Leather Armor
-Florin_Fabric_Cloak	Pororin Cloth Cloak
+Flordanus_Leather_Armor	Flordanus Leather Armor	Male
+Florin_Fabric_Cloak	Pororin Cloth Cloak	Male
 Florin_Fabric_Helm	Pororin Petal Hat
-Flynn_PlateArmor_Helm	Flynn Plate Helm
+Flynn_PlateArmor_Helm	Flynn Plate Helm	Male
 Folorin_Earring	Flower Petal Earring
 Fontergear_OneHandMace	Bonepit Mace
-Fontine_Leather_Armor	Fontine Leather Armor
+Fontine_Leather_Armor	Fontine Leather Armor	Male
 Food_BaliOgluChub	Small Minnow
 Food_Bass_I	Bass
 Food_Bass_II	Yellow Bass
@@ -1771,13 +1777,14 @@ Food_Tenchi	Tench
 Food_Trout	Trout
 Food_river_Crab	Freshwater Crab
 ForestFairy_TwoHandedWarHammer	Shadowleaf Soul Branch
-Forest_Fairy_Leather_Armor	Forest Fae Armor
+Forest_Fairy_Leather_Armor	Forest Fae Armor	Male
 Forgotten_General_TwoHandAlebard	Awakened Spirit
-Formosa_Leather_Armor	Formosa Leather Armor
+Formosa_Leather_Armor	Formosa Leather Armor	Male
 FortMoru_Key	Fort Anvil Key
 Fort_Flag_02	Small Halberd of Carnage's Banner Pike
 Fort_Flag_03	Medium Halberd of Carnage's Banner Pike
 FoxBean_Flower	Dunbaria
+Frenoa_PlateArmor_Armor	Frenoa Plate Armor	Female
 Freshly_Grilled_Bird	Grilled Bird Meat
 Freshly_Grilled_Bird_Large	Satisfying Grilled Bird Meat
 Freshly_Grilled_Bird_Medium	Filling Grilled Bird Meat
@@ -1790,10 +1797,10 @@ Freshly_Grilled_Squid	Grilled Seafood
 Freshly_Grilled_Squid_Large	Satisfying Grilled Seafood
 Freshly_Grilled_Squid_Medium	Filling Grilled Seafood
 Freshly_Grilled_Squid_XLarge	Hearty Grilled Seafood
-Fri_PlateArmor_Armor	Prix Plate Armor
+Fri_PlateArmor_Armor	Prix Plate Armor	Male
 Friendly_Legendary_Animal_Book	Black Lion Observation Log
 Friendly_Legendary_Hunter	The Legendary Hunter's Whereabouts
-Frinyl_PlateArmor_Helm	Ferenna Plate Helm
+Frinyl_PlateArmor_Helm	Ferenna Plate Helm	Male
 FrontierMilitia_OneHandShield	Flame Knights Shield
 FruitTea	Fruit Tea
 Fruit_Porridge	Fruit Punch
@@ -1801,97 +1808,95 @@ Fruit_Porridge_Large	Satisfying Fruit Punch
 Fruit_Porridge_Medium	Filling Fruit Punch
 Fruit_Porridge_XLarge	Hearty Fruit Punch
 Fruit_Wine	Wine
-FryingPan_Lid_OneHandShield	Frying Pan Lid
-FryingPan_OneHandMace	Frying Pan
 Full_Course_of_Braised_Fish	Assorted Braised Fish
 Full_Course_of_Braised_Fish_Large	Satisfying Assorted Braised Fish
 Full_Course_of_Braised_Fish_Medium	Filling Assorted Braised Fish
 Full_Course_of_Braised_Fish_XLarge	Hearty Assorted Braised Fish
 Furniture_BackPack	Carpenter's Pack
-Gadget_Fabric_Helm	Tech Hat
-Gadget_Gloves	Tech Gloves
+Gadget_Fabric_Helm	Tech Hat	Male
+Gadget_Gloves	Tech Gloves	Male
 Gadherish_Fabric_Armor	Gadereich Cloth Armor
 Gadherish_Fabric_Gloves	Gadereich Cloth Gloves
 Gadherish_Fabric_Helm	Gadereich Cloth Cap
-Gael_Fabric_Armor	Gael Cloth Armor
-Gaeljude_PlateArmor_Gloves	Golden Greed Plate Gloves
-Gaeljude_Plate_Boots	Golden Greed Plate Boots
+Gael_Fabric_Armor	Gael Cloth Armor	Male
+Gaeljude_PlateArmor_Gloves	Golden Greed Plate Gloves	Male
+Gaeljude_Plate_Boots	Golden Greed Plate Boots	Male
 Gahlatain_OneHandAxe	Ring of the Earth
-Gaimeon_Leather_Gloves	Gaiman Leather Gloves
+Gaimeon_Leather_Gloves	Gaiman Leather Gloves	Male
 Gainarre_OneHandAxe	Leofric Double-Headed Axe
-Gainik_Leather_Boots	Gannech Leather Boots
-Galanta_Leather_Armor	Galanta Leather Armor
-Galbon_ChainMail_Armor	Galbon Chain Mail
-Gallabay_Leather_Armor	Gallabay Leather Armor
-Gallophelt_Leather_Boots	Silverwolf Leather Boots
-Gallophelt_PlateArmor_Gloves	Geloufeld Plate Gloves
-Galustin_Leather_Armor	Galustin Leather Armor
-Gamelot_Plate_Boots	Sahazhad Plate Boots
+Gainik_Leather_Boots	Gannech Leather Boots	Male
+Galanta_Leather_Armor	Galanta Leather Armor	Male
+Galbon_ChainMail_Armor	Galbon Chain Mail	Male
+Gallabay_Leather_Armor	Gallabay Leather Armor	Male
+Gallophelt_Leather_Boots	Silverwolf Leather Boots	Male
+Gallophelt_PlateArmor_Gloves	Geloufeld Plate Gloves	Male
+Galustin_Leather_Armor	Galustin Leather Armor	Male
+Gamelot_Plate_Boots	Sahazhad Plate Boots	Male
 GantryCrane_Big_Key	Crane Control Room Key
-Gardbedeff_Fabric_Armor	Gardeiff Cloth Armor
-Garff_Fabric_Armor	Gaph Cloth Armor
+Gardbedeff_Fabric_Armor	Gardeiff Cloth Armor	Male
+Garff_Fabric_Armor	Gaph Cloth Armor	Male
 Garlic	Garlic
-Gas_Mask_Helm_I	Brimstone Gas Mask
-Gatin_Leather_Boots	Gatin Leather Boots
-Gaurah_Fabric_Helm	Gaurra Cloth Cap
-Gaut_Fabric_Armor	Gaut Cloth Armor
+Gas_Mask_Helm_I	Brimstone Gas Mask	Male
+Gatin_Leather_Boots	Gatin Leather Boots	Male
+Gaurah_Fabric_Helm	Gaurra Cloth Cap	Male
+Gaut_Fabric_Armor	Gaut Cloth Armor	Male
 Gaut_Fabric_Boots	Gaut Cloth Boots
-Gaut_Leather_Armor	Gaut Leather Armor
+Gaut_Leather_Armor	Gaut Leather Armor	Male
 Gelhouke_OneHandTowerShield	The Laughing Marionette Shield
-Georg_Leather_Armor	Gorg Leather Armor
-Gerano_Leather_Armor	Gerano Leather Armor
-Germion_PlateArmor_Armor	Jerrinmarne Plate Armor
-Ghaltain_Fabric_Helm	Ghaltain Cloth Cap
+Georg_Leather_Armor	Gorg Leather Armor	Male
+Gerano_Leather_Armor	Gerano Leather Armor	Male
+Germion_PlateArmor_Armor	Jerrinmarne Plate Armor	Male
+Ghaltain_Fabric_Helm	Ghaltain Cloth Cap	Male
 Ghost_TwohandSword	Invisible Longsword
 GiantBallista_Book	Pailunese Guard's Journal
 GiantIguana_Armor	Giant Iguana Saddle
 Giant_Copper_Drill	Copper Knuckledrill
 Giant_ReiGhis_TwoHandGiantAxe	Gorthak Greataxe
 Giant_Warriors_TwoHandGiantAxe	Patterned Stone Greataxe
-Gias_Leather_Armor	Giath's Leather Armor
+Gias_Leather_Armor	Giath's Leather Armor	Male
 Gias_OneHandSword	Savage Sawblade
 Gilded_OneHandShield	Gilded Shield
 Gilded_OneHandTowerShield	Large Gilded Shield
 Ginseng_Seed	Wild Ginseng Seed
-Girrin_PlateArmor_Armor	Guilan Plate Armor
-Gladiator_Fabric_Armor	Gladiator's Cloth Armor
-Gladiator_Fabric_Armor_I	Gladiator's Cloth Armor
-Gladiator_Fabric_Armor_II	Gladiator's Cloth Armor
-Gladiator_Fabric_Armor_III	Gladiator's Cloth Armor
-Gladiator_Fabric_Boots	Gladiator Cloth Boots
+Girrin_PlateArmor_Armor	Guilan Plate Armor	Male
+Gladiator_Fabric_Armor	Gladiator's Cloth Armor	Male
+Gladiator_Fabric_Armor_I	Gladiator's Cloth Armor	Male
+Gladiator_Fabric_Armor_II	Gladiator's Cloth Armor	Male
+Gladiator_Fabric_Armor_III	Gladiator's Cloth Armor	Male
+Gladiator_Fabric_Boots	Gladiator Cloth Boots	Male
 Gladiator_Fabric_Gloves_I	Gladiator Cloth Gloves
 Gladiator_Leather_Armor	Gladiator Leather Armor
 Gladiator_Leather_Boots	Troll Gladiator's Leather Boots
-Gladiator_Leather_Boots_II	Gladiator's Leather Boots
-Gladiator_PlateArmor_Gloves_I	Gladiator Plate Gloves
-Gladiator_Plate_Boots	Gladiator Plate Boots
+Gladiator_Leather_Boots_II	Gladiator's Leather Boots	Male
+Gladiator_PlateArmor_Gloves_I	Gladiator Plate Gloves	Male
+Gladiator_Plate_Boots	Gladiator Plate Boots	Male
 Gladiator_Stigma_TwoHandSpear	Slave Gladiator Branding Spear
-Glaville_Leather_Armor	Glaville Leather Armor
-Glosope_Leather_Armor	Glosope Leather Armor
+Glaville_Leather_Armor	Glaville Leather Armor	Male
+Glosope_Leather_Armor	Glosope Leather Armor	Male
 GlowFlower_Seed	Luminous Seed
 Glow_Fruit	Shineberry
 Goat_Horn_Potion	Mysterious Elixir
-Gobialthai_Fabric_Armor	Gobialta Cloth Armor
-Gobialthai_Leather_Gloves	Gobialta Leather Gloves
+Gobialthai_Fabric_Armor	Gobialta Cloth Armor	Male
+Gobialthai_Leather_Gloves	Gobialta Leather Gloves	Male
 Goblin_Boss_OneHandSword	Lightningblade of Greed
 Goblin_Director_House_Key	Overseer's House Key
-Goblin_Fight_PlateArmor_Gloves	Goblin Dueling Plate Gloves
-Goblin_Merchant_Fabric_Armor_V	Goldleaves' Cloth Armor
-Goblin_Merchant_Fabric_Armor_Ⅲ	Goldleaves' Cloth Armor
-Goblin_Merchant_Fabric_Armor_Ⅳ	Nibrak Cloth Armor
-Goblin_Merchant_Fabric_Armor_Ⅵ	Goldleaves' Cloth Armor
-Goblin_Merchant_Fabric_Cloak_Ⅳ	Goldleaves' Cloth Cloak
-Goblin_Merchant_Fabric_Cloak_Ⅵ	Goldleaves' Cloth Cloak
-Goblin_Merchant_Fabric_Helm	Goldleaf Soldier Cloth Headband
-Goblin_Merchant_PlateArmor_Gloves_I	Goblin Merchant Guild's Plate Gloves
-Goblin_Merchant_Soldier_Leather_Boots	Goldleaves' Short Leather Boots
-Goblin_Merchant_Soldier_Leather_Boots_I	Goldleaves' Leather Boots
-Goblin_Merchant_Soldier_Leather_Helm_I	Goldleaves' Cone Leather Cap
-Goblin_Merchant_Soldier_Leather_Helm_II	Goldleaves' Leather Cap
+Goblin_Fight_PlateArmor_Gloves	Goblin Dueling Plate Gloves	Male
+Goblin_Merchant_Fabric_Armor_V	Goldleaves' Cloth Armor	Male
+Goblin_Merchant_Fabric_Armor_Ⅲ	Goldleaves' Cloth Armor	Male
+Goblin_Merchant_Fabric_Armor_Ⅳ	Nibrak Cloth Armor	Male
+Goblin_Merchant_Fabric_Armor_Ⅵ	Goldleaves' Cloth Armor	Male
+Goblin_Merchant_Fabric_Cloak_Ⅳ	Goldleaves' Cloth Cloak	Male
+Goblin_Merchant_Fabric_Cloak_Ⅵ	Goldleaves' Cloth Cloak	Male
+Goblin_Merchant_Fabric_Helm	Goldleaf Soldier Cloth Headband	Male
+Goblin_Merchant_PlateArmor_Gloves_I	Goblin Merchant Guild's Plate Gloves	Male
+Goblin_Merchant_Soldier_Leather_Boots	Goldleaves' Short Leather Boots	Male
+Goblin_Merchant_Soldier_Leather_Boots_I	Goldleaves' Leather Boots	Male
+Goblin_Merchant_Soldier_Leather_Helm_I	Goldleaves' Cone Leather Cap	Male
+Goblin_Merchant_Soldier_Leather_Helm_II	Goldleaves' Leather Cap	Male
 Goblin_Pot	Goldleaf Censer
-Goblin_Pumpkin_Helm_I	Pumpkin Head
-Godhehart_ChainMail_Gloves	Goldheart Chain Gloves
-Gohol_Leather_Boots	Gohol Leather Boots
+Goblin_Pumpkin_Helm_I	Pumpkin Head	Male
+Godhehart_ChainMail_Gloves	Goldheart Chain Gloves	Male
+Gohol_Leather_Boots	Gohol Leather Boots	Male
 GoldArmor_OneHandSword	Sword of Greed
 GoldBar	Gold Bar
 GoldBar_Fake	Crude Gold Bar
@@ -1901,104 +1906,104 @@ Gold_Armor_OneHandShield	Golden Shield
 Gold_Plating_Lantern	Shroud Lantern
 GoldenGoose_Egg	Golden Goose Egg
 Golden_OneHandSword	Golden Sword
-Golden_PlateArmor_Armor	Golden Greed Plate Armor
-Golden_PlateArmor_Cloak	Golden Greed Plate Cloak
-Golden_PlateArmor_Helm	Golden Greed Plate Helm
-Goldur_Leather_Armor	Goldur Leather Armor
-Goloduan_PlateArmor_Gloves	Demenissian Elite Plate Gloves
-Gomel_Leather_Armor	Gomel Leather Armor
+Golden_PlateArmor_Armor	Golden Greed Plate Armor	Male
+Golden_PlateArmor_Cloak	Golden Greed Plate Cloak	Male
+Golden_PlateArmor_Helm	Golden Greed Plate Helm	Male
+Goldur_Leather_Armor	Goldur Leather Armor	Male
+Goloduan_PlateArmor_Gloves	Demenissian Elite Plate Gloves	Male
+Gomel_Leather_Armor	Gomel Leather Armor	Male
 Goorba_OneHandMace	Saltroad Mace
 GraceMansion_MetalDoor_Key	Glenbright Manor Key
 GraceMansion_RoomDoor_Key	Glenbright Manor Basement Key
 Grace_Blueprint	Cloudcart Blueprint
-Grace_Fabric_Gloves	Runae Cloth Gloves
-Grace_PlateArmor_Helm	Grace Plate Helm
-Grace_Plate_Boots	Canta Plate Boots
+Grace_Fabric_Gloves	Runae Cloth Gloves	Male
+Grace_PlateArmor_Helm	Grace Plate Helm	Male
+Grace_Plate_Boots	Canta Plate Boots	Male
 Grape	Grape
-GraveRobber_Leather_Armor_I	Grave Robber's Leather Armor
-GraveRobber_Leather_Armor_II	Grave Robber's Leather Armor
-GraveRobber_Leather_Armor_III	Grave Robber's Leather Armor
-GraveRobber_Leather_Armor_IV	Grave Robber's Leather Armor
+GraveRobber_Leather_Armor_I	Grave Robber's Leather Armor	Male
+GraveRobber_Leather_Armor_II	Grave Robber's Leather Armor	Male
+GraveRobber_Leather_Armor_III	Grave Robber's Leather Armor	Male
+GraveRobber_Leather_Armor_IV	Grave Robber's Leather Armor	Male
 Graymane_Token	Greymane's Token
 GreenOrc_TwoHandedWarHammer	Gorthak Warhammer
 GreenStone	Epidote
-Greeney_Leather_Armor	Greeney Leather Armor
+Greeney_Leather_Armor	Greeney Leather Armor	Male
 Gregor_OneHandShield	Khaled Shield
 Gregrick_TwoHandSword	Dewhaven Longsword
 Grenvar_HorseArmor_Armor	Grenbar Cloth Barding
-GreyWolf_OneHandBow	Grey Wolf Bow
-Greyfur_Fabric_Armor	Balder's Cloth Armor
-Greyfur_Fabric_Armor_C	Ronald's Cloth Armor
-Greyfur_Fabric_Armor_CI	Greymane Cloth Armor
-Greyfur_Fabric_Armor_D	Fritz's Cloth Armor
-Greyfur_Fabric_Armor_I	Matilda's Cloth Armor
-Greyfur_Fabric_Armor_III	Devan's Cloth Armor
-Greyfur_Fabric_Armor_IV	Terry's Cloth Armor
-Greyfur_Fabric_Armor_IX	Falstaff's Cloth Armor
-Greyfur_Fabric_Armor_L	Brennan's Cloth Armor
-Greyfur_Fabric_Armor_LX	Niall's Cloth Armor
-Greyfur_Fabric_Armor_LXX	Luke's Cloth Armor
-Greyfur_Fabric_Armor_LXXX	Vernon's Cloth Armor
-Greyfur_Fabric_Armor_M	Otto's Cloth Armor
-Greyfur_Fabric_Armor_MI	Jian's Cloth Armor
-Greyfur_Fabric_Armor_MII	Marius's Cloth Armor
-Greyfur_Fabric_Armor_MIII	Greymane Cloth Armor
-Greyfur_Fabric_Armor_V	Ryan's Cloth Armor
-Greyfur_Fabric_Armor_VI	Lars's Cloth Armor
-Greyfur_Fabric_Armor_VII	Luther's Cloth Armor
-Greyfur_Fabric_Armor_VIII	Colton's Cloth Armor
-Greyfur_Fabric_Armor_X	Arnold's Cloth Armor
-Greyfur_Fabric_Armor_XC	Xavier's Cloth Armor
-Greyfur_Fabric_Armor_XI	Lucius's Cloth Armor
-Greyfur_Fabric_Armor_XII	Duncan's Cloth Armor
-Greyfur_Fabric_Armor_XL	Wybert's Cloth Armor
-Greyfur_Fabric_Armor_XX	Anders's Cloth Armor
-Greyfur_Fabric_Armor_XXX	Fred's Cloth Armor
-Greyfur_Fabric_Gloves	Greymane Cloth Gloves
-Greyfur_Fabric_Helm	Colton's Cloth Cap
-Greyfur_Fabric_Helm_I	Arnold's Cloth Cap
-Greyfur_Fabric_Helm_II	Wybert's Cloth Cap
-Greyfur_Fabric_Helm_III	Fritz's Cloth Cap
-Greyfur_Fabric_Helm_IV	Shane's Cloth Headband
-Greyfur_Leather_Armor	Greymanes' Leather Armor
-Greyfur_Leather_Armor_I	Greymanes' Leather Armor
-Greyfur_Leather_Armor_II	Greymanes' Leather Armor
-Greyfur_Leather_Armor_III	Greymanes' Leather Armor
-Greyfur_Leather_Armor_IV	Greymanes' Leather Armor
-Greyfur_Leather_Armor_IX	Gilbert's Leather Armor
-Greyfur_Leather_Armor_L	Kenneth's Leather Armor
-Greyfur_Leather_Armor_LX	Aldric's Leather Armor
-Greyfur_Leather_Armor_LXX	Gerald's Leather Armor
-Greyfur_Leather_Armor_LXXX	Duane's Leather Armor
-Greyfur_Leather_Armor_LXXXI	Shane's Leather Armor
-Greyfur_Leather_Armor_LXXXII	Greymanes' Leather Armor
-Greyfur_Leather_Armor_LXXXIII	Greymane's Leather Armor
-Greyfur_Leather_Armor_V	Morrow's Leather Armor
-Greyfur_Leather_Armor_VI	Laurent's Leather Armor
-Greyfur_Leather_Armor_VII	Brant's Leather Armor
-Greyfur_Leather_Armor_VIII	Joseph's Leather Armor
-Greyfur_Leather_Armor_X	Max's Leather Armor
-Greyfur_Leather_Armor_XI	Silvan's Leather Armor
-Greyfur_Leather_Armor_XII	Pierce's Leather Armor
-Greyfur_Leather_Armor_XL	Joan's Leather Armor
-Greyfur_Leather_Armor_XX	Evelyn's Leather Armor
-Greyfur_Leather_Armor_XXX	Andrew's Leather Armor
-Greyfur_Leather_Boots	Evelyn's Leather Boots
-Greyfur_Leather_Boots_I	Morrow's Leather Boots
-Greyfur_Leather_Boots_II	Luther's Leather Boots
-Greyfur_Leather_Boots_III	Andrew's Leather Boots
-Greyfur_Leather_Boots_IV	Arnold's Leather Boots
-Greyfur_Leather_Boots_V	Joan's Leather Boots
-Greyfur_Leather_Boots_VI	Duncan's Leather Boots
-Greyfur_Leather_Boots_VII	Ronald's Leather Boots
-Greyfur_Leather_Gloves	Brant's Leather Gloves
-Greyfur_Leather_Gloves_I	Vernon's Leather Gloves
-Greyfur_Leather_Gloves_II	Laurent's Leather Gloves
-Greyfur_Leather_Helm	Matilda's Leather Headband
-Greyfur_Leather_Helm_I	Jian's Leather Helm
-Greyfur_Leather_Helm_II	Greymanes' Leather Helm
+GreyWolf_OneHandBow	Grey Wolf Bow	Male
+Greyfur_Fabric_Armor	Balder's Cloth Armor	Male
+Greyfur_Fabric_Armor_C	Ronald's Cloth Armor	Male
+Greyfur_Fabric_Armor_CI	Greymane Cloth Armor	Male
+Greyfur_Fabric_Armor_D	Fritz's Cloth Armor	Male
+Greyfur_Fabric_Armor_I	Matilda's Cloth Armor	Female
+Greyfur_Fabric_Armor_III	Devan's Cloth Armor	Male
+Greyfur_Fabric_Armor_IV	Terry's Cloth Armor	Male
+Greyfur_Fabric_Armor_IX	Falstaff's Cloth Armor	Male
+Greyfur_Fabric_Armor_L	Brennan's Cloth Armor	Male
+Greyfur_Fabric_Armor_LX	Niall's Cloth Armor	Male
+Greyfur_Fabric_Armor_LXX	Luke's Cloth Armor	Male
+Greyfur_Fabric_Armor_LXXX	Vernon's Cloth Armor	Male
+Greyfur_Fabric_Armor_M	Otto's Cloth Armor	Male
+Greyfur_Fabric_Armor_MI	Jian's Cloth Armor	Male
+Greyfur_Fabric_Armor_MII	Marius's Cloth Armor	Male
+Greyfur_Fabric_Armor_MIII	Greymane Cloth Armor	Male
+Greyfur_Fabric_Armor_V	Ryan's Cloth Armor	Male
+Greyfur_Fabric_Armor_VI	Lars's Cloth Armor	Male
+Greyfur_Fabric_Armor_VII	Luther's Cloth Armor	Male
+Greyfur_Fabric_Armor_VIII	Colton's Cloth Armor	Male
+Greyfur_Fabric_Armor_X	Arnold's Cloth Armor	Male
+Greyfur_Fabric_Armor_XC	Xavier's Cloth Armor	Male
+Greyfur_Fabric_Armor_XI	Lucius's Cloth Armor	Male
+Greyfur_Fabric_Armor_XII	Duncan's Cloth Armor	Male
+Greyfur_Fabric_Armor_XL	Wybert's Cloth Armor	Male
+Greyfur_Fabric_Armor_XX	Anders's Cloth Armor	Male
+Greyfur_Fabric_Armor_XXX	Fred's Cloth Armor	Male
+Greyfur_Fabric_Gloves	Greymane Cloth Gloves	Female
+Greyfur_Fabric_Helm	Colton's Cloth Cap	Male
+Greyfur_Fabric_Helm_I	Arnold's Cloth Cap	Male
+Greyfur_Fabric_Helm_II	Wybert's Cloth Cap	Male
+Greyfur_Fabric_Helm_III	Fritz's Cloth Cap	Male
+Greyfur_Fabric_Helm_IV	Shane's Cloth Headband	Male
+Greyfur_Leather_Armor	Greymanes' Leather Armor	Male
+Greyfur_Leather_Armor_I	Greymanes' Leather Armor	Male
+Greyfur_Leather_Armor_II	Greymanes' Leather Armor	Male
+Greyfur_Leather_Armor_III	Greymanes' Leather Armor	Male
+Greyfur_Leather_Armor_IV	Greymanes' Leather Armor	Male
+Greyfur_Leather_Armor_IX	Gilbert's Leather Armor	Male
+Greyfur_Leather_Armor_L	Kenneth's Leather Armor	Male
+Greyfur_Leather_Armor_LX	Aldric's Leather Armor	Male
+Greyfur_Leather_Armor_LXX	Gerald's Leather Armor	Male
+Greyfur_Leather_Armor_LXXX	Duane's Leather Armor	Male
+Greyfur_Leather_Armor_LXXXI	Shane's Leather Armor	Male
+Greyfur_Leather_Armor_LXXXII	Greymanes' Leather Armor	Male
+Greyfur_Leather_Armor_LXXXIII	Greymane's Leather Armor	Male
+Greyfur_Leather_Armor_V	Morrow's Leather Armor	Male
+Greyfur_Leather_Armor_VI	Laurent's Leather Armor	Male
+Greyfur_Leather_Armor_VII	Brant's Leather Armor	Male
+Greyfur_Leather_Armor_VIII	Joseph's Leather Armor	Male
+Greyfur_Leather_Armor_X	Max's Leather Armor	Male
+Greyfur_Leather_Armor_XI	Silvan's Leather Armor	Male
+Greyfur_Leather_Armor_XII	Pierce's Leather Armor	Male
+Greyfur_Leather_Armor_XL	Joan's Leather Armor	Female
+Greyfur_Leather_Armor_XX	Evelyn's Leather Armor	Female
+Greyfur_Leather_Armor_XXX	Andrew's Leather Armor	Male
+Greyfur_Leather_Boots	Evelyn's Leather Boots	Female
+Greyfur_Leather_Boots_I	Morrow's Leather Boots	Male
+Greyfur_Leather_Boots_II	Luther's Leather Boots	Male
+Greyfur_Leather_Boots_III	Andrew's Leather Boots	Male
+Greyfur_Leather_Boots_IV	Arnold's Leather Boots	Male
+Greyfur_Leather_Boots_V	Joan's Leather Boots	Female
+Greyfur_Leather_Boots_VI	Duncan's Leather Boots	Male
+Greyfur_Leather_Boots_VII	Ronald's Leather Boots	Male
+Greyfur_Leather_Gloves	Brant's Leather Gloves	Male
+Greyfur_Leather_Gloves_I	Vernon's Leather Gloves	Male
+Greyfur_Leather_Gloves_II	Laurent's Leather Gloves	Male
+Greyfur_Leather_Helm	Matilda's Leather Headband	Female
+Greyfur_Leather_Helm_I	Jian's Leather Helm	Male
+Greyfur_Leather_Helm_II	Greymanes' Leather Helm	Male
 Greyfur_Necklace	Greymane Necklace
-Greyfur_PlateArmor_Gloves_I	Darren Plate Gloves
+Greyfur_PlateArmor_Gloves_I	Darren Plate Gloves	Male
 Greymane_Nobility_Degree_I	Greymane Signet
 Grilled_Big_Fish	Large Grilled Fish
 Grilled_Big_Fish_Large	Satisfying Large Grilled Fish
@@ -2028,24 +2033,24 @@ Grilled_Vegetables	Grilled Vegetables
 Grilled_Vegetables_Large	Satisfying Grilled Vegetables
 Grilled_Vegetables_Medium	Filling Grilled Vegetables
 Grilled_Vegetables_XLarge	Hearty Grilled Vegetables
-Grolla_Leather_Armor	Grolla Leather Armor
-Grommet_Leather_Armor	Grommet Leather Armor
-Gronerd_Leather_Armor	Gronerd Leather Armor
-Groucca_Leather_Armor	Groucca Leather Armor
-Gruun_Fabric_Armor	Gruun Cloth Armor
+Grolla_Leather_Armor	Grolla Leather Armor	Male
+Grommet_Leather_Armor	Grommet Leather Armor	Male
+Gronerd_Leather_Armor	Gronerd Leather Armor	Male
+Groucca_Leather_Armor	Groucca Leather Armor	Male
+Gruun_Fabric_Armor	Gruun Cloth Armor	Male
 GuardianTree_Pear	Fruit of Life
-Guardian_PlateArmor_Armor	Guardian Plate Armor
-Guff_Leather_Armor	Guff Leather Armor
+Guardian_PlateArmor_Armor	Guardian Plate Armor	Male
+Guff_Leather_Armor	Guff Leather Armor	Male
 Gun_OneHandShield	Shotgun Shield
 Gun_Powder	Gunpowder
 Gungjung_Tteokbokki	Pan-Fried Rice Cakes
 Gungjung_Tteokbokki_Large	Satisfying Pan-Fried Rice Cakes
 Gungjung_Tteokbokki_Medium	Filling Pan-Fried Rice Cakes
 Gungjung_Tteokbokki_XLarge	Hearty Pan-Fried Rice Cakes
-Gursus_Leather_Armor	Gersens Leather Armor
+Gursus_Leather_Armor	Gersens Leather Armor	Male
 Gustav_OneHandMusket	Gustav Musket
-Gut_Leather_Boots	Goot Leather Boots
-Guts_PlateArmor_Armor	Gwets Plate Armor
+Gut_Leather_Boots	Goot Leather Boots	Male
+Guts_PlateArmor_Armor	Gwets Plate Armor	Male
 Haasam	False Starwort
 Hacking_PlateArmor_Helm	Circuit Hijacking Helm
 Haemuljjim	Steamed Seafood
@@ -2055,73 +2060,73 @@ Haemuljjim_XLarge	Hearty Steamed Seafood
 Hagmundt_HorseArmor_Armor	Hagmund Barding
 Hagmundt_HorseArmor_Helm	Hagmund Champron
 Hagmundt_HorseArmor_Saddle	Hagmund Saddle
-Hagwood_Leather_Gloves	Hagwood Leather Gloves
-Hailbrin_Fabric_Armor	Nevin Cloth Armor
-Hailbrin_Fabric_Helm	Nevin Cloth Bandana
-Hailbrin_Leather_Armor	Helfryn Leather Armor
-Hailbrin_Leather_Boots	Helfryn Leather Boots
-Hailbrin_Leather_Cloak	Helfryn Leather Cloak
-Hailbrin_Leather_Gloves	Helfryn Leather Gloves
+Hagwood_Leather_Gloves	Hagwood Leather Gloves	Male
+Hailbrin_Fabric_Armor	Nevin Cloth Armor	Male
+Hailbrin_Fabric_Helm	Nevin Cloth Bandana	Male
+Hailbrin_Leather_Armor	Helfryn Leather Armor	Male
+Hailbrin_Leather_Boots	Helfryn Leather Boots	Male
+Hailbrin_Leather_Cloak	Helfryn Leather Cloak	Male
+Hailbrin_Leather_Gloves	Helfryn Leather Gloves	Male
 Hailbrin_Necklace	Helfryn Necklace
-Hailen_Fabric_Armor	Haillen Cloth Armor
-Halkias_Leather_Gloves	Harkias Leather Gloves
+Hailen_Fabric_Armor	Haillen Cloth Armor	Male
+Halkias_Leather_Gloves	Harkias Leather Gloves	Male
 Halsius_Record	Journal on Treating Lunatics
-Hanbok_Fabric_Gloves_T1_QA	Hanbok Fabric Gloves T1 QA
-Harald_Fabric_Cloak	Dewhaven Standard Cloth Cloak
-Harald_Leather_Armor	Dewhaven Standard Leather Armor
-Haran_Fabric_Armor	Harran Cloth Armor
+Hanbok_Fabric_Gloves_T1_QA	Hanbok Fabric Gloves T1 QA	Male
+Harald_Fabric_Cloak	Dewhaven Standard Cloth Cloak	Male
+Harald_Leather_Armor	Dewhaven Standard Leather Armor	Male
+Haran_Fabric_Armor	Harran Cloth Armor	Female
 Hard_Thorn_OneHandTowerShield	Legion Spearmen's Large Shield
-Harghai_Fabric_Armor	Harghai Cloth Armor
-Hark_Leather_Gloves	Hark Leather Gloves
-Harker_Fabric_Helm	Harker Cloth Cap
+Harghai_Fabric_Armor	Harghai Cloth Armor	Male
+Hark_Leather_Gloves	Hark Leather Gloves	Male
+Harker_Fabric_Helm	Harker Cloth Cap	Male
 Harkias_OneHandAxe	Gilliam Axe
-Haron_Fabric_Gloves	Haron Cloth Wristband
+Haron_Fabric_Gloves	Haron Cloth Wristband	Male
 Harpy_Feather	Harpy Feather
-Hartman_PlateArmor_Helm	Hartmann Plate Helm
-Hasets_ChainMail_Armor	Hasets Chain Mail
-Hassal_Fabric_Armor	Hassal Cloth Armor
-Hazuka_Leather_Armor	Hashaka Leather Armor
-Heat_PlateArmor_Helm	Helm of Ignition
+Hartman_PlateArmor_Helm	Hartmann Plate Helm	Male
+Hasets_ChainMail_Armor	Hasets Chain Mail	Male
+Hassal_Fabric_Armor	Hassal Cloth Armor	Male
+Hazuka_Leather_Armor	Hashaka Leather Armor	Male
+Heat_PlateArmor_Helm	Helm of Ignition	Male
 Heavy_Copper_Pack	Full Copper Pouch
 Heavy_Silver_Pack	Overflowing Silver Pouch
-Hegeh_Leather_Gloves	Hegea Leather Gloves
+Hegeh_Leather_Gloves	Hegea Leather Gloves	Female
 Hegeh_TwoHandAlebard	Marauder's Halberd
 Hegeh_TwoHandedWarHammer	Bonepit Warhammer
 Heisellen_Fabric_Armor	The Masked Liberator's Cloth Armor
 Heisellen_Fabric_Cloak	The Masked Liberator's Cloth Cloak
-Heisellen_Fabric_Cloak_T1_QA	Heisellen Fabric Cloak T1 QA
-Hellad_Leather_Armor	Hellad Leather Armor
-Hellhonds_Leather_Helm	Hellhound Leather Helm
-Hemon_Vindel_Leather_Armor	Duskfang Leather Armor
-Hemon_Vindel_Leather_Cloak	Duskfang Leather Cloak
+Heisellen_Fabric_Cloak_T1_QA	Heisellen Fabric Cloak T1 QA	Male
+Hellad_Leather_Armor	Hellad Leather Armor	Male
+Hellhonds_Leather_Helm	Hellhound Leather Helm	Male
+Hemon_Vindel_Leather_Armor	Duskfang Leather Armor	Male
+Hemon_Vindel_Leather_Cloak	Duskfang Leather Cloak	Male
 HemondBindel_TwoHandSword	Hound
-Hentti_Fabric_Armor	Hentree Cloth Armor
+Hentti_Fabric_Armor	Hentree Cloth Armor	Male
 Herbal_Tea	Mild Herbal Tea
 Herbalist_BackPack_I	Herbalist's Pack
 Herbalist_BackPack_II	Herbalist's Pack
-Herdel_Leather_Boots	Herdel Leather Boots
-Hermalfaya_Leather_Armor	Helpaia Leather Armor
-Hernand_Cloak	Hernandian Noble's Cloak
+Herdel_Leather_Boots	Herdel Leather Boots	Female
+Hermalfaya_Leather_Armor	Helpaia Leather Armor	Female
+Hernand_Cloak	Hernandian Noble's Cloak	Male
 Hernand_Contribution_Flag	Hernandian Contribution Banner Pike
-Hernand_Crown	Hernandian Circlet
+Hernand_Crown	Hernandian Circlet	Male
 Hernand_Flag_I	Small Hernandian Banner Pike
 Hernand_Flag_II	Medium Hernandian Banner Pike
-Hernand_GuardCaptain_Fabric_Armor	Hernandian Honor Guard Armor
-Hernand_GuardCaptain_Fabric_Cloak	Hernandian Honor Guard Cloak
-Hernand_GuardCaptain_Leather_Boots	Hernandian Honor Guard Boots
-Hernand_GuardCaptain_Leather_Gloves	Hernandian Honor Guard Gloves
+Hernand_GuardCaptain_Fabric_Armor	Hernandian Honor Guard Armor	Male
+Hernand_GuardCaptain_Fabric_Cloak	Hernandian Honor Guard Cloak	Male
+Hernand_GuardCaptain_Leather_Boots	Hernandian Honor Guard Boots	Male
+Hernand_GuardCaptain_Leather_Gloves	Hernandian Honor Guard Gloves	Male
 Hernand_HorseArmor_Armor	Hernandian Barding
 Hernand_HorseArmor_Helm	Hernandian Champron
 Hernand_HorseArmor_Saddle	Hernandian Saddle
 Hernand_HorseArmor_Stirrup	Hernandian Stirrups
 Hernand_Nobility_Degree_I	Hernandian Signet
-Hernand_Party_Leather_Boots	Hernandian Leather Boots
+Hernand_Party_Leather_Boots	Hernandian Leather Boots	Male
 Hernand_Soldier_HorseArmor_Armor	Hernandian Soldier's Cloth Barding
-Hernand_William_Middler_Fabric_Armor	Williem Middler Cloth Armor
+Hernand_William_Middler_Fabric_Armor	Williem Middler Cloth Armor	Male
 Hernand_Winery_Key	Hernand Wine Storehouse Key
-Herween_Leather_Armor	Herwin Leather Armor
-Hewlette_Fabric_Armor	Hewlette Cloth Armor
-Hexe_Archer_OneHandBow	Bow of the Fleeting
+Herween_Leather_Armor	Herwin Leather Armor	Male
+Hewlette_Fabric_Armor	Hewlette Cloth Armor	Male
+Hexe_Archer_OneHandBow	Bow of the Fleeting	Male
 Hexe_Earring	Witch's Earring
 Hexe_Soldier_OneHandMace	Mace of the Fleeting
 Hexe_Soldier_OneHandShield	Shell of the Fleeting
@@ -2145,19 +2150,19 @@ High_Meat	Tough Meat
 High_Wine	Delesyian Wine
 Hleinmers_TwoHandAlebard	Iris Halberd
 Hleinmers_TwoHandedWarHammer	Cactus Warhammer
-Hobuka_Leather_Armor	Hobbuca Leather Armor
-Hodges_Leather_Armor	Hodges Leather Armor
+Hobuka_Leather_Armor	Hobbuca Leather Armor	Male
+Hodges_Leather_Armor	Hodges Leather Armor	Male
 HolyWater	Holy Water
 Home_Key	Key
 Honey	Honey
 HoneyComb	Beehive
 HoneyComb_OneHandMace	Beehive Club
 Honey_Tea	Honey Tea
-Hooburn_Leather_Boots	Hauvern Leather Boots
-Hoobus_Fabric_Helm	Hubus Cloth Cap
-Hoobus_Leather_Armor	Hubus Leather Armor
-Hordyroar_Leather_Boots	Hoardroar Leather Boots
-Horizon_Leather_Armor	Horizon Leather Armor
+Hooburn_Leather_Boots	Hauvern Leather Boots	Male
+Hoobus_Fabric_Helm	Hubus Cloth Cap	Female
+Hoobus_Leather_Armor	Hubus Leather Armor	Female
+Hordyroar_Leather_Boots	Hoardroar Leather Boots	Male
+Horizon_Leather_Armor	Horizon Leather Armor	Male
 HorseFeed_Hay	Hay
 HorseFeed_Hp_Potion	Horse Tonic
 HorseFeed_Lump_Sugar	Sugar Cubes
@@ -2184,33 +2189,34 @@ Hound_Flag_II	Medium Hellhounds Banner Pike
 Huge_TwoHandGiantAxe	Inquisitor's Greataxe
 Hunter_BackPack_I	Hunter's Pack
 Hunter_BackPack_II	Hunter's Pack
-Huntington_Leather_Boots	Huntington Leather Boots
+Huntington_Leather_Boots	Huntington Leather Boots	Female
 Huntington_OneHandMusket	Arlen Musket
-Huon_Leather_Armor	Huron Leather Armor
-Huroi_Leather_Boots	Scholastone Boots
-Huroi_Leather_Helm	Scholastone Cap
-Huskall_Leather_Armor	Huskall Leather Armor
+Huon_Leather_Armor	Huron Leather Armor	Male
+Huroi_Leather_Boots	Scholastone Boots	Male
+Huroi_Leather_Helm	Scholastone Cap	Male
+Huskall_Fabric_Cloak	Huskall Cloth Cloak	Male
+Huskall_Leather_Armor	Huskall Leather Armor	Male
 Hwando_TwoHandSword	Hwando
 Hyde_OneHandCrossBow	Hyde Crossbow
-Hyena_Leather_Helm	Hyena Helm
-Hymns_of_Dusk_Fabric_Armor_I	Musket Border Guard Standard Armor
-Hymns_of_Dusk_Leather_Armor_I	Dusksongs Leather Armor
-Hymns_of_Dusk_Leather_Boots_I	Dusksongs Leather Boots
-Hymns_of_Dusk_PlateArmor_Armor_I	Dusksongs Plate Armor
+Hyena_Leather_Helm	Hyena Helm	Male
+Hymns_of_Dusk_Fabric_Armor_I	Musket Border Guard Standard Armor	Male
+Hymns_of_Dusk_Leather_Armor_I	Dusksongs Leather Armor	Male
+Hymns_of_Dusk_Leather_Boots_I	Dusksongs Leather Boots	Male
+Hymns_of_Dusk_PlateArmor_Armor_I	Dusksongs Plate Armor	Male
 Hymns_of_Dusk_PlateArmor_Armor_II	The Dusksong Vice Captain's Plate Armor
-Hymns_of_Dusk_PlateArmor_Gloves_I	Dusksongs Plate Gloves
+Hymns_of_Dusk_PlateArmor_Gloves_I	Dusksongs Plate Gloves	Male
 Hyosi_Arrow	Whistling Arrow
-Hysilda_Fabric_Armor	Hysilda Cloth Armor
+Hysilda_Fabric_Armor	Hysilda Cloth Armor	Male
 IceStrandedShip_Book	Shipwreck Voyage Log
 IceThrower	Electromagnetic Frostspitter
 Ice_Arrow	Chill Arrow
 Ignir_TwoHandSword	Ignir
-Iguana_Rider_Leather_Boots	Iguana Rider Leather Boots
-Iguana_Rider_Leather_Cloak_III	Lizard Leather Cloak
-Iguana_Rider_PlateArmor_Armor_I	Iguana Rider's Plate Armor
-Iguana_Rider_PlateArmor_Armor_II	Iguana Rider's Plate Armor
-Iguana_Rider_PlateArmor_Armor_III	Iguana Rider's Plate Armor
-Illinoeon_Leather_Boots	Infreen Leather Boots
+Iguana_Rider_Leather_Boots	Iguana Rider Leather Boots	Male
+Iguana_Rider_Leather_Cloak_III	Lizard Leather Cloak	Male
+Iguana_Rider_PlateArmor_Armor_I	Iguana Rider's Plate Armor	Male
+Iguana_Rider_PlateArmor_Armor_II	Iguana Rider's Plate Armor	Male
+Iguana_Rider_PlateArmor_Armor_III	Iguana Rider's Plate Armor	Male
+Illinoeon_Leather_Boots	Infreen Leather Boots	Male
 Immediate_SubLevel_AttackSpeedRate	Increased Attack Speed
 Immediate_SubLevel_Hp	Health Amplification
 Immediate_SubLevel_MoveSpeedRate	Increased Movement Speed
@@ -2232,14 +2238,14 @@ Inventory_Expansion_Sellable_2	Medium Bag
 Inventory_Expansion_Sellable_3	Large Bag
 Inventory_Expansion_Sellable_4	Extra Large Bag
 Invisible_TwoHandGiantBastard	Dandelion Longsword
-Inyr_PlateArmor_Helm	Inyr Plate Helm
-Inytium_Leather_Armor	Ynitium Leather Armor
-Inytium_Leather_Boots	Ynitium Leather Boots
-Inytium_Leather_Cloak	Ynitium Leather Cloak
-Inytium_Leather_Gloves	Ynitium Leather Gloves
+Inyr_PlateArmor_Helm	Inyr Plate Helm	Male
+Inytium_Leather_Armor	Ynitium Leather Armor	Male
+Inytium_Leather_Boots	Ynitium Leather Boots	Male
+Inytium_Leather_Cloak	Ynitium Leather Cloak	Male
+Inytium_Leather_Gloves	Ynitium Leather Gloves	Male
 IronStone	Iron Ore
-Ironfist_Boss_Knuckle	Iron Fists Gauntlet
-Isilon_Leather_Boots	Isilon Leather Boots
+Ironfist_Boss_Knuckle	Iron Fists Gauntlet	Male
+Isilon_Leather_Boots	Isilon Leather Boots	Male
 Itano_CannonBall	Itano Cannonball
 Itano_CannonBall_Errant	Crude Itano Cannonball
 ItemCatch_FishingRod	The Claw
@@ -2328,10 +2334,11 @@ Item_Eastern_Tailed_Blue	Blue Tailed Butterfly
 Item_Eastern_Tiger_Swallowtail	Swallowtail
 Item_Egg_KuKu	Kuku Bird's Egg
 Item_Egg_Wyvern	Wyvern Egg
+Item_FireFly_Box	Firefly Colony
 Item_Firefly	Firefly
-Item_Fist_Damian	Ordinary Gloves
-Item_Fist_Kliff	Ordinary Gloves
-Item_Fist_Oongka	Ordinary Gloves
+Item_Fist_Damian	Ordinary Gloves	Female
+Item_Fist_Kliff	Ordinary Gloves	Male
+Item_Fist_Oongka	Ordinary Gloves	Male
 Item_Flying_Squirrel	Flying Squirrel
 Item_Frilled_Lizard	Frilled-neck Lizard
 Item_Giant_Salamander	Burrowing Salamander
@@ -2935,15 +2942,15 @@ Itemgimmick_lamp_side_candle_0003_index02	Lilac Octagonal Lantern
 Itemgimmick_lamp_stand_candlestick_0001	Icy White Candlestick Lamp
 Itemgimmick_lamp_stand_candlestick_0001_index01	Twilight Candlestick Lamp
 Itemgimmick_lamp_stand_candlestick_0001_index02	Lilac Candlestick Lamp
-Ivano_Fabric_Armor	Bleed Cloth Armor
+Ivano_Fabric_Armor	Bleed Cloth Armor	Male
 Ivory	Ivory
-Iyratti_Fabric_Armor	Eyratt Cloth Armor
-Iytis_PlateArmor_Gloves	Ettis Plate Gloves
-Izumit_Fabric_Armor	Izumit Cloth Armor
-Jackal_Leather_Helm	Jackals' Leather Helm
-Jackal_Leather_Helm_II	Jackals' Leather Helm
-Jacktar_PlateArmor_Helm	Zachar Plate Helm
-Jacob_Fabric_Armor	Yakkov Cloth Armor
+Iyratti_Fabric_Armor	Eyratt Cloth Armor	Male
+Iytis_PlateArmor_Gloves	Unyielding Hero's Plate Gloves	Male
+Izumit_Fabric_Armor	Izumit Cloth Armor	Male
+Jackal_Leather_Helm	Jackals' Leather Helm	Male
+Jackal_Leather_Helm_II	Jackals' Leather Helm	Male
+Jacktar_PlateArmor_Helm	Zachar Plate Helm	Male
+Jacob_Fabric_Armor	Yakkov Cloth Armor	Male
 Japchae	Pan-Fried Vegetables
 Japchae_Large	Satisfying Pan-Fried Vegetables
 Japchae_Medium	Filling Pan-Fried Vegetables
@@ -2955,120 +2962,119 @@ Jeonju_Bibimbap_Medium	Filling Mixed Harvest Bowl
 Jeonju_Bibimbap_XLarge	Hearty Mixed Harvest Bowl
 Jerky	Fine Jerky
 Jerky_Pieces	Jerky
-Jermill_Fabric_Helm	Jermill Cloth Headband
+Jermill_Fabric_Helm	Jermill Cloth Headband	Male
 Jerrphin_TwoHandSpear	Valgash's Incomplete Work
-Jevanars_Leather_Armor	Jevanars Leather Armor
+Jevanars_Leather_Armor	Jevanars Leather Armor	Female
 JijeongTempleShipLog_Book	Voyage Log to Jijeong Temple
-Johannes_PlateArmor_Armor	Johannes Plate Armor
-Johnnycolo_Leather_Armor	Janiklo Leather Armor
-Johnnycolo_Leather_Gloves	Janiklo Leather Gloves
-Joseph_PlateArmor_Armor	Yosef Plate Armor
-Juden_Fabric_Armor	Juden Cloth Armor
-Judge_PlateArmor_Armor	Inquisitor's Plate Armor
-Judge_PlateArmor_Gloves	Inquisitor's Plate Gloves
-Judge_Plate_Boots	Inquisitor's Plate Boots
+Johannes_PlateArmor_Armor	Johannes Plate Armor	Male
+Johnnycolo_Leather_Armor	Janiklo Leather Armor	Male
+Johnnycolo_Leather_Gloves	Janiklo Leather Gloves	Male
+Joseph_PlateArmor_Armor	Yosef Plate Armor	Male
+Juden_Fabric_Armor	Juden Cloth Armor	Male
+Judge_PlateArmor_Armor	Inquisitor's Plate Armor	Male
+Judge_PlateArmor_Gloves	Inquisitor's Plate Gloves	Male
+Judge_Plate_Boots	Inquisitor's Plate Boots	Male
 Judge_TwoHandSpear	Alfonso Spear
-Juman_Leather_Boots	Juman Leather Boots
+Juman_Leather_Boots	Juman Leather Boots	Male
 JumpUp_Boots	Kuku Breeze-Step Boots
-Kadel_Leather_Gloves	Rheigis Leather Gloves
+Kadel_Leather_Gloves	Rheigis Leather Gloves	Male
 Kadel_OneHandMace	Kadel Mace
-Kahbokahn_Fabric_Armor	Kavokin Cloth Armor
-Kahbotune_Fabric_Armor	Kabotun Cloth Armor
-Kahdet_PlateArmor_Helm	Cadet Plate Helm
-Kahsunan_Fabric_Armor	Kasunan Cloth Armor
-Kahtrahah_Fabric_Armor	Kaetra Cloth Armor
+Kahbokahn_Fabric_Armor	Kavokin Cloth Armor	Male
+Kahbotune_Fabric_Armor	Kabotun Cloth Armor	Male
+Kahdet_PlateArmor_Helm	Cadet Plate Helm	Male
+Kahsunan_Fabric_Armor	Kasunan Cloth Armor	Male
+Kahtrahah_Fabric_Armor	Kaetra Cloth Armor	Male
 Kahturaon_Fabric_Armor	Qaturan Cloth Armor
 Kahturaon_Fabric_Armor_II	The Blinding Arrow Vice Captain's Cloth Armor
 Kaiko_Leather_Boots	Caico Leather Boots
-Kailok_Fabric_Armor	Kailok's Cloth Armor
+Kailok_Fabric_Armor	Kailok's Cloth Armor	Male
 Kairu_Leather_Boots	Caelough Leather Boots
-Kaisan_Leather_Armor	Kaisan Leather Armor
+Kaisan_Leather_Armor	Kaisan Leather Armor	Male
 Kajet_Leather_Boots	Kasset Leather Boots
-Kakuta_PlateArmor_Armor	Kakuta Plate Armor
+Kakuta_PlateArmor_Armor	Kakuta Plate Armor	Male
 Kali_TwoHandedWarHammer	Zargan Warhammer
-Kalrari_ChainMail_Armor	Kallari Chain Mail
+Kalrari_ChainMail_Armor	Kallari Chain Mail	Male
 Kamperdian_TwoHandSpear	Warspike Spear
-Kamsen_Leather_Gloves	Camsen Leather Gloves
-Kamsen_PlateArmor_Gloves	Camsen Plate Bracers
+Kamsen_Leather_Gloves	Camsen Leather Gloves	Female
+Kamsen_PlateArmor_Gloves	Camsen Plate Bracers	Male
 Kamsen_TwoHandAlebard	Alabaster Halberd
-Kang_Fabric_Armor	Kang Cloth Armor
-Kantana_PlateArmor_Armor	Kantana Plate Armor
-Kantuna_PlateArmor_Armor	Kantona Plate Armor
-Karacorum_Leather_Gloves	Cacoreum Leather Gloves
-Karacorum_Leather_Gloves_I	Cacoreum Leather Gloves
+Kang_Fabric_Armor	Kang Cloth Armor	Male
+Kantana_PlateArmor_Armor	Kantana Plate Armor	Male
+Kantuna_PlateArmor_Armor	Kantona Plate Armor	Male
+Karacorum_Leather_Gloves	Cacoreum Leather Gloves	Male
+Karacorum_Leather_Gloves_I	Cacoreum Leather Gloves	Male
 Karanda_Necklace	Karanda's Necklace
-Karas_Fabric_Helm	Karas Cloth Headband
-Kark_ChainMail_Armor	Kark Chain Mail
-Karnitta_Fabric_Armor	Killua Cloth Armor
-Kasria_Leather_Gloves	Kasria Leather Gloves
-Katerm_Leather_Armor	Katerm Leather Armor
-Katian_Leather_Boots	Katian Leather Boots
-Katitz_Leather_Boots	Katitz Leather Boots
-Kattinan_Fabric_Armor	Kattinan Cloth Armor
-Kattinan_Leather_Gloves	Kattinan Leather Gloves
-Katunan_ChainMail_Armor_I	Katunan Chain Mail
-Katz_Leather_Boots	Katz Leather Boots
-Kauria_ChainMail_Armor	Kauria Chain Mail
-Kayson_PlateArmor_Helm	Demenissian Guard's Plate Helm
-Kayson_PlateArmor_Helm_I	Inquisitor's Plate Helm
-Kayson_PlateArmor_Helm_II	Caysonne Plate Helm
+Karas_Fabric_Helm	Karas Cloth Headband	Male
+Kark_ChainMail_Armor	Kark Chain Mail	Male
+Karnitta_Fabric_Armor	Killua Cloth Armor	Male
+Kasria_Leather_Gloves	Kasria Leather Gloves	Male
+Katerm_Leather_Armor	Katerm Leather Armor	Male
+Katian_Leather_Boots	Katian Leather Boots	Female
+Katitz_Leather_Boots	Katitz Leather Boots	Male
+Kattinan_Fabric_Armor	Kattinan Cloth Armor	Male
+Kattinan_Leather_Gloves	Kattinan Leather Gloves	Male
+Katunan_ChainMail_Armor_I	Katunan Chain Mail	Male
+Katz_Leather_Boots	Katz Leather Boots	Male
+Kauria_ChainMail_Armor	Kauria Chain Mail	Male
+Kayson_PlateArmor_Helm	Demenissian Guard's Plate Helm	Male
+Kayson_PlateArmor_Helm_I	Inquisitor's Plate Helm	Male
+Kayson_PlateArmor_Helm_II	Caysonne Plate Helm	Male
 Kebail_PlateArmor_Gloves	Kevile Plate Gloves
-Kedenly_Leather_Armor	Kednry Leather Armor
-Kenav_Fabric_Armor	Kennav Cloth Armor
-Kenav_Fabric_Helm	Kennav Cloth Headband
-Kenmore_PlateArmor_Armor	Kenmore Plate Armor
-Kenmore_PlateArmor_Armor_I	Kenmore Plate Armor
-Keoller_Fabric_Armor	Keller Cloth Armor
+Kedenly_Leather_Armor	Kednry Leather Armor	Male
+Kenav_Fabric_Armor	Kennav Cloth Armor	Male
+Kenav_Fabric_Helm	Kennav Cloth Headband	Male
+Kenmore_PlateArmor_Armor	Kenmore Plate Armor	Male
+Kenmore_PlateArmor_Armor_I	Kenmore Plate Armor	Male
+Keoller_Fabric_Armor	Keller Cloth Armor	Male
 Kephilray_TwoHandSpear	Sydmon Spear
-Kerburn_Leather_Armor	Kerburn Leather Armor
-Kerdmann_Fabric_Boots	Kerdmann Cloth Boots
-Keredig_Leather_Boots	Keredig Leather Greaves
-Keredig_PlateArmor_Gloves	Canta Plate Gloves
-Keredig_PlateArmor_Helm	Bolton Plate Helm
-Ketlan_ChainMail_Armor	Ketlan Chain Mail
+Kerburn_Leather_Armor	Kerburn Leather Armor	Male
+Kerdmann_Fabric_Boots	Kerdmann Cloth Boots	Male
+Keredig_Leather_Boots	Keredig Leather Greaves	Male
+Keredig_PlateArmor_Gloves	Canta Plate Gloves	Male
+Keredig_PlateArmor_Helm	Bolton Plate Helm	Male
+Ketlan_ChainMail_Armor	Ketlan Chain Mail	Male
 Khadiac_TwoHandAxe	Troll Hook Greataxe
 Khadiac_TwoHandSpear	Kylus Spear
 Khadion_TwoHandAlebard	Gilliam Halberd
 Khadion_TwoHandSword	Iris Longsword
 Khadion_TwoHandedWarHammer	Arlen Warhammer
-Khalbydan_Fabric_Armor	Khalbdan Cloth Armor
-Khalbydan_Leather_Gloves	Khalbdan Leather Bracers
-Khanoa_OneHandBow	Sydmon Bow
-Kiahtuth_PlateArmor_Helm	Kiatus Plate Helm
+Khalbydan_Fabric_Armor	Khalbdan Cloth Armor	Male
+Khalbydan_Leather_Gloves	Khalbdan Leather Bracers	Male
+Khanoa_OneHandBow	Sydmon Bow	Male
+Kiahtuth_PlateArmor_Helm	Kiatus Plate Helm	Male
 Kiehrius_TwoHandAlebard	Bonepit Halberd
 Kiehrius_TwoHandSword	Thalwynd Longsword
-Kililli_ChainMail_Armor	Killi Chain Mail
-Killeen_PlateArmor_Armor	Killian Plate Armor
-Killeen_PlateArmor_Armor_I	Killian Plate Armor
+Kililli_ChainMail_Armor	Killi Chain Mail	Male
+Killeen_PlateArmor_Armor	Killian Plate Armor	Male
+Killeen_PlateArmor_Armor_I	Killian Plate Armor	Male
 Kimbap	Battered Harvest Roll
 Kimbap_Large	Satisfying Battered Harvest Roll
 Kimbap_Medium	Filling Battered Harvest Roll
 Kimbap_XLarge	Hearty Battered Harvest Roll
-Kinloch_PlateArmor_Armor	Kinloch Plate Armor
-Kinloch_PlateArmor_Armor_I	Kinloch Plate Armor
-Kinov_Fabric_Armor	Keanoff Cloth Armor
-Kinross_PlateArmor_Armor	Kinross Plate Armor
-Kinross_PlateArmor_Armor_I	Kinross Plate Armor
-Kintun_ChainMail_Armor	Mortain Chain Mail
-KitchenKnife_OneHandDagger	Kitchen Knife
+Kinloch_PlateArmor_Armor	Kinloch Plate Armor	Male
+Kinloch_PlateArmor_Armor_I	Kinloch Plate Armor	Male
+Kinov_Fabric_Armor	Keanoff Cloth Armor	Male
+Kinross_PlateArmor_Armor	Kinross Plate Armor	Male
+Kinross_PlateArmor_Armor_I	Kinross Plate Armor	Male
+Kintun_ChainMail_Armor	Mortain Chain Mail	Male
 Kite_Metal_OneHandShield	Shield of a Blossoming Spring Day
 Kitee_OneHandShield	Kite Shield
 Kliff_Earring	Greymane's Earring
-Kliff_Glasses	Master Du's Circlet
+Kliff_Glasses	Master Du's Circlet	Male
 Kliff_Mask	Mask
 Kliff_OneHandShotgun	Pailunese Shotgun
-Kliff_PlateArmor_Armor	Kairos Plate Armor
-Kliff_PlateArmor_Cloak	Kairos Cloak
-Kliff_PlateArmor_Gloves	Kairos Plate Gloves
-Kliff_PlateArmor_Helm	Kairos Plate Helm
-Kliff_Plate_Boots	Kairos Plate Boots
+Kliff_PlateArmor_Armor	Kairos Plate Armor	Male
+Kliff_PlateArmor_Cloak	Kairos Cloak	Male
+Kliff_PlateArmor_Gloves	Kairos Plate Gloves	Male
+Kliff_PlateArmor_Helm	Kairos Plate Helm	Male
+Kliff_Plate_Boots	Kairos Plate Boots	Male
 Knight_King_OneHandSword	Knightlord's Sword
 Knowledge_PlateArmor_Helm	Helm of Knowledge
-Konkhar_Fabric_Armor	Concarr Cloth Armor
-Kordaav_Leather_Armor	Kordaav Leather Armor
-Kordaav_Leather_Gloves	Kordaav Leather Gloves
+Konkhar_Fabric_Armor	Concarr Cloth Armor	Male
+Kordaav_Leather_Armor	Kordaav Leather Armor	Male
+Kordaav_Leather_Gloves	Kordaav Leather Gloves	Male
 Kordaav_OneHandMace	Kordaav Mace
-Korean_PlateArmor_Armor	Corinne Plate Armor
+Korean_PlateArmor_Armor	Corinne Plate Armor	Male
 Kramer_TwoHandHammer	Helms Greathammer
 Kriella_Fabric_Armor	Kriella Cloth Armor
 Kriella_Fabric_Gloves	Kriella Cloth Wristband
@@ -3076,8 +3082,8 @@ Kritha_HorseArmor_Armor	Calphadean Barding
 Kritha_HorseArmor_Helm	Exclaire Champron
 Kritha_HorseArmor_Saddle	Exclaire Saddle
 Kritha_HorseArmor_Stirrup	Calphadean Stirrups
-Ktan_Fabric_Armor	Kithan Cloth Armor
-Ktian_Fabric_Armor	Ketian Cloth Armor
+Ktan_Fabric_Armor	Kithan Cloth Armor	Male
+Ktian_Fabric_Armor	Ketian Cloth Armor	Male
 KuKu_Bismuth_TwoHandSpear	Kuku Bismuth Spear
 KuKu_EMP_TwoHandSpear	Kuku Disruptor Spear
 KuKu_Fire_staff_spear_TwoHandSpear	Kuku Flame Spear
@@ -3089,8 +3095,8 @@ KuKubird_Armor	Kuku Bird Hatchling Saddle
 KuKubird_Armor_I	Kuku Bird Saddle
 KuKubird_Helm	Kuku Bird Eggshell
 Kudzu_seed	Skyroot Seed
-Kukan_PlateArmor_Armor	Coogan Plate Armor
-Kukan_PlateArmor_Armor_I	Blacksteel Coogan Plate Armor
+Kukan_PlateArmor_Armor	Coogan Plate Armor	Male
+Kukan_PlateArmor_Armor_I	Blacksteel Coogan Plate Armor	Male
 Kuku_Drone_Backpack	Kuku Watcher Pack
 Kuku_EMP_Enhance_BackPack	Enhanced Kuku Disruptor
 Kuku_FlameThrower	Kuku Flamespitter
@@ -3098,103 +3104,102 @@ Kuku_IceThrower	Kuku Frostspitter
 Kuku_LightningThrower	Kuku Boltspitter
 Kuku_Pot_BackPack	Kuku Pack
 Kuku_YamatoCannon_TwoHandSpear	Kuku Laser Cannon Spear
-Kunan_PlateArmor_Armor	Kunan Plate Armor
-Kunan_PlateArmor_Armor_I	Kunan Plate Armor
-Kurinan_PlateArmor_Armor	Gurrinan Plate Armor
-Kurinan_PlateArmor_Armor_I	Condemner's Plate Armor
-Kurinan_PlateArmor_Cloak_I	Condemner's Plate Cloak
-Kurua_Leather_Boots	Kurua Leather Boots
-Kurua_PlateArmor_Helm	Kurua Plate Helm
+Kunan_PlateArmor_Armor	Kunan Plate Armor	Male
+Kunan_PlateArmor_Armor_I	Kunan Plate Armor	Male
+Kurinan_PlateArmor_Armor	Gurrinan Plate Armor	Male
+Kurinan_PlateArmor_Armor_I	Condemner's Plate Armor	Male
+Kurinan_PlateArmor_Cloak_I	Condemner's Plate Cloak	Male
+Kurua_Leather_Boots	Kurua Leather Boots	Male
+Kurua_PlateArmor_Helm	Kurua Plate Helm	Male
 Kydalern_TwoHandSpear	Spear of Righteousness
-Kylidden_Leather_Gloves	Kaeridyn Leather Gloves
+Kylidden_Leather_Gloves	Kaeridyn Leather Gloves	Female
 Kylidden_TwoHandSpear	Alabaster Spear
-Labonion_ChainMail_Armor	Lavgnion Chain Mail
-Lacata_PlateArmor_Armor	Lacata Plate Armor
-Lachian_PlateArmor_Armor	Lachian Plate Armor
-Lacklean_Fabric_Gloves	Grey Wolf Cloth Gloves
-Lacquer_Leather_Gloves	Larkri Leather Gloves
-Lacquer_PlateArmor_Armor	Larkri Plate Armor
-Lacrunias_Leather_Helm	Lacrunias Leather Helm
-Lacsha_PlateArmor_Helm	Sahazhad Plate Helm
-Lacusane_PlateArmor_Armor	Lacusane Plate Armor
-Ladete_Leather_Gloves	Layddete Leather Gloves
-Ladete_Plate_Boots	Icewing Plate Boots
-Ladis_Fabric_Helm	Raditz Cloth Cap
-Ladle_OneHandMace	Ladle
-Ladran_Fabric_Armor	Ladran Cloth Armor
-Laehbern_PlateArmor_Helm	Laehbern Plate Helm
-Lafty_Leather_Gloves	Leffri's Leather Gloves
-Lafty_Leather_Gloves_I	Leffri's Leather Gloves
-Lain_Leather_Boots	Layne Leather Boots
-Laitaa_Leather_Boots	Layta Leather Boots
-Laitaa_Plate_Boots	Layta Plate Greaves
+Labonion_ChainMail_Armor	Lavgnion Chain Mail	Male
+Lacata_PlateArmor_Armor	Lacata Plate Armor	Male
+Lachian_PlateArmor_Armor	Lachian Plate Armor	Male
+Lacklean_Fabric_Gloves	Grey Wolf Cloth Gloves	Female
+Lacquer_Leather_Gloves	Larkri Leather Gloves	Male
+Lacquer_PlateArmor_Armor	Larkri Plate Armor	Female
+Lacrunias_Leather_Helm	Lacrunias Leather Helm	Male
+Lacsha_PlateArmor_Helm	Sahazhad Plate Helm	Male
+Lacusane_PlateArmor_Armor	Lacusane Plate Armor	Female
+Ladete_Leather_Gloves	Layddete Leather Gloves	Male
+Ladete_Plate_Boots	Icewing Plate Boots	Male
+Ladis_Fabric_Helm	Raditz Cloth Cap	Male
+Ladran_Fabric_Armor	Ladran Cloth Armor	Male
+Laehbern_PlateArmor_Helm	Laehbern Plate Helm	Male
+Lafty_Leather_Gloves	Leffri's Leather Gloves	Male
+Lafty_Leather_Gloves_I	Leffri's Leather Gloves	Male
+Lain_Leather_Boots	Layne Leather Boots	Male
+Laitaa_Leather_Boots	Layta Leather Boots	Male
+Laitaa_Plate_Boots	Layta Plate Greaves	Female
 LakeGolem_OnehandShield	Runewalker Shield
-Laksh_Leather_Armor	Lakshi Leather Armor
-Laksh_Leather_Boots	Lakshi Leather Shoes
+Laksh_Leather_Armor	Lakshi Leather Armor	Male
+Laksh_Leather_Boots	Lakshi Leather Shoes	Male
 Lance_OneHandLance	Lance OneHandLance
-Langphash_Fabric_Armor	Ranphas Cloth Armor
-Langtois_Fabric_Armor	Rangtua Cloth Armor
-Langust_Leather_Boots	Ashen Wolf's Leather Boots
-Lankaz_Fabric_Armor	Lancats Cloth Armor
-Lanok_PlateArmor_Armor	Lanauk Plate Armor
-Lanok_PlateArmor_Armor_I	Lanauk Plate Armor
+Langphash_Fabric_Armor	Ranphas Cloth Armor	Male
+Langtois_Fabric_Armor	Rangtua Cloth Armor	Male
+Langust_Leather_Boots	Ashen Wolf's Leather Boots	Male
+Lankaz_Fabric_Armor	Lancats Cloth Armor	Male
+Lanok_PlateArmor_Armor	Lanauk Plate Armor	Male
+Lanok_PlateArmor_Armor_I	Lanauk Plate Armor	Male
 Lanpheldt_OneHandAxe	Lambert Axe
 Lantern	Lantern
-Laonkel_Leather_Boots	Lankel Leather Boots
-Laplian_Fabric_Helm	Laplian Cloth Cap
-Laplus_Leather_Armor	Laplace Leather Armor
-Laplus_Leather_Gloves	Laplace Leather Gloves
-Laputi_Leather_Boots	Lapprette Leather Boots
-Lardein_Fabric_Helm	Radein Cloth Cap
+Laonkel_Leather_Boots	Lankel Leather Boots	Male
+Laplian_Fabric_Helm	Laplian Cloth Cap	Male
+Laplus_Leather_Armor	Laplace Leather Armor	Male
+Laplus_Leather_Gloves	Laplace Leather Gloves	Male
+Laputi_Leather_Boots	Lapprette Leather Boots	Male
+Lardein_Fabric_Helm	Radein Cloth Cap	Male
 Large_Bone	Large Bone
-Lariano_Fabric_Armor	Lariano Cloth Armor
-Lark_PlateArmor_Armor	Larc Plate Armor
-Larkarz_Fabric_Armor	Lacas Cloth Armor
-Larkritt_Fabric_Helm	Larkett Cloth Cap
-Larksia_PlateArmor_Helm	Renkshaw Plate Helm
-Larksia_PlateArmor_Helm_I	Blacksteel Renkshaw Plate Helm
-Larksis_PlateArmor_Helm	Langris Plate Helm
-Larsahn_Fabric_Helm	Larsan Cloth Headband
+Lariano_Fabric_Armor	Lariano Cloth Armor	Male
+Lark_PlateArmor_Armor	Larc Plate Armor	Male
+Larkarz_Fabric_Armor	Lacas Cloth Armor	Male
+Larkritt_Fabric_Helm	Larkett Cloth Cap	Male
+Larksia_PlateArmor_Helm	Renkshaw Plate Helm	Male
+Larksia_PlateArmor_Helm_I	Blacksteel Renkshaw Plate Helm	Male
+Larksis_PlateArmor_Helm	Langris Plate Helm	Male
+Larsahn_Fabric_Helm	Larsan Cloth Headband	Male
 Larsiras_Fabric_Helm	Lashiras Cowl
-Larstti_PlateArmor_Helm	Larstrom Plate Helm
-Lascaux_Leather_Boots	Lascaux Leather Boots
+Larstti_PlateArmor_Helm	Larstrom Plate Helm	Male
+Lascaux_Leather_Boots	Lascaux Leather Boots	Male
 LasentaKum_Leather_Gloves	Renshaku Leather Gloves
-Lashir_Fabric_Helm	Lashir Cloth Cap
-Lasian_Leather_Boots	Lasian Leather Boots
-Laspine_Leather_Armor	Raspin Leather Armor
-Latenta_PlateArmor_Helm	Laterna Plate Helm
-Lathia_Fabric_Armor	Lathia Cloth Armor
-Latian_Leather_Gloves	Latian Leather Bracers
-Latir_Leather_Boots	Latear Leather Boots
-Latrion_ChainMail_Armor	Latrion Chain Mail
-Lattua_Plate_Boots	Lattua Plate Boots
-Lattua_Plate_Boots_I	Blacksteel Lattua Plate Boots
-Laucatti_Fabric_Armor	Larcotti Cloth Armor
-Lauqus_PlateArmor_Helm	Lauques Plate Helm
-Lautar_Fabric_Armor	Lauta Cloth Armor
-Lautia_PlateArmor_Helm	Lautia Plate Helm
-Lave_Leather_Gloves	Lave Leather Gloves
+Lashir_Fabric_Helm	Lashir Cloth Cap	Male
+Lasian_Leather_Boots	Lasian Leather Boots	Male
+Laspine_Leather_Armor	Raspin Leather Armor	Male
+Latenta_PlateArmor_Helm	Laterna Plate Helm	Male
+Lathia_Fabric_Armor	Lathia Cloth Armor	Male
+Latian_Leather_Gloves	Latian Leather Bracers	Male
+Latir_Leather_Boots	Latear Leather Boots	Male
+Latrion_ChainMail_Armor	Latrion Chain Mail	Male
+Lattua_Plate_Boots	Lattua Plate Boots	Male
+Lattua_Plate_Boots_I	Blacksteel Lattua Plate Boots	Male
+Laucatti_Fabric_Armor	Larcotti Cloth Armor	Male
+Lauqus_PlateArmor_Helm	Lauques Plate Helm	Male
+Lautar_Fabric_Armor	Lauta Cloth Armor	Male
+Lautia_PlateArmor_Helm	Lautia Plate Helm	Male
+Lave_Leather_Gloves	Lave Leather Gloves	Male
 Lavender	Lavender
 Lavender_blue	Blue Lavender
 Lavender_white	White Lavender
 Lavender_yellow	Yellow Lavender
-Laviren_Fabric_Armor	Ravirun Cloth Armor
-Laviren_Fabric_Armor_1	Bandit Cloth Armor
-Laviren_Fabric_Cloak_I	Bandit Cloth Cloak
-Laviren_Fabric_Helm	Ravirun Cloth Cap
-Laviren_Leather_Armor	Ravirun Leather Armor
-Lavrak_Fabric_Helm	Labrak Cloth Cap
-Lawncheta_Leather_Gloves	Lawson Leather Gloves
-Leadahn_Leather_Helm	Ledan Leather Helm
+Laviren_Fabric_Armor	Ravirun Cloth Armor	Male
+Laviren_Fabric_Armor_1	Bandit Cloth Armor	Male
+Laviren_Fabric_Cloak_I	Bandit Cloth Cloak	Male
+Laviren_Fabric_Helm	Ravirun Cloth Cap	Male
+Laviren_Leather_Armor	Ravirun Leather Armor	Male
+Lavrak_Fabric_Helm	Labrak Cloth Cap	Male
+Lawncheta_Leather_Gloves	Lawson Leather Gloves	Male
+Leadahn_Leather_Helm	Ledan Leather Helm	Male
 Leather	Thin Hide
 Leather_Merchant_BackPack_I	Tanner's Pack
 Leather_Merchant_BackPack_II	Tanner's Pack
 Leather_Merchant_BackPack_III	Tanner's Pack
-Lebideuo_Leather_Boots	Levinto Leather Boots
-Lecruon_Leather_Gloves	Reclonne Leather Gloves
-Ledcy_Leather_Helm	Arkhan Leather Helm
-Leeksha_ChainMail_Armor	Riksha Chain Mail
-Leeksi_Fabric_Helm	Ricksley Cloth Cap
+Lebideuo_Leather_Boots	Levinto Leather Boots	Male
+Lecruon_Leather_Gloves	Reclonne Leather Gloves	Male
+Ledcy_Leather_Helm	Arkhan Leather Helm	Male
+Leeksha_ChainMail_Armor	Riksha Chain Mail	Male
+Leeksi_Fabric_Helm	Ricksley Cloth Cap	Male
 Leeksia_OneHandSword	Dekarr Sword
 Legend_Black_Lion_Report	Sighting of the Black Lion
 Legend_Coelacanth_Report	Sighting of the Coelacanth
@@ -3216,7 +3221,7 @@ Legend_White_Crocodile_Report	Sighting of the White-Scaled Crocodile
 Legend_White_Lion_Report	Sighting of the White Lion
 Legend_White_Moose_Report	Sighting of the White Moose
 Legend_White_Stag_Report	Sighting of the White Elk
-Legendary_Abyss_OneHandCannon	Sior Blaster
+Legendary_Abyss_OneHandCannon	Sior Blaster	Male
 Legendary_AncientGuardian_TwoHandAxe	Earthsplitter
 Legendary_Animal_Giant_Bull	White King's Candlestick
 Legendary_Animal_Phoenix	Nightmare Burner
@@ -3232,29 +3237,29 @@ Legendary_BridieGu_TwoHandGiantAxe	Wheel of the Last Toll
 Legendary_Caliburn_OneHandRapier	Royal Oath
 Legendary_CaptainGoblin_OneHandAxe	Double-Headed Axe of Greed
 Legendary_CrimsonScorpion_TwoHandHammer	Rune-Engraved Rock
-Legendary_Deer_Leather_Gloves	Counterweight Leather Gloves
-Legendary_Deer_Leather_Gloves_T4_QA	Legendary Deer Leather Gloves T4 QA
+Legendary_Deer_Leather_Gloves	Counterweight Leather Gloves	Male
+Legendary_Deer_Leather_Gloves_T4_QA	Legendary Deer Leather Gloves T4 QA	Male
 Legendary_DemenisMusket_OneHandMusket	Demenissian Hero's Musket
 Legendary_DragonSlayer_OneHandSword	Nazk Sword
 Legendary_Dragon_OneHandSword	Aeserion Sword
 Legendary_Dragon_TwoHandGiantSpear	Aeserion Spear
-Legendary_GoldStar_OneHandCannon	Golden Fire
+Legendary_GoldStar_OneHandCannon	Golden Fire	Male
 Legendary_HexeMarie_Earring	Earring of Dark Magic
 Legendary_Kings_OneHandDagger	King's Dagger
 Legendary_Korea_OneHandBow	Noble Man's Bow
-Legendary_MarniDragon_OneHandCannon	Mechanical Clockwork Blaster
-Legendary_MarniGolem_Plate_Armor	Frozen Heart Plate Armor
-Legendary_MarniGolem_Plate_Boots	Frozen Heart Plate Boots
-Legendary_MarniGolem_Plate_Cloak	Frozen Heart Plate Cloak
+Legendary_MarniDragon_OneHandCannon	Mechanical Clockwork Blaster	Male
+Legendary_MarniGolem_Plate_Armor	Frozen Heart Plate Armor	Male
+Legendary_MarniGolem_Plate_Boots	Frozen Heart Plate Boots	Male
+Legendary_MarniGolem_Plate_Cloak	Frozen Heart Plate Cloak	Male
 Legendary_MarniRegion_OneHandMace	Marni Devotee's Mace
-Legendary_MarniTank_OneHandCannon	Marni Tank Blaster
+Legendary_MarniTank_OneHandCannon	Marni Tank Blaster	Male
 Legendary_MarniTank_OneHandShield	Delesyian Ornamental Shield
-Legendary_Marni_OneHandCannon	Blaster No. 8
+Legendary_Marni_OneHandCannon	Blaster No. 8	Male
 Legendary_Moonhead_01_TwoHandGiantSpear	Diverging Moon
 Legendary_Moonhead_02_TwoHandGiantSpear	Circling Moon
 Legendary_Moonhead_TwoHandGiantSpear	Grasping Moon
 Legendary_Ogre_Ring	Ogre's Ring
-Legendary_Orc_Plate_Glove	Frozen Heart Plate Gloves
+Legendary_Orc_Plate_Glove	Frozen Heart Plate Gloves	Male
 Legendary_OwenCraber_TwoHandGiantSpear	Frostfang
 Legendary_Shakatu_OneHandDagger	Goblin King's Treasure Dagger
 Legendary_SkullKnight_OneHandShield	Balgran Shield
@@ -3264,18 +3269,18 @@ Legendary_StephenBleed_OneHandMace	Mace of Resolve
 Legendary_Tarandus_TwoHandedWarHamme	Ashen Execution
 Legendary_Titan_Ring	Ring of Lightning
 Legendary_WhiteHorn_OneHandSword	Chillfallen Sword
-Legendary_WhiteWolf_Leather_Helm	Silver Fang Helm
+Legendary_WhiteWolf_Leather_Helm	Silver Fang Helm	Male
 Leinstead_OneHandSword	Glenmore Sword
-Lekia_Leather_Boots	Rekhia Leather Boots
-Lekia_PlateArmor_Helm	Baltheon Plate Helm
-Lekia_Plate_Boots	Unyielding Warrior's Plate Boots
+Lekia_Leather_Boots	Rekhia Leather Boots	Male
+Lekia_PlateArmor_Helm	Baltheon Plate Helm	Male
+Lekia_Plate_Boots	Unyielding Warrior's Plate Boots	Male
 Lentils	Lentils
 Leone_OneHandRapier	Leonne Rapier
-Leontain_Leather_Boots	Leontyne Leather Boots
-Leontain_PlateArmor_Helm	Leontyne Plate Helm
-Leopard_Pattern_Leather_Armor	Leopard Print Leather Armor
-Lepra_Leather_Boots	Lepra Leather Boots
-Lercent_Leather_Gloves	Lercent Leather Gloves
+Leontain_Leather_Boots	Leontyne Leather Boots	Male
+Leontain_PlateArmor_Helm	Leontyne Plate Helm	Male
+Leopard_Pattern_Leather_Armor	Leopard Print Leather Armor	Male
+Lepra_Leather_Boots	Lepra Leather Boots	Male
+Lercent_Leather_Gloves	Lercent Leather Gloves	Male
 Letter_Azureian_Secret	Countess Azerian's Secret Letter
 Letter_Elimores_Secret	Countess Azerian's Letter
 Letter_Go_To_ScolaStone	Alustin's Letter
@@ -3283,66 +3288,68 @@ Letter_TraderLetter	Undelivered Trader's Letter
 Letter_Valgash	Valgash's Letter
 Letter_Visione_MotherLetter	Letter from a Mother
 Letter_Wolfmolar_Mountain_WifeLetter	A Wife's Letter
-Levibb_Fabric_Armor	Ruvib Cloth Armor
+Levibb_Fabric_Armor	Ruvib Cloth Armor	Male
 Liberry_OneHandRapier	Liberre Rapier
 License_Operation_CopperPaperBank	Copper Banknote Personal Strongbox Permit
 License_Operation_HernandBank	Personal Strongbox Permit
-Lickla_PlateArmor_Armor	Ricla Plate Armor
-Liculu_Leather_Gloves	Ricrau Leather Gloves
-Licuna_Leather_Boots	Leguna Leather Boots
+Lickla_PlateArmor_Armor	Ricla Plate Armor	Male
+Liculu_Leather_Gloves	Ricrau Leather Gloves	Male
+Licuna_Leather_Boots	Leguna Leather Boots	Male
 LightSaber_TwoHandSword	LightSaber TwoHandSword
-Light_Arrowhead_Fabric_Armor_I	Blinding Arrow Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_II	Blinding Arrow Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_III	Blinding Arrow Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_IV	Blinding Arrow Rider's Cloth Armor
-Light_Arrowhead_Fabric_Armor_V	Blinding Arrow Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_VI	Blinding Arrow Scout's Cloth Armor
-Light_Arrowhead_Fabric_Armor_VII	Blinding Arrow Scout's Cloth Armor
-Light_Arrowhead_Fabric_Cloak_I	Blinding Arrow's Cloth Cloak
-Light_Arrowhead_Fabric_Helm_V	Blinding Arrow's Cloth Cap
-Light_Arrowhead_Leader_OneHandBow	Tormented Soul Bow
-Light_Arrowhead_Leather_Armor_I	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Armor_II	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Armor_III	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Armor_IV	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Armor_IX	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Armor_V	Blinding Arrows' Leather Armor
-Light_Arrowhead_Leather_Armor_VI	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Armor_VII	Blinding Arrow Scout's Leather Armor
-Light_Arrowhead_Leather_Armor_VIII	Blinding Arrow Scout's Leather Armor
-Light_Arrowhead_Leather_Armor_X	Blinding Arrow's Leather Armor
-Light_Arrowhead_Leather_Boots_I	Blinding Arrow's Leather Boots
-Light_Arrowhead_Leather_Boots_II	Blinding Arrow's Leather Boots
-Light_Arrowhead_Leather_Gloves	Blinding Arrow's Leather Gloves
+Light_Arrowhead_Fabric_Armor_I	Blinding Arrow Scout's Cloth Armor	Male
+Light_Arrowhead_Fabric_Armor_II	Blinding Arrow Scout's Cloth Armor	Male
+Light_Arrowhead_Fabric_Armor_III	Blinding Arrow Scout's Cloth Armor	Male
+Light_Arrowhead_Fabric_Armor_IV	Blinding Arrow Rider's Cloth Armor	Male
+Light_Arrowhead_Fabric_Armor_V	Blinding Arrow Scout's Cloth Armor	Male
+Light_Arrowhead_Fabric_Armor_VI	Blinding Arrow Scout's Cloth Armor	Male
+Light_Arrowhead_Fabric_Armor_VII	Blinding Arrow Scout's Cloth Armor	Male
+Light_Arrowhead_Fabric_Cloak_I	Blinding Arrow's Cloth Cloak	Male
+Light_Arrowhead_Fabric_Helm_V	Blinding Arrow's Cloth Cap	Male
+Light_Arrowhead_Leader_OneHandBow	Tormented Soul Bow	Male
+Light_Arrowhead_Leather_Armor_I	Blinding Arrow's Leather Armor	Male
+Light_Arrowhead_Leather_Armor_II	Blinding Arrow's Leather Armor	Male
+Light_Arrowhead_Leather_Armor_III	Blinding Arrow's Light Leather Armor	Female
+Light_Arrowhead_Leather_Armor_IV	Blinding Arrow's Leather Armor	Female
+Light_Arrowhead_Leather_Armor_IX	Blinding Arrow's Leather Armor	Male
+Light_Arrowhead_Leather_Armor_V	Blinding Arrows' Leather Armor	Male
+Light_Arrowhead_Leather_Armor_VI	Blinding Arrow's Leather Armor	Female
+Light_Arrowhead_Leather_Armor_VII	Blinding Arrow Scout's Leather Armor	Male
+Light_Arrowhead_Leather_Armor_VIII	Blinding Arrow Scout's Leather Armor	Male
+Light_Arrowhead_Leather_Armor_X	Blinding Arrow's Leather Armor	Male
+Light_Arrowhead_Leather_Boots_I	Blinding Arrow's Leather Boots	Female
+Light_Arrowhead_Leather_Boots_II	Blinding Arrow's Leather Boots	Female
+Light_Arrowhead_Leather_Cloak	Blinding Arrow's Female Leather Cloak	Female
+Light_Arrowhead_Leather_Gloves	Blinding Arrow's Leather Gloves	Male
 Light_Of_Giant_Lantern	Shiny Blue Sea Lantern
 Light_Thorn_OneHandTowerShield	Rekel Large Spiked Shield
 LightningThrower	Electromagnetic Boltspitter
 Lightning_Arrow	Blitz Arrow
 Lightning_TwoHandSpear	Lightning Spear
 Ligtning_TwoHandHammer_I	Lightning Greathammer
-Likarz_Fabric_Armor	Rikkas Cloth Armor
-Likenin_Leather_Gloves	Lennigen Leather Gloves
-Likua_PlateArmor_Helm	Longia Plate Helm
-Likua_PlateArmor_Helm_I	Blacksteel Longia Plate Helm
+Likarz_Fabric_Armor	Rikkas Cloth Armor	Male
+Likenin_Leather_Gloves	Lennigen Leather Gloves	Male
+Likua_PlateArmor_Helm	Longia Plate Helm	Male
+Likua_PlateArmor_Helm_I	Blacksteel Longia Plate Helm	Male
 Limerhen_TwoHandSpear	Traitor's Spear
-Limerick_ChainMail_Armor	Lemerick Chain Mail
-Limerick_ChainMail_Armor_II	Flame Knight Vice Captain's Chain Mail
-Liornia_Fabric_Armor	Liorna Cloth Armor
+Limerick_ChainMail_Armor	Lemerick Chain Mail	Male
+Limerick_ChainMail_Armor_II	Flame Knight Vice Captain's Chain Mail	Male
+Liornia_Fabric_Armor	Liorna Cloth Armor	Male
 Lipsort_OneHandTowerShield	Lifsoth Large Shield
-Litra_Leather_Gloves	Leahdra Leather Gloves
-Livneh_Fabric_Armor	Livner Cloth Armor
-LoaderDam_Leather_Gloves	Loudan Leather Gloves
-Loccamashima_Leather_Armor	Locasima Leather Armor
-Lodi_ChainMail_Armor	Lodi Chain Mail
+Litra_Leather_Gloves	Leahdra Leather Gloves	Female
+Livneh_Fabric_Armor	Livner Cloth Armor	Male
+LoaderDam_Leather_Gloves	Loudan Leather Gloves	Male
+Loccamashima_Leather_Armor	Locasima Leather Armor	Male
+Lodi_ChainMail_Armor	Lodi Chain Mail	Male
 Logger_BackPack_I	Woodcutter's Pack
 Logger_BackPack_II	Woodcutter's Pack
 Logger_BackPack_III	Woodcutter's Pack
 Logger_BackPack_IV	Woodcutter's Pack
-Londel_Leather_Boots	Scorchflame Leather Boots
-Londel_Leather_Gloves	Rondel Leather Gloves
-Londel_Leather_Helm	Rondel Leather Cap
-Londel_PlateArmor_Gloves	Scorchflame Plate Gloves
-Londel_PlateArmor_Helm	Scorchflame Plate Helm
+Londel_Leather_Boots	Scorchflame Leather Boots	Male
+Londel_Leather_Gloves	Rondel Leather Gloves	Male
+Londel_Leather_Helm	Rondel Leather Cap	Male
+Londel_PlateArmor_Gloves	Scorchflame Plate Gloves	Male
+Londel_PlateArmor_Helm	Scorchflame Plate Helm	Male
+LoneBomb_Leather_Armor	Lonely Bomb Leather Armor	Male
 LongBeak_OneHandSword	Varnian Sword
 Lopelun_OneHandMusket	Bekker Musket
 LostLetter_Bartholomew	Priest Ordination Recommendation Letter
@@ -3362,85 +3369,85 @@ LostLetter_Roger	Letter with a Scorched Corner
 LostLetter_Skint	Crumpled Letter
 LostLetter_Slywick	Unknown Duke's Order
 LostLetter_Sniks	Letter with a Torn Corner
-Lotas_PlateArmor_Helm	Lotas Plate Helm
-Lotas_PlateArmor_Helm_I	Blacksteel Lotas Plate Helm
-Lotunsau_Leather_Armor	Rotunso Leather Armor
-Louis_Fabric_Armor	Louis Cloth Armor
-Lower_ChainMail_Armor	Flame Knights Chain Mail
-Lowuti_Leather_Boots	Loutte Leather Boots
+Lotas_PlateArmor_Helm	Lotas Plate Helm	Male
+Lotas_PlateArmor_Helm_I	Blacksteel Lotas Plate Helm	Male
+Lotunsau_Leather_Armor	Rotunso Leather Armor	Male
+Louis_Fabric_Armor	Louis Cloth Armor	Male
+Lower_ChainMail_Armor	Flame Knights Plate Armor	Male
+Lowuti_Leather_Boots	Loutte Leather Boots	Male
 Lucan_OneHandTowerShield	Lucon Large Shield
-Lucion_ChainMail_Armor	Lucion Chain Mail
-Lucion_Fabric_Armor	Lucion Cloth Armor
+Lucion_ChainMail_Armor	Lucion Chain Mail	Male
+Lucion_Fabric_Armor	Lucion Cloth Armor	Male
 Lucky_Letter	Letter of Fortune
-Luconek_Fabric_Helm	Rueconec Cloth Cap
-Luconek_Leather_Boots	Rueconec Leather Boots
-Luconek_Leather_Gloves	Rueconec Leather Bracers
-Luconek_Leather_Helm	Rueconec Leather Hat
-Luconek_PlateArmor_Helm	Rueconec Plate Helm
+Luconek_Fabric_Helm	Rueconec Cloth Cap	Male
+Luconek_Leather_Boots	Rueconec Leather Boots	Male
+Luconek_Leather_Gloves	Rueconec Leather Bracers	Male
+Luconek_Leather_Helm	Rueconec Leather Hat	Male
+Luconek_PlateArmor_Helm	Rueconec Plate Helm	Male
 Luconek_PlateArmor_Helm_I	Demenissian Guard's Plate Helm
 Luconek_PlateArmor_Helm_II	Inquisitor's Plate Helm
-Ludus_PlateArmor_Armor	Ludus Plate Armor
-Ludvic_Leather_Armor	Hungering Fang Leather Armor
-Ludvic_Leather_Armor_II	Lonely Jackals' Leather Armor
-Ludvic_Leather_Boots	Hungering Fang Leather Boots
-Ludvic_Leather_Boots_T4_QA	Ludvic Leather Boots T4 QA
-Ludvic_Leather_Cloak	Hungering Fang Leather Cloak
-Ludvic_Leather_Gloves	Hungering Fang Leather Gloves
-Ludvic_Leather_Gloves_II	Jackals' Leather Gloves
+Ludus_PlateArmor_Armor	Ludus Plate Armor	Male
+Ludvic_Leather_Armor	Hungering Fang Leather Armor	Male
+Ludvic_Leather_Armor_II	Lonely Jackals' Leather Armor	Male
+Ludvic_Leather_Boots	Hungering Fang Leather Boots	Male
+Ludvic_Leather_Boots_T4_QA	Ludvic Leather Boots T4 QA	Male
+Ludvic_Leather_Cloak	Hungering Fang Leather Cloak	Male
+Ludvic_Leather_Gloves	Hungering Fang Leather Gloves	Male
+Ludvic_Leather_Gloves_II	Jackals' Leather Gloves	Male
 Ludvic_Necklace	Crossroads Necklace
-Ludvic_OneArmed_Leather_Armor	One-Armed Jackal's Leather Armor
-Ludvic_OneArmed_Leather_Cloak	One-Armed Jackal's Leather Cloak
+Ludvic_OneArmed_Leather_Armor	One-Armed Jackal's Leather Armor	Male
+Ludvic_OneArmed_Leather_Cloak	One-Armed Jackal's Leather Cloak	Male
 Ludvig_OneHandSword	Red Rage
 Ludynn_Fabric_Gloves	Ludynn Cloth Gloves
 Ludynn_Fabric_Helm	Ludynn Cloth Cap
 Ludynn_Leather_Armor	Ludynn Leather Armor
 Ludynn_Leather_Boots	Ludynn Leather Greaves
-Lueh_Fabric_Armor	Luwea Cloth Armor
-Luekushi_Fabric_Helm	Ruckshi Cloth Cap
+Lueh_Fabric_Armor	Luwea Cloth Armor	Male
+Luekushi_Fabric_Helm	Ruckshi Cloth Cap	Male
 Luka_Leather_Gloves	Luca Leather Gloves
-Luka_PlateArmor_Armor	Luca Plate Armor
-Lukas_Leather_Gloves	Lukas' Leather Gloves
-Lukatz_PlateArmor_Armor	Lukatz Plate Armor
-Lukin_Leather_Armor	Lukin Leather Armor
-Luknaon_ChainMail_Armor	Lucnaon Chain Mail
-Luknian_ChainMail_Armor	Lucnian Chain Mail
-Luknian_PlateArmor_Helm	Canta Plate Helm
-Lukran_PlateArmor_Helm	Laccarsa Plate Helm
-Luksa_ChainMail_Armor	Leuksah Chain Mail
-Lunosier_Fabric_Armor	Pailunese Attire
-Lunosier_Fabric_Cloak	Pailunese Cloak
-Lunpherd_Leather_Armor	Lunpherd Leather Armor
-Lunther_PlateArmor_Gloves	Luthor Plate Gloves
-Luon_PlateArmor_Armor	Luon Plate Armor
-Luon_PlateArmor_Cloak	Luon Plate Cloak
-Luon_PlateArmor_Gloves	Luon Plate Gloves
-Luon_PlateArmor_Helm	Luon Plate Helm
-Luon_Plate_Boots	Luon Plate Boots
+Luka_PlateArmor_Armor	Luca Plate Armor	Male
+Lukas_Leather_Gloves	Lukas' Leather Gloves	Male
+Lukatz_PlateArmor_Armor	Lukatz Plate Armor	Male
+Lukin_Leather_Armor	Lukin Leather Armor	Male
+Luknaon_ChainMail_Armor	Lucnaon Chain Mail	Male
+Luknian_ChainMail_Armor	Lucnian Chain Mail	Male
+Luknian_PlateArmor_Helm	Canta Plate Helm	Male
+Lukran_PlateArmor_Helm	Laccarsa Plate Helm	Male
+Luksa_ChainMail_Armor	Leuksah Chain Mail	Male
+Lunosier_Fabric_Armor	Pailunese Attire	Male
+Lunosier_Fabric_Cloak	Pailunese Cloak	Male
+Lunpherd_Leather_Armor	Lunpherd Leather Armor	Male
+Lunther_PlateArmor_Gloves	Luthor Plate Gloves	Male
+Luon_PlateArmor_Armor	Knight of Carnage Plate Armor	Male
+Luon_PlateArmor_Cloak	Knight of Carnage Plate Cloak	Male
+Luon_PlateArmor_Gloves	Knight of Carnage Plate Gloves	Male
+Luon_PlateArmor_Helm	Knight of Carnage Plate Helm	Male
+Luon_Plate_Boots	Knight of Carnage Plate Boots	Male
 Luon_TwoHandAlebard	Golden Vanguard
-Lusek_Giant_TwoHandGiantBastard	Lusec Greatsword
-Lutia_Leather_Boots	Lutia Leather Boots
-Lutinas_Leather_Helm	Lutinas Leather Helm
-Lutis_Leather_Boots	Pailunese Boots
-Lutis_PlateArmor_Gloves	Pailunese Gloves
-Lutzen_Leather_Armor	Lutzen Leather Armor
-Luverne_Leather_Armor	Luverne Leather Armor
-Luwaiet_PlateArmor_Armor	Ruwaite Plate Armor
-Luwaiet_PlateArmor_Armor_I	Demeniss Guard's Plate Armor
-Luwaiet_PlateArmor_Armor_II	Demeniss Guard's Plate Armor
-Luwaiet_PlateArmor_Armor_III	Demeniss Guard's Plate Armor
-Lyfellen_ChainMail_Armor	Northern Fighter's Chain Mail
-Lyfellen_ChainMail_Cloak	Northern Fighter's Chain Cloak
-Lyfellen_Leather_Gloves	Northern Fighter's Leather Gloves
+Lusek_Giant_TwoHandGiantBastard	Lusec Greatsword	Female
+Lutia_Leather_Boots	Lutia Leather Boots	Male
+Lutinas_Leather_Helm	Lutinas Leather Helm	Male
+Lutis_Leather_Boots	Pailunese Boots	Male
+Lutis_PlateArmor_Gloves	Pailunese Gloves	Male
+Lutzen_Leather_Armor	Lutzen Leather Armor	Male
+Luverne_Leather_Armor	Luverne Leather Armor	Male
+Luwaiet_PlateArmor_Armor	Ruwaite Plate Armor	Male
+Luwaiet_PlateArmor_Armor_I	Demeniss Guard's Plate Armor	Male
+Luwaiet_PlateArmor_Armor_II	Demeniss Guard's Plate Armor	Male
+Luwaiet_PlateArmor_Armor_III	Demeniss Guard's Plate Armor	Male
+Lyfellen_ChainMail_Armor	Northern Fighter's Chain Mail	Male
+Lyfellen_ChainMail_Cloak	Northern Fighter's Chain Cloak	Male
+Lyfellen_Leather_Gloves	Northern Fighter's Leather Gloves	Male
 Lyfellen_OneHandMace	Frozen Soul
-Lyfellen_PlateArmor_Helm	Lyfellen Plate Helm
+Lyfellen_PlateArmor_Helm	Lyfellen Plate Helm	Male
 Lyfellen_TwoHandAxe	Incomplete Masterpiece
-Mache_Leather_Gloves	Mache Leather Gloves
-Machnan_Fabric_Armor	Maknan Cloth Armor
-Machnynn_Fabric_Armor	Marknin Cloth Armor
-Machrah_Fabric_Armor	Marka Cloth Armor
-Machrahahn_Fabric_Armor	Makran Cloth Armor
-Madacus_PlateArmor_Helm	Bedure Plate Helm
-Maeve_Leather_Gloves	Maeve Leather Gloves
+Mache_Leather_Gloves	Mache Leather Gloves	Male
+Machnan_Fabric_Armor	Maknan Cloth Armor	Male
+Machnynn_Fabric_Armor	Marknin Cloth Armor	Male
+Machrah_Fabric_Armor	Marka Cloth Armor	Male
+Machrahahn_Fabric_Armor	Makran Cloth Armor	Male
+Madacus_PlateArmor_Helm	Bedure Plate Helm	Male
+Maeve_Leather_Gloves	Maeve Leather Gloves	Male
 Maeve_OneHandAxe	Maeve Axe
 Maeve_OneHandMace	Marching Baton
 MagicBullet	Magic Bullet
@@ -3453,42 +3460,43 @@ MagicBullet_LightFist	Light Fist Magic Bullet
 MagicBullet_Snow	Snow Magic Bullet
 MagicBullet_Water	Water Magic Bullet
 Magnet_OneHandSword	Red Needle
-Maint_PlateArmor_Helm	Demeniss Ceremonial Plate Helm
-Maint_PlateArmor_Helm_I	Mentz Plate Helm
-Makan_PlateArmor_Armor	Ferman Plate Armor
-Makan_PlateArmor_Cloak	Ferman Plate Cloak
-Makutan_PlateArmor_Helm	Ator's Will Helm
+Maint_PlateArmor_Helm	Demeniss Ceremonial Plate Helm	Male
+Maint_PlateArmor_Helm_I	Mentz Plate Helm	Male
+Makan_PlateArmor_Armor	Ferman Plate Armor	Male
+Makan_PlateArmor_Cloak	Ferman Plate Cloak	Male
+Makutan_PlateArmor_Helm	Ator's Will Helm	Male
 Makutan_PlateArmor_Helm_II	Troll Maccutan Plate Helm
-Manios_PlateArmor_Armor	Manios Plate Armor
-Mant_PlateArmor_Armor	Mant Plate Armor
-Marathion_Leather_Boots	Marrada Leather Boots
-Marcree_Fabric_Armor	Makri Cloth Armor
-Marcs_PlateArmor_Armor	Malacs Plate Armor
-Marctah_Fabric_Armor	Magta Cloth Armor
-Maredid_Leather_Boots	Maldrick Leather Boots
+Manios_PlateArmor_Armor	Manios Plate Armor	Male
+Mant_PlateArmor_Armor	Mant Plate Armor	Female
+Marathion_Leather_Boots	Marrada Leather Boots	Female
+Marcree_Fabric_Armor	Makri Cloth Armor	Male
+Marcs_PlateArmor_Armor	Malacs Plate Armor	Male
+Marctah_Fabric_Armor	Magta Cloth Armor	Male
+Mardain_Leather_Armor	Mardain Leather Armor	Male
+Maredid_Leather_Boots	Maldrick Leather Boots	Male
 Marigold	Marigold
 Mark_Fabric_Helm	Marc Cloth Headband
 Mark_Leather_Armor	Marc Leather Armor
-Mark_PlateArmor_Armor	Marc Plate Armor
-Markman_PlateArmor_Armor	Markman Plate Armor
+Mark_PlateArmor_Armor	Marc Plate Armor	Male
+Markman_PlateArmor_Armor	Markman Plate Armor	Male
 Markna_Leather_Gloves	Markna Leather Gloves
-Markris_Plate_Boots	Marcris Plate Boots
+Markris_Plate_Boots	Marcris Plate Boots	Male
 MarniDragon_DemenissLetter	Caliburn's Orders
 MarniDragon_GoldenStar	Golden Star Blueprint
 MarniDragon_MarniRen	Careful Observation of H.A.L.L.
 MarniDragon_Visione	The Features of the Visione
-MarniKnight_PlateArmor_Helm	Marni's Machina Knight Headgear
+MarniKnight_PlateArmor_Helm	Marni's Machina Knight Headgear	Male
 MarniMachineDrill	Marni Drill Component
 MarniMachineLaser	Marni Laser Component
 MarniTower_Key	Spire of Clockwork Key
-Marni_ChainMail_Boots	Marni's Chain Boots
-Marni_ChainMail_Gloves	Marni's Chain Gloves
+Marni_ChainMail_Boots	Marni's Chain Boots	Male
+Marni_ChainMail_Gloves	Marni's Chain Gloves	Male
 Marni_Devotee_PlateArmor_Helm	Visione
 Marni_Devotee_PlateArmor_Helm_I	Bespoke Visione
 Marni_Devotee_PlateArmor_Helm_II	Guard Visione
 Marni_Devotee_PlateArmor_Helm_III	Military Visione
 Marni_Devotee_PlateArmor_Helm_IV	Prototype Visione
-Marni_Fabric_Armor	Marni's Cloth Armor
+Marni_Fabric_Armor	Marni's Cloth Armor	Male
 Marni_HorseArmor_Armor	Exclaire Barding
 Marni_HorseArmor_Helm	Wells Military Champron
 Marni_HorseArmor_Stirrup	Marni Stirrups
@@ -3499,37 +3507,37 @@ Marni_MachineKnight_TwoHandSpear	Electro-Mecha Spear
 Marni_MachineKnight_TwoHandSword	Electro-Mecha Longsword
 Marni_Special_CannonBall	Disruptor Cannonball
 Marozzo_OneHandRapier	Elemore Rapier
-Marqueeluon_Fabric_Armor	Maquealon Cloth Armor
-Marthana_Leather_Armor	Matana Leather Armor
+Marqueeluon_Fabric_Armor	Maquealon Cloth Armor	Male
+Marthana_Leather_Armor	Matana Leather Armor	Male
 MartialArts_Secret_Manual	Secret Book of Unknown Source
-Martin_Leather_Boots	Martin's Leather Boots
-Martindue_Fabric_Armor	Marindo Cloth Armor
-Martins_Leather_Boots	Matrinne Leather Boots
+Martin_Leather_Boots	Martin's Leather Boots	Male
+Martindue_Fabric_Armor	Marindo Cloth Armor	Male
+Martins_Leather_Boots	Matrinne Leather Boots	Male
 Mask_Liberator_TwoHandedWarHammer	Oblivion of the Past
-MastKey_Gloves	MastKey Gloves
+MastKey_Gloves	MastKey Gloves	Male
 MasterDoo_Scroll	Master Du's Message
 Master_Key	Master Key
-Masty_PlateArmor_Gloves	Masti Plate Gloves
+Masty_PlateArmor_Gloves	Masti Plate Gloves	Male
 Mataka_Leather_Boots	Matahka Leather Boots
-Matar_Leather_Boots	Matar Leather Boots
-Matarion_PlateArmor_Helm	Matarion Plate Helm
-Matazu_Leather_Gloves	Martail Leather Gloves
-Matia_Leather_Boots	Matia Leather Boots
-Matiras_PlateArmor_Helm	Rhinoceros Plate Helm
-Matiras_PlateArmor_Helm_I	Beaked Plate Helm
-Matis_Leather_Boots	Matis Leather Greaves
-Matraon_Fabric_Armor	Metron Cloth Armor
-Mats_Leather_Gloves	Maters Leather Gloves
-Matthias_Leather_Gloves	Matthias' Leather Gloves
+Matar_Leather_Boots	Matar Leather Boots	Female
+Matarion_PlateArmor_Helm	Matarion Plate Helm	Male
+Matazu_Leather_Gloves	Martail Leather Gloves	Male
+Matia_Leather_Boots	Matia Leather Boots	Male
+Matiras_PlateArmor_Helm	Rhinoceros Plate Helm	Male
+Matiras_PlateArmor_Helm_I	Beaked Plate Helm	Male
+Matis_Leather_Boots	Matis Leather Greaves	Male
+Matraon_Fabric_Armor	Metron Cloth Armor	Male
+Mats_Leather_Gloves	Maters Leather Gloves	Male
+Matthias_Leather_Gloves	Matthias' Leather Gloves	Male
 Maturah_PlateArmor_Helm	Matarra Plate Helm
-Mauryth_Fabric_Armor	Mauryth Cloth Armor
-Mautey_PlateArmor_Helm	Mottie Plate Helm
-Mautey_PlateArmor_Helm_I	Blacksteel Mottie Plate Helm
-Mawin_Leather_Armor	Mavin Leather Armor
-Maydocs_Leather_Armor_I	Maydocs Leather Armor
-Maydocs_PlateArmor_Helm	Maydocs Plate Helm
-Mayon_PlateArmor_Armor	Mahon Plate Armor
-Meadows_Leather_Boots	Meadows Leather Boots
+Mauryth_Fabric_Armor	Mauryth Cloth Armor	Male
+Mautey_PlateArmor_Helm	Mottie Plate Helm	Male
+Mautey_PlateArmor_Helm_I	Blacksteel Mottie Plate Helm	Male
+Mawin_Leather_Armor	Mavin Leather Armor	Male
+Maydocs_Leather_Armor_I	Maydocs Leather Armor	Male
+Maydocs_PlateArmor_Helm	Maydocs Plate Helm	Male
+Mayon_PlateArmor_Armor	Mahon Plate Armor	Male
+Meadows_Leather_Boots	Meadows Leather Boots	Female
 Meat_BackPack	Hunter's Meat Pack
 Meat_Fish_Fruit_Sanjeok	Assorted Meat and Fish Skewers
 Meat_Fish_Fruit_Sanjeok_Large	Satisfying Assorted Meat and Fish Skewers
@@ -3571,7 +3579,7 @@ Meat_Vegetable_Porridge	Meat and Vegetable Porridge
 Meat_Vegetable_Porridge_Large	Satisfying Meat and Vegetable Porridge
 Meat_Vegetable_Porridge_Medium	Filling Meat and Vegetable Porridge
 Meat_Vegetable_Porridge_XLarge	Hearty Meat and Vegetable Porridge
-Mechlin_Leather_Gloves	Mechlin Leather Gloves
+Mechlin_Leather_Gloves	Mechlin Leather Gloves	Male
 Medikit_BackPack_I	Healer's Pack
 Medikit_BackPack_II	Healer's Pack
 Medikit_BackPack_III	Healer's Pack
@@ -3580,11 +3588,11 @@ Medikit_BackPack_V	Healer's Pack
 Medikit_BackPack_VI	Healer's Pack
 Medikit_BackPack_VII	Healer's Pack
 Medikit_BackPack_VIII	Healer's Pack
-Mediratu_Leather_Gloves	Merridew Leather Bracers
-Melina_Fabric_Armor	Melina Cloth Armor
-Melion_Leather_Cloak	Melion Leather Cloak
-Melvin_Leather_Gloves	Melvin Leather Gloves
-Melvin_Leather_Helm	Melvin Leather Cap
+Mediratu_Leather_Gloves	Merridew Leather Bracers	Male
+Melina_Fabric_Armor	Melina Cloth Armor	Male
+Melion_Leather_Cloak	Melion Leather Cloak	Male
+Melvin_Leather_Gloves	Melvin Leather Gloves	Male
+Melvin_Leather_Helm	Melvin Leather Cap	Male
 Memo_ButlerLeftMemo	A Butler's Note
 Memo_CabinLeftMemo	Note in the Cabin
 Memo_Judgment	Warning of Judgment
@@ -3604,52 +3612,52 @@ Memo_Serkis_Piece_2	Piece from Lioncrest Watchtower
 Memo_Serkis_Piece_3	Piece from Duskwood
 Memo_Serkis_Piece_4	Piece from St. Halssius
 Memo_lightningstriketree	Lightning-Struck Tree
-Meravan_Fabric_Armor	Meravan Cloth Armor
-Meravan_Fabric_Helm	Meravan Cloth Cap
-Meravan_Leather_Boots	Meravan Leather Greaves
-Mercenary_Gloves	Grey Wolf Leather Gloves
-Mercenary_Leather_Armor	Grey Wolf Leather Armor
-Mercenary_Leather_Boots	Grey Wolf Leather Boots
-Mercenary_Leather_Cloak	Grey Wolf Leather Cloak
+Meravan_Fabric_Armor	Meravan Cloth Armor	Male
+Meravan_Fabric_Helm	Meravan Cloth Cap	Male
+Meravan_Leather_Boots	Meravan Leather Greaves	Male
+Mercenary_Gloves	Grey Wolf Leather Gloves	Male
+Mercenary_Leather_Armor	Grey Wolf Leather Armor	Male
+Mercenary_Leather_Boots	Grey Wolf Leather Boots	Male
+Mercenary_Leather_Cloak	Grey Wolf Leather Cloak	Male
 Mercenary_OneHandShield	Freesword's Shield
-Mercenary_PlateArmor_Helm	Troll Gladiator's Plate Helm
-Mercenary_PlateArmor_Helm_I	Gladiator's Thorn Plate Helm
-Mercenary_PlateArmor_Helm_II	Gladiator's Rat Plate Helm
-Mercenary_PlateArmor_Helm_III	Gladiator's Rake Plate Helm
-Mercernary_OneHandBow	White Wood Bow
+Mercenary_PlateArmor_Helm	Troll Gladiator's Plate Helm	Male
+Mercenary_PlateArmor_Helm_I	Gladiator's Thorn Plate Helm	Male
+Mercenary_PlateArmor_Helm_II	Gladiator's Rat Plate Helm	Male
+Mercenary_PlateArmor_Helm_III	Gladiator's Rake Plate Helm	Male
+Mercernary_OneHandBow	White Wood Bow	Male
 Merchant_BackPack_I	Peddler's Pack
 Merchant_BackPack_II	Peddler's Pack
 Merchant_BackPack_III	Peddler's Pack
-Merly_Leather_Armor	Merly Leather Armor
-Mestio_OneHandBow	Bloodsteel Bow
+Merly_Leather_Armor	Merly Leather Armor	Male
+Mestio_OneHandBow	Bloodsteel Bow	Male
 Metal_Gate_Key	Iron Gate Key
 Methilbalm_OneHandShotgun	Metilbahm Shotgun
-Method_Fabric_Armor	Meishod Cloth Armor
-MiddleBoss_Caliburn_BlackTower_PlateArmor_Armor	Caliburn's Vice Captain Plate Armor
+Method_Fabric_Armor	Meishod Cloth Armor	Male
+MiddleBoss_Caliburn_BlackTower_PlateArmor_Armor	Caliburn's Vice Captain Plate Armor	Male
 MiddleBoss_GoldenArmor_TwoHandHammer_I	Golden Greathammer
-MiddleBoss_Pailoon_Ludvig_Leather_Gloves	Jackal Officer's Leather Gloves
-Midlier_Leather_Boots	Midlier Leather Boots
-Militia_Fabric_Cloak_I	Beighen Cloth Cloak
+MiddleBoss_Pailoon_Ludvig_Leather_Gloves	Jackal Officer's Leather Gloves	Male
+Midlier_Leather_Boots	Midlier Leather Boots	Male
+Militia_Fabric_Cloak_I	Beighen Cloth Cloak	Male
 Militia_Flag	Small Militia Banner Pike
 Milk	Milk
 Mine_BackPack_I	Quarrier's Pack
 Mine_BackPack_II	Quarrier's Pack
-Miner_PlateArmor_Helm	Miner's Lantern Hat
-Minigame_OneHandBow	Competition Wooden Bow
+Miner_PlateArmor_Helm	Miner's Lantern Hat	Male
+Minigame_OneHandBow	Competition Wooden Bow	Male
 Minigame_OneHandMusket	Competition Musket
 Minigame_OneHandShield	Competition Shield
 Minigame_OneHandSword	Competition Sword
 Minigame_TwoHandSpear	Competition Spear
 Mining_Drill	Mining Knuckledrill
-Mintuan_Fabric_Armor	Minnutan Cloth Armor
+Mintuan_Fabric_Armor	Minnutan Cloth Armor	Female
 Mjordin_Lantern	Flame Lantern
 Mjordin_OneHandSword	Melted Ambition
-Mocian_ChainMail_Armor	Moshane Chain Mail
-Mocke_Leather_Armor	Mocke Leather Armor
-Mohill_Leather_Armor	Mohill Leather Armor
-Molduer_Leather_Armor	Moldur Leather Armor
+Mocian_ChainMail_Armor	Moshane Chain Mail	Male
+Mocke_Leather_Armor	Mocke Leather Armor	Male
+Mohill_Leather_Armor	Mohill Leather Armor	Male
+Molduer_Leather_Armor	Moldur Leather Armor	Male
 MonasteryVisitorPass	St. Halssius Visitor Pass
-Mondian_Leather_Armor	Greymane Light Armor
+Mondian_Leather_Armor	Greymane Light Armor	Male
 Money_Camp_Food	Camp Food
 Money_Camp_Money	Camp Funds
 Money_Camp_Stone	Camp Stone
@@ -3659,110 +3667,110 @@ Money_Copper	Copper
 Money_Kuku_MachineBug	Clockwork Insect
 Money_Pearl	Pearl
 Monita_OneHandTowerShield	Balton Large Shield
-Montellanico_Leather_Armor	Montlanico Leather Armor
-Monterima_Fabric_Armor	Monterima Cloth Armor
-Moonhead_PlateArmor_Armor	Half Moon Reaper Plate Armor
-Moonhead_PlateArmor_Armor_Full	Full Moon Reaper Plate Armor
-Moonhead_PlateArmor_Armor_Waning	New Moon Reaper Plate Armor
-Moonhead_PlateArmor_Gloves	Lunar Reaper Plate Gloves
-Moonhead_PlateArmor_Helm	Half Moon Reaper Plate Helm
-Moonhead_PlateArmor_Helm_Full	Full Moon Reaper Plate Helm
-Moonhead_PlateArmor_Helm_Waning	New Moon Reaper Plate Helm
-Moonhead_Plate_Boots	Half Moon Reaper Plate Boots
-Moonhead_Plate_Boots_Full	Full Moon Reaper Plate Boots
-Moonhead_Plate_Boots_Waning	New Moon Reaper Plate Boots
-Morgren_Fabric_Armor	Morgren Cloth Armor
-Mornington_Fabric_Gloves	Mornington Cloth Gloves
-Mornington_Leather_Boots	Mornington Leather Boots
-Mortain_PlateArmor_Helm	Mortain Plate Helm
+Montellanico_Leather_Armor	Montlanico Leather Armor	Male
+Monterima_Fabric_Armor	Monterima Cloth Armor	Male
+Moonhead_PlateArmor_Armor	Half Moon Reaper Plate Armor	Male
+Moonhead_PlateArmor_Armor_Full	Full Moon Reaper Plate Armor	Male
+Moonhead_PlateArmor_Armor_Waning	New Moon Reaper Plate Armor	Male
+Moonhead_PlateArmor_Gloves	Lunar Reaper Plate Gloves	Male
+Moonhead_PlateArmor_Helm	Half Moon Reaper Plate Helm	Male
+Moonhead_PlateArmor_Helm_Full	Full Moon Reaper Plate Helm	Male
+Moonhead_PlateArmor_Helm_Waning	New Moon Reaper Plate Helm	Male
+Moonhead_Plate_Boots	Half Moon Reaper Plate Boots	Male
+Moonhead_Plate_Boots_Full	Full Moon Reaper Plate Boots	Male
+Moonhead_Plate_Boots_Waning	New Moon Reaper Plate Boots	Male
+Morgren_Fabric_Armor	Morgren Cloth Armor	Male
+Mornington_Fabric_Gloves	Mornington Cloth Gloves	Male
+Mornington_Leather_Boots	Mornington Leather Boots	Male
+Mortain_PlateArmor_Helm	Mortain Plate Helm	Male
 Mortimer_OneHandShotgun	Mortimer Shotgun
-Muchia_Fabric_Armor	Muchia Cloth Armor
-Muchia_Fabric_Helm	Muchia Cloth Cap
-Muddlers_Fabric_Armor	Muddliss Cloth Armor
-Mueo_PlateArmor_Armor	Meyer Plate Armor
+Muchia_Fabric_Armor	Muchia Cloth Armor	Female
+Muchia_Fabric_Helm	Muchia Cloth Cap	Male
+Muddlers_Fabric_Armor	Muddliss Cloth Armor	Male
+Mueo_PlateArmor_Armor	Meyer Plate Armor	Male
 Mueo_PlateArmor_Armor_I	Meyer Plate Armor
-Mueo_PlateArmor_Armor_II	Meyer Plate Armor
+Mueo_PlateArmor_Armor_II	Meyer Plate Armor	Male
 Mueo_PlateArmor_Armor_III	Meyer Plate Armor
-Muglah_Fabric_Armor	Mugleah Cloth Armor
-Muglah_Fabric_Armor_II	The Wyvernflames Vice Captain's Cloth Armor
-Mulia_Leather_Boots	Mulia Leather Boots
+Muglah_Fabric_Armor	Mugleah Cloth Armor	Male
+Muglah_Fabric_Armor_II	The Wyvernflames Vice Captain's Cloth Armor	Male
+Mulia_Leather_Boots	Mulia Leather Boots	Male
 MultiArrow	Bundle of Arrows
 MultiArrow_Package_Small	Bundle of Arrows
 MultiBullet	Bundle of Bullets
 MultiBullet_Package_Small	Bundle of Bullets
 MultiCannonBall	Bundle of Cannonballs
 MultiCannonBall_Package_Small	Bundle of Cannonballs
-Munterd_Leather_Boots	Munndt Leather Boots
+Munterd_Leather_Boots	Munndt Leather Boots	Male
 Murard_Leather_Armor	Murad Leather Armor
-Muscan_Ghost_Fist	Muskan's Upper Body Clone
-Muscan_Ghost_Fist_I	Muskan's Lower Body Clone
-Muscan_PlateArmor_Armor	Muskan Armor
-Muscan_PlateArmor_Gloves	Champion's Plate Gloves
+Muscan_Ghost_Fist	Muskan's Upper Body Clone	Male
+Muscan_Ghost_Fist_I	Muskan's Lower Body Clone	Male
+Muscan_PlateArmor_Armor	Muskan Armor	Male
+Muscan_PlateArmor_Gloves	Champion's Plate Gloves	Male
 Mynein_OneHandRapier	Gilliam Rapier
-Myrenenn_Fabric_Armor	Myrnen Cloth Armor
-Mysterm_Leather_Boots	Mistum Leather Boots
-Mysterm_Leather_Gloves	Mistum Leather Gloves
-Myurdin_Leather_Armor_II	Myurdin's Leather Armor
-Myurdin_Leather_Boots	Myurdin's Leather Boots
+Myrenenn_Fabric_Armor	Myrnen Cloth Armor	Male
+Mysterm_Leather_Boots	Mistum Leather Boots	Male
+Mysterm_Leather_Gloves	Mistum Leather Gloves	Male
+Myurdin_Leather_Armor_II	Myurdin's Leather Armor	Male
+Myurdin_Leather_Boots	Myurdin's Leather Boots	Male
 NahabVillage_Pendant	Nahab Pendant
-Nahu_ChainMail_Helm	Nahu Chain Coif
+Nahu_ChainMail_Helm	Nahu Chain Coif	Male
 Nairaden_OneHandMace	Iris Mace
-Nairah_Basic_Leather_Armor	Naira's Basic Attire
-Nairah_Basic_Leather_Cloak	Naira's Cloak
-Nairah_Leather_Boots	Naira's Boots
-Nairah_Leather_Gloves	Naira's Gloves
-Nakmore_Leather_Boots	Nagmore Leather Boots
+Nairah_Basic_Leather_Armor	Naira's Basic Attire	Female
+Nairah_Basic_Leather_Cloak	Naira's Cloak	Female
+Nairah_Leather_Boots	Naira's Boots	Female
+Nairah_Leather_Gloves	Naira's Gloves	Female
+Nakmore_Leather_Boots	Nagmore Leather Boots	Male
 Namarc_TwoHandedWarHammer	Saltroad Warhammer
 Nantukka_Fabric_Armor	Nantuka Cloth Armor
 Natural_Enemy_Mask	Blinding Arrow's Mask
-Natural_Enemy_PlateArmor_Helm	Thunderbird Mask Plate Helm
-Navan_Fabric_Armor	Navan Cloth Armor
+Natural_Enemy_PlateArmor_Helm	Thunderbird Mask Plate Helm	Male
+Navan_Fabric_Armor	Navan Cloth Armor	Male
 Navet	Turnip
-NearNym_Leather_Boots	Neirnim Leather Boots
-Neblin_Fabric_Armor	Neblin Cloth Armor
-Nellaccio_Leather_Armor	Nellaccio Leather Armor
-Nelton_Leather_Armor	Nelton Leather Armor
-Nerdhal_OneHandBow	Warspike Bow
+NearNym_Leather_Boots	Neirnim Leather Boots	Female
+Neblin_Fabric_Armor	Neblin Cloth Armor	Male
+Nellaccio_Leather_Armor	Nellaccio Leather Armor	Male
+Nelton_Leather_Armor	Nelton Leather Armor	Male
+Nerdhal_OneHandBow	Warspike Bow	Male
 Neut_Delpheon_EMP_key	Gate of Peace Disruptor Key
-NeutralZone_PlateArmor_Helm	Gorthak Orc's Helm
-Nevin_Leather_Boots	Nevin Leather Boots
-Nickna_Leather_Boots	Northern Fighter's Leather Boots
-Nihrutte_Leather_Armor	Nehrut Leather Armor
-Nihrutte_Leather_Boots	Nehrut Leather Shoes
-NoName_Wiseman_Leather_Armor	Nameless Sage's Leather Armor
-NoName_Wiseman_Leather_Cloak	Nameless Sage's Leather Cloak
-NoName_Wiseman_Leather_Gloves_I	Nameless Sage's Leather Gloves
-Noble_Fabric_Armor	Noble Cloth Armor
-Noble_Leather_Helm	Noble's Hat
-Noble_Retainer_Leather_Gloves	Private Soldier's Leather Gloves
-Noble_Retainer_PlateArmor_Armor	Sungrove Standard Plate Armor
-Noble_Retainer_PlateArmor_Armor_I	Marshell Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_II	Marshell Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_III	Azerian Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_IV	Azerian Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_V	Azerian Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_VI	Elemore Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_VII	Elemore Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_VIII	Elemore Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_X	Byron's Soldier Plate Armor
-Noble_Retainer_PlateArmor_Armor_XI	Windmere Standard Plate Armor
-Noble_Retainer_PlateArmor_Armor_XII	Byron's Soldier Plate Armor
-Noble_Retainer_PlateArmor_Armor_XIII	Byron's Soldier Plate Armor
-Noble_Retainer_PlateArmor_Armor_XIV	Private Soldier's Plate Armor
-Noble_Retainer_PlateArmor_Armor_XV	Private Soldier's Plate Armor
-Nocburn_Leather_Gloves	Nocburn Leather Gloves
+NeutralZone_PlateArmor_Helm	Gorthak Orc's Helm	Male
+Nevin_Leather_Boots	Nevin Leather Boots	Male
+Nickna_Leather_Boots	Northern Fighter's Leather Boots	Male
+Nihrutte_Leather_Armor	Nehrut Leather Armor	Male
+Nihrutte_Leather_Boots	Nehrut Leather Shoes	Male
+NoName_Wiseman_Leather_Armor	Nameless Sage's Leather Armor	Male
+NoName_Wiseman_Leather_Cloak	Nameless Sage's Leather Cloak	Male
+NoName_Wiseman_Leather_Gloves_I	Nameless Sage's Leather Gloves	Male
+Noble_Fabric_Armor	Noble Cloth Armor	Male
+Noble_Leather_Helm	Noble's Hat	Male
+Noble_Retainer_Leather_Gloves	Private Soldier's Leather Gloves	Male
+Noble_Retainer_PlateArmor_Armor	Sungrove Standard Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_I	Marshell Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_II	Marshell Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_III	Azerian Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_IV	Azerian Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_V	Azerian Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_VI	Elemore Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_VII	Elemore Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_VIII	Elemore Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_X	Byron's Soldier Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_XI	Windmere Standard Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_XII	Byron's Soldier Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_XIII	Byron's Soldier Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_XIV	Private Soldier's Plate Armor	Male
+Noble_Retainer_PlateArmor_Armor_XV	Private Soldier's Plate Armor	Male
+Nocburn_Leather_Gloves	Nocburn Leather Gloves	Male
 Noname_OneHandDagger	Varnian Dagger
-Norman_Leather_Boots	Norman Leather Boots
-Norswitch_Leather_Armor	Norswich Leather Armor
-North_Mercenary_Fabric_Cloak_I	Jackal Cloth Cloak
-North_Mercenary_Leather_Armor_I	Jackals' Leather Armor
-North_Mercenary_Leather_Armor_II	Jackals' Leather Armor
-North_Mercenary_Leather_Armor_III	Jackals' Leather Armor
-North_Mercenary_Leather_Armor_IV	Jackals' Leather Armor
-North_Mercenary_Leather_Gloves_III	Northern Freesword's Leather Bracers
+Norman_Leather_Boots	Norman Leather Boots	Male
+Norswitch_Leather_Armor	Norswich Leather Armor	Male
+North_Mercenary_Fabric_Cloak_I	Jackal Cloth Cloak	Male
+North_Mercenary_Leather_Armor_I	Jackals' Leather Armor	Male
+North_Mercenary_Leather_Armor_II	Jackals' Leather Armor	Male
+North_Mercenary_Leather_Armor_III	Jackals' Leather Armor	Male
+North_Mercenary_Leather_Armor_IV	Jackals' Leather Armor	Male
+North_Mercenary_Leather_Gloves_III	Northern Freesword's Leather Bracers	Male
 North_Warrior_OneHandTowerShield	North Wind Shield
 North_Warrior_TwoHandSpear	North Wind Trident
-Northernbead_Leather_Armor	Nordbeid Leather Armor
+Northernbead_Leather_Armor	Nordbeid Leather Armor	Male
 Notepad	Notepad
 NoticePaper_ArmWrestle	Recruiting Arm Wrestlers
 NoticePaper_BloodWalkerCrussis	Bounty on the Bloodied Monster
@@ -3828,92 +3836,94 @@ NoticePaper_Skill_Wrestle_AirBodySlam	Hernand Constabulary Warning Notice No. 10
 NoticePaper_Skill_Wrestle_GrabSpinThrow	Pailune Anonymous Jottings No. 77
 NoticePaper_Skill_Wrestle_Lariat	Call for Challengers: Black Bear
 NoticePaper_Village_Muiquun	Request to Punish Outlaws in Muiquun
-Noyvarn_Leather_Armor	Noyvarn Leather Armor
+Noyvarn_Leather_Armor	Noyvarn Leather Armor	Male
 Nureumjeok	Mixed Skewers
 Nureumjeok_Large	Satisfying Mixed Skewers
 Nureumjeok_Medium	Filling Mixed Skewers
 Nureumjeok_XLarge	Hearty Mixed Skewers
-Nusiran_Fabric_Armor	Nuslan Cloth Armor
-Nusiran_Leather_Armor	Nuslan Leather Armor
+Nusiran_Fabric_Armor	Nuslan Cloth Armor	Male
+Nusiran_Leather_Armor	Nuslan Leather Armor	Male
 Nysron_Fabric_Armor	Neslan Cloth Armor
 OOngka_Daeil_Band	Oongka's Axiom Bracelet
-Oakleyman_PlateArmor_Armor	Oakley Plate Armor
-Oakten_Leather_Boots	Oakten Leather Boots
+OakBarrel_Mimic_Leather_Armor	Oak Barrel Leather Armor	Male
+Oakleyman_PlateArmor_Armor	Oakley Plate Armor	Male
+Oakten_Leather_Boots	Oakten Leather Boots	Male
 Oathring_OneHandShield	Oath Ring Shield
 Oats	Oats
-Obit_Leather_Boots	Orbit Leather Boots
-Odori_Fabric_Armor	Odorrey Cloth Armor
-Oharah_Leather_Armor	Ohara Leather Armor
+Obit_Leather_Boots	Orbit Leather Boots	Male
+Odori_Fabric_Armor	Odorrey Cloth Armor	Male
+Oharah_Leather_Armor	Ohara Leather Armor	Male
 Oil_Barrel	Oil Canister
 Oil_Sprayer_BackPack	Lubricant Sprayer
 Old_HorseArmor_Saddle	Shabby Horse Saddle
 Old_Kliff_OneHandSword	Fated Shadow
-Old_Kliff_PlateArmor_Armor	Goyen's Plate Armor
-Old_Kliff_PlateArmor_Cloak	Goyen's Cloak
-Old_Kliff_PlateArmor_Gloves	Goyen's Plate Gloves
-Old_Kliff_Plate_Boots	Goyen's Plate Boots
+Old_Kliff_PlateArmor_Armor	Goyen's Plate Armor	Male
+Old_Kliff_PlateArmor_Cloak	Goyen's Cloak	Male
+Old_Kliff_PlateArmor_Gloves	Goyen's Plate Gloves	Male
+Old_Kliff_Plate_Boots	Goyen's Plate Boots	Male
 Old_Necklace	Worn Necklace
 Old_Ring	Worn Ring
 Old_Wood_Doll_II	Old Wooden Doll
 Old_Wood_OneHandShield	Bekker Shield
 Oleander	Rosebay
-Oltmann_ChainMail_Armor	Oltmann Chain Mail
-Ondrikhan_Leather_Armor	Undriga Leather Armor
+Oltmann_ChainMail_Armor	Oltmann Chain Mail	Male
+Ondrikhan_Leather_Armor	Undriga Leather Armor	Male
 Onion	Onion
-Oongka_Basic_Leather_Armor	Ashen Wolf's Leather Armor
-Oongka_Basic_Leather_Cloak	Ashen Wolf's Leather Cloak
-Oongka_Basic_Leather_Gloves	Ashen Wolf's Leather Gloves
-Oongka_PlateArmor_Armor_II	Valortread Plate Armor
-Oongka_PlateArmor_Armor_III	Belkandor Plate Armor
-Oongka_PlateArmor_Boots_II	Valortread Plate Boots
-Oongka_PlateArmor_Boots_III	Belkandor Plate Boots
-Oongka_PlateArmor_Cloak_II	Valortread Plate Cloak
-Oongka_PlateArmor_Cloak_III	Belkandor Plate Cloak
-Oongka_PlateArmor_Gloves_II	Valortread Plate Gloves
-Oongka_PlateArmor_Gloves_III	Belkandor Plate Gloves
-Oongka_PlateArmor_Helm_II	Valortread Plate Helm
-Oongka_PlateArmor_Helm_III	Belkandor Plate Helm
-Oongka_Plate_Glove	Brass Warden's Plate Gloves
-Oongka_Rocket_BackPack	Kuku Rocket Pack
-Oongka_Rocket_Helm	Kuku Rocket Helmet - Equipped by Default
-Ophenber_PlateArmor_Helm	Offenberg Plate Helm
-Optionary_Beekeeping_Cloak	Beekeeping Cloak
-Optionary_Beekeeping_Cloth	Beekeeping Suit
-Optionary_Beekeeping_Leather_Boots	Beekeeping Boots
-Optionary_Beekeeping_Leather_Gloves	Beekeeping Gloves
-Optionary_Bleed_Fabric_Armor	Scarlet Blades Cloth Armor
-Optionary_Demeniss_Soldier_Armor	Demeniss Ceremonial Plate Armor
-Optionary_Demeniss_Soldier_Cloak	Demeniss Ceremonial Cloak
-Optionary_Demeniss_Spy_Cloak	Disguise Cloak
-Optionary_Demeniss_Spy_Cloth	Camouflage Outfit
-Optionary_Desert_Plunderer_Helmet	Desert Marauder's Plate Helm
-Optionary_Ent_Boots	Shadowleaf Boots
-Optionary_Ent_Cloak	Shadowleaf Cloak
-Optionary_Ent_Cloth	Shadowleaf Outfit
-Optionary_Ent_Gloves	Shadowleaf Gloves
-Optionary_Ent_Helm	Shadowleaf Helm
-Optionary_Florin_Cloth	Pororin Cloth Attire
-Optionary_Hernand_Party_Cloak	Hernandian Cloak
-Optionary_Hernand_Party_Cloth	Hernandian Attire
-Optionary_Monk_Cloth	St. Halssius Priest Attire
+Oongka_Basic_Leather_Armor	Ashen Wolf's Leather Armor	Male
+Oongka_Basic_Leather_Cloak	Ashen Wolf's Leather Cloak	Male
+Oongka_Basic_Leather_Gloves	Ashen Wolf's Leather Gloves	Male
+Oongka_PlateArmor_Armor_II	Valortread Plate Armor	Male
+Oongka_PlateArmor_Armor_III	Belkandor Plate Armor	Male
+Oongka_PlateArmor_Boots_II	Valortread Plate Boots	Male
+Oongka_PlateArmor_Boots_III	Belkandor Plate Boots	Male
+Oongka_PlateArmor_Cloak_II	Valortread Plate Cloak	Male
+Oongka_PlateArmor_Cloak_III	Belkandor Plate Cloak	Male
+Oongka_PlateArmor_Gloves_II	Valortread Plate Gloves	Male
+Oongka_PlateArmor_Gloves_III	Belkandor Plate Gloves	Male
+Oongka_PlateArmor_Helm_II	Valortread Plate Helm	Male
+Oongka_PlateArmor_Helm_III	Belkandor Plate Helm	Male
+Oongka_Plate_Glove	Brass Warden's Plate Gloves	Male
+Oongka_Rocket_BackPack	Kuku Rocket Pack	Male
+Oongka_Rocket_Helm	Kuku Rocket Helmet - Equipped by Default	Male
+Ophenber_PlateArmor_Helm	Offenberg Plate Helm	Male
+Optionary_Beekeeping_Cloak	Beekeeping Cloak	Male
+Optionary_Beekeeping_Cloth	Beekeeping Suit	Male
+Optionary_Beekeeping_Leather_Boots	Beekeeping Boots	Male
+Optionary_Beekeeping_Leather_Gloves	Beekeeping Gloves	Male
+Optionary_Bleed_Fabric_Armor	Scarlet Blades Cloth Armor	Male
+Optionary_Demeniss_Soldier_Armor	Demeniss Ceremonial Plate Armor	Male
+Optionary_Demeniss_Soldier_Cloak	Demeniss Ceremonial Cloak	Male
+Optionary_Demeniss_Spy_Cloak	Disguise Cloak	Male
+Optionary_Demeniss_Spy_Cloth	Camouflage Outfit	Male
+Optionary_Desert_Plunderer_Helmet	Desert Marauder's Plate Helm	Male
+Optionary_Ent_Boots	Shadowleaf Boots	Male
+Optionary_Ent_Cloak	Shadowleaf Cloak	Male
+Optionary_Ent_Cloth	Shadowleaf Outfit	Male
+Optionary_Ent_Gloves	Shadowleaf Gloves	Male
+Optionary_Ent_Helm	Shadowleaf Helm	Male
+Optionary_Florin_Cloth	Pororin Cloth Attire	Male
+Optionary_Hernand_Party_Cloak	Hernandian Cloak	Male
+Optionary_Hernand_Party_Cloth	Hernandian Attire	Male
+Optionary_Monk_Cloth	St. Halssius Priest Attire	Male
 Optionary_Monk_Necklace	Saint's Necklace
-Optionary_Monk_cloak	St. Halssius Priest's Cloak
-Optionary_NonSlip_Boots	Stirrups of the Open Sky
-Optionary_NonSlip_Gloves	Reins of Open Sky
-Optionary_Scholar_Stone_Cloth	Scholastone Uniform
-Optionary_Scholar_Stone_cloak	Scholastone Cloak
+Optionary_Monk_cloak	St. Halssius Priest's Cloak	Male
+Optionary_NonSlip_Boots	Stirrups of the Open Sky	Male
+Optionary_NonSlip_Gloves	Reins of Open Sky	Male
+Optionary_Scholar_Stone_Cloth	Scholastone Uniform	Male
+Optionary_Scholar_Stone_cloak	Scholastone Cloak	Male
 Opuntia_seed	Prickly Pear Seed
 Orange	Orange
-Orbs_Fabric_Armor	Orbus Cloth Armor
-Orbs_Fabric_Armor_I	The Faceless Vice Captain's Cloth Armor
+Orbs_Fabric_Armor	Orbus Cloth Armor	Male
+Orbs_Fabric_Armor_I	The Faceless Vice Captain's Cloth Armor	Male
 Orc_Flag_I	Small Ironflame Orcs Banner Pike
 Orc_Flag_II	Medium Ironflame Orcs Banner Pike
-Orc_OneHandCannon	Orc Blaster
+Orc_OneHandCannon	Orc Blaster	Male
 Orc_Warrior_OneHandMace	Octarr's Legacy
-OrcuMer_Fabric_Armor	T'rukan's Cloth Armor
-OrcuMer_Fabric_Boots	T'rukan's Cloth Boots
-OrcuMer_Fabric_Cloak	T'rukan's Cloth Cloak
-OrcuMer_Fabric_Gloves	T'rukan's Cloth Gloves
+OrcuMer_Fabric_Armor	Martial Monk's Cloth Robe	Male
+OrcuMer_Fabric_Boots	Martial Monk's Cloth Boots	Male
+OrcuMer_Fabric_Cloak	T'rukan's Cloth Cloak	Male
+OrcuMer_Fabric_Gloves	Damaged Martial Monk's Cloth Gloves	Male
+OrcuMer_Fabric_Gloves_I	Martial Monk's Cloth Gloves	Male
 OrcuMer_PlateArmor_Armor	Odeck's Protector Plate Armor
 OrcuMer_PlateArmor_Cloak	Odeck's Protector Plate Cloak
 OrcuMer_PlateArmor_Gloves	Odeck's Protector Plate Gloves
@@ -3925,28 +3935,28 @@ Orjekel_HorseArmor_Armor	Varnian Barding
 Orjekel_HorseArmor_Helm	Varnian Champron
 Orjekel_HorseArmor_Saddle	Varnian Saddle
 Orjekel_HorseArmor_Stirrup	Varnian Stirrups
-Ort_Fabric_Armor	Ort Cloth Armor
-Orthu_Fabric_Armor	Orthu Cloth Armor
-Orton_Fabric_Armor	Orton Cloth Armor
-Otant_PlateArmor_Armor	Ostent Plate Armor
-Ouvre_Fabric_Armor	Oubreve Cloth Armor
-Owls_of_the_Mist_Leahter_Armor_I	Mistcloaked Owl Leather Armor
-Owls_of_the_Mist_Leahter_Armor_II	Mistcloaked Owl Leather Armor
-Owls_of_the_Mist_Leahter_Armor_III	Mistcloaked Owl Leather Armor
-Owls_of_the_Mist_Leahter_Armor_IV	Mistcloaked Owl Leather Armor
-Owls_of_the_Mist_Leahter_Armor_V	Mistcloaked Owl Leather Armor
+Ort_Fabric_Armor	Ort Cloth Armor	Male
+Orthu_Fabric_Armor	Orthu Cloth Armor	Male
+Orton_Fabric_Armor	Orton Cloth Armor	Male
+Otant_PlateArmor_Armor	Ostent Plate Armor	Male
+Ouvre_Fabric_Armor	Oubreve Cloth Armor	Male
+Owls_of_the_Mist_Leahter_Armor_I	Mistcloaked Owl Leather Armor	Male
+Owls_of_the_Mist_Leahter_Armor_II	Mistcloaked Owl Leather Armor	Female
+Owls_of_the_Mist_Leahter_Armor_III	Mistcloaked Owl Leather Armor	Male
+Owls_of_the_Mist_Leahter_Armor_IV	Mistcloaked Owl Leather Armor	Male
+Owls_of_the_Mist_Leahter_Armor_V	Mistcloaked Owl Leather Armor	Male
 Owls_of_the_Mist_Leather_Boots	Mistcloaked Owl Leather Boots
-Owls_of_the_Mist_Leather_Cloak	Mistcloaked Owl Leather Cloak
-Owls_of_the_Mist_PlateArmor_Helm	Mistcloaked Owl Plate Helm
+Owls_of_the_Mist_Leather_Cloak	Mistcloaked Owl Leather Cloak	Male
+Owls_of_the_Mist_PlateArmor_Helm	Mistcloaked Owl Plate Helm	Male
 Owls_of_the_Mist_PlateArmor_Helm_II	Mistcloaked Owl Plate Helm
-Paijal_PlateArmor_Helm	Paizel Bone Helm
+Paijal_PlateArmor_Helm	Paizel Bone Helm	Male
 Pailoon_OneHandMace	Savage Woodland Spirit Killer
 Pailune_Contribution_Flag	Pailunese Contribution Banner Pike
 Pailune_Necklace	Blue Fang Necklace
 Pailune_Nobility_Degree_I	Pailunese Signet
-Palen_Leather_Armor	Palen Leather Armor
-Paliano_Leather_Armor	Paliano Leather Armor
-Paltz_Leather_Armor	Paltz Leather Armor
+Palen_Leather_Armor	Palen Leather Armor	Male
+Paliano_Leather_Armor	Paliano Leather Armor	Male
+Paltz_Leather_Armor	Paltz Leather Armor	Female
 Pan_fried_Fish_Fruit_Pancake	Seafood Stew
 Pan_fried_Fish_Fruit_Pancake_Large	Satisfying Seafood Stew
 Pan_fried_Fish_Fruit_Pancake_Medium	Filling Seafood Stew
@@ -4008,7 +4018,7 @@ Pan_fried_Vegetable_Pancake_Large	Satisfying Battered Vegetables
 Pan_fried_Vegetable_Pancake_Medium	Filling Battered Vegetables
 Pan_fried_Vegetable_Pancake_XLarge	Hearty Battered Vegetables
 Pansy	Pansy
-Pantafe_Fabric_Armor	Pantafe Cloth Armor
+Pantafe_Fabric_Armor	Pantafe Cloth Armor	Male
 Paper_Adelina	Adrina's Note
 Paper_Adelina_I	Carpenter's Note
 Paper_Adelina_II	Training Field Note
@@ -4079,17 +4089,17 @@ Paper_Ugmum	Ugmon's Note
 Paper_VegetableBox	Produce Order Form
 Paphneil_PlateArmor_Armor	Scorchflame Plate Armor
 Paphneil_PlateArmor_Armor_Upgrade	Kuku Flame-Resistant Armor
-Paphneil_PlateArmor_Cloak	Scorchflame Plate Cloak
+Paphneil_PlateArmor_Cloak	Scorchflame Plate Cloak	Male
 Parachu_OneHandAxe	Parashu Axe
 Paralyze_OneHandSword	Sword of Wayward Woods
-Parastis_PlateArmor_Helm	Parasis Plate Helm
-Parmen_PlateArmor_Gloves	Ferman Plate Gloves
+Parastis_PlateArmor_Helm	Parasis Plate Helm	Male
+Parmen_PlateArmor_Gloves	Ferman Plate Gloves	Male
 Parsley	Parsley
-Parvel_Giant_TwoHandGiantBastard	Parvel Greatsword
+Parvel_Giant_TwoHandGiantBastard	Parvel Greatsword	Female
 Pasti_Leather_Boots	Pasti Leather Boots
 Patent_Leather_Gloves	Patten's Leather Gloves
 Patent_Leather_Gloves_I	Patten's Leather Gloves
-Patika_Fabric_Armor	Patika Cloth Armor
+Patika_Fabric_Armor	Patika Cloth Armor	Male
 Patrol_OneHandShield	Odeck Hardwood Shield
 Pattern_Bronze_Earring	Engraved Copper Earring
 Pattern_Copper_Necklace	Engraved Copper Necklace
@@ -4099,23 +4109,23 @@ Pattern_Gold_Earring	Engraved Gold Earring
 Pattern_Silver_Earring	Engraved Silver Earring
 Pattern_Silver_Necklace	Engraved Silver Necklace
 Pattern_Silver_Ring	Ancient Shell Ring
-Pauherr_Fabric_Armor	Pouhel Cloth Armor
-Paulus_Basic_Leather_Armor	Ironwilled Guardian's Leather Armor
-Paulus_Basic_Leather_cloak	Ironwilled Guardian's Leather Cloak
-Paulus_Leather_Boots	Ironwilled Guardian's Leather Boots
-Paulus_Leather_Gloves	Ironwilled Guardian's Leather Gloves
-Paunah_Leather_Boots	Pahna Leather Boots
-Paunah_OneHandBow	Bekker Bow
-Pavis_Leather_Boots	Pavis Leather Boots
-Pavis_Leather_Boots_I	Pavis Leather Boots
+Pauherr_Fabric_Armor	Pouhel Cloth Armor	Male
+Paulus_Basic_Leather_Armor	Ironwilled Guardian's Leather Armor	Male
+Paulus_Basic_Leather_cloak	Ironwilled Guardian's Leather Cloak	Male
+Paulus_Leather_Boots	Ironwilled Guardian's Leather Boots	Male
+Paulus_Leather_Gloves	Ironwilled Guardian's Leather Gloves	Male
+Paunah_Leather_Boots	Pahna Leather Boots	Female
+Paunah_OneHandBow	Bekker Bow	Male
+Pavis_Leather_Boots	Pavis Leather Boots	Male
+Pavis_Leather_Boots_I	Pavis Leather Boots	Male
 Pavis_OneHandTowerShield	Gilliam Large Shield
 Peach	Peach
 Peach_Seed	Peach Seed
 Pear	Pear
 PearTree_Seed	Pear Tree Seed
 Peony	Peony
-Peori_Leather_Gloves	Fiori Leather Gloves
-Perelli_Leather_Boots	Perelli Leather Boots
+Peori_Leather_Gloves	Fiori Leather Gloves	Male
+Perelli_Leather_Boots	Perelli Leather Boots	Male
 Permit_Bei_General	Provisions Supply Contract - Beighen
 Permit_Cal_Costume	Outfit Supply Contract - Calphade
 Permit_Cal_Equipment	Equipment Supply Contract - Calphade
@@ -4167,9 +4177,9 @@ Permit_Var_General	Provisions Supply Contract - Varnia
 Permit_Var_Seed	Seed Supply Contract - Varnia
 Permit_Var_Tavern	Food Supply Contract - Varnia
 Permit_Vellua_General	Provisions Supply Contract - Vellua
-Persein_Leather_Gloves	Persein Leather Gloves
-Persein_Leather_Gloves_I	Persein Leather Gloves
-Perseus_Leather_Gloves	Perseus Leather Gloves
+Persein_Leather_Gloves	Persein Leather Gloves	Male
+Persein_Leather_Gloves_I	Persein Leather Gloves	Male
+Perseus_Leather_Gloves	Perseus Leather Gloves	Male
 Pervin_Bomb	Perwin Explosive
 PetArmor_Fabric_Helm_WyvernBaby	Small Wyvern Aviator Hat
 PetArmor_Helm_Cucubirdbaby	Small Kuku Bird Eggshell
@@ -4197,50 +4207,50 @@ Pet_Slot_Expansion_2_2	Haven for Pets
 Pet_Slot_Expansion_2_3	Haven for Pets
 Pet_Slot_Expansion_3	Large Haven for Pets
 Pet_Slot_Expansion_Start	Small Haven for Pets
-Petra_Leather_Gloves	Petra Leather Gloves
-Phavan_Leather_Armor	Favan Leather Armor
+Petra_Leather_Gloves	Petra Leather Gloves	Male
+Phavan_Leather_Armor	Favan Leather Armor	Male
 Philaphy_OneHandMace	Thalwynd Hammer
-Piatol_Leather_Boots	Fiatol Leather Boots
-Pictead_Leather_Armor	Pictead Leather Armor
+Piatol_Leather_Boots	Fiatol Leather Boots	Male
+Pictead_Leather_Armor	Pictead Leather Armor	Male
 Pieren_OneHandMace	Sydmon Hammer
-Pierpont_Leather_Boots	Pierpont Leather Boots
-Pieti_Leather_Boots	Pieti Leather Boots
-Pieti_OneHandBow	Dekarr Bow
+Pierpont_Leather_Boots	Pierpont Leather Boots	Male
+Pieti_Leather_Boots	Pieti Leather Boots	Male
+Pieti_OneHandBow	Dekarr Bow	Male
 Pietisus_TwoHandedWarHammer	Dark Worshiper's Staff
-Pinball_Fabric_Helm	Circus Jester Hat
+Pinball_Fabric_Helm	Circus Jester Hat	Male
 Pineapple	Pineapple
-Pioneer_Fabric_Armor	Pioneer Cloth Armor
+Pioneer_Fabric_Armor	Pioneer Cloth Armor	Male
 Piranhas_Report	Sighting of the Piranha
-Pirante_PlateArmor_Armor	Frente Plate Armor
-Pirate_Fabric_Armor	Pirate Cloth Armor
-Pirate_Fabric_Armor_I	Pirate Cloth Armor
-Pirate_Fabric_Armor_II	Dancing Catfish Cloth Armor
-Pirate_Fabric_Armor_III	Pirate Cloth Armor
-Pirate_Fabric_Armor_IV	Pirate Cloth Armor
-Pirate_King_Leather_Helm	Pirate King Hat
-Pirate_PlateArmor_Gloves	Pirate Plate Gloves
-Pirate_PlateArmor_Gloves_I	Pirate Plate Gloves
-Pirate_Vice_Captain_Armor	The Singing Catfish Vice Captain's Armor
-Pirin_Leather_Armor	Pirin Leather Armor
-Pisoniano_Leather_Armor	Pisonia Leather Armor
-Pitspec_PlateArmor_Armor	Unyielding Warrior's Plate Armor
-Pitspec_PlateArmor_Cloak	Unyielding Warrior's Plate Cloak
+Pirante_PlateArmor_Armor	Frente Plate Armor	Male
+Pirate_Fabric_Armor	Pirate Cloth Armor	Male
+Pirate_Fabric_Armor_I	Pirate Cloth Armor	Male
+Pirate_Fabric_Armor_II	Dancing Catfish Cloth Armor	Male
+Pirate_Fabric_Armor_III	Pirate Cloth Armor	Male
+Pirate_Fabric_Armor_IV	Pirate Cloth Armor	Male
+Pirate_King_Leather_Helm	Pirate King Hat	Male
+Pirate_PlateArmor_Gloves	Pirate Plate Gloves	Male
+Pirate_PlateArmor_Gloves_I	Pirate Plate Gloves	Male
+Pirate_Vice_Captain_Armor	The Singing Catfish Vice Captain's Armor	Male
+Pirin_Leather_Armor	Pirin Leather Armor	Male
+Pisoniano_Leather_Armor	Pisonia Leather Armor	Male
+Pitspec_PlateArmor_Armor	Unyielding Warrior's Plate Armor	Male
+Pitspec_PlateArmor_Cloak	Unyielding Warrior's Plate Cloak	Male
 PlainsGuard_OneHandShield	Musket Shield
 Plant_Collect_BackPack	Kuku Gardening Pack
-Plune_Leather_Armor	Plune Leather Armor
+Plune_Leather_Armor	Plune Leather Armor	Male
 Poison_Arrow	Poison Arrow
 Poison_Stick	Soporific Blowpipe
 Pomegranate	Pomegranate
 Pomegranate_Seed	Pomegranate Seed
-Porcell_Fabric_Gloves_I	Porcell Cloth Gloves
-Porcell_Fabric_Gloves_II	Porcell Cloth Gloves
-Pormeranian_Leather_Armor	Pomerin Leather Armor
+Porcell_Fabric_Gloves_I	Porcell Cloth Gloves	Male
+Porcell_Fabric_Gloves_II	Porcell Cloth Gloves	Male
+Pormeranian_Leather_Armor	Pomerin Leather Armor	Male
 PororinChildrenForest_Book	A Traveler's Log
 Pororin_Sacred	Pororin Relic
-Porugate_Leather_Gloves	Brogant Leather Gloves
+Porugate_Leather_Gloves	Brogant Leather Gloves	Male
 Possesion_Insam	Ginseng
-Possesion_Myurdin_Leather_Armor	Umbra's Hierophany Leather Armor
-Possesion_Myurdin_Leather_Gloves	Umbra's Hierophany Leather Gloves
+Possesion_Myurdin_Leather_Armor	Umbra's Hierophany Leather Armor	Male
+Possesion_Myurdin_Leather_Gloves	Umbra's Hierophany Leather Gloves	Male
 Pot_Head	Jar
 Potato	Potato
 Potion_StatBuff_Tier1_0001	Freya's Lesser Elixir
@@ -4258,65 +4268,65 @@ Potion_StatBuff_Tier3_0002	Apollonia's Greater Elixir
 Potion_StatBuff_Tier3_0003	Meliara's Greater Elixir
 Potion_StatBuff_Tier3_0004	Haiden's Greater Elixir
 Potion_StatBuff_Tier3_0005	Astrid's Greater Elixir
-PowerDraw_Gloves	Strongbow Gloves
-Prani_PlateArmor_Helm	Prani Plate Helm
+PowerDraw_Gloves	Strongbow Gloves	Male
+Prani_PlateArmor_Helm	Prani Plate Helm	Male
 Premium_Stone	Flawless Stone
 Premium_Wood	Flawless Timber
 PriestWand_Big	Solumen Priest's Big Staff
 PriestWand_Big_III	Varnian Priest's Big Staff
-Prinkeypes_PlateArmor_Armor	Princeps Plate Armor
+Prinkeypes_PlateArmor_Armor	Princeps Plate Armor	Male
 Prison_Key	Prison Key
-Prisoner_Fabric_Armor	Captive's Cloth Armor
-Prisoner_Fabric_Armor_I	Captive's Cloth Armor
-Prisoner_Fabric_Armor_II	Captive's Cloth Armor
-Prisoner_Fabric_Armor_III	Captive's Cloth Armor
-Prisoner_Fabric_Armor_IV	Captive's Cloth Armor
-Prisoner_Fabric_Armor_IX	Captive's Cloth Armor
-Prisoner_Fabric_Armor_V	Captive's Cloth Armor
-Prisoner_Fabric_Armor_VI	Captive's Cloth Armor
-Prisoner_Fabric_Armor_VII	Captive's Cloth Armor
-Prisoner_Fabric_Armor_VIII	Captive's Cloth Armor
-Prisoner_Fabric_Boots	Captive's Cloth Boots
-Prisoner_Fabric_Helm	Captive's Cloth Cap
-Prisoner_Fabric_Helm_I	Captive's Cloth Helm
-Prisoner_Fabric_Helm_II	Captive's Cloth Cap
-Prisoner_Fabric_Helm_III	Captive's Cloth Headband
-Prisoner_Fabric_Helm_IV	Captive's Cloth Cap
-Prisoner_Leather_Gloves	Leather Half-Gloves
-Prisoner_Leather_Gloves_I	Darren Leather Gloves
-Prisoner_Leather_Gloves_II	Darren Leather Gloves
-Prisoner_Leather_Helm	Captive's Leather Hat
-Prisoner_Leather_Helm_I	Captive's Folded Leather Hat
-Protect_Electric_Leather_Gloves	Insulated Gloves
-Protective_Leather_Armor	Antumbra Bismuth Protection Suit
+Prisoner_Fabric_Armor	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_I	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_II	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_III	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_IV	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_IX	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_V	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_VI	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_VII	Captive's Cloth Armor	Male
+Prisoner_Fabric_Armor_VIII	Captive's Cloth Armor	Male
+Prisoner_Fabric_Boots	Captive's Cloth Boots	Male
+Prisoner_Fabric_Helm	Captive's Cloth Cap	Male
+Prisoner_Fabric_Helm_I	Captive's Cloth Helm	Male
+Prisoner_Fabric_Helm_II	Captive's Cloth Cap	Male
+Prisoner_Fabric_Helm_III	Captive's Cloth Headband	Male
+Prisoner_Fabric_Helm_IV	Captive's Cloth Cap	Male
+Prisoner_Leather_Gloves	Leather Half-Gloves	Male
+Prisoner_Leather_Gloves_I	Darren Leather Gloves	Male
+Prisoner_Leather_Gloves_II	Darren Leather Gloves	Male
+Prisoner_Leather_Helm	Captive's Leather Hat	Male
+Prisoner_Leather_Helm_I	Captive's Folded Leather Hat	Male
+Protect_Electric_Leather_Gloves	Insulated Gloves	Male
+Protective_Leather_Armor	Antumbra Bismuth Protection Suit	Male
 Pumpkin	Pumpkin
-Purani_Leather_Boots	Purani Leather Boots
+Purani_Leather_Boots	Purani Leather Boots	Male
 Puzzle_Reward_TreasureMap_Del	Forgotten Memory
 Puzzle_Reward_TreasureMap_Dem_First	Memories of Prosperity
 Puzzle_Reward_TreasureMap_Dem_Second	Memory of Turbulence
 Puzzle_Reward_TreasureMap_Her_First	Memories of Abundance
 Puzzle_Reward_TreasureMap_Her_Second	Memory of Tide
 Puzzle_Reward_TreasureMap_Kwe	Memories of the Northern Winds
-Pycian_PlateArmor_Helm	Ferman Plate Helm
+Pycian_PlateArmor_Helm	Ferman Plate Helm	Male
 Pyeonjeon_Arrow	Stub Arrow
-Pyinca_PlateArmor_Gloves	Pernicia Plate Gloves
+Pyinca_PlateArmor_Gloves	Pernicia Plate Gloves	Male
 Pyogo_Mushroom	Oakwood Mushroom
 Pyogo_Mushroom_BackPack	Oakwood Mushroom Pack
 Pyogo_Mushroom_Tea	Oakwood Mushroom Tea
-Pypho_Fabric_Armor	Paifo Cloth Armor
-Pyrantha_Fabric_Armor	Pyrantha Cloth Armor
-Querunty_Leather_Boots	Quent Leather Boots
-Querville_Leather_Boots	Kervel Leather Boots
+Pypho_Fabric_Armor	Paifo Cloth Armor	Male
+Pyrantha_Fabric_Armor	Pyrantha Cloth Armor	Male
+Querunty_Leather_Boots	Quent Leather Boots	Male
+Querville_Leather_Boots	Kervel Leather Boots	Male
 Quest_Bloodcoronation_CampDocument_I	Informant's First Letter
 Quest_Bloodcoronation_CampDocument_II	Informant's Second Letter
 Quest_Bloodcoronation_CampDocument_III	Informant's Third Letter
 Quest_Bloodcoronation_Document	Report on Myurdin's Whereabouts
 Quest_Book_Mansion_I	Book
-Quest_BrokenVisionPro_Bremer	Broken Visione
-Quest_BrokenVisionPro_Ibano	Broken Visione
-Quest_BrokenVisionPro_MasterGrundir_Diary	Broken Visione
-Quest_BrokenVisionPro_ThiefCave	Broken Visione
-Quest_BrokenVisionPro_Witch_Kidnapped_Memory	Broken Visione
+Quest_BrokenVisionPro_Bremer	Broken Visione	Male
+Quest_BrokenVisionPro_Ibano	Broken Visione	Male
+Quest_BrokenVisionPro_MasterGrundir_Diary	Broken Visione	Male
+Quest_BrokenVisionPro_ThiefCave	Broken Visione	Male
+Quest_BrokenVisionPro_Witch_Kidnapped_Memory	Broken Visione	Male
 Quest_Burham_Maze_I	Engraved Stone
 Quest_Burham_Maze_II	Engraved Stone
 Quest_Burham_Maze_III	Engraved Stone
@@ -4529,57 +4539,57 @@ Quest_Witch_Token_II	Witch's Token
 Quest_Witch_Token_III	Witch's Token
 Quest_Witch_Token_IV	Witch's Token
 Quiver	Replenishing Arrows
-Qunicks_Leather_Armor	Kenecks Leather Armor
-Rabbid_Fabric_Helm	Raveed Cloth Cap
-Raccoon_Fabric_Helm	Raccoon Cloth Hat
-Racky_Fabric_Armor	Lackey Cloth Armor
-Raddlerz_Fabric_Armor	Raddler Cloth Armor
-Radian_Fabric_Armor	Radian Cloth Armor
-Radiano_Leather_Armor	Radiano Leather Armor
-Radley_Fabric_Armor	Radley Cloth Armor
-Rafflia_Leather_Boots	Raphelia Leather Boots
+Qunicks_Leather_Armor	Kenecks Leather Armor	Male
+Rabbid_Fabric_Helm	Raveed Cloth Cap	Male
+Raccoon_Fabric_Helm	Raccoon Cloth Hat	Male
+Racky_Fabric_Armor	Lackey Cloth Armor	Male
+Raddlerz_Fabric_Armor	Raddler Cloth Armor	Male
+Radian_Fabric_Armor	Radian Cloth Armor	Male
+Radiano_Leather_Armor	Radiano Leather Armor	Male
+Radley_Fabric_Armor	Radley Cloth Armor	Male
+Rafflia_Leather_Boots	Raphelia Leather Boots	Male
 Raging_Tempests_Leader_Leather_Gloves	Raging Tempest's Leather Gloves
 Raging_Tempests_Leader_PlateArmor_Armor	Raging Tempest's Plate Armor
 Raging_Tempests_Leader_PlateArmor_Helm	Raging Tempest's Plate Helm
 Raging_Tempests_Leader_Plate_Boots	Raging Tempest's Plate Boots
-Rahelm_Fabric_Helm	Rahelm Cloth Headband
-Rakhir_Fabric_Gloves	Rakhir Cloth Wristband
-Rakkli_PlateArmor_Armor	Rakkli Plate Armor
-Rakuzen_Leather_Boots	Rezzcan Leather Boots
-Ramastern_Leather_Boots	Ramastern Leather Boots
-Ranibider_Leather_Helm	Lanweiter Leather Helm
-Ranubio_Leather_Armor	Ranubio Leather Armor
-Raphtha_PlateArmor_Helm_I	Demenissian Guard's Plate Helm
-Raphtha_PlateArmor_Helm_II	Demenissian Guard's Plate Helm
-Raphtha_PlateArmor_Helm_III	Inquisitor's Plate Helm
+Rahelm_Fabric_Helm	Rahelm Cloth Headband	Female
+Rakhir_Fabric_Gloves	Rakhir Cloth Wristband	Male
+Rakkli_PlateArmor_Armor	Rakkli Plate Armor	Male
+Rakuzen_Leather_Boots	Rezzcan Leather Boots	Male
+Ramastern_Leather_Boots	Ramastern Leather Boots	Male
+Ranibider_Leather_Helm	Lanweiter Leather Helm	Male
+Ranubio_Leather_Armor	Ranubio Leather Armor	Male
+Raphtha_PlateArmor_Helm_I	Demenissian Guard's Plate Helm	Male
+Raphtha_PlateArmor_Helm_II	Demenissian Guard's Plate Helm	Male
+Raphtha_PlateArmor_Helm_III	Inquisitor's Plate Helm	Male
 Rapid_Leather_Armor	Rapid Leather Armor
-Rapid_Leather_Gloves	Rapid Leather Gloves
-Rapitz_Leather_Gloves	Rannys Leather Gloves
-Rarchrah_Fabric_Armor	Lokra Cloth Armor
-Rarkah_Fabric_Armor	Rarkah Cloth Armor
-Rarksian_Leather_Armor	Larkson Leather Armor
+Rapid_Leather_Gloves	Rapid Leather Gloves	Female
+Rapitz_Leather_Gloves	Rannys Leather Gloves	Male
+Rarchrah_Fabric_Armor	Lokra Cloth Armor	Male
+Rarkah_Fabric_Armor	Rarkah Cloth Armor	Male
+Rarksian_Leather_Armor	Larkson Leather Armor	Male
 Rasb_Leather_Gloves	Rainier Leather Gloves
 Rasberry	Raspberry
 Rasens_Leather_Gloves	Reshesh Leather Gloves
 Raska_Leather_Gloves	Remebrou Leather Gloves
 Rasku_Leather_Gloves	Ravellu Leather Gloves
-Raspel_Leather_Gloves	Lasfeld Leather Gloves
+Raspel_Leather_Gloves	Lasfeld Leather Gloves	Male
 Ratisan_Fabric_Gloves	Ratisan Cloth Gloves
 Rattan_Wood_OneHandShield	Rattan Shield
-Ratti_Leather_Boots	Ratti Leather Boots
-Ratti_PlateArmor_Gloves	Ratti Plate Gloves
-Ratti_PlateArmor_Gloves_I	Blacksteel Ratti Plate Gloves
-Ratti_PlateArmor_Gloves_II	Ratti Plate Gloves II
-Ratu_Fabric_Gloves	Rattu Cloth Gloves
-Ratuni_Leather_Boots	Lutteri Leather Boots
-Raukington_Fabric_Helm	Rockington Cloth Cap
-Raven_PlateArmor_Armor	Levin Plate Armor
-Raven_PlateArmor_Armor_I	Levin Plate Armor
-Raven_PlateArmor_Armor_II	Levin Plate Armor
+Ratti_Leather_Boots	Ratti Leather Boots	Male
+Ratti_PlateArmor_Gloves	Ratti Plate Gloves	Male
+Ratti_PlateArmor_Gloves_I	Blacksteel Ratti Plate Gloves	Male
+Ratti_PlateArmor_Gloves_II	Ratti Plate Gloves II	Male
+Ratu_Fabric_Gloves	Rattu Cloth Gloves	Male
+Ratuni_Leather_Boots	Lutteri Leather Boots	Male
+Raukington_Fabric_Helm	Rockington Cloth Cap	Female
+Raven_PlateArmor_Armor	Levin Plate Armor	Male
+Raven_PlateArmor_Armor_I	Levin Plate Armor	Male
+Raven_PlateArmor_Armor_II	Levin Plate Armor	Male
 Raxion_TwoHandAxe	Bonepit Greataxe
 Rayhorn_TwoHandSword	Rhett's Longsword
-Rayra_Fabric_Helm	Leila Cloth Cap
-Rayra_Leather_Gloves	Leila Leather Gloves
+Rayra_Fabric_Helm	Leila Cloth Cap	Female
+Rayra_Leather_Gloves	Leila Leather Gloves	Female
 Reak_Leather_Armor	Reak Leather Armor
 Recipe_Beef_Bone_Soup	Recipe: Meat Stew
 Recipe_Berry_Juice	Recipe: Fruit Juice
@@ -4783,6 +4793,10 @@ Recipe_Item_gimmick_in_dpf_carpet_0007	Blueprint: Large Stone Knotted Carpet
 Recipe_Item_gimmick_in_dpf_carpet_0008	Blueprint: Sunset Plaid Carpet
 Recipe_Item_gimmick_in_dpf_carpet_0008_index01	Blueprint: Double Mist-woven Carpet
 Recipe_Item_gimmick_in_dpf_carpet_0009	Blueprint: Large Rosy Dragonscale Carpet
+Recipe_Item_gimmick_in_dpf_carpet_0013	Blueprint: Wide Dawndrop Garden Carpet
+Recipe_Item_gimmick_in_dpf_carpet_0014	Blueprint: Round Wide Mist-woven Carpet
+Recipe_Item_gimmick_in_dpf_carpet_0015	Blueprint: Wide Multicolor Knotted Carpet
+Recipe_Item_gimmick_in_dpf_carpet_0016	Blueprint: Round Wide Moonlit Garden Carpet
 Recipe_Item_gimmick_jukebox_0001	Blueprint: Faust's Music Box
 Recipe_Item_gimmick_lamp_streetlamp_0001	Blueprint: Cold Streetlight
 Recipe_Item_gimmick_lamp_streetlamp_0001_index01	Blueprint: Warm Streetlight
@@ -4849,6 +4863,7 @@ Recipe_Pan_fried_Meat_Vegetable_Pancake	Recipe: Steamed Eggs
 Recipe_Pan_fried_Vegetable_Fruit_Pancake	Recipe: Vegetable Rice Cake
 Recipe_Pan_fried_Vegetable_Grain_Pancake	Recipe: Grain Soup
 Recipe_Pan_fried_Vegetable_Pancake	Recipe: Battered Vegetables
+Recipe_Paphneil_PlateArmor_Armor	Blueprint: Scorchflame Plate Armor
 Recipe_Platinum	Alchemy Formula: Platinum
 Recipe_Potion_DDD_LV1	Alchemy Formula: Freya's Lesser Elixir
 Recipe_Potion_DDD_LV2	Alchemy Formula: Freya's Elixir
@@ -4881,10 +4896,12 @@ Recipe_Surasang_02	Recipe: Lavish Meal
 Recipe_Surasang_03	Recipe: Fine Meal
 Recipe_Surasang_04	Recipe: Special Meal
 Recipe_Surasang_05	Recipe: Meal
+Recipe_Titan_PlateArmor_Armor	Blueprint: Lightning Bolt Plate Armor
 Recipe_Tteokgalbi	Recipe: Grilled Meat Patties
 Recipe_Vegetable_Fruit_Porridge	Recipe: Harvest Roll
 Recipe_Vegetable_Juice	Recipe: Vegetable Juice
 Recipe_Vegetable_Porridge	Recipe: Vegetable Porridge
+Recipe_king_LostPeople_PlateArmor_Armor	Blueprint: Frostcursed Plate Armor
 Reckleeman_TwoHandSword	Balton Longsword
 Recle_OneHandTowerShield	Rekel Large Shield
 RedDeerHorn_Mushroom	Poison Fire Coral Mushroom
@@ -4893,121 +4910,122 @@ RedNose_Lantern	Dark Fog Lantern
 RedStone	Bloodstone
 Red_Ring	Rough Bluestone Ring
 Redbeet	Beet
-Redin_ChainMail_Armor	Reddin Chain Mail
-Redknight_PlateArmor_Armor	Plate Armor of Cursed Soul
-Redknight_PlateArmor_Cloak	Plate Cloak of Cursed Soul
-Redknight_PlateArmor_Gloves	Plate Gloves of Cursed Soul
-Redknight_PlateArmor_Helm	Plate Helm of Cursed Soul
-Redknight_PlateArmor_Helm_II	Turncoat Plate Helm
-Redknight_PlateArmor_Helm_III	Plumed Wells Rebel's Plate Helm
-Redknight_PlateArmor_Helm_IV	Turncoat Silver Plate Helm
-Redknight_Plate_Boots	Plate Boots of Cursed Soul
-Redleader_Leather_Gloves	Red Rider's Leather Gloves
-Redleader_PlateArmor_Armor	Red Rider's Plate Armor
-Redleader_PlateArmor_Helm	Red Rider's Plate Helm
-Redman_PlateArmor_Armor	Redman Plate Armor
-Redrin_Fabric_Helm	Redrin Cloth Cap
-Redsentinel_ChainMail_Armor	Crimson Chaser Mail
-Redsentinel_ChainMail_Cloak	Crimson Chaser Chain Cloak
+Redin_ChainMail_Armor	Reddin Chain Mail	Male
+Redknight_PlateArmor_Armor	Plate Armor of Cursed Soul	Male
+Redknight_PlateArmor_Cloak	Plate Cloak of Cursed Soul	Male
+Redknight_PlateArmor_Gloves	Plate Gloves of Cursed Soul	Male
+Redknight_PlateArmor_Helm	Plate Helm of Cursed Soul	Male
+Redknight_PlateArmor_Helm_II	Turncoat Plate Helm	Male
+Redknight_PlateArmor_Helm_III	Plumed Wells Rebel's Plate Helm	Male
+Redknight_PlateArmor_Helm_IV	Turncoat Silver Plate Helm	Male
+Redknight_Plate_Boots	Plate Boots of Cursed Soul	Male
+Redleader_Leather_Gloves	Red Rider's Leather Gloves	Male
+Redleader_PlateArmor_Armor	Damaged Red Rider's Plate Armor	Male
+Redleader_PlateArmor_Armor_I	Red Rider's Plate Armor	Male
+Redleader_PlateArmor_Helm	Red Rider's Plate Helm	Male
+Redman_PlateArmor_Armor	Redman Plate Armor	Male
+Redrin_Fabric_Helm	Redrin Cloth Cap	Male
+Redsentinel_ChainMail_Armor	Crimson Chaser Mail	Male
+Redsentinel_ChainMail_Cloak	Crimson Chaser Chain Cloak	Male
 Redsentinel_Necklace	Crimson Warden's Necklace
-Redsentinel_PlateArmor_Gloves	Crimson Chaser Chain Gloves
-Redsentinel_PlateArmor_Helm	Crimson Chaser Plate Helm
+Redsentinel_PlateArmor_Gloves	Crimson Chaser Chain Gloves	Male
+Redsentinel_PlateArmor_Helm	Crimson Chaser Plate Helm	Male
 ReedDevil_Doll	Devil of the Reed Field's Doll
 ReedDevil_Mask	Mask of the Devil of the Reed Field
-Reeddevil_Fabric_Boots	Sunset Reed Cloth Boots
-Reeddevil_Fabric_Boots_T5_QA	Reeddevil Fabric Boots T5 QA
-Reeddevil_Fabric_Gloves	Sunset Reed Cloth Gloves
-Reeddevil_Fabric_Gloves_T5_QA	Reeddevil Fabric Gloves T5 QA
-Reeddevil_Fabric_Helm_I	Reed Devil Minion's Cloth Helm
-Reeddevil_Fabric_Helm_II	Reed Devil Minion's Cloth Helm
-Reeddevil_Fabric_Helm_III	Reed Devil Minion's Cloth Helm
-Reeddevil_Leather_Armor	Sunset Reed Leather Armor
-Reeddevil_Leather_Armor_I	Reed Devil Underling's Red Armor
-Reeddevil_Leather_Armor_II	Reed Devil Underling's Yellow Armor
-Reeddevil_Leather_Armor_III	Reed Devil Underling's Armor
-Reeddevil_Leather_Cloak	Sunset Reed Leather Cloak
+Reeddevil_Fabric_Boots	Sunset Reed Cloth Boots	Male
+Reeddevil_Fabric_Boots_T5_QA	Reeddevil Fabric Boots T5 QA	Male
+Reeddevil_Fabric_Gloves	Sunset Reed Cloth Gloves	Male
+Reeddevil_Fabric_Gloves_T5_QA	Reeddevil Fabric Gloves T5 QA	Male
+Reeddevil_Fabric_Helm_I	Reed Devil Minion's Cloth Helm	Male
+Reeddevil_Fabric_Helm_II	Reed Devil Minion's Cloth Helm	Male
+Reeddevil_Fabric_Helm_III	Reed Devil Minion's Cloth Helm	Male
+Reeddevil_Leather_Armor	Sunset Reed Leather Armor	Male
+Reeddevil_Leather_Armor_I	Reed Devil Underling's Red Armor	Male
+Reeddevil_Leather_Armor_II	Reed Devil Underling's Yellow Armor	Male
+Reeddevil_Leather_Armor_III	Reed Devil Underling's Armor	Male
+Reeddevil_Leather_Cloak	Sunset Reed Leather Cloak	Male
 Reeddevil_Troll_Fabric_Helm	Reed Devil Minion Troll's Cloth Helm
 Reeddevil_Troll_Leather_Armor	Reed Devil Troll Armor
-Regglin_Boss_Fabric_Boots	Fundamentalist Officer Cloth Boots
-Regglin_Boss_Helm	Leather Hat of Enlightenment
+Regglin_Boss_Fabric_Boots	Fundamentalist Officer Cloth Boots	Male
+Regglin_Boss_Helm	Leather Hat of Enlightenment	Male
 Regglin_Boss_TwoHandSword	Bringer of Balance
-Regglin_Fabric_Armor	Fundamentalist's Cloth Armor
-Regglin_Fabric_Armor_I	Fundamentalist's Cloth Armor
-Regglin_Fabric_Armor_II	Fundamentalist's Cloth Armor
-Regglin_Fabric_Armor_III	Fundamentalist's Cloth Armor
-Regglin_Fabric_Armor_IV	Gilded Goblin's Cloth Armor
-Regglin_Fabric_Armor_MiddleBoss	Fundamentalist Goblin Cloth Armor
-Regglin_Fabric_Armor_MiddleBoss_I	Fundamentalist Goblin Cloth Armor
-Regglin_Fabric_Armor_MiddleBoss_II	Fundamentalist Goblin Cloth Armor
-Regglin_Fabric_Armor_MiddleBoss_III	Fundamentalist Goblin Cloth Armor
-Regglin_Fabric_Armor_V	Gilded Goblin's Cloth Armor
-Regglin_Fabric_Armor_VI	Gilded Goblin's Cloth Armor
-Regglin_Leather_Boots	Fundamentalist Goblin Leather Boots
-Regglin_PlateArmor_Helm	Regglin Plate Helm
-Rehsian_Leather_Armor	Resian Leather Armor
-ReiGhis_Leather_Boots	Rhegis Leather Boots
+Regglin_Fabric_Armor	Fundamentalist's Cloth Armor	Male
+Regglin_Fabric_Armor_I	Fundamentalist's Cloth Armor	Male
+Regglin_Fabric_Armor_II	Fundamentalist's Cloth Armor	Male
+Regglin_Fabric_Armor_III	Fundamentalist's Cloth Armor	Male
+Regglin_Fabric_Armor_IV	Gilded Goblin's Cloth Armor	Male
+Regglin_Fabric_Armor_MiddleBoss	Fundamentalist Goblin Cloth Armor	Male
+Regglin_Fabric_Armor_MiddleBoss_I	Fundamentalist Goblin Cloth Armor	Male
+Regglin_Fabric_Armor_MiddleBoss_II	Fundamentalist Goblin Cloth Armor	Male
+Regglin_Fabric_Armor_MiddleBoss_III	Fundamentalist Goblin Cloth Armor	Male
+Regglin_Fabric_Armor_V	Gilded Goblin's Cloth Armor	Male
+Regglin_Fabric_Armor_VI	Gilded Goblin's Cloth Armor	Male
+Regglin_Leather_Boots	Fundamentalist Goblin Leather Boots	Male
+Regglin_PlateArmor_Helm	Regglin Plate Helm	Male
+Rehsian_Leather_Armor	Resian Leather Armor	Female
+ReiGhis_Leather_Boots	Rhegis Leather Boots	Male
 ReiGhis_Leather_Boots_I	Large Rhegis Leather Boots
-ReiGhis_Leather_Boots_II	Rhegis Leather Boots
+ReiGhis_Leather_Boots_II	Rhegis Leather Boots	Male
 ReiGhis_Leather_Boots_III	Large Rhegis Leather Boots
-ReiGhis_PlateArmor_Helm	Musket Border Guard Standard Helm
+ReiGhis_PlateArmor_Helm	Musket Border Guard Standard Helm	Male
 ReiGhis_Wood_OneHandShield	Balton Shield
-Reikiru_Leather_Boots	Leegrau Leather Boots
-Reinbaldt_Plate_Boots	Demenissian Plate Boots
-ReinforcedSteel_OneHandCannon	Reinforced Steel Blaster
-Rekklann_Fabric_Armor	Rexlan Cloth Armor
+Reikiru_Leather_Boots	Leegrau Leather Boots	Male
+Reinbaldt_Plate_Boots	Demenissian Plate Boots	Male
+ReinforcedSteel_OneHandCannon	Reinforced Steel Blaster	Male
+Rekklann_Fabric_Armor	Rexlan Cloth Armor	Male
 Reklenne_Fabric_Gloves	Recklin Cloth Gloves
-Rellone_Fabric_Armor	Rellone Cloth Armor
-Reltan_Fabric_Armor	Reltan Cloth Armor
-Reltian_Fabric_Armor	Reltian Cloth Armor
-Reltinan_Fabric_Armor	Reltinan Cloth Armor
+Rellone_Fabric_Armor	Rellone Cloth Armor	Male
+Reltan_Fabric_Armor	Reltan Cloth Armor	Male
+Reltian_Fabric_Armor	Reltian Cloth Armor	Male
+Reltinan_Fabric_Armor	Reltinan Cloth Armor	Male
 Renarto_OneHandRapier	Brass Rose Rapier
-Rendal_Leather_Boots	Wendahl Leather Shoes
-Rendal_Leather_Gloves	Wendahl Leather Gloves
-Repen_PlateArmor_Armor	Reppin Plate Armor
-Repo_Leather_Gloves	Leppo Leather Gloves
+Rendal_Leather_Boots	Wendahl Leather Shoes	Male
+Rendal_Leather_Gloves	Wendahl Leather Gloves	Male
+Repen_PlateArmor_Armor	Reppin Plate Armor	Male
+Repo_Leather_Gloves	Leppo Leather Gloves	Male
 Reputy_Leather_Boots	Rafferty Leather Shoes
 Restraint_Rope_Fabric_Gloves_I	Restraint Rope Fabric Gloves I
 RevivalItem	Refined Palmar Pill
 RevivalItemPartialRecovery	Palmar Pill
-Revog_PlateArmor_Armor	Leighbog Plate Armor
-RevolutionaryArmy_Fabric_Armor	Demenissian Rebel Cloth Armor
-RevolutionaryArmy_Fabric_Armor_I	Demenissian Rebel Cloth Armor
-RevolutionaryArmy_Fabric_Armor_II	Demenissian Rebel Cloth Armor
-RevolutionaryArmy_Fabric_Armor_III	Demenissian Rebel Cloth Armor
-RevolutionaryArmy_Leather_Gloves	Demenissian Rebel Leather Bracers
-Rhapts_Leather_Armor	Rapps Leather Armor
-Rhapts_PlateArmor_Helm	Rapps Plate Helm
-Rhias_Fabric_Boots	Reus Cloth Boots
-Rhias_Leather_Boots	Reus Leather Boots
+Revog_PlateArmor_Armor	Leighbog Plate Armor	Male
+RevolutionaryArmy_Fabric_Armor	Demenissian Rebel Cloth Armor	Male
+RevolutionaryArmy_Fabric_Armor_I	Demenissian Rebel Cloth Armor	Male
+RevolutionaryArmy_Fabric_Armor_II	Demenissian Rebel Cloth Armor	Male
+RevolutionaryArmy_Fabric_Armor_III	Demenissian Rebel Cloth Armor	Male
+RevolutionaryArmy_Leather_Gloves	Demenissian Rebel Leather Bracers	Male
+Rhapts_Leather_Armor	Rapps Leather Armor	Male
+Rhapts_PlateArmor_Helm	Rapps Plate Helm	Male
+Rhias_Fabric_Boots	Reus Cloth Boots	Male
+Rhias_Leather_Boots	Reus Leather Boots	Male
 Rhias_OneHandAxe	Rhias's Axe
-Rhinard_Leather_Gloves	Rhinard Leather Gloves
+Rhinard_Leather_Gloves	Rhinard Leather Gloves	Male
 Rhinard_TwoHandCannon	Rhinard Cannon
 Rhinard_TwoHandCannon_I	Finest Rhinard Cannon
-Rhodelphine_Leather_Armor	Rhodelphine Leather Armor
-Rhonda_Leather_Boots	Rhonda Leather Boots
-Rhyspidon_Leather_Armor	Lespedan Leather Armor
-Rhyspidon_Leather_Gloves	Lespedan Leather Gloves
-Rhystizer_Leather_Gloves_I	Rowley Leather Gloves
+Rhodelphine_Leather_Armor	Rhodelphine Leather Armor	Male
+Rhonda_Leather_Boots	Rhonda Leather Boots	Male
+Rhyspidon_Leather_Armor	Lespedan Leather Armor	Male
+Rhyspidon_Leather_Gloves	Lespedan Leather Gloves	Male
+Rhystizer_Leather_Gloves_I	Rowley Leather Gloves	Male
 Rhystizer_OneHandMusket	Helms Musket
-Rhytem_Leather_Armor	Rittem Leather Armor
-Rhytrian_Fabric_Helm	Rhytrian Cloth Cap
-Ribben_Fabric_Helm	Riven Cloth Cap
+Rhytem_Leather_Armor	Rittem Leather Armor	Male
+Rhytrian_Fabric_Helm	Rhytrian Cloth Cap	Male
+Ribben_Fabric_Helm	Riven Cloth Cap	Male
 Ribentain_Priest_OneHandShield	Saint's Blessing
 Ribentain_Priest_TwoHandSpear	Reventine Priest's Spear
 Rice	Toasted Grains
 Rice_Large	Satisfying Toasted Grains
 Rice_Medium	Filling Toasted Grains
 Rice_XLarge	Hearty Toasted Grains
-Rickaltje_Leather_Boots	Ligatra Leather Boots
-Riclia_Leather_Armor	Riclia Leather Armor
+Rickaltje_Leather_Boots	Ligatra Leather Boots	Male
+Riclia_Leather_Armor	Riclia Leather Armor	Male
 Riding_AlpineIbex_Amulet	Sigil of Solidarity (Icicle Edge Alpine Ibex)
 Riding_AlpineIbex_Horn	Icicle Edge Alpine Ibex Horn
 Riding_Bear_Amulet	Sigil of Solidarity (White Bear)
 Riding_Bear_Claw	White Bear's Claws
 Riding_Deer_Amulet	Sigil of Solidarity (Snowwhite Deer)
 Riding_Deer_Horn	Snowwhite Deer's Antlers
-Riding_Fabric_Armor	Riding Attire
-Riding_Fabric_Cloak	Riding Cloak
+Riding_Fabric_Armor	Riding Attire	Male
+Riding_Fabric_Cloak	Riding Cloak	Male
 Riding_Warthog_Amulet	Sigil of Solidarity (Rock Tusk Warthog)
 Riding_Warthog_Tooth	Rock Tusk Warthog's Tusk
 Riding_Wolf_Amulet	Sigil of Solidarity (Silver Fang)
@@ -5016,14 +5034,15 @@ Riesi_Boots	Shoddy Rishi's Boots
 Riesi_Boots_Upgrade	Kuku Rishi's Boots
 Rik_Leather_Gloves	Reak Leather Bracers
 Rikisis_OneHandDagger	Sydmon Dagger
-Rikkmah_Fabric_Helm	Rigma Cloth Headband
-Rikkmah_Leather_Armor	Rigma Leather Armor
-Rikkmah_Leather_Gloves	Rigma Leather Gloves
-Rikkutan_Fabric_Armor	Rikkutan Cloth Armor
-Riknaon_Leather_Gloves	Rignon Leather Gloves
+Rikkmah_Fabric_Helm	Rigma Cloth Headband	Male
+Rikkmah_Leather_Armor	Rigma Leather Armor	Male
+Rikkmah_Leather_Gloves	Rigma Leather Gloves	Male
+Rikkutan_Fabric_Armor	Rikkutan Cloth Armor	Male
+Riknaon_Leather_Gloves	Rignon Leather Gloves	Male
 Riurian_OneHandDagger	Dekarr Dagger
-Rivelorn_Fabric_Helm	Rivellon Cloth Cap
-Riverdine_ChainMail_Armor	Riverdine Chain Mail
+Rivelorn_Fabric_Helm	Rivellon Cloth Cap	Male
+Rivenheim_Fabric_Armor	Rivenheim Cloth Armor	Female
+Riverdine_ChainMail_Armor	Riverdine Chain Mail	Male
 Roast_Chicken	Salt-Roasted Bird Meat
 Roast_Chicken_Large	Satisfying Salt-Roasted Bird Meat
 Roast_Chicken_Medium	Filling Salt-Roasted Bird Meat
@@ -5032,57 +5051,58 @@ Roast_Fish	Salt-Roasted Fish
 Roast_Fish_Large	Satisfying Salt-Roasted Fish
 Roast_Fish_Medium	Filling Salt-Roasted Fish
 Roast_Fish_XLarge	Hearty Salt-Roasted Fish
-Robbery_Boots	Pillager's Leather Boots
-Robinhood_OneHandBow	Crimson Warden's Bow
-Rochi_PlateArmor_Armor	Roshee Plate Armor
-Rochi_PlateArmor_Armor_I	Blacksteel Roshee Plate Armor
-Rocko_PlateArmor_Armor	Rhogo Plate Armor
-Rocko_PlateArmor_Armor_I	Rhogo Plate Armor
-Roctar_Fabric_Armor	Roctar Cloth Armor
-Roderem_Leather_Boots	Rodderham Leather Boots
-Roderem_PlateArmor_Helm	Rodderham Plate Helm
-Romaned_PlateArmor_Armor	Romund Plate Armor
-Romaned_PlateArmor_Armor_I	Romund Plate Armor
-Rombardina_Leather_Armor	Rombardina Leather Armor
-Ronied_Fabric_Armor	Rhonid Cloth Armor
+Robbery_Boots	Pillager's Leather Boots	Male
+Robinhood_OneHandBow	Crimson Warden's Bow	Male
+Rochi_PlateArmor_Armor	Roshee Plate Armor	Male
+Rochi_PlateArmor_Armor_I	Blacksteel Roshee Plate Armor	Male
+Rocko_PlateArmor_Armor	Rhogo Plate Armor	Male
+Rocko_PlateArmor_Armor_I	Rhogo Plate Armor	Male
+Roctar_Fabric_Armor	Roctar Cloth Armor	Male
+Roderem_Leather_Boots	Rodderham Leather Boots	Male
+Roderem_PlateArmor_Helm	Rodderham Plate Helm	Male
+Romaned_PlateArmor_Armor	Romund Plate Armor	Male
+Romaned_PlateArmor_Armor_I	Romund Plate Armor	Male
+Rombardina_Leather_Armor	Rombardina Leather Armor	Male
+Ronied_Fabric_Armor	Rhonid Cloth Armor	Male
 Ronied_OneHandTowerShield	Rhonid Large Shield
-Rosardeuin_Fabric_Armor	Rosarduin Cloth Armor
+Rosardeuin_Fabric_Armor	Rosarduin Cloth Armor	Male
 Rosemand_OneHandPistol	Rosemond Pistol
 Rosemary	Rosemary
 Rosemary_pink	Pink Rosemary
 Rosemary_white	White Rosemary
 Rosemary_yellow	Yellow Rosemary
-Roshine_Fabric_Armor	Roshayne Cloth Armor
-Rossbara_Leather_Gloves	Rossbara Leather Gloves
+Roshine_Fabric_Armor	Roshayne Cloth Armor	Male
+Rossbara_Leather_Gloves	Rossbara Leather Gloves	Male
 Rosvar_HorseArmor_Helm	Rosbar Champron
+Rovenia_Fabric_Armor	Rovenia Cloth Armor	Female
 RoyalGuard_OneHandShield	Royal Guard Shield
 Royal_Hunting_Ground_Flag_III	Small Royal Hunting Ground Banner Pike
-Rubaunon_Fabric_Armor	Lubonon Cloth Armor
+Rubaunon_Fabric_Armor	Lubonon Cloth Armor	Male
 Rubber_seed	Rubber Tree Seed
-Rubbiden_Leather_Armor	Rubidan Leather Armor
-Ruberfeldy_Leather_Armor	Roverfelt Leather Armor
+Rubbiden_Leather_Armor	Rubidan Leather Armor	Female
+Ruberfeldy_Leather_Armor	Roverfelt Leather Armor	Male
 Ruby	Garnet
-Rudion_PlateArmor_Armor	Ludeon Plate Armor
-Ruischule_Fabric_Armor	Ruschelle Cloth Armor
-Rune_Leather_Boots	Runae Leather Boots
-Ruschar_Fabric_Cloak	Ruschar Cloth Cloak
-Ruschar_Leather_Armor	Ruschar Leather Armor
+Rudion_PlateArmor_Armor	Ludeon Plate Armor	Male
+Ruischule_Fabric_Armor	Ruschelle Cloth Armor	Male
+Rune_Leather_Boots	Runae Leather Boots	Male
+Ruschar_Fabric_Cloak	Ruschar Cloth Cloak	Male
+Ruschar_Leather_Armor	Ruschar Leather Armor	Male
 Rush_Storm_Wood_OneHandShield	Iris Shield
-Russell_Leather_Armor	Russell Leather Armor
-Russmore_Leather_Boots	Russmore Leather Boots
-Rusty_Cigar_TwoHandAxe	Dekarr Greataxe
+Russell_Leather_Armor	Russell Leather Armor	Male
+Russmore_Leather_Boots	Russmore Leather Boots	Male
+Rusty_Cigar_TwoHandAxe	Dekarr Greataxe	Male
 Rusty_Deadwid_TwoHandAxe	Bekker Greataxe
 Rusty_Hagwood_OneHandDagger	Bekker Dagger
 Rusty_Hunter_OneHandSword	Volono Sword
 Rusty_TwoHandHammer	Bekker Greathammer
-Ruthie_Leather_Boots	Ruthie Leather Boots
-Rybee_PlateArmor_Helm	Rahbae Plate Helm
-Rybee_PlateArmor_Helm_I	Modified Rahbae Plate Helm
-Salami_Leather_Boots	Salmae Leather Shoes
-Salami_Leather_Gloves	Salmae Leather Wristband
-Salash_Fabric_Armor	Salash Cloth Armor
-Salimi_Fabric_Helm	Salimi Cloth Cap
-Salimi_Leather_Armor	Salimi Leather Armor
+Ruthie_Leather_Boots	Ruthie Leather Boots	Male
+Rybee_PlateArmor_Helm	Rahbae Plate Helm	Male
+Rybee_PlateArmor_Helm_I	Modified Rahbae Plate Helm	Male
+Salami_Leather_Boots	Salmae Leather Shoes	Male
+Salami_Leather_Gloves	Salmae Leather Wristband	Male
+Salash_Fabric_Armor	Salash Cloth Armor	Male
+Salimi_Fabric_Helm	Salimi Cloth Cap	Male
+Salimi_Leather_Armor	Salimi Leather Armor	Male
 Salt	Salt
 SamGyeTang	Bird Soup
 SamGyeTang_Large	Satisfying Bird Soup
@@ -5092,41 +5112,41 @@ Samuel_PlateArmor_Armor	Dark Marksman's Plate Armor
 Samuel_PlateArmor_Cloak	Dark Marksman's Plate Cloak
 Samuel_PlateArmor_Gloves	Dark Marksman's Plate Gloves
 Samuel_Plate_Boots	Dark Marksman's Plate Boots
-Saolo_Leather_Armor	Saolo Leather Armor
-Sarantos_Leather_Boots	Sarantos Leather Boots
+Saolo_Leather_Armor	Saolo Leather Armor	Male
+Sarantos_Leather_Boots	Sarantos Leather Boots	Male
 Sarantos_Leather_Boots_I	Dirty Sarantos Leather Boots
 Sarantos_Leather_Boots_II	Worn Sarantos Leather Boots
-Sarendion_Fabric_Armor	Sarendion Cloth Armor
-Saristi_Fabric_Helm	Saristi Cloth Headband
-Sartalos_Leather_Gloves	Salatos Leather Gloves
-Saruen_Leather_Armor	Saruen Leather Armor
-Saruen_Leather_Boots	Saruen Leather Boots
-Saruen_Leather_Gloves	Saruen Leather Gloves
-Sarun_Leather_Gloves	Salun Leather Gloves
-Satyr_PlateArmor_Gloves	Satyros Plate Gloves
+Sarendion_Fabric_Armor	Sarendion Cloth Armor	Male
+Saristi_Fabric_Helm	Saristi Cloth Headband	Male
+Sartalos_Leather_Gloves	Salatos Leather Gloves	Female
+Saruen_Leather_Armor	Saruen Leather Armor	Female
+Saruen_Leather_Boots	Saruen Leather Boots	Female
+Saruen_Leather_Gloves	Saruen Leather Gloves	Female
+Sarun_Leather_Gloves	Salun Leather Gloves	Male
+Satyr_PlateArmor_Gloves	Satyros Plate Gloves	Male
 Satyr_TwoHandedWarHammer	Thalwynd Warhammer
-Sazahan_PlateArmor_Armor	Sahazhad Plate Armor
-Sazahan_PlateArmor_Cloak	Sahazhad Plate Cloak
-Scalaphynion_Fabric_Armor	Skyblazer Cloth Armor
-Scalaphynion_Fabric_Armor_T4_QA	Scalaphynion Fabric Armor T4 QA
-Scalaphynion_Fabric_Cloak	Skyblazer Cloth Cloak
-Scalaphynion_Fabric_Cloak_T4_QA	Scalaphynion Fabric Cloak T4 QA
-Scalaphynion_Fabric_Helm	Skyblazer Cloth Helm
-Scalaphynion_Fabric_Helm_T4_QA	Scalaphynion Fabric Helm T4 QA
-Scalaphynion_Leather_Gloves	Skyblazer Leather Gloves
-Scarecrow_Camouflage_Cloak	Scarecrow Cloak
+Sazahan_PlateArmor_Armor	Sahazhad Plate Armor	Male
+Sazahan_PlateArmor_Cloak	Sahazhad Plate Cloak	Male
+Scalaphynion_Fabric_Armor	Skyblazer Cloth Armor	Male
+Scalaphynion_Fabric_Armor_T4_QA	Scalaphynion Fabric Armor T4 QA	Male
+Scalaphynion_Fabric_Cloak	Skyblazer Cloth Cloak	Male
+Scalaphynion_Fabric_Cloak_T4_QA	Scalaphynion Fabric Cloak T4 QA	Male
+Scalaphynion_Fabric_Helm	Skyblazer Cloth Helm	Male
+Scalaphynion_Fabric_Helm_T4_QA	Scalaphynion Fabric Helm T4 QA	Male
+Scalaphynion_Leather_Gloves	Skyblazer Leather Gloves	Male
+Scarecrow_Camouflage_Cloak	Scarecrow Cloak	Male
 Scarfle_OneHandMace	Balton Mace
-Scarlet_Excecutioner_Leather_Boots	Crimson Warden's Leather Boots
-Schillerbin_Fabric_Armor	Schillerbin Cloth Armor
-Schlitz_Leather_Armor	Schlitz Leather Armor
-Schmidt_PlateArmor_Armor	Schmidt Plate Armor
-Schtump_Fabric_Armor	Schtump Cloth Armor
-Schtump_Fabric_Cloak	Schtump Cloth Cloak
-Scopa_Leather_Boots	Scoppa Leather Boots
-Scouter_HP_PlateArmor_Helm	Health Detection Device
-Scovi_Fabric_Helm	Scobby Cloth Headband
+Scarlet_Excecutioner_Leather_Boots	Crimson Warden's Leather Boots	Female
+Schillerbin_Fabric_Armor	Schillerbin Cloth Armor	Male
+Schlitz_Leather_Armor	Schlitz Leather Armor	Male
+Schmidt_PlateArmor_Armor	Schmidt Plate Armor	Male
+Schtump_Fabric_Armor	Schtump Cloth Armor	Male
+Schtump_Fabric_Cloak	Schtump Cloth Cloak	Male
+Scopa_Leather_Boots	Scoppa Leather Boots	Male
+Scouter_HP_PlateArmor_Helm	Health Detection Device	Male
+Scovi_Fabric_Helm	Scobby Cloth Headband	Male
 ScrapMetal_BackPack_I	Scrap Metal Pack
-ScrapMetal_BackPack_II	Scrap Metal Pack
+ScrapMetal_BackPack_II	Scrap Metal Pack	Male
 ScrapMetal_BackPack_III	Scrap Metal Pack
 Seafood_Soup	Seafood Soup
 Seafood_Soup_Large	Satisfying Seafood Soup
@@ -5283,99 +5303,102 @@ Sealed_Abyss_Artifact_0147	Sealed Abyss Artifact
 Sealed_Abyss_Artifact_0148	Sealed Abyss Artifact
 Sealed_Abyss_Artifact_0149	Sealed Abyss Artifact
 Sealed_Abyss_Artifact_0150	Sealed Abyss Artifact
-Seidin_Leather_Armor	Seiden Leather Armor
-Sein_Leather_Boots	Sein Leather Boots
-Senian_ChainMail_Armor	Senian Chain Mail
-Senian_Fabric_Armor	Senian Cloth Armor
-Senon_PlateArmor_Armor	Senon Plate Armor
-Seodri_PlateArmor_Armor	Seddry Plate Armor
-Seras_Leather_Boots	Seras Leather Boots
-Serdhal_Plate_Boots	Serval Plate Boots
-Serdhal_Plate_Boots_I	Serval Plate Boots
-Serdin_Giant_TwoHandGiantBastard	Serdin Greatsword
-Serrin_PlateArmor_Helm	Sorin Plate Helm
+Seidin_Leather_Armor	Seiden Leather Armor	Male
+Sein_Leather_Boots	Sein Leather Boots	Male
+Senian_ChainMail_Armor	Senian Chain Mail	Male
+Senian_Fabric_Armor	Senian Cloth Armor	Male
+Senon_PlateArmor_Armor	Senon Plate Armor	Male
+Seodri_PlateArmor_Armor	Seddry Plate Armor	Female
+Seras_Leather_Boots	Seras Leather Boots	Male
+Serdhal_Plate_Boots	Serval Plate Boots	Male
+Serdhal_Plate_Boots_I	Serval Plate Boots	Male
+Serdin_Giant_TwoHandGiantBastard	Serdin Greatsword	Female
+Sermena_Fabric_Armor	Sermena Cloth Armor	Female
+Serrin_PlateArmor_Helm	Sorin Plate Helm	Male
 Servano_HorseArmor_Saddle	Servano Saddle
 Sestio_OneHandRapier	Rapier of Amity
 Shakatu_Scroll	Shakatu's Letter
 Shaman_TwoHandedWarHammer	Shaman's Staff
 Shay_Cat_Clue	Shai's Pendant
 Shay_Cat_Clue_Shining	Shining Shai Pendant
-Shellus_Leather_Gloves	Shellus Leather Gloves
-Shellus_Leather_Helm	Shellus Leather Helm
-Shepherd_Leather_Gloves	Herder Leather Gloves
-Sherborn_Leather_Armor_I	Sherborn Leather Armor
-Sherwooden_Fabric_Armor	Sherwood Cloth Armor
+Shellus_Leather_Gloves	Shellus Leather Gloves	Male
+Shellus_Leather_Helm	Shellus Leather Helm	Male
+Shepherd_Leather_Gloves	Herder Leather Gloves	Male
+Sherborn_Leather_Armor_I	Sherborn Leather Armor	Male
+Sherwooden_Fabric_Armor	Sherwood Cloth Armor	Male
 Shield_Flag_IV	Damaged Medium Calphadean Banner Pike
 ShinyStone_02	Shiny Rock
 Short_Horn	Short Horn
 Shotgun_Bullet	Buckshot Bullet
-Sian_Fabric_Helm	Sian Cloth Cap
-Sicillion_Leather_Armor	Sicillion Leather Armor
-Sidmon_Leather_Boots	Sydmon Leather Boots
+Sian_Fabric_Helm	Sian Cloth Cap	Male
+Sicillion_Leather_Armor	Sicillion Leather Armor	Male
+Sidmon_Leather_Boots	Sydmon Leather Boots	Male
 Sidmon_OneHandSword	Sydmon Sword
-Silencer_PlateArmor_Helm	Silent Conqueror Plate Helm
-Silien_Leather_Boots	Cyllian Leather Boots
+Silencer_PlateArmor_Helm	Silent Conqueror Plate Helm	Male
+Silien_Leather_Boots	Cyllian Leather Boots	Male
 Silien_OneHandSword	Wells Sword
-SilverArmor_PlateArmor_Gloves	Silver Plate Gloves
-SilverArmor_PlateArmor_Helm	Inquisitor's Plate Helm
+Silvarin_Fabric_Cloak	Silvarin Cloth Cloak	Male
+SilverArmor_PlateArmor_Gloves	Silver Plate Gloves	Male
+SilverArmor_PlateArmor_Helm	Inquisitor's Plate Helm	Male
 SilverOre	Silver Ore
 Silver_Armor_OneHandMace	Mace of Betrayal
 Silver_Armor_OneHandTowerShield	Shield of Betrayal
 Silver_Bullet	Silver Bullet
 Silver_Pack	Full Silver Pouch
-Silver_PlateArmor_Armor	Sliver Plate Armor
-Silver_PlateArmor_Cloak	Silver Plate Cloak
+Silver_PlateArmor_Armor	Unyielding Hero's Plate Armor	Male
+Silver_PlateArmor_Cloak	Unyielding Hero's Plate Cloak	Male
 Silver_Vizione_Stand_TwoHandSpear	Silver Visione Stand
 Sinseollo	Harvest Soup
 Sinseollo_Large	Satisfying Harvest Soup
 Sinseollo_Medium	Filling Harvest Soup
 Sinseollo_XLarge	Hearty Harvest Soup
-Sir_Catfish_PlateArmor_Armor	Sir Catfish's Armor
-Sir_Catfish_PlateArmor_Gloves	Sir Catfish's Plate Gloves
-Sir_Catfish_Plate_Boots	Sir Catfish's Plate Boots
-Sirion_Fabric_Armor	Sirion Cloth Armor
-Sirius_Barley_Fabric_Helm	Wyvernflame Cloth Helm
-Sitanca_PlateArmor_Armor	Sitanca Plate Armor
-Skardoo_Leather_Armor	Scarteau Leather Armor
-Skian_Fabric_Helm	Skian Cloth Cap
-SkullKnight_Follower_Plate_Boots_I	Skull Knight Follower's Plate Boots
-SkullKnight_PlateArmor_Helm	Frostcursed Plate Helm
-Skull_Knight_PlateArmor_Gloves	Frostcursed Plate Gloves
-Skull_Knight_Plate_Boots	Frostcursed Plate Boots
-Sladen_Leather_Gloves	Sladen Leather Gloves
+Sir_Catfish_PlateArmor_Armor	Sir Catfish's Armor	Male
+Sir_Catfish_PlateArmor_Gloves	Sir Catfish's Plate Gloves	Male
+Sir_Catfish_Plate_Boots	Sir Catfish's Plate Boots	Male
+Sirion_Fabric_Armor	Sirion Cloth Armor	Male
+Sirius_Barley_Fabric_Helm	Wyvernflame Cloth Helm	Male
+Sitanca_PlateArmor_Armor	Sitanca Plate Armor	Male
+Skardoo_Leather_Armor	Scarteau Leather Armor	Male
+Skian_Fabric_Helm	Skian Cloth Cap	Male
+SkullKnight_Follower_Plate_Boots_I	Skull Knight Follower's Plate Boots	Male
+SkullKnight_PlateArmor_Helm	Frostcursed Plate Helm	Male
+Skull_Knight_PlateArmor_Gloves	Frostcursed Plate Gloves	Male
+Skull_Knight_Plate_Boots	Frostcursed Plate Boots	Male
+Sladen_Leather_Gloves	Sladen Leather Gloves	Male
 Slarke_OneHandMace	Dekarr Hammer
-Slaughterer_Leahter_Armor	Slaughterer's Leather Armor
-Slave_Fabric_Boots	Slave's Cloth Boots
+Slaughterer_Leahter_Armor	Slaughterer's Leather Armor	Male
+Slave_Fabric_Boots	Slave's Cloth Boots	Male
 Sleep_Arrow	Sleep Arrow
-Sleeshorn_Leather_Gloves	Sleishorn Leather Gloves
-Slowin_Leather_Armor	Slouwen Leather Armor
+Sleeshorn_Leather_Gloves	Sleishorn Leather Gloves	Male
+Slowin_Leather_Armor	Slouwen Leather Armor	Male
 SmallAnimal_Poop	Manure
 Small_Copper_Pack	Light Copper Pouch
+Small_Fire_Bomb	Small Explosive
 Small_Mechanical_Powerplant	Small Battery
 Small_Mechanical_Powerplant_Pack	Small Battery
 Small_Silver_Pack	Modest Silver Pouch
-Smilodon_Leather_Armor	Smilodon Leather Armor
+Smilodon_Leather_Armor	Smilodon Leather Armor	Male
 Smoke_Bomb	Smoke Bomb
 SnapDragon	Snapdragon
-Socket_Test_Gloves	Socket Test Gloves
-Solas_PlateArmor_Armor	Solas Plate Armor
-Solas_PlateArmor_Boots	Solas Plate Boots
-Solas_PlateArmor_Cloak	Solas Plate Cloak
-Solas_PlateArmor_Gloves	Solas Plate Gloves
-Solas_PlateArmor_Gloves_I	Eclipsed Solas Plate Gloves
-Solas_PlateArmor_Helm	Solas Plate Helm
+Socket_Test_Gloves	Socket Test Gloves	Male
+Solas_PlateArmor_Armor	Solas Plate Armor	Male
+Solas_PlateArmor_Boots	Solas Plate Boots	Male
+Solas_PlateArmor_Cloak	Solas Plate Cloak	Male
+Solas_PlateArmor_Gloves	Solas Plate Gloves	Male
+Solas_PlateArmor_Gloves_I	Eclipsed Solas Plate Gloves	Male
+Solas_PlateArmor_Helm	Solas Plate Helm	Male
 Soldier_BackPack	Soldier's Pack
-Soldier_General_Fabric_Cloak	Hernandian Guard Captain's Cloth Cloak
-Soldier_General_PlateArmor_Armor	Guard Captain's Plate Armor
-Soldier_General_PlateArmor_Gloves	Hernandian Guard Captain's Plate Gloves
-Soldier_General_PlateArmor_Helm	Guard Captain's Plate Helm
-Soldier_General_Plate_Boots	Guard Captain's Plate Boots
-Soldworth_Leather_Armor	Solworth Leather Armor
-Somieh_Leather_Armor	Somier Leather Armor
+Soldier_General_Fabric_Cloak	Hernandian Guard Captain's Cloth Cloak	Male
+Soldier_General_PlateArmor_Armor	Guard Captain's Plate Armor	Male
+Soldier_General_PlateArmor_Gloves	Hernandian Guard Captain's Plate Gloves	Male
+Soldier_General_PlateArmor_Helm	Guard Captain's Plate Helm	Male
+Soldier_General_Plate_Boots	Guard Captain's Plate Boots	Male
+Soldworth_Leather_Armor	Solworth Leather Armor	Male
+Somieh_Leather_Armor	Somier Leather Armor	Male
 Songyi_Mushroom	Pine Mushroom
 Songyi_Mushroom_BackPacK	Pine Mushroom Pack
 Songyi_Mushroom_Tea	Pine Mushroom Tea
-Soron_Leather_Armor	Soron Leather Armor
+Soron_Leather_Armor	Soron Leather Armor	Male
 SoulKnight_OneHandSword	Shackle of Might
 Soul_TwoHandSpear	Soul Spear
 Soulknight_Sprit_OneHandSword	Specter Sword
@@ -5388,45 +5411,46 @@ Specialty_Dragon_Slayer_OneHandSword	Specialty Dragon Slayer OneHandSword
 Specialty_Mercenary_OneHandSword	Specialty Mercenary OneHandSword
 Specialty_Oil	Lubricant
 Specialty_Oil_Pack	Lubricant
-Sphezajon_Fabric_Armor	Spetsahorn Cloth Armor
+Sphezajon_Fabric_Armor	Spetsahorn Cloth Armor	Male
 Spider	Spider
 Spider_Poison	Poison
 Spider_Web	Spider Web
-Spiken_Fabric_Armor	Spiken Cloth Armor
-Spital_PlateArmor_Armor	Spiddle Plate Armor
+Spiken_Fabric_Armor	Spiken Cloth Armor	Male
+Spital_PlateArmor_Armor	Spiddle Plate Armor	Male
 Spital_PlateArmor_Armor_I	Spiddle Plate Armor
-Spital_PlateArmor_Armor_II	Blacksteel Spiddle Plate Armor
+Spital_PlateArmor_Armor_II	Blacksteel Spiddle Plate Armor	Male
 Spital_PlateArmor_Armor_III	Blacksteel Spiddle Plate Armor
 Sprayer_BackPack	Field Sprayer
-Srasika_Leather_Gloves	Duskfang Leather Gloves
+Srasika_Leather_Gloves	Duskfang Leather Gloves	Male
 Ssari_Mushroom	Coral Mushroom
 Ssari_Mushroom_BackPack	Coral Mushroom Pack
 Ssari_Mushroom_Tea	Coral Mushroom Tea
-Stammers_Leather_Gloves	Steinmers Leather Gloves
+Stammers_Leather_Gloves	Steinmers Leather Gloves	Female
 Star_OneHandRapier	Sword of Starlight
 Stardust_Necklace	Stardust Necklace
-Steel_OneHandCannon	Steel Blaster
-Steelmaw_PlateArmor_Helm	Steelmaw Plate Helm
+Steel_OneHandCannon	Steel Blaster	Male
+Steelmaw_PlateArmor_Helm	Steelmaw Plate Helm	Male
+Stein_Leather_Armor	Stein Leather Armor	Male
 StellenManor_ClosetKey	Stellen Manor Closet Key
 Stephan_Bleed_Metal_OneHandTowerShield	Shield of Conviction
-Steyer_Leather_Boots	Steyer Leather Boots
-Stian_Fabric_Helm	Stian Cloth Headband
-Stiff_Leather_Armor	Stiv Leather Armor
-Stole_PlateArmor_Armor	Strell Plate Armor
+Steyer_Leather_Boots	Steyer Leather Boots	Male
+Stian_Fabric_Helm	Stian Cloth Headband	Male
+Stiff_Leather_Armor	Stiv Leather Armor	Male
+Stole_PlateArmor_Armor	Strell Plate Armor	Male
 Stone_Honey	Wild Rock Honey
 Stone_Quarry	Stone
 StoreWitchHint_Book	Witches of Pywel
 Storm_Cliff_Flag	Small Vellua Pirates Banner Pike
 Storm_Cliff_Flag_I	Small Vellua Pirates Banner Pike
 Storm_Cliff_Flag_II	Medium Vellua Pirate Banner Pike
-Stratton_Leather_Gloves	Stratton Leather Gloves
-Straw_Fabric_Helm	Straw Bale Helm
+Stratton_Leather_Gloves	Stratton Leather Gloves	Male
+Straw_Fabric_Helm	Straw Bale Helm	Male
 Strawberry	Strawberry
-Studded_Leather_Boots	Stoddard Leather Boots
-Stugrub_Fabric_Gloves	Stugrub Cloth Gloves
+Studded_Leather_Boots	Stoddard Leather Boots	Male
+Stugrub_Fabric_Gloves	Stugrub Cloth Gloves	Male
 Stugrub_Leather_Boots	The Masked Liberator's Leather Boots
 Stugrub_TwoHandSword	Tardik Longsword
-Stugrup_Leather_Armor	Stugrub Leather Armor
+Stugrup_Leather_Armor	Stugrub Leather Armor	Male
 Sugar	Sugar
 SungroveManor_HomeKey	Sungrove Manor Key
 Surasang_00	Grand Meal
@@ -5447,78 +5471,78 @@ Surasang_04_Kudzu	Tart Special Meal
 Surasang_05	Meal
 Surasang_05_amaranth	Fluffy Meal
 Surasang_05_opuntia	Fancy Meal
-Sven_Fabric_Armor	Sven's Cloth Armor
+Sven_Fabric_Armor	Sven's Cloth Armor	Male
 SweetPotato	Sweet Potato
 Sword_DelesyiaInstitute_Clue_CrimDagger	Sharp Dagger
-Syritina_Fabric_Armor	Sirenta Cloth Armor
-Tachan_PlateArmor_Armor	Takhan Plate Armor
-Taebaerae_Leather_Armor	Tarabe Leather Armor
-Tahkah_Fabric_Gloves	Takah Cloth Gloves
-Tahntutta_Fabric_Armor	Tantuta Cloth Armor
+Syritina_Fabric_Armor	Sirenta Cloth Armor	Male
+Tachan_PlateArmor_Armor	Takhan Plate Armor	Male
+Taebaerae_Leather_Armor	Tarabe Leather Armor	Male
+Tahkah_Fabric_Gloves	Takah Cloth Gloves	Male
+Tahntutta_Fabric_Armor	Tantuta Cloth Armor	Male
 Tainsel_OneHandAxe	Black Iron Axe
 Taitolan_TwoHandAlebard	Freesword Halberd
-Takao_PlateArmor_Armor	Takao Plate Armor
-Takat_Leather_Armor	Takkat Leather Armor
-Takatin_Leather_Gloves	Takkan Leather Gloves
-Talbern_Fabric_Armor	Talbern Cloth Armor
-Taliesin_Leather_Gloves	Talisin Leather Gloves
-Tanfat_Leather_Armor	Tavat Leather Armor
-Tanion_Fabric_Armor	Tanion Cloth Armor
-Tanion_PlateArmor_Helm	Tanion Plate Helm
-Tanturhee_Fabric_Armor	Tanturi Cloth Armor
-Taorant_Fabric_Armor	Militia Cloth Armor
-Taorant_Fabric_Armor_II	Tiorant Cloth Armor
-Taorant_Fabric_Cloak	Tiorant Cloth Cloak
+Takao_PlateArmor_Armor	Takao Plate Armor	Male
+Takat_Leather_Armor	Takkat Leather Armor	Male
+Takatin_Leather_Gloves	Takkan Leather Gloves	Male
+Talbern_Fabric_Armor	Talbern Cloth Armor	Male
+Taliesin_Leather_Gloves	Talisin Leather Gloves	Male
+Tanfat_Leather_Armor	Tavat Leather Armor	Male
+Tanion_Fabric_Armor	Tanion Cloth Armor	Female
+Tanion_PlateArmor_Helm	Tanion Plate Helm	Female
+Tanturhee_Fabric_Armor	Tanturi Cloth Armor	Male
+Taorant_Fabric_Armor	Militia Cloth Armor	Male
+Taorant_Fabric_Armor_II	Tiorant Cloth Armor	Male
+Taorant_Fabric_Cloak	Tiorant Cloth Cloak	Male
 Taoria_OneHandSword	Tauria Curved Sword
 Taos_OneHandTowerShield	Lanford Large Shield
-Taos_PlateArmor_Helm	Taos Plate Helm
-Tarandus_Leather_Boots	Tarandus Leather Boots
-Tarandus_PlateArmor_Armor	Tarandus Plate Armor
-Tarandus_PlateArmor_Cloak	Tarandus Leather Cloak
-Tarandus_PlateArmor_Gloves	Tarandus Plate Gloves
-Tarandus_PlateArmor_Helm	Tarandus Plate Helm
-Tarbal_PlateArmor_Helm	Northern Fighter's Plate Helm
-Tarchana_Fabric_Armor	Takana Cloth Armor
-Tarchet_PlateArmor_Helm	Unyielding Warrior's Plate Helm
+Taos_PlateArmor_Helm	Taos Plate Helm	Male
+Tarandus_Leather_Boots	The Ashen's Leather Boots	Male
+Tarandus_PlateArmor_Armor	The Ashen's Plate Armor	Male
+Tarandus_PlateArmor_Cloak	The Ashen's Leather Cloak	Male
+Tarandus_PlateArmor_Gloves	The Ashen's Plate Gloves	Male
+Tarandus_PlateArmor_Helm	The Ashen's Plate Helm	Male
+Tarbal_PlateArmor_Helm	Northern Fighter's Plate Helm	Male
+Tarchana_Fabric_Armor	Takana Cloth Armor	Male
+Tarchet_PlateArmor_Helm	Unyielding Warrior's Plate Helm	Male
 Tardik_OneHandAxe	Tardik Axe
-Tardik_OneHandBow	Golden-Knotted Ancestral Bow
+Tardik_OneHandBow	Golden-Knotted Ancestral Bow	Male
 Tardik_OneHandTowerShield	Reinforced Warspike Large Shield
-Tarif_Fabric_Armor	Tariv Cloth Attire
-Tarif_Fabric_Boots	Tariv Cloth Boots
-Tarif_Fabric_Boots_T3_QA	Tarif Fabric Boots T3 QA
-Tarif_Fabric_Boots_T4_QA	Tarif Fabric Boots T4 QA
-Tarif_Fabric_Cloak	Tariv Cloth Cloak
-Tarif_Fabric_Cloak_I	Bleed Officer's Cloth Cloak
-Tarif_Fabric_Gloves	Tariv Cloth Gloves
-Tarif_Fabric_Gloves_T3_QA	Tarif Fabric Gloves T3 QA
-Tarif_Fabric_Gloves_T4_QA	Tarif Fabric Gloves T4 QA
+Tarif_Fabric_Armor	Tariv Cloth Attire	Male
+Tarif_Fabric_Boots	Tariv Cloth Boots	Male
+Tarif_Fabric_Boots_T3_QA	Tarif Fabric Boots T3 QA	Male
+Tarif_Fabric_Boots_T4_QA	Tarif Fabric Boots T4 QA	Male
+Tarif_Fabric_Cloak	Tariv Cloth Cloak	Male
+Tarif_Fabric_Cloak_I	Bleed Officer's Cloth Cloak	Male
+Tarif_Fabric_Gloves	Tariv Cloth Gloves	Male
+Tarif_Fabric_Gloves_T3_QA	Tarif Fabric Gloves T3 QA	Male
+Tarif_Fabric_Gloves_T4_QA	Tarif Fabric Gloves T4 QA	Male
 Tarif_Necklace	Tarivian Necklace
-Tarman_ChainMail_Armor	Tarman Chain Mail
-Tarmiden_Fabric_Armor	Tarmiden Cloth Armor
+Tarman_ChainMail_Armor	Tarman Chain Mail	Male
+Tarmiden_Fabric_Armor	Tarmiden Cloth Armor	Male
 Taro_seed	Taro Seed
-Tarofierer_Leather_Armor	Tallofer Leather Armor
-Taron_Leather_Gloves	Taylonne Leather Gloves
-Taroon_Fabric_Armor	Tarun Cloth Armor
+Tarofierer_Leather_Armor	Tallofer Leather Armor	Male
+Taron_Leather_Gloves	Taylonne Leather Gloves	Male
+Taroon_Fabric_Armor	Tarun Cloth Armor	Male
 Tarrdik_Wood_OneHandShield	Dekarr Shield
-Tartinan_Fabric_Armor	Lauques Cloth Armor
-Tartinan_Fabric_Cloak	Lauques Cloth Cloak
+Tartinan_Fabric_Armor	Lauques Cloth Armor	Male
+Tartinan_Fabric_Cloak	Lauques Cloth Cloak	Male
 Tartis_TwoHandSpear	Sorcerer's Staff
-Tartti_PlateArmor_Helm	Tartry Plate Helm
-Tarura_Leather_Armor	Tatura Leather Armor
+Tartti_PlateArmor_Helm	Tartry Plate Helm	Male
+Tarura_Leather_Armor	Tatura Leather Armor	Male
 Tashkalp_Contribution_Flag	Tommasoan Contribution Banner Pike
 Tashkalpan_Nobility_Degree_I	Tashkalpian Signet
 Teaghbed_TwoHandAxe	Pailunese Logging Axe
 Technician_BackPack	Technician's Pack
-Telford_Fabric_Armor	Telford Cloth Armor
-Telin_Fabric_Armor	Telin Cloth Armor
-Tenacity_PlateArmor_Helm	Sentinel of Tenacity Helm
-Tesslit_Leather_Boots	Tesslit Leather Boots
-Tesslit_Leather_Gloves	Pavis Leather Gloves
+Telford_Fabric_Armor	Telford Cloth Armor	Male
+Telin_Fabric_Armor	Telin Cloth Armor	Male
+Tenacity_PlateArmor_Helm	Sentinel of Tenacity Helm	Male
+Tesslit_Leather_Boots	Tesslit Leather Boots	Male
+Tesslit_Leather_Gloves	Pavis Leather Gloves	Male
 Tesslit_Leather_Gloves_I	Large Pavis Leather Gloves
-Tesslit_Leather_Gloves_II	Russet Pavis Leather Gloves
+Tesslit_Leather_Gloves_II	Russet Pavis Leather Gloves	Male
 Tesslit_Leather_Gloves_III	Large Pavis Leather Gloves
-Tesslit_Leather_Helm	Helm of Loyal Friendship
-Tesslit_Leather_Helm_T2_QA	Tesslit Leather Helm T2 QA
+Tesslit_Leather_Helm	Helm of Loyal Friendship	Male
+Tesslit_Leather_Helm_T2_QA	Tesslit Leather Helm T2 QA	Male
 TestNeck_1_1	TestNeck 1 1
 TestNeck_1_2	TestNeck 1 2
 TestNeck_2_1	TestNeck 2 1
@@ -5535,62 +5559,62 @@ TestSword	TestSword
 TestTwoHandAxe	TestTwoHandAxe
 Test_OneHandAxe	Test OneHandAxe
 Test_OneHandMace	Test OneHandMace
-Testarmor	Testarmor
-ThiefGloves	Great Thief's Gloves
+Testarmor	Testarmor	Male
+ThiefGloves	Great Thief's Gloves	Male
 ThiefWand_Flower	Shrubby Sophora
-Tibbletanus_Fabric_Cloak	Black Bears' Cloth Cloak
-Tibbletanus_Leather_Armor	Ashclaw Leather Armor
+Tibbletanus_Fabric_Cloak	Black Bears' Cloth Cloak	Male
+Tibbletanus_Leather_Armor	Ashclaw Leather Armor	Male
 Tickatle_Fabric_Armor	Tegatel Cloth Armor
-Ticon_PlateArmor_Armor	Ticon Plate Armor
+Ticon_PlateArmor_Armor	Ticon Plate Armor	Male
 Tiger_Report	Sighting of the White Tiger
 Tiger_Tooth_Ring	Tigerfang Ring
-Tikan_Leather_Gloves	Dark Ringleader's Leather Gloves
+Tikan_Leather_Gloves	Dark Ringleader's Leather Gloves	Male
 Tikkar_Leather_Armor	Tikkal Leather Armor
 Tikkar_Leather_Gloves	Tikkal Leather Bracers
-Tikkree_Fabric_Helm	Tegri Cloth Headband
-Tiknean_Fabric_Armor	Teknin Cloth Armor
+Tikkree_Fabric_Helm	Tegri Cloth Headband	Female
+Tiknean_Fabric_Armor	Teknin Cloth Armor	Male
 TimeBomb	Time Bomb
 Tina_Noble_Leather_Helm	Noble's Hat
-Tinchaon_Fabric_Armor	Tenkan Cloth Armor
+Tinchaon_Fabric_Armor	Tenkan Cloth Armor	Male
 Tinian_Fabric_Armor	Tynion Cloth Armor
-Tionis_Leather_Boots	Grey Rhegis Leather Boots
-Tionis_Leather_Boots_I	Russet Rhegis Leather Boots
-Tirone_Fabric_Armor	Tiron Cloth Armor
-Tirone_Fabric_Gloves	Tiron Cloth Gloves
-Tirone_Leather_Armor	Tiron Leather Armor
-Tirone_Leather_Boots	Tiron Leather Boots
-Tirone_Leather_Gloves	Tiron Leather Gloves
+Tionis_Leather_Boots	Grey Rhegis Leather Boots	Male
+Tionis_Leather_Boots_I	Russet Rhegis Leather Boots	Male
+Tirone_Fabric_Armor	Tiron Cloth Armor	Male
+Tirone_Fabric_Gloves	Tiron Cloth Gloves	Female
+Tirone_Leather_Armor	Tiron Leather Armor	Male
+Tirone_Leather_Boots	Tiron Leather Boots	Male
+Tirone_Leather_Gloves	Tiron Leather Gloves	Male
 Tirone_OneHandAxe	Crow Brothers Axe
 Tironet_OneHandRapier	Grace Rapier
-Tirtit_Leather_Boots	Ator's Will Leather Boots
-Tiruna_Leather_Boots	Tiruna Leather Boots
+Tirtit_Leather_Boots	Ator's Will Leather Boots	Male
+Tiruna_Leather_Boots	Tiruna Leather Boots	Male
 Titan_Necklace	Necklace of Lightning
 Titan_PlateArmor_Armor	Lightning Bolt Plate Armor
 Titan_PlateArmor_Armor_Upgrade	Kuku Lightning-Resistant Armor
-Titan_PlateArmor_Gloves	Lightning Bolt Plate Gloves
-Titan_PlateArmor_Helm	Lightning Bolt Plate Helm
-Titan_Plate_Boots	Lightning Bolt Plate Boots
+Titan_PlateArmor_Gloves	Lightning Bolt Plate Gloves	Male
+Titan_PlateArmor_Helm	Lightning Bolt Plate Helm	Male
+Titan_Plate_Boots	Lightning Bolt Plate Boots	Male
 Titan_Spear	Titan's Spear
 Titunan_Fabric_Armor	Tytuan Cloth Armor
-Tobias_Leather_Boots	Tobias Leather Boots
+Tobias_Leather_Boots	Tobias Leather Boots	Male
 Toddbern_OneHandShotgun	Delesyian Shotgun
-Tohkar_Fabric_Armor	Tohkar Cloth Armor
-Toireth_Fabric_Armor	Torress Cloth Armor
-Toitte_Fabric_Armor	Totte Cloth Armor
-Tokart_Fabric_Armor	Wyvernflames Cloth Armor
-Tokart_Fabric_Cloak	Toggart Cloth Cloak
-Tolkane_Fabric_Armor	Tolkane Cloth Armor
+Tohkar_Fabric_Armor	Tohkar Cloth Armor	Male
+Toireth_Fabric_Armor	Torress Cloth Armor	Male
+Toitte_Fabric_Armor	Totte Cloth Armor	Male
+Tokart_Fabric_Armor	Wyvernflames Cloth Armor	Male
+Tokart_Fabric_Cloak	Toggart Cloth Cloak	Male
+Tolkane_Fabric_Armor	Tolkane Cloth Armor	Male
 Tomaso_Soldiers_TwoHandSpear	Tommaso Guard's Dagger-Tipped Spear
 Tomato	Tomato
 Tomato_Seed	Tomato Seed
-Torben_Fabric_Helm	Torben Cloth Cap
+Torben_Fabric_Helm	Torben Cloth Cap	Male
 Torch	Torch
-Tormand_ChainMail_Armor	Tormand Chain Mail
+Tormand_ChainMail_Armor	Tormand Chain Mail	Male
 Torphel_TwoHandAxe	Hellhounds Chopping Axe
-Torrance_Leather_Armor	Torrance Leather Armor
+Torrance_Leather_Armor	Torrance Leather Armor	Male
 Torretlan_OneHandMusket	Wells Musket
 Tortriden_TwoHandHammer	Lanford Greathammer
-Toudon_Fabric_Armor	Toudon Cloth Armor
+Toudon_Fabric_Armor	Toudon Cloth Armor	Male
 Tower_Key	Beacon Key
 Trade_Armor_03	Ceremonial Armor
 Trade_Armor_PackedInVehicle	Packaged Ceremonial Armor
@@ -5655,8 +5679,8 @@ Trade_Wine_PackedInVehicle	Packaged Wine
 Trade_Wood_PackedInVehicle	Packaged Timber
 Trade_Wool_03	Wool
 Trade_Wool_PackedInVehicle	Packaged Wool
-Traley_ChainMail_Armor	Traley Chain Mail
-Tran_Leather_Gloves	Dram Leather Bracers
+Traley_ChainMail_Armor	Traley Chain Mail	Male
+Tran_Leather_Gloves	Dram Leather Bracers	Female
 Trap_Bomb	Trap Bomb
 Trap_Summon_Decoy_Ball_I	Decoy Summon Ball
 TreasureBuried_FirstPiece	First Piece
@@ -5679,19 +5703,19 @@ TreasureMap_Summer_II	Farmer's Treasure Map Piece 2
 TreasureMap_Summer_III	Farmer's Treasure Map Piece 3
 TreasureMap_Summer_IV	Farmer's Treasure Map Piece 4
 TreasureMap_TreasureBuried	Ursula's Treasure Map
-Treeon_Leather_Gloves	Trion Leather Gloves
+Treeon_Leather_Gloves	Trion Leather Gloves	Male
 Tregllin_TwoHandAlebard	Bekker Halberd
-Triali_PlateArmor_Armor	Triali Plate Armor
+Triali_PlateArmor_Armor	Triali Plate Armor	Male
 Triden_OneHandMace	Artisan's Hand
-Trier_ChainMail_Armor	Trier Chain Mail
-Trier_Leather_Boots	Trier Leather Boots
+Trier_ChainMail_Armor	Trier Chain Mail	Male
+Trier_Leather_Boots	Trier Leather Boots	Male
 Trillion_Leather_Armor	Trellian Leather Armor
 Trinodd_TwoHandAlebard	Celeste Halberd
-Triroan_Fabric_Helm	Triloan Cloth Headband
-Triroan_Leather_Boots	Triloan Leather Boots
-Triroan_Leather_Gloves	Silverwolf Leather Gloves
-Trish_Leather_Boots	Trish Leather Boots
-Trish_Leather_Gloves	Trish Leather Gloves
+Triroan_Fabric_Helm	Triloan Cloth Headband	Male
+Triroan_Leather_Boots	Triloan Leather Boots	Male
+Triroan_Leather_Gloves	Silverwolf Leather Gloves	Male
+Trish_Leather_Boots	Trish Leather Boots	Male
+Trish_Leather_Gloves	Trish Leather Gloves	Male
 Trizion_Leather_Boots	Tression Leather Boots
 TrollMerchant_BackPack_I	Troll Peddler's Pack
 Troom_TwoHandSpear	Ancient Wood Pole
@@ -5702,70 +5726,70 @@ Troopers_HorseArmor_Saddle_I	Wells Military Saddle
 Troopers_HorseArmor_Stirrup	Hyperion Stirrups
 Troopers_TwoHandSpear	Derictus Spear
 Trosdern_OneHandMace	Lanford Mace
-Trouter_Leather_Boots	Trowder Leather Boots
-Trouter_Leather_Gloves	Trowder Leather Gloves
-Troyquartz_Plate_Armor	Troccars Plate Armor
-Trudy_Leather_Armor	Trudy Leather Armor
+Trouter_Leather_Boots	Trowder Leather Boots	Male
+Trouter_Leather_Gloves	Trowder Leather Gloves	Male
+Troyquartz_Plate_Armor	Troccars Plate Armor	Male
+Trudy_Leather_Armor	Trudy Leather Armor	Male
 Trumpet_OneHandShotgun	Trumpet Shotgun
-Trust_PlateArmor_Helm	Sentinel of Trust Helm
-Tryah_Fabric_Armor	Tryah Cloth Armor
+Trust_PlateArmor_Helm	Sentinel of Trust Helm	Male
+Tryah_Fabric_Armor	Tryah Cloth Armor	Male
 Tteokgalbi	Grilled Meat Patties
 Tteokgalbi_Large	Satisfying Grilled Meat Patties
 Tteokgalbi_Medium	Filling Grilled Meat Patties
 Tteokgalbi_XLarge	Hearty Grilled Meat Patties
-Tuetti_Fabric_Armor	Trilly Cloth Armor
-Tuetti_Leather_Boots	Trilly Leather Boots
+Tuetti_Fabric_Armor	Trilly Cloth Armor	Male
+Tuetti_Leather_Boots	Trilly Leather Boots	Male
 Tulio_OneHandTowerShield	Bekker Large Shield
 Turacon_OneHandMusket	Leofric Musket
 Turcadian_TwoHandHammer	Bonepit Greathammer
 Turden_OneHandMace	The Grove's Thorn
 Turtle_BackPack	Turtle Pack
-Tutan_Fabric_Armor	Tutan Cloth Armor
-Twelgh_Leather_Armor	Twell Leather Armor
+Tutan_Fabric_Armor	Tutan Cloth Armor	Male
+Twelgh_Leather_Armor	Twell Leather Armor	Male
 Twich_Earring	Purple Scout Earring
-Twich_Fabric_Armor	Purple Scout Armor
-Twich_Fabric_Cloak	Purple Scout Cloak
+Twich_Fabric_Armor	Purple Scout Armor	Male
+Twich_Fabric_Cloak	Purple Scout Cloak	Male
 Twich_HorseArmor_Helm	Purple Scout Champron
 Twich_HorseArmor_Saddle	Purple Scout Saddle
 Twich_HorseArmor_Stirrup	Purple Scout Stirrups
 Twich_Lantern	Purple Scout Lantern
-Twich_Leather_Helm	Purple Scout Hat
+Twich_Leather_Helm	Purple Scout Hat	Male
 Twich_Necklace	Purple Scout Necklace
 Twich_OneHandShield	Purple Scout Shield
 Twich_Ring	Purple Scout Ring
-Twilight_Whistlers_PlateArmor_Armor_I	Twilight Messengers' Plate Armor
-Twilight_Whistlers_PlateArmor_Armor_II	Golden Free Company's Plate Armor
-Twilight_Whistlers_PlateArmor_Armor_III	Golden Freesword Light Armor
-Twilight_Whistlers_PlateArmor_Armor_IV	Twilight Messenger Vice Captain's Plate Armor
+Twilight_Whistlers_PlateArmor_Armor_I	Twilight Messengers' Plate Armor	Male
+Twilight_Whistlers_PlateArmor_Armor_II	Golden Free Company's Plate Armor	Male
+Twilight_Whistlers_PlateArmor_Armor_III	Golden Freesword Light Armor	Female
+Twilight_Whistlers_PlateArmor_Armor_IV	Twilight Messenger Vice Captain's Plate Armor	Male
 Twilight_Whistlers_PlateArmor_Cloak	Twilight Messengers' Cloak
-Twilight_Whistlers_PlateArmor_Gloves	Twilight Messengers' Plate Gloves
+Twilight_Whistlers_PlateArmor_Gloves	Twilight Messengers' Plate Gloves	Female
 Twilight_Whistlers_PlateArmor_Helm_I	Twilight Messengers' Plate Helm
-Twilight_Whistlers_PlateArmor_Helm_II	Golden Free Company's Plate Helm
-Tybloc_Leather_Armor	Teblecc Leather Armor
-Tychaon_Fabric_Armor	Dark Ringleader's Cloth Armor
-Tychaon_Fabric_Armor_T5_QA	Tychaon Fabric Armor T5 QA
-Tychaon_Fabric_Cloak	Dark Ringleader's Cloth Cloak
-Tychaon_Fabric_Cloak_T5_QA	Tychaon Fabric Cloak T5 QA
+Twilight_Whistlers_PlateArmor_Helm_II	Golden Free Company's Plate Helm	Male
+Tybloc_Leather_Armor	Teblecc Leather Armor	Male
+Tychaon_Fabric_Armor	Dark Ringleader's Cloth Armor	Male
+Tychaon_Fabric_Armor_T5_QA	Tychaon Fabric Armor T5 QA	Male
+Tychaon_Fabric_Cloak	Dark Ringleader's Cloth Cloak	Male
+Tychaon_Fabric_Cloak_T5_QA	Tychaon Fabric Cloak T5 QA	Male
 Tyguis_OneHandMace	Entwined Red Thread Hammer
 Tykatan_Fabric_Armor	Tikatan Cloth Armor
-Tynion_Giant_TwoHandGiantBastard	Absolute Justice Greatsword
+Tynion_Giant_TwoHandGiantBastard	Absolute Justice Greatsword	Female
 Tynion_TwoHandWarHammer	Crow Brothers Warhammer
-Tyran_Fabric_Armor	Tyran Cloth Armor
-Tyran_Leather_Armor	Tyran Leather Armor
-Tyran_Leather_Boots	Tyran Leather Boots
-Tyran_Leather_Gloves	Tyran Leather Gloves
-Tyran_PlateArmor_Helm	Tailan Plate Helm
+Tyran_Fabric_Armor	Tyran Cloth Armor	Male
+Tyran_Leather_Armor	Tyran Leather Armor	Male
+Tyran_Leather_Boots	Tyran Leather Boots	Male
+Tyran_Leather_Gloves	Tyran Leather Gloves	Male
+Tyran_PlateArmor_Helm	Tailan Plate Helm	Male
 Tyrandah_TwoHandedWarHammer	Tardik Warhammer
-Tyrannus_Leather_Armor	Tyrannus Leather Armor
-Tyrcion_Leather_Gloves	Tershan Leather Gloves
-Tyrdal_Leather_Boots	Tyrdall Leather Boots
+Tyrannus_Leather_Armor	Tyrannus Leather Armor	Male
+Tyrcion_Leather_Gloves	Tershan Leather Gloves	Male
+Tyrdal_Leather_Boots	Tyrdall Leather Boots	Male
 Tyrendhal_OneHandMace	Alabaster Mace
-Tyrun_Fabric_Boots	Tyrune Cloth Boots
-Tyrune_Fabric_Armor	Tyrune Cloth Armor
-Ulman_Fabric_Helm	Ulman Cloth Cap
-Ulrich_PlateArmor_Helm	Ulrich Plate Helm
-Ultar_Fabric_Armor	Ultar Cloth Armor
-Ultarine_Leather_Helm	Uphren Leather Helm
+Tyrun_Fabric_Boots	Tyrune Cloth Boots	Male
+Tyrune_Fabric_Armor	Tyrune Cloth Armor	Male
+Ulman_Fabric_Helm	Ulman Cloth Cap	Male
+Ulrich_PlateArmor_Helm	Ulrich Plate Helm	Male
+Ultar_Fabric_Armor	Ultar Cloth Armor	Male
+Ultarine_Leather_Helm	Uphren Leather Helm	Female
 Umbra_Necklace	Eternal Darkness
 Umbrella_Mushroom	Grisette Mushroom
 UnSeal_Epistle	Unsealed Letter
@@ -5784,31 +5808,32 @@ UnknownDiary_Richart	Unknown Adventurer's Log
 UnknownDiary_RonHardt	Unknown Adventurer's Log
 UnknownDiary_Shay_Research	Unknown Adventurer's Log
 UnyieldingShields_Flag	Small Calphadean Banner Pike
-Uronthai_Leather_Armor	Ulontai Leather Armor
-Vain_Leather_Gloves	Byren's Leather Gloves
-Vainbridge_Fabric_Armor	Vainbridge Cloth Armor
-Valcroden_Leather_Armor	Balgraun Leather Armor
-Valion_Leather_Armor	Valion Leather Armor
-Valkyder_PlateArmor_Armor	Valkyder Plate Armor
-Valkyder_PlateArmor_Armor_I	Valkyder Plate Armor
+Uronthai_Leather_Armor	Ulontai Leather Armor	Male
+Vain_Leather_Gloves	Byren's Leather Gloves	Male
+Vainbridge_Fabric_Armor	Vainbridge Cloth Armor	Female
+Valcroden_Leather_Armor	Balgraun Leather Armor	Male
+Valion_Leather_Armor	Valion Leather Armor	Male
+Valkyder_PlateArmor_Armor	Valkyder Plate Armor	Male
+Valkyder_PlateArmor_Armor_I	Valkyder Plate Armor	Male
 ValleyRockWatchTower_Book	Gorgerock Watchman's Journal
-Valliron_ChainMail_Armor	Valton Chain Mail
-Valoric_PlateArmor_Helm	Sungrove Standard Plate Helm
-Valteon_PlateArmor_Armor	Baltheon Plate Armor
-Valteon_PlateArmor_Gloves	Baltheon Plate Gloves
-Vanti_Fabric_Armor	Bantree Cloth Armor
-Varanguard_Leather_Armor	Varanguard Leather Armor
+Valliron_ChainMail_Armor	Valton Chain Mail	Male
+Valnos_Leather_Armor	Valnos Leather Armor	Male
+Valoric_PlateArmor_Helm	Sungrove Standard Plate Helm	Male
+Valteon_PlateArmor_Armor	Baltheon Plate Armor	Male
+Valteon_PlateArmor_Gloves	Baltheon Plate Gloves	Male
+Vanti_Fabric_Armor	Bantree Cloth Armor	Male
+Varanguard_Leather_Armor	Varanguard Leather Armor	Male
 Varantine_Fabric_Armor	Delesyian Cloth Attire
-Varantine_Fabric_Cloak	Delesyian Cloth Cloak
+Varantine_Fabric_Cloak	Delesyian Cloth Cloak	Male
 Varantine_Necklace	Varantin Necklace
 Variska_Leather_Armor	Variska Leather Armor
 Varken_HorseArmor_Helm	Varken Champron
-Varnia_Cloak	Varnian Noble's Cloak
+Varnia_Cloak	Varnian Noble's Cloak	Male
 Varnia_Contribution_Flag	Varnian Contribution Banner Pike
-Varnia_Crown	Varnian Circlet
-Varunin_Leather_Armor	Barunin Leather Armor
-Vdure_ChainMail_Armor	Bedure Chain Mail
-Vdure_ChainMail_Cloak	Bedure Chain Cloak
+Varnia_Crown	Varnian Circlet	Male
+Varunin_Leather_Armor	Barunin Leather Armor	Male
+Vdure_ChainMail_Armor	Bedure Chain Mail	Male
+Vdure_ChainMail_Cloak	Bedure Chain Cloak	Male
 Vegetable_Fruit_Porridge	Harvest Roll
 Vegetable_Fruit_Porridge_Large	Satisfying Harvest Roll
 Vegetable_Fruit_Porridge_Medium	Filling Harvest Roll
@@ -5818,30 +5843,30 @@ Vegetable_Porridge	Vegetable Porridge
 Vegetable_Porridge_Large	Satisfying Vegetable Porridge
 Vegetable_Porridge_Medium	Filling Vegetable Porridge
 Vegetable_Porridge_XLarge	Hearty Vegetable Porridge
-Veil_Leather_Gloves	Veile Leather Gloves
-Vellian_OneHandBow	Kylus Bow
-Vendurs_Leather_Armor	Bendurs Leather Armor
-Vennebis_PlateArmor_Armor_I	Vennebis Plate Armor
-Vennebis_PlateArmor_Armor_II	Righteous Inquisitors Guard's Plate Armor
-Vennebis_PlateArmor_Armor_III	Righteous Inquisitors Guard's Plate Armor
-Vennebis_PlateArmor_Armor_IV	Righteous Inquisitors Guard's Plate Armor
-Verak_Giant_TwoHandGiantBastard	Verak Greatsword
-Verdinan_Fabric_Armor	Verdinan Cloth Armor
-Vergill_Fabric_Armor	Berghill Cloth Armor
-Vergill_Fabric_Helm	Berghill Cloth Cap
+Veil_Leather_Gloves	Veile Leather Gloves	Male
+Vellian_OneHandBow	Kylus Bow	Male
+Vendurs_Leather_Armor	Bendurs Leather Armor	Male
+Vennebis_PlateArmor_Armor_I	Vennebis Plate Armor	Male
+Vennebis_PlateArmor_Armor_II	Righteous Inquisitors Guard's Plate Armor	Male
+Vennebis_PlateArmor_Armor_III	Righteous Inquisitors Guard's Plate Armor	Male
+Vennebis_PlateArmor_Armor_IV	Righteous Inquisitors Guard's Plate Armor	Male
+Verak_Giant_TwoHandGiantBastard	Verak Greatsword	Female
+Verdinan_Fabric_Armor	Verdinan Cloth Armor	Male
+Vergill_Fabric_Armor	Berghill Cloth Armor	Male
+Vergill_Fabric_Helm	Berghill Cloth Cap	Male
 Verheim_TwoHandSword	Sielos Longsword
-Veronde_Fabric_Armor	Veronde Cloth Armor
-Veronde_Fabric_Helm	Veronde Cloth Cap
-Veroon_Leather_Gloves	Behrun Leather Bracers
-Vertical_PlateArmor_Armor	Serroa Plate Armor
+Veronde_Fabric_Armor	Veronde Cloth Armor	Male
+Veronde_Fabric_Helm	Veronde Cloth Cap	Male
+Veroon_Leather_Gloves	Behrun Leather Bracers	Male
+Vertical_PlateArmor_Armor	Serroa Plate Armor	Male
 Very_Small_Copper_Pack	Paltry Copper Pouch
-Vex_Fabric_Armor	Vex Cloth Armor
+Vex_Fabric_Armor	Vex Cloth Armor	Male
 Victorialis	Wild Garlic
 Vigil_OneHandMace	Crude Club
 Vilancia_OneHandPistol	Vilancia Pistol
 Vine_Bomb	Vine Bomb
 Viranche_TwoHandAxe	Horseshoe-Blade Greataxe
-Virerette_Fabric_Armor	Verette Cloth Armor
+Virerette_Fabric_Armor	Verette Cloth Armor	Male
 Visione_Chip_AbandonedHouse	Abandoned House
 Visione_Chip_AbandonedMineVillage	Abandoned Mining Village
 Visione_Chip_Abyss_Platform_01	Memories of the Disconnected Truth
@@ -6212,41 +6237,41 @@ Visione_Chip_pharmacy	Halssius Apothecary
 Visione_Chip_precipicecoffin	Clifftop Coffin
 Visione_Chip_riverdam	Upper Nas River Dam
 Visione_Chip_vinevillage	Ivynook
-Vixer_Leather_Boots	Vixer Leather Shoes
-Volcanic_OneHandCannon	Volcanic Blaster
-Volcker_Fabric_Helm	St. Halssius Priest's Hat
-Volcker_Leather_Boots	St. Halssius Priest's Leather Boots
-Volcker_Leather_Gloves	Vulker Leather Gloves
-Volcker_Leather_Gloves_I	Vulker Leather Gloves
-Volf_Leather_Armor	Rolfe Leather Armor
-Volghan_Fabric_Armor	Bolgan Cloth Armor
+Vixer_Leather_Boots	Vixer Leather Shoes	Male
+Volcanic_OneHandCannon	Volcanic Blaster	Male
+Volcker_Fabric_Helm	St. Halssius Priest's Hat	Male
+Volcker_Leather_Boots	St. Halssius Priest's Leather Boots	Male
+Volcker_Leather_Gloves	Vulker Leather Gloves	Male
+Volcker_Leather_Gloves_I	Vulker Leather Gloves	Male
+Volf_Leather_Armor	Rolfe Leather Armor	Female
+Volghan_Fabric_Armor	Bolgan Cloth Armor	Male
 Volghan_Leather_Gloves	The Masked Liberator's Leather Gloves
-Volghan_PlateArmor_Helm	Bolgan Plate Helm
-Volkard_Fabric_Armor	Volghad Cloth Armor
-Volkirk_Fabric_Armor	Volkirk Cloth Armor
-Volmers_Fabric_Armor	Bahlmers Cloth Armor
+Volghan_PlateArmor_Helm	Bolgan Plate Helm	Male
+Volkard_Fabric_Armor	Volghad Cloth Armor	Male
+Volkirk_Fabric_Armor	Volkirk Cloth Armor	Male
+Volmers_Fabric_Armor	Bahlmers Cloth Armor	Male
 Volono_OneHandRapier	Volono Rapier
-Volruin_Fabric_Armor	Bollin Cloth Armor
-Volruin_Fabric_Helm	Bollin Cloth Cap
-Volruin_Leather_Boots	Bollin Leather Boots
-Volruin_Leather_Gloves	Bollin Leather Gloves
+Volruin_Fabric_Armor	Bollin Cloth Armor	Male
+Volruin_Fabric_Helm	Bollin Cloth Cap	Male
+Volruin_Leather_Boots	Bollin Leather Boots	Male
+Volruin_Leather_Gloves	Bollin Leather Gloves	Male
 Volta_OneHandRapier	Dueling Rapier
-Vorren_Leather_Helm	Boren Leather Helm
+Vorren_Leather_Helm	Boren Leather Helm	Male
 Vueh_OneHandRapier	Inquisitor's Rapier
-Vuldrion_Leather_Armor	Valldren Leather Armor
-Vyrer_Leather_Armor	Vyer Leather Armor
+Vuldrion_Leather_Armor	Valldren Leather Armor	Female
+Vyrer_Leather_Armor	Vyer Leather Armor	Male
 Wagon_HorseArmor_Armor	Wagon Barding
 Wagon_HorseArmor_Armor_II	Wagon Barding II
-Wakhan_Leather_Armor	Wakhan Leather Armor
-Walder_Leather_Boots	Walder Leather Boots
-Waller_Leather_Gloves	Waller Leather Gloves
+Wakhan_Leather_Armor	Wakhan Leather Armor	Male
+Walder_Leather_Boots	Walder Leather Boots	Male
+Waller_Leather_Gloves	Waller Leather Gloves	Male
 Walter_OneHandShotgun	Bleed Shotgun
 Wanderer_Mercenary_TwoHandSword	Sydmon Longsword
-Wandering_Leather_Helm	Wandering Leather Helm
-Wandering_Mercenary_Leather_Armor	Wandering Freesword's Leather Armor
+Wandering_Leather_Helm	Wandering Leather Helm	Female
+Wandering_Mercenary_Leather_Armor	Wandering Freesword's Leather Armor	Male
 Wanted_Criminal_BackPack_I	Outlaw's Gold Ore Pack
-Wanted_Criminal_BackPack_II	Outlaw's Graverobber Pack
-Wants_Leather_Gloves	Wentz Leather Gloves
+Wanted_Criminal_BackPack_II	Outlaw's Graverobber Pack	Female
+Wants_Leather_Gloves	Wentz Leather Gloves	Male
 WarRobot_Backpack_01	A.T.A.G. Thrusterpack Mk I
 WarRobot_Backpack_02	A.T.A.G. Thrusterpack Mk II
 WarRobot_Backpack_03	A.T.A.G. Thrusterpack Mk III
@@ -6263,16 +6288,16 @@ WarRobot_Gatling_01	A.T.A.G. Machine Gun
 WarRobot_Laser_01	A.T.A.G. Laser
 WarRobot_RepairTool_01_L	A.T.A.G. Pincers
 WarRobot_RepairTool_01_R	A.T.A.G. Welder
-Warblick_Fabric_Armor	Warblick Cloth Armor
-Warren_Beynon_Leather_Boots	Warren Beynon's Leather Boots
-Warstein_Fabric_Armor	Warstein Cloth Armor
+Warblick_Fabric_Armor	Warblick Cloth Armor	Male
+Warren_Beynon_Leather_Boots	Warren Beynon's Leather Boots	Male
+Warstein_Fabric_Armor	Warstein Cloth Armor	Male
 Warthog_Armor	Warthog Saddle
 Watcher_BackPack	Watcher Pack
 Water	Water
 WaterPower_BackPack	Hydro Generator Bag
-WaterSliding_Plate_Boots	Vaporwalker
+WaterSliding_Plate_Boots	Vaporwalker	Male
 Water_Bomb	Water Bomb
-Watous_Leather_Gloves	Wertesh Leather Gloves
+Watous_Leather_Gloves	Wertesh Leather Gloves	Male
 Weapon_BackPack_I	Weaponsmith's Pack
 Weapon_BackPack_II	Weaponsmith's Pack
 Weapon_BackPack_III	Weaponsmith's Pack
@@ -6283,37 +6308,37 @@ Weapon_BackPack_VI	Weaponsmith's Pack
 Weapon_BackPack_VII	Weaponsmith's Pack
 Weapon_BackPack_VIII	Weaponsmith's Pack
 Weapon_BackPack_X	Weaponsmith's Pack
-Weasel_Leather_Armor	Weasel Leather Armor
-Weasel_Leather_Boots	Weasel Leather Boots
-Weasel_Leather_Cloak	Weasel Leather Cloak
-Weasel_Leather_Gloves	Weasel Leather Gloves
+Weasel_Leather_Armor	Weasel Leather Armor	Male
+Weasel_Leather_Boots	Weasel Leather Boots	Male
+Weasel_Leather_Cloak	Weasel Leather Cloak	Male
+Weasel_Leather_Gloves	Weasel Leather Gloves	Male
 WeatherWeaver_Necklace	Rainstorm Necklace
 WeatherWeaver_Sunny_Necklace	Radiant Necklace
-Weeren_PlateArmor_Gloves	Weirren Plate Gloves
-Wegalawn_Leather_Gloves	Vicaron Leather Gloves
+Weeren_PlateArmor_Gloves	Weirren Plate Gloves	Male
+Wegalawn_Leather_Gloves	Vicaron Leather Gloves	Female
 WellsDungeon_Key	Thornbriar Dungeon Key
-WellsKnight_PlateArmor_Armor	Grotevant Plate Armor
-WellsKnight_PlateArmor_Cloak	Grotevant Cloak
-WellsKnight_PlateArmor_Gloves	Grotevant Plate Gloves
-WellsKnight_PlateArmor_Helm	Grotevant Plate Helm
-WellsKnight_Plate_Boots	Grotevant Plate Boots
+WellsKnight_PlateArmor_Armor	Grotevant Plate Armor	Male
+WellsKnight_PlateArmor_Cloak	Grotevant Cloak	Male
+WellsKnight_PlateArmor_Gloves	Grotevant Plate Gloves	Male
+WellsKnight_PlateArmor_Helm	Grotevant Plate Helm	Male
+WellsKnight_Plate_Boots	Grotevant Plate Boots	Male
 Wells_Brigade_Flag	Small Wells Brigade Banner Pike
-Wells_Brigade_Rebel_ChainMail_Armor_I	Turncoat Chain Mail
-Wells_Brigade_Rebel_ChainMail_Armor_II	Turncoat Chain Mail
-Wells_Brigade_Rebel_Fabric_Armor_I	Turncoat Cloth Armor
-Wells_Brigade_Rebel_Fabric_Armor_II	Turncoat Light Cloth Armor
-Wells_Brigade_Rebel_Fabric_Armor_III	Turncoat Cloth Armor
-Wells_Brigade_Rebel_Leather_Armor_I	Turncoat Leather Armor
-Wells_Brigade_Rebel_PlateArmor_Armor_I	Turncoat Plate Armor
-Wells_Brigade_Rebel_PlateArmor_Armor_II	Turncoat Plate Armor
-Wells_Brigade_Rebel_PlateArmor_Armor_III	Turncoat Plate Armor
-Wells_Brigade_Rebel_PlateArmor_Armor_IV	Elite Turncoat Plate Armor
-Wells_Brigade_Rebel_PlateArmor_Armor_V	Elite Turncoat Plate Armor
-Wells_Brigade_Rebel_PlateArmor_Gloves	Turncoat Plate Gloves
+Wells_Brigade_Rebel_ChainMail_Armor_I	Turncoat Chain Mail	Male
+Wells_Brigade_Rebel_ChainMail_Armor_II	Turncoat Chain Mail	Male
+Wells_Brigade_Rebel_Fabric_Armor_I	Turncoat Cloth Armor	Male
+Wells_Brigade_Rebel_Fabric_Armor_II	Turncoat Light Cloth Armor	Male
+Wells_Brigade_Rebel_Fabric_Armor_III	Turncoat Cloth Armor	Male
+Wells_Brigade_Rebel_Leather_Armor_I	Turncoat Leather Armor	Male
+Wells_Brigade_Rebel_PlateArmor_Armor_I	Turncoat Plate Armor	Male
+Wells_Brigade_Rebel_PlateArmor_Armor_II	Turncoat Plate Armor	Male
+Wells_Brigade_Rebel_PlateArmor_Armor_III	Turncoat Plate Armor	Male
+Wells_Brigade_Rebel_PlateArmor_Armor_IV	Elite Turncoat Plate Armor	Male
+Wells_Brigade_Rebel_PlateArmor_Armor_V	Elite Turncoat Plate Armor	Male
+Wells_Brigade_Rebel_PlateArmor_Gloves	Turncoat Plate Gloves	Male
 Wells_Flag_I	Small Wells Banner Pike
 Wells_Flag_II	Medium Wells Banner Pike
 Wells_HorseArmor_Armor	Wells Military Barding
-Wells_PlateArmor_Armor	Turncoat Rider Plate Armor
+Wells_PlateArmor_Armor	Turncoat Rider Plate Armor	Male
 Wells_TwoHandGiantSpear	Elite Vanguard
 WestDemenissChurch_Key	Church Crypt Key
 Wheat	Wheat
@@ -6324,18 +6349,18 @@ WhiteHair_Root	Satintail Root
 WhiteHorn_Earring	White Horn's Earring
 WhiteHorn_Leather_Helm	White Horn Leather Helm
 WhiteStone	Scolecite Ore
-White_Bear_Leather_Helm	White Bear Helm
-White_Crocodile_Leather_Gloves	Pale Predator's Leather Gloves
-White_Douglas_Leather_Gloves	Crowcaller's White Leather Bracers
+White_Bear_Leather_Helm	White Bear Helm	Male
+White_Crocodile_Leather_Gloves	Pale Predator's Leather Gloves	Male
+White_Douglas_Leather_Gloves	Crowcaller's White Leather Bracers	Male
 White_Horse_Report	Sighting of Royler
 White_Lion_Necklace	White Lion Necklace
 Wild_Honey	Wild Honey
 Wild_Insam	Wild Ginseng
-Wildness_PlateArmor_Helm	Feral Sentinel Helm
+Wildness_PlateArmor_Helm	Feral Sentinel Helm	Male
 Wind_Power_OneHandShield	Gale Shield
 Wind_TwoHandSpear	Propeller Spear
 WindmillCoastShipWreck_Book	Navigator's Log
-Wintharden_Fabric_Armor	Ator's Will Cloth Armor
+Wintharden_Fabric_Armor	Ator's Will Cloth Armor	Male
 WitchWarehouse_Key	Witch's Storehouse Key
 Witch_WingFan	Eastern Witch's Fan
 Witch_WingFan_01	Desert Journey Fan
@@ -6348,23 +6373,23 @@ Witch_WingFan_07	Fan of Leisure
 Witch_WingFan_08	Fan of Bitter Love
 Witch_WingFan_09	Fan of Secret Garden
 Witch_WingFan_10	Fan of Noble Lady's Rest
-Witley_Fabric_Boots	Whitley Cloth Boots
-Witley_Fabric_Gloves	Whitley Cloth Gloves
-Witley_Leather_Armor	Whitley Leather Armor
-Witters_PlateArmor_Gloves	Witters Plate Gloves
-Witters_PlateArmor_Helm	Witters Plate Helm
-Witters_Plate_Boots	Witters Plate Boots
+Witley_Fabric_Boots	Whitley Cloth Boots	Male
+Witley_Fabric_Gloves	Whitley Cloth Gloves	Male
+Witley_Leather_Armor	Whitley Leather Armor	Male
+Witters_PlateArmor_Gloves	Witters Plate Gloves	Male
+Witters_PlateArmor_Helm	Witters Plate Helm	Male
+Witters_Plate_Boots	Witters Plate Boots	Male
 Wolf_Armor	Wolf Saddle
-Wolf_Chief_Leather_Helm	Alpha Wolf Helm
+Wolf_Chief_Leather_Helm	Alpha Wolf Helm	Male
 Wolf_Leather	Long Hair Hide
-Wolf_OneHandSword	Sword of the Wolf
-Wolf_Pursuer_Fabric_Armor	Wolf Tracker Cloth Armor
-Wolf_Pursuer_Fabric_Cloak	Wolf Tracker Cloth Cloak
-Wolf_Pursuer_Fabric_Helm	Wolf Tracker Helm
-Wolf_Pursuer_Leather_Armor	Wolf Tracker Leather Armor
-Wolf_Pursuer_Leather_Armor_II	Wolf Tracker Vice Captain's Leather Armor
-Wolf_Pursuer_Leather_Boots	Wolf Tracker Leather Boots
-Wolf_Pursuer_Leather_Gloves	Wolf Tracker Leather Gloves
+Wolf_OneHandSword	Sword of the Wolf	Male
+Wolf_Pursuer_Fabric_Armor	Wolf Tracker Cloth Armor	Male
+Wolf_Pursuer_Fabric_Cloak	Wolf Tracker Cloth Cloak	Male
+Wolf_Pursuer_Fabric_Helm	Wolf Tracker Helm	Male
+Wolf_Pursuer_Leather_Armor	Wolf Tracker Leather Armor	Male
+Wolf_Pursuer_Leather_Armor_II	Wolf Tracker Vice Captain's Leather Armor	Male
+Wolf_Pursuer_Leather_Boots	Wolf Tracker Leather Boots	Male
+Wolf_Pursuer_Leather_Gloves	Wolf Tracker Leather Gloves	Male
 Wolf_Test_OneHandSword	Wolf Test OneHandSword
 Wood	Timber
 Wood_Branch_01	Tree Branch
@@ -6391,33 +6416,33 @@ Wood_Branch_Hard_Usable	Rough and Sturdy Tree Branch
 Wood_Branch_Usable	Rough Tree Branch
 Wood_Branch_WildSpirit	Divine Tree Branch
 Wood_Lantern	Wooden Lantern
-Wood_OneHandShield	Grey Wolf Wooden Shield
-Woodbrock_Leather_Boots	Woodbrock Leather Boots
-Woodys_Leather_Gloves	Wyrdins Leather Gloves
-Wooeun_Leather_Boots	Wattern Leather Greaves
+Wood_OneHandShield	Grey Wolf Wooden Shield	Male
+Woodbrock_Leather_Boots	Woodbrock Leather Boots	Male
+Woodys_Leather_Gloves	Wyrdins Leather Gloves	Male
+Wooeun_Leather_Boots	Wattern Leather Greaves	Male
 Wool	Fleece
-Worstern_Leather_Gloves	Weiston Leather Gloves
-Wurten_Leather_Armor	Buellen Leather Armor
-Wusian_Fabric_Armor	Ushreen Cloth Armor
+Worstern_Leather_Gloves	Weiston Leather Gloves	Male
+Wurten_Leather_Armor	Buellen Leather Armor	Male
+Wusian_Fabric_Armor	Ushreen Cloth Armor	Male
 Wyvern_Flag_I	Small Wyvernflames Banner Pike
 Wyvern_Flag_II	Medium Wyvernflames Banner Pike
-Wyvern_Leather_Helm	Lizard Leather Helm
-Xasameruen_Leather_Gloves	Jasmern Leather Gloves
+Wyvern_Leather_Helm	Lizard Leather Helm	Male
+Xasameruen_Leather_Gloves	Jasmern Leather Gloves	Female
 YamatoCannon_TwoHandSpear	Laser Cannon Spear
-Yann_Basic_Leather_Armor	Silverwolf Leather Armor
-Yann_Basic_Leather_Cloak	Silverwolf Leather Cloak
-Yorkey_Fabric_Armor	Yorkey Cloth Armor
-Yuzel_Fabric_Helm	Yuzel Cloth Cap
-Zamir_Fabric_Armor	Zamir Cloth Armor
-Zial_Fabric_Armor	Ziahl Cloth Armor
+Yann_Basic_Leather_Armor	Silverwolf Leather Armor	Male
+Yann_Basic_Leather_Cloak	Silverwolf Leather Cloak	Male
+Yorkey_Fabric_Armor	Yorkey Cloth Armor	Male
+Yuzel_Fabric_Helm	Yuzel Cloth Cap	Male
+Zamir_Fabric_Armor	Zamir Cloth Armor	Male
+Zial_Fabric_Armor	Ziahl Cloth Armor	Male
 Ziane_Diary	Jian's Journal
 Ziane_OneHandSword	Wolf's Fang
-Ziggurat_Fabric_Helm	Ziggurat Cloth Helm
-Ziggurat_Leather_Gloves_I	Ziggurat Leather Gloves
-Ziggurat_Leather_Gloves_II	Ziggurat Leather Gloves
-Ziggurat_Leather_Helm_II	Chemists' Mask Leather Helm
-Ziggurat_Leather_Helm_III	Chemists' Iron Mask Leather Helm
-Zinianne_Fabric_Armor	Zynian Cloth Armor
+Ziggurat_Fabric_Helm	Ziggurat Cloth Helm	Male
+Ziggurat_Leather_Gloves_I	Ziggurat Leather Gloves	Male
+Ziggurat_Leather_Gloves_II	Ziggurat Leather Gloves	Male
+Ziggurat_Leather_Helm_II	Chemists' Mask Leather Helm	Male
+Ziggurat_Leather_Helm_III	Chemists' Iron Mask Leather Helm	Male
+Zinianne_Fabric_Armor	Zynian Cloth Armor	Male
 barnia_Flag_I	Small Varnian Banner Pike
 barnia_Flag_II	Medium Varnian Banner Pike
 burrowingtoad	Burrowing Toad
@@ -6435,7 +6460,7 @@ demenissnobility_Flag_III	Small Demenissian Noble's Banner
 demenissnobility_Flag_IV	Medium Demenissian Noble's Banner Pike
 demenissnobility_Flag_V	Medium Demenissian Noble's Banner Pike
 demenissnobility_Flag_VI	Medium Demenissian Noble's Banner Pike
-diereuben_Leather_Gloves	Dirrebin Leather Bracers
+diereuben_Leather_Gloves	Dirrebin Leather Bracers	Male
 dragonkiller_Flag_I	Small Flame Knights Banner Pike
 dragonkiller_Flag_II	Medium Flame Knights Banner Pike
 fort_Flag_I	Small Dusksongs Banner Pike
@@ -6459,8 +6484,8 @@ graymane_Flag_III	Medium Greymane Banner Pike
 greenfrog	Tree Frog
 king_LostPeople_PlateArmor_Armor	Frostcursed Plate Armor
 king_LostPeople_PlateArmor_Armor_Upgrade	Kuku Ice-Resistant Armor
-king_LostPeople_PlateArmor_Cloak	Frostcursed Plate Cloak
-lilian_Leather_Boots	Lilian Leather Boots
+king_LostPeople_PlateArmor_Cloak	Frostcursed Plate Cloak	Male
+lilian_Leather_Boots	Lilian Leather Boots	Male
 marni_Flag_I	Small Marni Banner Pike
 marni_Flag_II	Medium Marni Banner Pike
 musket_Flag_I	Small Musket of Demeniss Banner Pike
@@ -6471,9 +6496,9 @@ orchids_BackPack	Dendrobium Orchid Pack
 pailloon_Flag_I	Small Pailunese Banner Pike
 pailloon_Flag_II	Medium Pailunese Banner Pike
 peas	Peas
-riding_Leather_Boots	Riding Boots
-riding_Leather_Gloves	Master Trainer's Touch
-riding_Leather_Helm	Leather Riding Hat
+riding_Leather_Boots	Riding Boots	Male
+riding_Leather_Gloves	Master Trainer's Touch	Male
+riding_Leather_Helm	Leather Riding Hat	Male
 scorpion	Scorpion
 silence_Flag_I	Small Heavy Silence Banner Pike
 silence_Flag_II	Medium Heavy Silence Banner Pike

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Title for next release]
+## Correct female armor and body filter restored
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed boss and unique armor (Guardian of Odeck, Dark Marksman, Masked Liberator) looking male on Damiane; it now shows her correct female version.
+- The Dye button now works before you have saved an outfit preset, creating one for you automatically instead of doing nothing.
+- Improved gear filtering so each character only sees the items their body can actually wear.

--- a/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
+++ b/CrimsonDesertLiveTransmog/docs/nexus-bbcode.txt
@@ -20,7 +20,7 @@ Change the visual appearance of your equipped armor [b]in real time[/b] without 
 [*][b]Body-mesh prefab picker[/b] -optional per-slot prefab swap for users who want to mix and match individual mesh variants beyond what the item picker exposes
 [*][b]Preset system[/b] -save, load, rename, and cycle through multiple transmog presets per character
 [*][b]Multi-character support[/b] -independent preset lists for Kliff, Damiane, and Oongka. Every visible protagonist's preset is applied automatically on world entry (and to followers as soon as they're summoned in-game), and the active preset follows whoever you control
-[*][b]Body-type filter[/b] -hides items whose body type (male/female) does not match the active character so broken meshes stay out of the picker. Per-character override available in the overlay for body-swap mod users. Temporarily disabled on game version 1.13.00 while it is reworked; all other picker filters work normally
+[*][b]Body-type filter[/b] -hides items whose body type (male/female) does not match the active character so broken meshes stay out of the picker. Per-character override available in the overlay for body-swap mod users
 [*][b]NPC and damaged variants[/b] -NPC armor variants and damaged variants render via automatic carrier swap
 [*][b]Safety filters[/b] -non-player gear (horse tack, pet armor) and wrong-slot items are filtered out by default
 [*][b]Per-slot control[/b] -enable/disable transmog independently for each equipment slot

--- a/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
+++ b/CrimsonDesertLiveTransmog/src/aob_resolver.hpp
@@ -529,14 +529,13 @@ namespace Transmog
      * no mesh. Toggling this one byte 0x74 (jz rel8) -> 0xEB (jmp rel8) forces the match, so NPC/variant items render
      * on the carrier's body.
      *
-     * v1.13.00 RELOCATION (the final carrier-invisible bug, and a subtle mis-fix). The evaluator moved -- it was
-     * sub_141D5F470+0xC8 (0x141D5F538 on v1.02) -- and its inner loop gained a `90` (nop) between the movzx and the
-     * cmp. A prior 1.13 "fix" changed the allowed-array load register `4C 8B 43` (rbx) -> `4D 8B 45` (r13), which made
-     * the AOB re-lock onto a STRUCTURALLY IDENTICAL loop in an UNRELATED function (~0x1423AAxxx) that is never on the
-     * carrier-apply path -- so the bypass silently toggled dead code (proven live: 0 breakpoint hits at 0x1423AAAE8
-     * during a carrier apply, while this site fires). The real gate KEEPS `4C 8B 43` (rbx) and reads the item's
-     * char-class at `word[rax+0xAC]` (was +0x8A pre-1.13). It resolves to 0x141F90723; the jz is at match+0x12 =
-     * 0x141F90735. Verified live: forcing this jz renders the Preset-4 NPC/boss armor.
+     * v1.13.00 RELOCATION (the final carrier-invisible bug, and a subtle mis-fix). The evaluator moved -- it was a
+     * sub_...+0xC8 offset on earlier builds -- and its inner loop gained a `90` (nop) between the movzx and the cmp. A
+     * prior 1.13 "fix" changed the allowed-array load register `4C 8B 43` (rbx) -> `4D 8B 45` (r13), which made the AOB
+     * re-lock onto a STRUCTURALLY IDENTICAL loop in an UNRELATED function that is never on the carrier-apply path -- so
+     * the bypass silently toggled dead code (proven live: 0 breakpoint hits at the look-alike during a carrier apply,
+     * while this site fires). The real gate KEEPS `4C 8B 43` (rbx) and reads the item's char-class at `word[rax+0xAC]`
+     * (was +0x8A pre-1.13); the jz is at match+0x12. Verified live: forcing this jz renders the Preset-4 NPC/boss armor.
      *
      * The `90` nop AND the `4C 8B 43` (rbx) register disambiguate from the ~0x1423AAxxx look-alike (which has r13 and
      * no nop) and from the +0x70 sibling loop in the same function; the trailing `EB` (the OUTER loop's no-match jmp,
@@ -566,6 +565,75 @@ namespace Transmog
          "33 C9 85 D2 74 ?? 4C 8B 43 ?? 44 0F B7 88 ?? ?? 00 00 90 "
          "66 45 3B 0C 48 74 ?? FF C1 3B CA 72 ?? EB",
          ResolveMode::Direct, 0x18, 0},
+    };
+
+    // -----------------------------------------------------------------------
+    // BodyVariantHook targets: the per-body mesh variant resolver + its render primitive.
+    //
+    //   BodyVariantResolver : sub_141F90630 -- walks each item's per-body variant entries (list at arg1+0x3E0, count
+    //                                          +0x3E8, stride 0x58) and renders the entry whose token list matches the
+    //                                          wearer's body token, or nothing if none match. Inline-hooked so LT keeps
+    //                                          the natural per-body match yet can still force entry[0] for NPC items
+    //                                          the player cannot naturally wear. The char-class bypass jz (see
+    //                                          k_charClassBypassCandidates, resolved inside this same function) is
+    //                                          the force lever. Returns void (its sole caller discards rax).
+    //   BodyVariantRender   : sub_1412B2370 -- render primitive the resolver calls once per matched entry (call site:
+    //                                          rcx=ctx, rdx=entry+0x10 mesh, r8d=entry+0x18). Midhooked as a pure
+    //                                          observer so LT can tell whether the un-bypassed resolver rendered.
+    //
+    // Each target carries a 3-anchor cascade per the ordering rule in
+    // CrimsonDesertCore/external/DetourModKit/docs/misc/aob-signatures.md: P1 is the full prologue (most specific),
+    // P2 and P3 are progressively deeper body landmarks that walk back to the function start via a negative dispOffset.
+    // P2 and P3 both anchor PAST the SafetyHook 5-byte prologue window, so if a sibling mod inline-hooks the prologue
+    // the regular cascade still resolves the function without depending on the prologue-overwrite fallback. All six
+    // patterns verified as single unique hits (require_unique) on v1.13.00 .text.
+    inline constexpr AddrCandidate k_bodyVariantResolverCandidates[] = {
+        // P1 -- full prologue: 5 callee-saved pushes + 0x30 frame + mov r13,rcx + the edx spill, ending on the opcode
+        // of the registry load `mov rcx,[rip+disp32]`. The disp32 is left off the tail rather than wildcarded, so no
+        // shifting field is committed.
+        {"BodyVariantResolver_P1_Prologue",
+         "40 55 57 41 54 41 55 41 57 48 83 EC 30 4C 8B E9 89 54 24 68 48 8B 0D",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- post-prologue registry-lookup setup: mov r13,rcx / spill edx / load registry global (RIP disp32
+        // wildcarded) / lea rdx,[rsp+0x68] / add rcx,0x60 / mov r15,r9 / movzx edi,r8w. Anchors at function start + 0xD,
+        // so walk-back -0xD. Survives a prologue push/frame reshuffle that leaves this argument setup intact.
+        {"BodyVariantResolver_P2_RegistryLookupSetup",
+         "4C 8B E9 89 54 24 68 48 8B 0D ?? ?? ?? ?? 48 8D 54 24 68 48 83 C1 60 4D 8B F9 41 0F B7 F8",
+         ResolveMode::Direct, -0xD, 0},
+
+        // P3 -- the variant-list walk that defines this function: mov rsi,[r13+0x3E0] (entry list) / mov eax,[r13+0x3E8]
+        // (count) / imul r14,rax,0x58 (entry stride) / add r14,rsi / cmp rsi,r14 (empty-list guard). The 0x3E0/0x3E8
+        // field offsets and the 0x58 stride are stable game-struct constants kept literal. Anchors at function start +
+        // 0x8B, so walk-back -0x8B.
+        {"BodyVariantResolver_P3_VariantListWalk",
+         "49 8B B5 E0 03 00 00 41 8B 85 E8 03 00 00 4C 6B F0 58 4C 03 F6 49 3B F6",
+         ResolveMode::Direct, -0x8B, 0},
+    };
+
+    inline constexpr AddrCandidate k_bodyVariantRenderCandidates[] = {
+        // P1 -- full prologue: two shadow-slot spills + push rdi + 0x20 frame + the argument shuffle
+        // (mov rbx,rcx / mov esi,r8d / mov rcx,[rcx] / mov rdi,rdx). All-literal; no field the linker can move.
+        {"BodyVariantRender_P1_Prologue",
+         "48 89 5C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B D9 41 8B F0 48 8B 09 48 8B FA",
+         ResolveMode::Direct, 0, 0},
+
+        // P2 -- the argument shuffle + list deref/null-test after the frame setup: mov rbx,rcx / mov esi,r8d /
+        // mov rcx,[rcx] (deref the entry-list holder) / mov rdi,rdx / test rcx,rcx. Anchors at function start + 0xF, so
+        // walk-back -0xF. Stops before the rel8 early-out jz, which is not anchored on (jz flips between rel8 and rel32
+        // encodings across builds).
+        {"BodyVariantRender_P2_ArgShuffleListDeref",
+         "48 8B D9 41 8B F0 48 8B 09 48 8B FA 48 85 C9",
+         ResolveMode::Direct, -0xF, 0},
+
+        // P3 -- the empty-list early-out tail: mov r8d,esi (pass the count through) / restore rbx from [rsp+0x38] and
+        // rsi from [rsp+0x40] / add rsp,0x20 / pop rdi / jmp (tail-call to the fallback; the rel32 jmp opcode is the
+        // trailing anchor, its displacement left off the tail). The r8d passthrough plus the exact shadow-slot restores
+        // make this site function-specific where the shared vector-insert body further down does not. Anchors at
+        // function start + 0x20, so walk-back -0x20.
+        {"BodyVariantRender_P3_EmptyListTailCall",
+         "44 8B C6 48 8B 5C 24 38 48 8B 74 24 40 48 83 C4 20 5F E9",
+         ResolveMode::Direct, -0x20, 0},
     };
 
     // -----------------------------------------------------------------------

--- a/CrimsonDesertLiveTransmog/src/body_variant_hook.cpp
+++ b/CrimsonDesertLiveTransmog/src/body_variant_hook.cpp
@@ -1,0 +1,176 @@
+// body_variant_hook.cpp
+#include "body_variant_hook.hpp"
+
+#include "aob_resolver.hpp"
+#include "shared_state.hpp"
+
+#include <DetourModKit.hpp>
+#include <safetyhook.hpp>
+
+#include <Windows.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace DMK = DetourModKit;
+
+namespace Transmog::BodyVariantHook
+{
+    namespace
+    {
+        // sub_141F90630(arg1, arg2, arg3, arg4) -> void. arg1 (rcx) holds the per-body variant-entry list at +0x3E0
+        // and its count at +0x3E8 (stride 0x58). The sole caller discards rax, so the wrapper forwards no return. The
+        // args are taken at register width (uint64_t) to avoid any truncation across the trampoline; the engine reads
+        // only the low parts (edx, r8w).
+        using ResolverFn = void (*)(void *, std::uint64_t, std::uint64_t, void *);
+        ResolverFn g_origResolver = nullptr;
+
+        // The char-class bypass jz byte inside the resolver's token-match loop (resolved via
+        // k_charClassBypassCandidates into resolved_addrs().charClassBypass). 0xEB force-accepts entry[0]; 0x74
+        // restores the natural jz.
+        std::uintptr_t g_bypassAddr = 0;
+
+        // Set true once install() has wired both hooks. Read by the transmog apply path via is_active() to decide
+        // whether to engage the legacy bypass-force fallback. Written once during init before any apply runs; the
+        // apply reads run on the game thread afterwards, so a relaxed atomic is sufficient.
+        std::atomic<bool> g_active{false};
+
+        // Observation state for the current resolver call. The resolver and its render call run on the same thread;
+        // thread_local keeps the flags correct even if the engine resolves an appearance off the game thread.
+        thread_local bool tl_inResolver = false;
+        thread_local bool tl_rendered = false;
+
+        void write_bypass(std::uint8_t value) noexcept
+        {
+            if (!g_bypassAddr)
+            {
+                return;
+            }
+            const auto byteValue = static_cast<std::byte>(value);
+            (void)DMK::Memory::write_bytes(reinterpret_cast<std::byte *>(g_bypassAddr), &byteValue, 1);
+        }
+
+        // Pure observer on the render primitive: notes that the resolver rendered a matching variant. Guarded by
+        // tl_inResolver so it only counts renders from the natural (observed) resolver pass -- never the forced retry,
+        // nor renders from unrelated callers of this primitive.
+        void on_render(SafetyHookContext & /*ctx*/) noexcept
+        {
+            if (tl_inResolver)
+            {
+                tl_rendered = true;
+            }
+        }
+
+        void on_resolver(void *arg1, std::uint64_t arg2, std::uint64_t arg3, void *arg4) noexcept
+        {
+            // Only intervene during an LT transmog apply; real equips (and any other resolve) run untouched so the
+            // engine still hides items that legitimately have no mesh for the wearer.
+            if (!in_transmog().load(std::memory_order_relaxed))
+            {
+                g_origResolver(arg1, arg2, arg3, arg4);
+                return;
+            }
+
+            // Run the natural, un-bypassed match and observe whether it rendered. Save/restore the flags so a nested
+            // resolver call (should the engine ever make one) keeps this frame's observation isolated. The engine
+            // resolver faults on early load (game data not ready); __finally restores the flags even on an SEH unwind
+            // so a fault cannot strand tl_inResolver true and mis-attribute a later frame's render.
+            const bool prevInResolver = tl_inResolver;
+            const bool prevRendered = tl_rendered;
+            bool rendered = false;
+            tl_rendered = false;
+            tl_inResolver = true;
+            __try
+            {
+                g_origResolver(arg1, arg2, arg3, arg4);
+                rendered = tl_rendered;
+            }
+            __finally
+            {
+                tl_inResolver = prevInResolver;
+                tl_rendered = prevRendered;
+            }
+
+            if (rendered)
+            {
+                // A variant entry matched the wearer's body -> the correct per-body mesh already rendered.
+                return;
+            }
+
+            // Nothing matched: an NPC/cross-class item that would otherwise be invisible on the player. Re-run the
+            // resolver with the char-class bypass so its match loop force-accepts entry[0] -- the same fallback the old
+            // transmog-side bypass gave, but now ONLY when the natural match failed. tl_inResolver is false here, so
+            // this forced pass is not observed. The bypass byte is a live GLOBAL code byte: __finally guarantees the
+            // 0x74 restore even if the forced pass SEH-unwinds, so a fault cannot leave the bypass forced-on for every
+            // later resolve (which would reintroduce the male-variant mis-render on all characters). A plain RAII guard
+            // is insufficient here -- under /EHsc, C++ destructors do not run during an async SEH unwind.
+            __try
+            {
+                write_bypass(0xEB);
+                g_origResolver(arg1, arg2, arg3, arg4);
+            }
+            __finally
+            {
+                write_bypass(0x74);
+            }
+        }
+    } // namespace
+
+    bool install()
+    {
+        auto &logger = DMK::Logger::get_instance();
+        auto &hookMgr = DMK::HookManager::get_instance();
+
+        const auto resolverAddr = resolve_address(k_bodyVariantResolverCandidates, "BodyVariantResolver");
+        const auto renderAddr = resolve_address(k_bodyVariantRenderCandidates, "BodyVariantRender");
+
+        if (!resolverAddr || !renderAddr)
+        {
+            logger.warning("[body-variant] AOB resolve failed (resolver={:#x} render={:#x}) -- per-body mesh hook "
+                           "disabled",
+                           resolverAddr, renderAddr);
+            return false;
+        }
+
+        g_bypassAddr = resolved_addrs().charClassBypass;
+        if (!g_bypassAddr)
+        {
+            logger.warning("[body-variant] charClassBypass unresolved -- NPC-item fallback will be a no-op");
+        }
+
+        // Install the observer first: the resolver hook must never fire before the primitive it observes is watched.
+        const auto renderRes = hookMgr.create_mid_hook("BodyVariantRenderObserve", renderAddr, &on_render);
+        if (!renderRes.has_value())
+        {
+            logger.warning("[body-variant] render observer midhook failed: {}",
+                           DMK::Hook::error_to_string(renderRes.error()));
+            return false;
+        }
+
+        const auto resolverRes =
+            hookMgr.create_inline_hook("BodyVariantResolver", resolverAddr, reinterpret_cast<void *>(on_resolver),
+                                       reinterpret_cast<void **>(&g_origResolver));
+        if (!resolverRes.has_value())
+        {
+            logger.warning("[body-variant] resolver inline hook failed: {}",
+                           DMK::Hook::error_to_string(resolverRes.error()));
+            // Roll back the render observer installed above. Without this a partial install leaves a dangling midhook
+            // firing on the render primitive for the rest of the process: on_render would keep taking the SafetyHook
+            // context save/restore round-trip on every render call while only ever no-op'ing (tl_inResolver never set,
+            // since the resolver hook that sets it did not install).
+            (void)hookMgr.remove_hook(*renderRes);
+            return false;
+        }
+
+        logger.info("[body-variant] hooks installed: resolver={:#x} render={:#x} bypass={:#x}", resolverAddr,
+                    renderAddr, g_bypassAddr);
+        g_active.store(true, std::memory_order_relaxed);
+        return true;
+    }
+
+    bool is_active() noexcept
+    {
+        return g_active.load(std::memory_order_relaxed);
+    }
+} // namespace Transmog::BodyVariantHook

--- a/CrimsonDesertLiveTransmog/src/body_variant_hook.hpp
+++ b/CrimsonDesertLiveTransmog/src/body_variant_hook.hpp
@@ -1,0 +1,34 @@
+// body_variant_hook.hpp
+#ifndef TRANSMOG_BODY_VARIANT_HOOK_HPP
+#define TRANSMOG_BODY_VARIANT_HOOK_HPP
+
+namespace Transmog::BodyVariantHook
+{
+    /**
+     * @brief Install the per-body mesh resolver hook and its render observer.
+     *
+     * The engine's variant resolver (sub_141F90630) renders the item variant entry whose token list matches the
+     * wearer's body token, or nothing if none match. This hook wraps it so that, during an LT transmog apply, the
+     * natural per-body match runs (giving each character its correct cd_ph[mw]_* mesh); only when nothing matched -- an
+     * NPC/cross-class item that would otherwise be invisible -- does it re-run the resolver with the char-class bypass
+     * to force the first (entry[0]) variant. Real equips are left untouched. This replaces LT's former transmog-side
+     * bypass toggling, which always forced entry[0] and so mis-rendered every wearer's mesh.
+     *
+     * @return true if both the resolver inline hook and the render observer midhook installed.
+     */
+    [[nodiscard]] bool install();
+
+    /**
+     * @brief Whether both hooks are live, i.e. install() completed successfully.
+     *
+     * False when either the resolver or render AOB failed to resolve, or either hook failed to install. The transmog
+     * apply path reads this to decide its fallback: with the hook down it forces the char-class bypass for the whole
+     * apply window (the pre-hook behavior), so an unresolved hook degrades to visible-but-default-mesh rendering
+     * instead of blocking the transmog outright.
+     *
+     * @return true once install() has succeeded; false otherwise.
+     */
+    [[nodiscard]] bool is_active() noexcept;
+} // namespace Transmog::BodyVariantHook
+
+#endif // TRANSMOG_BODY_VARIANT_HOOK_HPP

--- a/CrimsonDesertLiveTransmog/src/item_name_table.cpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.cpp
@@ -110,211 +110,6 @@ namespace Transmog
         return v.value_or(0);
     }
 
-    // --- Body-type classification via rule-classifier tokens ---
-    //
-    // Every armor descriptor at +0x248 holds a stride-0x38 rule list (count at +0x250). Each rule's classifier array at
-    // rule+0x20 (count at rule+0x28) is a list of u16 body-type tokens the engine's rule evaluator accepts for that
-    // item. Mount/pet/non-humanoid gear (horse tack, wagon gear, dragon armor) uses a disjoint, high-valued token pool
-    // and crashes the mesh binder if bound to a player body.
-    //
-    // The class-enum is re-keyed across major game versions; the descriptor layout (the offsets above, 0x38 stride) is
-    // stable, only the enum values move. Token sets per version, kept for drift tracking:
-    //
-    //   v1.03.01:  male {0x0018,0x0058,0x02E3}  female {0x0072,0x0382,0x0300}
-    //   v1.04.00:  male {0x0019,0x0059,0x02E5}  female {0x0073,0x0384,0x0302}
-    //   v1.08.00:  male {0x0012,0x0052,0x02DE}  female {0x006C,0x037D,0x02FB}
-    //   v1.09.00:  male {0x0012,0x0054,0x02DF}  female {0x001D,0x037E,0x02FC}
-    //
-    // Each body has three interchangeable markers; an armor item may carry any subset (r0{0x12} and r0{0x12,0x54,0x2DF}
-    // are both male). 0x12 and 0x1D are the male/female primary markers and counterparts; the other two of each set are
-    // secondary. All three female markers must be matched because some female items carry only the primary 0x1D with
-    // neither 0x37E nor 0x2FC. Every value drifts on a game update; re-derive then.
-    //
-    // To re-derive after a drift, read the rule cls array
-    // (desc+0x248 -> rule+0x20, see item_body_bits) of a known male and a
-    // known female armor item; those cls values are the male and female token sets. The deltas are not uniform across
-    // patches, so map by inspection rather than a fixed offset. The male markers do not appear in clean female items,
-    // so the OR-any-token classification stays sound.
-    static constexpr std::uint16_t k_maleBodyTokens[] = {
-        0x0011,
-        0x005E,
-        0x02E9,
-    };
-    static constexpr std::uint16_t k_femaleBodyTokens[] = {
-        0x001C,
-        0x0388,
-        0x0306,
-    };
-    // Shared / NPC-body token. Carried as a secondary tag by most male (cd_phm_*) human armor alongside a male token,
-    // and in isolation (no human gender token) by a handful of NPC/demon-body items whose mesh is cd_ndm_*/cd_pdm_*.
-    // The mesh body code's last letter is the true gender (m=male, w=female), and every isolated-shared-token armor
-    // item resolves to a *dm (male) body, so an item carrying only this token is classified
-    // Male (see sorted_entries). Items that also carry a real male token classify Male from that token, so this
-    // fallback never alters them.
-    static constexpr std::uint16_t k_sharedBodyTokens[] = {
-        0x03A3, // *dm (male) NPC/demon body marker; drifts on game updates
-    };
-    // Body bits.
-    //   Male / Female  -- a male/female token appeared in ANY rule (OR across
-    //                     all rules). Drives is_player_compatible (Kliff-
-    //                     centric "has a male rule" => safe to bind). DO NOT
-    //                     narrow these: transmog_apply.cpp's carrier-path
-    //                     fallback reads is_player_compatible, and the
-    //                     regression fix was validated against this OR
-    //                     semantics.
-    //   CleanMale /     -- gender seen in a "clean" rule = a gender rule with
-    //   CleanFemale        NO NPC-identity token (>= k_nonHumanoidTokenThreshold,
-    //                      e.g. an NPC armor's 0x1E8C/0x1F46). A clean rule
-    //                      reflects a real player mesh; an NPC-gated rule is an
-    //                      acceptance gate. Used for BodyKind / picker display
-    //                      ONLY. This keeps NPC armor whose female rule is
-    //                      NPC-gated classified Male, while letting a
-    //                      protagonist item with a clean female rule show for
-    //                      female. KNOWN LIMITATION: a male-mesh item that
-    //                      carries a CLEAN female rule over-shows for female,
-    //                      because the classifier tokens alone cannot separate
-    //                      it from a real female item (identical token
-    //                      patterns); only the mesh prefab gender letter can.
-    //                      A future mesh-based classifier supersedes this. The
-    //                      trade-off is deliberate: it favours zero female
-    //                      false-negatives over a handful of male false-positives.
-    //   HasTokens      -- saw ANY classifier token (humanoid or not)
-    //   NonHumanoid    -- saw a token >= 0x1000 (mount/pet/wagon/dragon
-    //                     pools all sit in this range; every humanoid
-    //                     token observed so far lives below 0x0400).
-    //   SharedBody     -- saw a k_sharedBodyTokens entry (0x399); only
-    //                     decisive when no gendered human token is present.
-    // BodyKind (derived in sorted_entries):
-    //   CleanMale + CleanFemale              -> Both
-    //   CleanMale                            -> Male
-    //   CleanFemale                          -> Female
-    //   (no clean) Male + Female  [OR bits]  -> Male  (NPC-dual, both gender
-    //                                           rules NPC-gated -> default Male)
-    //   (no clean) Male                      -> Male
-    //   (no clean) Female                    -> Female
-    //   SharedBody only (no M/F)             -> Male  (0x399 NPC-body items are
-    //                                           male-mesh, cd_*dm)
-    //   NonHumanoid (no gender, no shared)   -> BodyKind::NonHumanoid (hide)
-    //   HasTokens but no body                -> Ambiguous  (e.g. {0x012F}-only
-    //                                           NPC variants; picker amber)
-    //   No tokens at all                     -> Generic    (rule-less items)
-    static constexpr std::uint8_t k_bodyBitMale = 0x01;
-    static constexpr std::uint8_t k_bodyBitFemale = 0x02;
-    static constexpr std::uint8_t k_bodyBitHasTokens = 0x04;
-    static constexpr std::uint8_t k_bodyBitNonHumanoid = 0x08;
-    // Set when a k_sharedBodyTokens entry (0x399) is seen. Used only as a classification fallback for items that carry
-    // it WITHOUT any gendered human body token (NPC/demon-body carrier items) -- see sorted_entries.
-    static constexpr std::uint8_t k_bodyBitSharedBody = 0x20;
-    // Clean gender = gender seen in a rule that has NO NPC-identity/high token (>= k_nonHumanoidTokenThreshold). A
-    // clean rule reflects a real player mesh; an NPC-gated rule is just an acceptance gate. BodyKind prefers clean
-    // gender (see sorted_entries); is_player_compatible uses the OR-ed Male/Female bits above. See the
-    // bit-doc block for rationale.
-    static constexpr std::uint8_t k_bodyBitCleanMale = 0x40;
-    static constexpr std::uint8_t k_bodyBitCleanFemale = 0x80;
-    // Any classifier token >= this threshold is treated as non-humanoid (horse saddles, dragon armors, pet harnesses);
-    // every humanoid token observed sits well below it.
-    static constexpr std::uint16_t k_nonHumanoidTokenThreshold = 0x1000;
-
-    static constexpr std::ptrdiff_t k_ruleListPtrOffset = 0x248;
-    static constexpr std::ptrdiff_t k_ruleListCountOffset = 0x250;
-    static constexpr std::size_t k_ruleStride = 0x38;
-    static constexpr std::ptrdiff_t k_ruleClassPtrOffset = 0x20;
-    static constexpr std::ptrdiff_t k_ruleClassCountOffset = 0x28;
-    static constexpr std::uint32_t k_maxPlausibleRuleCount = 64;
-    static constexpr std::uint32_t k_maxPlausibleClassCount = 32;
-
-    // Walk an item's rule-classifier arrays once and return the packed body-kind bit mask documented with the
-    // k_bodyBit* constants above (Male / Female / HasTokens / NonHumanoid / SharedBody / CleanMale /
-    // CleanFemale). Items with no rules (or unreadable fields) return 0 (Generic) -- the picker treats Generic as
-    // "accepted by every body", matching the engine's observed behaviour for rule-less cosmetics.
-    static std::uint8_t item_body_bits(uintptr_t descPtr) noexcept
-    {
-        bool ok = false;
-        const auto rulesPtr = read_qword_safe(descPtr + k_ruleListPtrOffset, ok);
-        if (!ok || rulesPtr < 0x10000)
-            return 0;
-        const auto ruleCount = read_u32_safe(descPtr + k_ruleListCountOffset, ok);
-        if (!ok || ruleCount == 0 || ruleCount > k_maxPlausibleRuleCount)
-            return 0;
-
-        std::uint8_t bits = 0;
-
-        for (std::uint32_t i = 0; i < ruleCount; ++i)
-        {
-            const auto rule = rulesPtr + i * k_ruleStride;
-            const auto clsPtr = read_qword_safe(rule + k_ruleClassPtrOffset, ok);
-            if (!ok || clsPtr < 0x10000)
-                continue;
-            const auto clsCount = read_u32_safe(rule + k_ruleClassCountOffset, ok);
-            if (!ok || clsCount == 0 || clsCount > k_maxPlausibleClassCount)
-                continue;
-
-            bool ruleHasMale = false;
-            bool ruleHasFemale = false;
-            // A token >= k_nonHumanoidTokenThreshold inside a gender rule is an NPC-identity gate (e.g. Samuel
-            // 0x1E8C/0x1F46), not a player body. A rule carrying one is NOT "clean" -- its gender tokens are an
-            // acceptance gate, not a real player mesh.
-            bool ruleHasHighToken = false;
-            for (std::uint32_t j = 0; j < clsCount; ++j)
-            {
-                const auto clsOpt = DMKMemory::seh_read<std::uint16_t>(clsPtr + 2ull * j);
-                if (!clsOpt)
-                    break;
-                const std::uint16_t cls = *clsOpt;
-                bits |= k_bodyBitHasTokens;
-                if (cls >= k_nonHumanoidTokenThreshold)
-                {
-                    bits |= k_bodyBitNonHumanoid;
-                    ruleHasHighToken = true;
-                }
-                for (const auto mt : k_maleBodyTokens)
-                {
-                    if (cls == mt)
-                    {
-                        ruleHasMale = true;
-                        break;
-                    }
-                }
-                for (const auto ft : k_femaleBodyTokens)
-                {
-                    if (cls == ft)
-                    {
-                        ruleHasFemale = true;
-                        break;
-                    }
-                }
-                // Shared / NPC-body token. Tracked globally (not per-rule) as a fallback in sorted_entries when
-                // no gendered human token classified the item.
-                for (const auto st : k_sharedBodyTokens)
-                {
-                    if (cls == st)
-                    {
-                        bits |= k_bodyBitSharedBody;
-                        break;
-                    }
-                }
-            }
-            // OR-across-rules Male/Female (drives is_player_compatible).
-            if (ruleHasMale)
-                bits |= k_bodyBitMale;
-            if (ruleHasFemale)
-                bits |= k_bodyBitFemale;
-            // "Clean" gender = a gender rule with NO NPC-identity/high token. These reflect a real player mesh;
-            // NPC-gated rules (Samuel, Heisellen, etc.) are excluded. BodyKind prefers clean gender so a male item with
-            // an NPC-gated female rule stays Male, while a protagonist item with a clean female rule (Demian_Greyfur_*
-            // cloak) shows for female.
-            if (!ruleHasHighToken)
-            {
-                if (ruleHasMale)
-                    bits |= k_bodyBitCleanMale;
-                if (ruleHasFemale)
-                    bits |= k_bodyBitCleanFemale;
-            }
-        }
-
-        return bits;
-    }
-
     /**
      * Decode a relative-call instruction ( `E8 disp32` ) at the given address and return its target. Returns 0 on
      * failure.
@@ -801,16 +596,12 @@ namespace Transmog
         std::unordered_map<uint16_t, std::string> idToName;
         std::unordered_map<std::string, uint16_t> nameToId;
         std::unordered_map<uint16_t, uint8_t> variantFlag;
-        std::unordered_map<uint16_t, uint8_t> playerFlag;
         std::unordered_map<uint16_t, uint16_t> equipTypeMap;
-        std::unordered_map<uint16_t, uint8_t> bodyBitsMap;
         std::unordered_map<uint16_t, uint16_t> typeCodeMap;
         idToName.reserve(count);
         nameToId.reserve(count);
         variantFlag.reserve(count);
-        playerFlag.reserve(count);
         equipTypeMap.reserve(count);
-        bodyBitsMap.reserve(count);
         typeCodeMap.reserve(count);
 
         // Pass 1: walk the catalog, collect names + variant-meta pointers
@@ -821,10 +612,8 @@ namespace Transmog
         {
             uint16_t id;
             std::string name;
-            uintptr_t metaPtr; // 0 on read fault
-            bool playerCompatible;
+            uintptr_t metaPtr;  // 0 on read fault
             uint16_t equipType; // raw u16 at desc+0x42, 0 on read fault
-            uint8_t bodyBits;   // k_bodyBit* mask from item_body_bits()
             uint16_t typeCode;  // desc+0x44 -- canonical item-type code
         };
         std::vector<ScratchEntry> scratch;
@@ -832,7 +621,6 @@ namespace Transmog
 
         std::size_t valid = 0;
         std::size_t collisions = 0;
-        std::size_t nonPlayerCount = 0;
         char buf[k_maxNameLen + 1];
 
         for (uint32_t id = 0; id < count; ++id)
@@ -841,9 +629,9 @@ namespace Transmog
             if (!ok || !DMKMemory::plausible_userspace_ptr(descPtr))
                 continue;
 
-            // descPtr is reused by four downstream reads (metaPtr, item_body_bits, equipType@+0x42, typeCode@+0x44), so
-            // it is resolved separately; only the wrapper -> string pointer hops
-            // (descPtr -> +0x8 -> +0x0) are folded into one guarded walk.
+            // descPtr is reused by three downstream reads (metaPtr, equipType@+0x42, typeCode@+0x44), so it is resolved
+            // separately; only the wrapper -> string pointer hops (descPtr -> +0x8 -> +0x0) are folded into one guarded
+            // walk.
             const auto strPtrOpt = DMKMemory::seh_read_chain<uintptr_t>(descPtr, {0x8, 0x0});
             if (!strPtrOpt || !DMKMemory::plausible_userspace_ptr(*strPtrOpt))
                 continue;
@@ -856,12 +644,11 @@ namespace Transmog
             const auto id16 = static_cast<uint16_t>(id);
             const uintptr_t metaPtr = read_qword_safe(descPtr + k_descVariantMetaOffset, ok);
 
-            // Body-bits summary walked once; Kliff "PlayerSafe" is equivalent to "item has a male-body token".
-            const uint8_t bodyBits = item_body_bits(descPtr);
-            const bool playerCompat = (bodyBits & k_bodyBitMale) != 0;
-            if (!playerCompat)
-                ++nonPlayerCount;
-
+            // Wearer-body classification is NOT read here: the 1.13 game re-keyed the descriptor rule-classifier body
+            // tokens (the rule list at +0x248 no longer yields a usable body class), so body now comes from the
+            // equip-eligibility ("Male"/"Female") column of the display_names TSV (see load_display_names / m_bodyByName),
+            // applied at query time in sorted_entries and is_player_compatible. scripts/gen_item_body_table.py fills that
+            // column from the packed gamedata.
             bool etOk = false;
             const uint16_t equipType = read_u16_safe(descPtr + 0x42, etOk);
 
@@ -879,9 +666,7 @@ namespace Transmog
                 id16,
                 std::string(buf, len),
                 ok ? metaPtr : 0,
-                playerCompat,
                 etOk ? equipType : uint16_t{0},
-                bodyBits,
                 tcOk ? typeCode : uint16_t{0xFFFF},
             });
             ++valid;
@@ -953,10 +738,8 @@ namespace Transmog
             if (!inserted)
                 ++collisions;
             variantFlag.emplace(e.id, hasVariant ? uint8_t{1} : uint8_t{0});
-            playerFlag.emplace(e.id, e.playerCompatible ? uint8_t{1} : uint8_t{0});
             if (e.equipType != 0)
                 equipTypeMap.emplace(e.id, e.equipType);
-            bodyBitsMap.emplace(e.id, e.bodyBits);
             typeCodeMap.emplace(e.id, e.typeCode);
         }
 
@@ -1035,9 +818,7 @@ namespace Transmog
             m_idToName = std::move(idToName);
             m_nameToId = std::move(nameToId);
             m_variantFlag = std::move(variantFlag);
-            m_playerFlag = std::move(playerFlag);
             m_equipType = std::move(equipTypeMap);
-            m_bodyBits = std::move(bodyBitsMap);
             m_typeCode = std::move(typeCodeMap);
             m_sortedCache.clear(); // will be rebuilt lazily on next access
         }
@@ -1046,8 +827,8 @@ namespace Transmog
         const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
 
         logger.info("[nametable] built: {}/{} entries ({} name collisions, "
-                    "{} variant-meta, {} non-player) in {}ms",
-                    valid, count, collisions, variantCount, nonPlayerCount, ms);
+                    "{} variant-meta) in {}ms",
+                    valid, count, collisions, variantCount, ms);
         return BuildResult::Ok;
     }
 
@@ -1079,11 +860,31 @@ namespace Transmog
     bool ItemNameTable::is_player_compatible(uint16_t itemId) const
     {
         std::lock_guard<std::mutex> lk(s_tableMtx);
-        auto it = m_playerFlag.find(itemId);
-        // Unknown ids default to true -- prefer to surface rather than hide.
-        if (it == m_playerFlag.end())
-            return true;
-        return it->second != 0;
+        // Kliff-centric: safe to bind on the (male) player unless the item is restricted to the female body. Body is
+        // sourced from the display_names equip-eligibility column (m_bodyByName, keyed by lowercase internal name).
+        auto nit = m_idToName.find(itemId);
+        if (nit == m_idToName.end())
+            return true; // unknown -> prefer to surface
+        std::string key = nit->second;
+        for (auto &c : key)
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        auto bit = m_bodyByName.find(key);
+        return bit == m_bodyByName.end() || bit->second != BodyKind::Female;
+    }
+
+    ItemNameTable::BodyKind ItemNameTable::body_kind_for_item(uint16_t itemId) const
+    {
+        std::lock_guard<std::mutex> lk(s_tableMtx);
+        // Lowercase the internal name to match m_bodyByName's keys; an item wearable by both bodies (or
+        // unrestricted) is absent from the map and resolves to BodyKind::Generic.
+        auto nit = m_idToName.find(itemId);
+        if (nit == m_idToName.end())
+            return BodyKind::Generic;
+        std::string key = nit->second;
+        for (auto &c : key)
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        auto bit = m_bodyByName.find(key);
+        return bit != m_bodyByName.end() ? bit->second : BodyKind::Generic;
     }
 
     uint16_t ItemNameTable::equip_type_of(uint16_t itemId) const noexcept
@@ -1136,10 +937,9 @@ namespace Transmog
 
     ItemNameTable::BodyKind ItemNameTable::body_kind_for_character(const std::string &charName) noexcept
     {
-        // Male: Kliff, Oongka (their native rule sets include male-body
-        //       tokens -- see k_maleBodyTokens above).
-        // Female: Damiane (see k_femaleBodyTokens above). Unknown characters default to Generic -- we don't know their
-        // body, so treat every item as potentially compatible rather than silently hiding their picker.
+        // Fixed per-character body: Kliff and Oongka use the male humanoid skeleton, Damiane the female one. Unknown
+        // characters default to Generic -- we don't know their body, so treat every item as potentially compatible
+        // rather than silently hiding their picker.
         if (charName == "Kliff" || charName == "Oongka")
             return BodyKind::Male;
         if (charName == "Damiane")
@@ -1174,55 +974,25 @@ namespace Transmog
         {
             auto vit = m_variantFlag.find(id);
             const bool hasVariant = (vit != m_variantFlag.end()) && (vit->second != 0);
-            auto pit = m_playerFlag.find(id);
-            const bool isPlayer = (pit == m_playerFlag.end()) || (pit->second != 0);
             auto eit = m_equipType.find(id);
             const uint16_t equipT = (eit != m_equipType.end()) ? eit->second : uint16_t{0};
-            auto bit = m_bodyBits.find(id);
-            // Unknown ids default to Generic (bodyBits=0). Picker shows Generic on every character, matching the
-            // engine's behaviour for rule-less cosmetics.
-            const uint8_t bBits = (bit != m_bodyBits.end()) ? bit->second : uint8_t{0};
-            BodyKind kind;
-            // BodyKind prefers CLEAN gender (a gender rule with no NPC-identity token) so NPC armor with an NPC-gated
-            // female rule stays Male while a protagonist item with a clean female rule shows for female. The OR
-            // Male/Female bits are the fallback when no rule is clean.
-            const bool cleanM = (bBits & k_bodyBitCleanMale) != 0;
-            const bool cleanF = (bBits & k_bodyBitCleanFemale) != 0;
-            const bool anyM = (bBits & k_bodyBitMale) != 0;
-            const bool anyF = (bBits & k_bodyBitFemale) != 0;
-            const bool hasT = (bBits & k_bodyBitHasTokens) != 0;
-            const bool hasNH = (bBits & k_bodyBitNonHumanoid) != 0;
-            const bool hasShared = (bBits & k_bodyBitSharedBody) != 0;
-            if (cleanM && cleanF)
-                kind = BodyKind::Both;
-            else if (cleanM)
-                kind = BodyKind::Male;
-            else if (cleanF)
-                kind = BodyKind::Female;
-            else if (anyM)
-                // Only NPC-gated gender rules. If it has both male and female NPC rules (Samuel/Heisellen) it defaults
-                // Male; a male-only NPC rule is Male too. Render is via carrier on the native class; keeping it Male
-                // matches "no clean female mesh".
-                kind = BodyKind::Male;
-            else if (anyF)
-                kind = BodyKind::Female;
-            else if (hasShared)
-                // Shared/NPC-body token (0x399) only, no gendered human token. Mesh is an NPC/demon body ending in 'm'
-                // (cd_ndm_*/cd_pdm_*, e.g. Greyfur_Fabric_Armor_L, Cantina_ChainMail_Armor) = MALE.
-                kind = BodyKind::Male;
-            else if (hasNH)
-                // Token >= 0x1000 with no humanoid body-token present => actual mount/pet/wagon/dragon gear. Hide.
-                kind = BodyKind::NonHumanoid;
-            else if (hasT)
-                // Humanoid-range tokens but no body-specific match -- NPC-variant glove/armor items that carry only
-                // identity tokens like `0x012F`. Render behaviour is inconsistent so the picker colours these amber.
-                kind = BodyKind::Ambiguous;
-            else
-                kind = BodyKind::Generic;
-            // Look up display name by lowercased internal name.
+
+            // Lowercased internal name keys both the display-name and the wearer-body maps (both loaded from the
+            // display_names TSV).
             std::string lowerName = name;
             for (auto &c : lowerName)
                 c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+            // Wearer-body classification comes from the equip-eligibility column of the display_names TSV
+            // (m_bodyByName). Only single-body-restricted items are listed; anything wearable by both bodies (or
+            // unrestricted) is absent -> BodyKind::Generic, shown on every character. This supersedes the old
+            // rule-classifier token machinery, which the 1.13 game update rendered inert. See
+            // scripts/gen_item_body_table.py for how the column is filled.
+            auto brit = m_bodyByName.find(lowerName);
+            const BodyKind kind = (brit != m_bodyByName.end()) ? brit->second : BodyKind::Generic;
+            // Kliff-centric "PlayerSafe": an item is player-safe unless it is restricted to the female body.
+            const bool isPlayer = (kind != BodyKind::Female);
+
             auto dit = m_displayNames.find(lowerName);
             std::string dispName = (dit != m_displayNames.end()) ? dit->second : std::string();
 
@@ -1320,6 +1090,7 @@ namespace Transmog
         }
 
         std::unordered_map<std::string, std::string> names;
+        std::unordered_map<std::string, BodyKind> bodyByName;
         names.reserve(6100);
         std::string line;
         while (std::getline(file, line))
@@ -1329,25 +1100,46 @@ namespace Transmog
             if (line.back() == '\r')
                 line.pop_back();
 
-            const auto tab = line.find('\t');
-            if (tab == std::string::npos || tab == 0 || tab + 1 >= line.size())
+            const auto t1 = line.find('\t');
+            if (t1 == std::string::npos || t1 == 0)
                 continue;
 
-            std::string key = line.substr(0, tab);
+            std::string key = line.substr(0, t1);
             for (auto &c : key)
                 c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-            names.emplace(std::move(key), line.substr(tab + 1));
+
+            // Columns: <internal name> \t <display name> [\t <wearer body: "Male"|"Female">]. The optional 3rd column
+            // carries the equip-eligibility body restriction (scripts/gen_item_body_table.py fills it from the packed
+            // gamedata) and is only present for single-body-restricted items, so an older 2-column TSV still loads --
+            // absent body just means "unrestricted / shown on every character".
+            std::string display, body;
+            const auto t2 = line.find('\t', t1 + 1);
+            if (t2 == std::string::npos)
+                display = line.substr(t1 + 1);
+            else
+            {
+                display = line.substr(t1 + 1, t2 - (t1 + 1));
+                body = line.substr(t2 + 1);
+            }
+            if (body == "Male")
+                bodyByName.emplace(key, BodyKind::Male);
+            else if (body == "Female")
+                bodyByName.emplace(key, BodyKind::Female);
+            if (!display.empty())
+                names.emplace(std::move(key), std::move(display));
         }
 
         {
             std::lock_guard<std::mutex> lk(s_tableMtx);
             m_displayNames = std::move(names);
+            m_bodyByName = std::move(bodyByName);
             // Callers must invoke load_display_names() before any sorted_entries() access (i.e. before
             // dump_catalog_tsv) so the cache is still empty here -- no re-sort needed.
             m_sortedCache.clear();
         }
 
-        logger.info("[nametable] loaded {} display names from '{}'", m_displayNames.size(), tsvPath);
+        logger.info("[nametable] loaded {} display names ({} body-restricted) from '{}'", m_displayNames.size(),
+                    m_bodyByName.size(), tsvPath);
     }
 
     std::string ItemNameTable::display_name_of(std::string_view internalName) const

--- a/CrimsonDesertLiveTransmog/src/item_name_table.hpp
+++ b/CrimsonDesertLiveTransmog/src/item_name_table.hpp
@@ -97,16 +97,14 @@ namespace Transmog
         bool has_variant_meta(uint16_t itemId) const;
 
         /**
-         * @brief True if the item is safe to equip on the player.
+         * @brief True if the item is safe to equip on the (male) player.
          *
-         * Player-compatible means at least one of the item's rules in the descriptor rule list at `+0x248` carries a
-         * male body-type token. The default player (Kliff) uses the male humanoid skeleton; items whose rules use only
-         * non-player classifiers (horse/mount/pet tack, wagon gear) are flagged unsafe -- binding them to a player body
-         * crashes the mesh binder downstream.
+         * Kliff-centric: an item is player-safe unless it is restricted to the female body. The restriction is sourced
+         * from the equip-eligibility ("Male"/"Female") column of the display_names TSV (m_bodyByName, keyed by lowercase
+         * internal name); an item wearable by both bodies or unrestricted is absent from that map and counts as safe.
+         * This supersedes the former descriptor rule-classifier token walk, which the 1.13 game update rendered inert.
          *
-         * Unknown ids and items with no rules default to `true`: the picker prefers to surface inert cosmetics rather
-         * than hide them accidentally. See `k_maleBodyTokens` in the .cpp for the token set and how to re-derive it
-         * after a game patch.
+         * Unknown ids default to `true`: the picker prefers to surface an item rather than hide it accidentally.
          */
         bool is_player_compatible(uint16_t itemId) const;
 
@@ -169,20 +167,20 @@ namespace Transmog
          * armor, quest item, etc).
          */
         /**
-         * Body-type classification derived from an item's rule classifier tokens. Drives the picker's per-character
-         * visibility: an item rendered on the wrong body produces broken meshes, so the filter hides opposite-body
-         * items by default.
+         * Body-type classification that drives the picker's per-character visibility: an item rendered on the wrong
+         * body produces broken meshes, so the filter hides opposite-body items by default.
          *
-         *   Generic:     no classifier tokens at all (rule-less items)
-         *   Male:        has a male token   (k_maleBodyTokens)
-         *   Female:      has a female token (k_femaleBodyTokens)
-         *   Both:        rare -- has both male and female tokens
-         *   Ambiguous:   humanoid-range tokens only, but not in the
-         *                male or female body sets (e.g. NPC-specific variants like `0x012F`-only items --
-         *                Antumbra/Badran/Luka gloves). Picker shows with an amber badge because render fidelity is
-         *                inconsistent -- some work, some break.
-         *   NonHumanoid: has any token >= 0x1000 (mount/pet/wagon/
-         *                dragon armors). Hidden from all human-character pickers.
+         * The live source is the equip-eligibility column of the display_names TSV (m_bodyByName): only single-body
+         * restricted items are listed, so classification currently resolves to Male, Female, or Generic. This
+         * superseded the former rule-classifier token walk, which the 1.13 game update rendered inert; the remaining
+         * kinds are retained as picker display vocabulary for a future mesh-based classifier.
+         *
+         *   Generic:     unrestricted / wearable by both bodies (also the default for unknown ids)
+         *   Male:        restricted to the male humanoid skeleton
+         *   Female:      restricted to the female humanoid skeleton
+         *   Both:        wearable by both bodies (reserved; not currently emitted)
+         *   Ambiguous:   humanoid item whose body cannot be decided; picker shows an amber badge (reserved)
+         *   NonHumanoid: mount/pet/wagon/dragon gear, hidden from all human-character pickers (reserved)
          */
         enum class BodyKind : std::uint8_t
         {
@@ -220,6 +218,20 @@ namespace Transmog
          * for unknown names so future characters produce a wide-open picker instead of an empty one.
          */
         static BodyKind body_kind_for_character(const std::string &charName) noexcept;
+
+        /**
+         * @brief Single-body restriction for an item: BodyKind::Male / BodyKind::Female, or BodyKind::Generic when the
+         *        item is dual-body / unrestricted (or the id is unknown / catalog not yet built).
+         *
+         * Unlike is_player_compatible (which is Kliff-centric), this returns the raw kind so callers can compare it
+         * against a specific character's body -- e.g. to decide whether the engine's own body/class check will accept
+         * the item (and therefore pick the correct body variant) WITHOUT LT's char-class bypass. Sourced from the same
+         * display_names equip-eligibility column (m_bodyByName, keyed by lowercase internal name).
+         *
+         * Named to parallel body_kind_for_character(); distinct from PresetManager::body_kind_of(), which returns a
+         * character's configured body as a string.
+         */
+        BodyKind body_kind_for_item(uint16_t itemId) const;
 
         /**
          * @brief Look up the transmog slot for an item id.
@@ -286,9 +298,7 @@ namespace Transmog
         std::unordered_map<uint16_t, std::string> m_idToName;
         std::unordered_map<std::string, uint16_t> m_nameToId;
         std::unordered_map<uint16_t, uint8_t> m_variantFlag;
-        std::unordered_map<uint16_t, uint8_t> m_playerFlag;
         std::unordered_map<uint16_t, uint16_t> m_equipType;
-        std::unordered_map<uint16_t, uint8_t> m_bodyBits;
         std::unordered_map<uint16_t, uint16_t> m_typeCode; // desc+0x44 canonical item-type code
         // Runtime-learned `itemId -> TransmogSlot` map. Populated by
         // `record_observed_slot` (called from the slot-discovery dump when it observes live auth-table bindings).
@@ -296,6 +306,11 @@ namespace Transmog
         // given slot, we trust that over any heuristic. Session-scoped (no disk persistence).
         std::unordered_map<uint16_t, TransmogSlot> m_observedSlot;
         std::unordered_map<std::string, std::string> m_displayNames; // lowercase internal -> display
+        // Wearer-body restriction, loaded from the optional 3rd column of the display_names TSV. Keyed by lowercase
+        // internal name; only single-body-restricted items are present (Male / Female). Absent -> unrestricted
+        // (BodyKind::Generic). Drives the per-character picker filter and is_player_compatible. Replaced the old
+        // runtime rule-classifier tokens, which the 1.13 game update rendered inert.
+        std::unordered_map<std::string, BodyKind> m_bodyByName;
         mutable std::vector<Entry> m_sortedCache;
 
         // Stability detector: tracks the valid count from the previous build() attempt. The catalog is accepted only

--- a/CrimsonDesertLiveTransmog/src/itemmesh_dumper.cpp
+++ b/CrimsonDesertLiveTransmog/src/itemmesh_dumper.cpp
@@ -63,6 +63,20 @@ namespace Transmog
         constexpr ptrdiff_t kOffRuleMeshCount = 0x08;
         constexpr uint32_t kRuleScanCap = 64; // bound on garbage counts
 
+        // Per-body mesh variant entry list (desc+0x3E0), the structure the engine's variant resolver (sub_141F90630)
+        // walks to render an item's mesh for the wearer's body. Each 0x58-byte entry names one body variant of the item;
+        // the mesh handle is reached via a pointer at entry+0x10 (deref -> handle whose low 16 bits index stringinfo).
+        // This is the authoritative, per-item, noise-free source of every mesh an item uses across bodies (human male /
+        // orc / female / NPC), which the shared, rig-stripped icon cannot enumerate -- e.g. Kliff_Mask binds three rig
+        // meshes here (`cd_phm_` / `cd_pom_` / `cd_phw_`) behind one `cd_phm_` icon. 1.13 offsets; re-confirm on a
+        // descriptor reshape. (The engine also stores each entry's wearer body-class token array at entry+0x40 / count
+        // +0x48; the dump links every entry's mesh regardless of which body selects it, so those are not needed here.)
+        constexpr ptrdiff_t kOffDescVariantEntries = 0x3E0;
+        constexpr ptrdiff_t kOffDescVariantCount = 0x3E8;
+        constexpr ptrdiff_t kVariantEntryStride = 0x58;
+        constexpr ptrdiff_t kOffEntryMesh = 0x10; // pointer into the variant table -> mesh handle
+        constexpr uint32_t kVariantEntryCap = 32;
+
         // ----- safe reads -----
         //
         // The `(value, bool& ok)` shape distinguishes a faulted read from a legitimate zero result, which matters at
@@ -654,14 +668,90 @@ namespace Transmog
 
         // ----- per-item record collected from iteminfo/stringinfo -----
 
+        // A garbage byte fragment the "cd_"-prefix pool walk picks up: a body-rig prefix (cd_phm_ / cd_pom_ / ... which
+        // always name a body PART) directly followed by a short digits-then-letters token and nothing else -- e.g.
+        // `cd_pom_0jl`, `cd_phm_00fv` (proven in memory to be a `cd_pom_0jl,<binary>` exe-static fragment). A real
+        // body-rig mesh carries a `_<NN>_<part>_` or `_m<NNNN>_` structure, so it never has this shape, and none of
+        // these fragments is ever linked to an item. Used to skip them at emission so the dump stays clean.
+        bool is_junk_rig_fragment(std::string_view name) noexcept
+        {
+            static constexpr std::string_view kRigs[] = {"cd_phm_", "cd_phw_", "cd_pom_", "cd_pgm_",
+                                                         "cd_pdm_", "cd_ptm_", "cd_nhm_", "cd_ndm_"};
+            std::string_view tail;
+            for (auto rig : kRigs)
+            {
+                if (name.size() > rig.size() && name.substr(0, rig.size()) == rig)
+                {
+                    tail = name.substr(rig.size());
+                    break;
+                }
+            }
+            if (tail.empty())
+                return false;
+            // Junk iff the tail is one digit-run followed by one letter-run and nothing else. A real mesh's tail has an
+            // underscore here (`00_ub_...`) or leads with a model letter (`m0001_...`), so it fails one of these checks.
+            std::size_t i = 0;
+            while (i < tail.size() && tail[i] >= '0' && tail[i] <= '9')
+                ++i;
+            if (i == 0 || i == tail.size())
+                return false;
+            for (std::size_t j = i; j < tail.size(); ++j)
+                if (tail[j] < 'a' || tail[j] > 'z')
+                    return false;
+            return true;
+        }
+
+        // Resolve EVERY distinct mesh an item uses across bodies, from the per-body variant entry list (desc+0x3E0) --
+        // the authoritative linkage source. Each entry's mesh (via entry+kOffEntryMesh -> handle -> stringinfo slot) is
+        // one body variant of the item (human male / orc / female / NPC), all item-specific and noise-free; the shared,
+        // rig-stripped icon cannot enumerate them. The ground-drop mesh (`..._dropitem_...`) is skipped -- it is a
+        // shared prop, not a wearer variant. Returns the deduplicated meshes in entry order (the first is the item's
+        // default/primary mesh); empty for items with no variant list, which fall back to their icon-derived prefab.
+        std::vector<std::string> resolve_variant_meshes(uintptr_t desc, uintptr_t stringArr, uint32_t stringCount) noexcept
+        {
+            std::vector<std::string> meshes;
+            if (!desc || !stringArr)
+                return meshes;
+            bool ok = false;
+            const uintptr_t entries = read_qword_safe(desc + kOffDescVariantEntries, ok);
+            const uint32_t count = read_u32_safe(desc + kOffDescVariantCount, ok);
+            if (!entries || count == 0 || count > kVariantEntryCap)
+                return meshes;
+            for (uint32_t e = 0; e < count; ++e)
+            {
+                const uintptr_t entry = entries + static_cast<uintptr_t>(e) * kVariantEntryStride;
+                // entry+kOffEntryMesh points into the variant table at the entry's mesh handle; deref -> handle whose
+                // low 16 bits index stringinfo.
+                const uintptr_t meshPtr = read_qword_safe(entry + kOffEntryMesh, ok);
+                if (!meshPtr)
+                    continue;
+                const uintptr_t handle = read_qword_safe(meshPtr, ok);
+                if (!ok)
+                    continue;
+                const uint16_t slot = static_cast<uint16_t>(handle & 0xFFFFu);
+                if (slot == 0xFFFF || slot >= stringCount)
+                    continue;
+                const uintptr_t wrap = read_qword_safe(stringArr + static_cast<uintptr_t>(slot) * 8, ok);
+                std::string mesh = to_lower(read_wrapper_string(wrap));
+                if (mesh.empty() || !starts_with_asset_prefix(mesh) || mesh.find("dropitem") != std::string::npos)
+                    continue;
+                if (std::find(meshes.begin(), meshes.end(), mesh) == meshes.end())
+                    meshes.push_back(std::move(mesh));
+            }
+            return meshes;
+        }
+
         struct ItemEntry
         {
             uint32_t runtimeIdx;
             std::string internalName;
             uint16_t iconSlot;
-            std::string fullIcon;   // raw stringinfo string, may have ItemIcon_Prefab_ prefix
-            std::string iconPrefab; // lowercased, prefix stripped
-            std::string base;       // last `_NNNN`-anchored prefix of iconPrefab
+            std::string fullIcon;    // raw stringinfo string, may have ItemIcon_Prefab_ prefix
+            std::string iconPrefab;  // lowercased, prefix stripped
+            std::string base;        // last `_NNNN`-anchored prefix of iconPrefab
+            // Distinct player rig meshes (Kliff / Oongka / Damiane) recovered from the variant entry list; empty when
+            // the item has none. Links the male / orc / female body variants the icon-derived prefab cannot pair.
+            std::vector<std::string> variantMeshes;
         };
     } // namespace
 
@@ -825,9 +915,13 @@ namespace Transmog
             std::string_view iconPrefab = fullLower;
             constexpr std::string_view kLongPrefix = "itemicon_prefab_";
             constexpr std::string_view kShortPrefix = "itemicon_";
+            // `itemicon_prefab_<mesh>` carries the real mesh name; a bare `itemicon_<name>` (e.g. `ItemIcon_Lantern_On`)
+            // does not, so its stripped remainder is a non-mesh item name that must not be trusted as a prefab.
+            bool isPrefabIcon = false;
             if (iconPrefab.size() >= kLongPrefix.size() && iconPrefab.substr(0, kLongPrefix.size()) == kLongPrefix)
             {
                 iconPrefab = iconPrefab.substr(kLongPrefix.size());
+                isPrefabIcon = true;
             }
             else if (iconPrefab.size() >= kShortPrefix.size() &&
                      iconPrefab.substr(0, kShortPrefix.size()) == kShortPrefix)
@@ -837,14 +931,39 @@ namespace Transmog
             // Prefer the item's actual rig mesh over the icon-derived prefab. The icon is shared across rig variants,
             // so the rule chain is the only place the real cd_phw / cd_pom mesh appears; for an ordinary item the rule
             // mesh equals the icon prefab and this is a no-op.
+            // The variant entry list is the authoritative source of every mesh the item uses across bodies; resolve it
+            // once and reuse it for both the primary-prefab recovery below and the per-body-variant linkage in PASS 3.
+            std::vector<std::string> variantMeshes = resolve_variant_meshes(desc, stringArr, stringCount);
+
             std::string bodyMesh = resolve_rule_body_mesh(desc, stringArr, stringCount, strip_rig_prefix(iconPrefab));
-            std::string resolvedPrefab = bodyMesh.empty() ? std::string(iconPrefab) : std::move(bodyMesh);
+            std::string resolvedPrefab;
+            if (!bodyMesh.empty())
+            {
+                resolvedPrefab = std::move(bodyMesh);
+            }
+            else if (isPrefabIcon)
+            {
+                resolvedPrefab = std::string(iconPrefab); // the `_Prefab_` icon already names the real mesh
+            }
+            else
+            {
+                // The icon is not a mesh, so the stripped iconPrefab is a bogus item name and the item would be dropped
+                // as UI-only even though a mesh exists. Recover it from the variant entry list -- held / non-body items
+                // (a lantern) keep their mesh in an untoken default entry there even when the rule chain is empty. Fall
+                // back to the icon name only when the item has no variant mesh.
+                resolvedPrefab = variantMeshes.empty() ? std::string(iconPrefab) : variantMeshes.front();
+            }
             // Prefer the LIVE partprefab wrapper name. For helm variants the engine instantiates `<mesh>_dd`; the bare
             // `<mesh>` has no live wrapper, so the icon/rule-derived name never matches the swap/carrier path. Rewrite
             // to `_dd` only when the bare form is NOT itself a live wrapper but its `_dd` twin IS -- so ordinary items
             // (whose bare name is the live wrapper) are untouched. See the carrier_defaults.hpp Oongka-helm note.
             if (liveWrapperSet.count(resolvedPrefab) == 0 && liveWrapperSet.count(resolvedPrefab + "_dd") != 0)
                 resolvedPrefab += "_dd";
+            for (auto &vm : variantMeshes)
+            {
+                if (liveWrapperSet.count(vm) == 0 && liveWrapperSet.count(vm + "_dd") != 0)
+                    vm += "_dd";
+            }
             ItemEntry e;
             e.runtimeIdx = id;
             e.internalName = std::move(internalName);
@@ -852,6 +971,7 @@ namespace Transmog
             e.fullIcon = full;
             e.iconPrefab = std::move(resolvedPrefab);
             e.base = extract_base_prefix(e.iconPrefab);
+            e.variantMeshes = std::move(variantMeshes);
             items.push_back(std::move(e));
         }
         logger.info("[itemprefab] item-pass: {} entries collected, {} skipped", items.size(), skipped);
@@ -920,11 +1040,32 @@ namespace Transmog
         exact_map.reserve(items.size());
         std::unordered_map<std::string, std::vector<size_t>> base_map;
         base_map.reserve(items.size());
+        // Claim every item's primary (icon-derived) prefab FIRST, so a primary link can never be stolen by another
+        // item's body variant in the second pass below.
         for (size_t i = 0; i < items.size(); ++i)
         {
             exact_map.emplace(items[i].iconPrefab, i);
             base_map[items[i].base].push_back(i);
         }
+        // Then link each item's body-mesh variants (human male / orc / female / NPC) from the variant entry list so
+        // their prefab rows resolve to this item instead of orphaning -- the shared, rig-stripped icon can only name
+        // one. emplace keeps the first claimant, so a primary link is never overwritten and a mesh shared across items
+        // is attributed to (and grouped under) its first owner.
+        uint32_t variantLinks = 0;
+        for (size_t i = 0; i < items.size(); ++i)
+        {
+            for (const auto &vm : items[i].variantMeshes)
+            {
+                if (vm.empty() || vm == items[i].iconPrefab)
+                    continue;
+                if (exact_map.emplace(vm, i).second)
+                {
+                    base_map[extract_base_prefix(vm)].push_back(i);
+                    ++variantLinks;
+                }
+            }
+        }
+        logger.info("[itemprefab] body-mesh variants linked from the variant entry list: {}", variantLinks);
 
         // PASS 4 -- emit one row per pool prefab. Also emit a row for each item whose iconPrefab is NOT in the pool (so
         // the dump never silently drops an item). Track them via `phantomItems`.
@@ -983,6 +1124,7 @@ namespace Transmog
         uint32_t rowsExact = 0;
         uint32_t rowsSiblingOnly = 0;
         uint32_t rowsOrphan = 0;
+        uint32_t rowsJunkSkipped = 0;
         for (const auto &p : pool)
         {
             const std::string rowBase = extract_base_prefix(p);
@@ -1004,6 +1146,14 @@ namespace Transmog
                 }
             }
             const bool orphan = !exact && siblings.empty();
+            // Skip a junk exe-static string fragment (cd_<rig>_<digits><letters>) that resolves to no item -- it is not
+            // a real mesh, just noise the cd_-prefix pool walk captured. Guarded on `orphan`, so a linked prefab is
+            // never dropped even if one somehow matched the shape.
+            if (orphan && is_junk_rig_fragment(p))
+            {
+                ++rowsJunkSkipped;
+                continue;
+            }
             if (exact)
                 ++rowsExact;
             else if (!siblings.empty())
@@ -1057,8 +1207,8 @@ namespace Transmog
         }
 
         logger.info("[itemprefab] dumped {} rows: {} exact, {} sibling-only, "
-                    "{} orphan, {} phantom-item, {} UI-only skipped -> "
+                    "{} orphan, {} phantom-item, {} UI-only skipped, {} junk-fragment skipped -> "
                     "CrimsonDesertLiveTransmog_itemprefabs.tsv",
-                    rowsEmitted, rowsExact, rowsSiblingOnly, rowsOrphan, phantomRows, uiSkipped);
+                    rowsEmitted, rowsExact, rowsSiblingOnly, rowsOrphan, phantomRows, uiSkipped, rowsJunkSkipped);
     }
 } // namespace Transmog

--- a/CrimsonDesertLiveTransmog/src/overlay_ui/dye_popup.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui/dye_popup.cpp
@@ -230,10 +230,21 @@ namespace Transmog
             ImGui::Dummy(ImVec2(chip_h, chip_h));
         }
 
-        if (dyeBtn && slotDye)
+        if (dyeBtn)
         {
-            ImGui::OpenPopup("##dye_picker");
-            s_dyePopupJumpToDye[slot] = true;
+            // If the editing character has no preset yet, mint one from the current state so the popup has somewhere to
+            // write instead of dropping the click. Re-fetch slotDye off the freshly-created preset so the popup body
+            // below (and this frame's OpenPopup) observe it.
+            if (!slotDye)
+            {
+                editPreset = PresetManager::instance().active_preset_mut_or_create();
+                slotDye = editPreset ? &editPreset->slots[slot].dye : nullptr;
+            }
+            if (slotDye)
+            {
+                ImGui::OpenPopup("##dye_picker");
+                s_dyePopupJumpToDye[slot] = true;
+            }
         }
 
         // 10 color groups, ordered by HSL hue (red -> rose). Anchored by `string_key` (the data file's _stringKey

--- a/CrimsonDesertLiveTransmog/src/overlay_ui/item_picker_popup.cpp
+++ b/CrimsonDesertLiveTransmog/src/overlay_ui/item_picker_popup.cpp
@@ -253,9 +253,8 @@ namespace Transmog
 
         // Active character's body kind. Stable for the entire popup invocation: PresetManager state cannot mutate
         // between picker frames on the render thread, so resolving it once here avoids ~6k redundant PresetManager +
-        // string comparisons per frame inside the filter loop. Armor rule classifier tokens partition the catalog into
-        // disjoint body families (male/female token sets live in item_name_table.cpp::k_maleBodyTokens /
-        // k_femaleBodyTokens):
+        // string comparisons per frame inside the filter loop. The catalog's body families come from the
+        // equip-eligibility column of the display_names TSV (item_name_table.cpp::m_bodyByName):
         //   Horse / pet / wagon / dragon: separate token pools with
         //     zero overlap with humanoid. Flagged as NonHumanoid and
         //     hidden unconditionally -- these never render on a human

--- a/CrimsonDesertLiveTransmog/src/preset_manager.cpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.cpp
@@ -925,6 +925,23 @@ namespace Transmog
         return &it->second.presets[static_cast<std::size_t>(idx)];
     }
 
+    Preset *PresetManager::active_preset_mut_or_create()
+    {
+        if (auto *p = active_preset_mut())
+            return p;
+        // No preset for the editing character yet -- mint one from the current in-game/edit state so the caller (e.g.
+        // the Dye picker) has somewhere to write, instead of swallowing the interaction. Mirrors the auto-create branch
+        // of replace_current_from_state().
+        auto &cp = ensure_character(m_editingCharacter);
+        int idx = static_cast<int>(cp.presets.size());
+        std::string name = "Preset " + std::to_string(idx);
+        cp.presets.push_back(capture_from_state(name));
+        cp.activePreset = idx;
+        DMK::Logger::get_instance().info("Preset auto-created for dye/edit: '{}' (index {})", name, idx);
+        save();
+        return active_preset_mut();
+    }
+
     const std::vector<Preset> &PresetManager::presets() const
     {
         static const std::vector<Preset> s_empty;

--- a/CrimsonDesertLiveTransmog/src/preset_manager.hpp
+++ b/CrimsonDesertLiveTransmog/src/preset_manager.hpp
@@ -244,6 +244,13 @@ namespace Transmog
         int preset_count() const;
         const Preset *active_preset() const;
         Preset *active_preset_mut();
+        /**
+         * Like active_preset_mut(), but if the editing character has no presets yet, mint one from the current state
+         * (so callers such as the Dye picker always have a preset to write to instead of silently no-op'ing) and return
+         * it. Persists via save(). Returns nullptr only on an unexpected failure. Mirrors the auto-create branch of
+         * replace_current_from_state().
+         */
+        Preset *active_preset_mut_or_create();
         const std::vector<Preset> &presets() const;
 
         /**

--- a/CrimsonDesertLiveTransmog/src/transmog.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog.cpp
@@ -1,5 +1,6 @@
 #include "transmog.hpp"
 #include "aob_resolver.hpp"
+#include "body_variant_hook.hpp"
 #include "color_override/color_override.hpp"
 #include "color_override/color_token_table.hpp"
 #include "color_override/host_scope.hpp"
@@ -948,6 +949,14 @@ namespace Transmog
                 }
             }
         }
+
+        // BodyVariantHook: lets each character render its correct per-body mesh variant on transmog by keeping the
+        // engine's natural per-body match and forcing entry[0] only for items the wearer cannot equip. Supersedes the
+        // former transmog-side char-class bypass toggling (see body_variant_hook.hpp). If either of its AOBs fails to
+        // resolve, install() returns false and BodyVariantHook::is_active() stays false; the apply path then falls back
+        // to that legacy bypass force (see legacy_bypass_force_needed in transmog_apply.cpp) so a failed hook cannot
+        // block transmog rendering.
+        (void)BodyVariantHook::install();
 
         // PartAddShow (sub_14081DC20) inline hook -- transition-flash polish.
         //

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -1,4 +1,5 @@
 #include "transmog_apply.hpp"
+#include "body_variant_hook.hpp"
 #include "color_override/color_override.hpp"
 #include "color_override/color_reinit.hpp"
 #include "color_override/host_scope.hpp"
@@ -79,8 +80,9 @@ namespace Transmog
     static constexpr auto &k_tearDownSlots = k_slotMetadata;
     static constexpr std::size_t k_tearDownCount = k_slotCount;
 
-    // Forward decls -- both functions are defined further down this TU. apply_transmog needs them for the
-    // bypass-during-direct-apply path that fixes cross-class accessory teardown.
+    // Forward decls -- both functions are defined further down this TU. needs_carrier drives the carrier decision in
+    // the apply paths; set_char_class_bypass is toggled by the per-slot tear-down bypass in apply_single_slot_transmog,
+    // apply_all_transmog, and clear_all_transmog so a cross-class carrier fake stays reachable while it is torn down.
     bool needs_carrier(uint16_t itemId, const std::string &charName);
     static bool set_char_class_bypass(uintptr_t addr, uint8_t val) noexcept;
 
@@ -151,7 +153,67 @@ namespace Transmog
     // The auth table at actor+472 was the WRONG source: LT's 0xFFFF sentinel propagates into it on every apply,
     // polluting the capture. The instance table at actor+0x88 is updated by the natural equip flow and unaffected by
     // LT.
-    void apply_transmog(__int64 a1, uint16_t targetId)
+    // Body-eligibility half of the bypass-skip decision (see should_skip_bypass): true when the target's body
+    // restriction is compatible with the wearer -- it has no single-body restriction (Generic/dual, so the engine
+    // decides), or its restricted body equals the wearer's. A Male-only item on Damiane (or a Female-only item on a
+    // male character) is ineligible. Before the catalog resolves, report ineligible so the bypass stays on (fail-safe:
+    // an unresolved item keeps the forced-render path).
+    static bool char_eligible_for_target(uint16_t targetId, const std::string &charName)
+    {
+        const auto &table = ItemNameTable::instance();
+        if (!table.ready())
+            return false;
+        const auto itemBody = table.body_kind_for_item(targetId);
+        if (itemBody != ItemNameTable::BodyKind::Male && itemBody != ItemNameTable::BodyKind::Female)
+            return true;
+        return itemBody == ItemNameTable::body_kind_for_character(charName);
+    }
+
+    // Descriptor offset of the per-body MESH variant table (0 for items without one). Boss/dual-body armor the 1.13
+    // patch opened to a second body (Samuel/OrcuMer/Heisellen, ...) stores its {male mesh, female mesh, per-body token
+    // groups} here; the engine walks it, keyed on the wearer's body token, to pick the mesh. The offset is
+    // build-specific; re-confirm it if a patch reshuffles the item descriptor.
+    static constexpr std::ptrdiff_t k_descBodyVariantTableOffset = 0x220;
+
+    // The full bypass-skip decision: LT should NOT force the char-class bypass when the target carries a per-body mesh
+    // variant table (desc+0x220) AND the wearer is body-eligible for it. Only those items suffer the bypass locking the
+    // default (male) mesh; an item without a variant table (a plain accessory, or a cross-class NPC item) needs the
+    // bypass to render and keeps it. Consulted when applying (skip the enable) and when tearing down (a fake applied
+    // without the bypass is reachable normally; forcing it during tear-down would restore the real item on the wrong
+    // body).
+    static bool should_skip_bypass(uint16_t targetId, const std::string &charName)
+    {
+        if (!char_eligible_for_target(targetId, charName))
+            return false;
+        const uintptr_t desc = ItemNameTable::instance().descriptor_of(targetId);
+        if (desc == 0)
+            return false;
+        return DMKMemory::seh_read<uintptr_t>(desc + k_descBodyVariantTableOffset).value_or(0) > 0x10000;
+    }
+
+    // Legacy fallback gate: force the char-class bypass for the whole apply window ONLY when BodyVariantHook is not live
+    // (its resolver/render AOBs did not resolve, or its hooks failed to install). BodyVariantHook normally owns the
+    // per-body mesh pick -- it observes the engine's natural match and forces entry[0] only for items the wearer cannot
+    // equip. With the hook down that observation is gone, so LT falls back to the pre-hook behavior: force entry[0] via
+    // the bypass so cross-class/NPC items still render (visible, default mesh) instead of turning invisible.
+    // should_skip_bypass still excludes dual-body armor the wearer is eligible for, so that armor keeps its correct mesh
+    // through the engine's own resolver; an unresolved catalog reports "do not skip" (fail-safe: keep the forced-render
+    // path). Returns false when charClassBypass itself did not resolve -- there is no byte to flip.
+    static bool legacy_bypass_force_needed(uint16_t targetId)
+    {
+        if (BodyVariantHook::is_active())
+            return false;
+        if (resolved_addrs().charClassBypass == 0)
+            return false;
+        return !should_skip_bypass(targetId, current_apply_owner());
+    }
+
+    // SlotPopulator choke point shared by the direct and carrier apply paths. `id` is the descriptor id fed to the
+    // engine (the real target on the direct path, the carrier id on the carrier path, where the target visuals arrive
+    // via the swapped hybrid descriptor). `forceBypass` requests the legacy char-class-bypass force for the duration of
+    // the call and is decided by the caller from the REAL target (see legacy_bypass_force_needed); it is always false
+    // while BodyVariantHook is live, since the hook then owns the per-body mesh pick.
+    static void apply_transmog_core(__int64 a1, uint16_t id, bool forceBypass)
     {
         auto slotPop = slot_populator_fn();
         auto initEntry = init_swap_entry_fn();
@@ -163,7 +225,7 @@ namespace Transmog
         // The engine validates the +4..+11 region as part of its dye/material-instance lookup; reordering those dwords
         // causes the engine to fall back to default colors even when the wrapper-swap mesh is correct.
         alignas(16) uint8_t itemData[16]{};
-        *reinterpret_cast<uint16_t *>(itemData + 0) = targetId;
+        *reinterpret_cast<uint16_t *>(itemData + 0) = id;
         itemData[2] = 2;
         // bytes 4..7 left as 0 (zero-init)
         *reinterpret_cast<uint32_t *>(itemData + 8) = 0xFFFFFFFF;
@@ -173,19 +235,10 @@ namespace Transmog
         alignas(16) uint8_t swapEntry[256]{};
         initEntry(reinterpret_cast<__int64>(swapEntry));
 
-        // Enable charClass bypass for cross-class direct applies. Cross-character WEAPON visibility is gated separately
-        // at equipslotinfo.entries[N].etl_hashes (bypass here does NOT help that case). What it DOES fix: cross-class
-        // accessory teardown for slots without a Damiane/Oongka-specific carrier family (Mask, etc.). Without bypass,
-        // SlotPopulator's class check silently rejects the equip, the auth-table never gets a row, and Phase A's
-        // tear_down_by_item_id no-ops because safeFn(a1, hash, slotTag) walks auth and finds nothing -- the scene mesh
-        // ends up orphaned and stuck. With bypass on, SlotPopulator writes the auth row, tear-down anchors on it, scene
-        // cleanup succeeds. Cost: two memory writes per cross-class direct apply, only when needs_carrier returns true.
-        const auto &activeChar = PresetManager::instance().active_character();
-        const bool useBypass = needs_carrier(targetId, activeChar);
-        const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
-        bool bypassApplied = false;
-        if (useBypass && bypassAddr)
-            bypassApplied = set_char_class_bypass(bypassAddr, 0xEB);
+        // When BodyVariantHook is live it selects the per-body mesh (and force-renders entry[0] only for items the
+        // wearer cannot equip), gated on the in_transmog() flag set here, and forceBypass is false. When it is down,
+        // forceBypass holds the char-class bypass forced for the whole apply so cross-class/NPC items still render.
+        const uintptr_t bypassAddr = forceBypass ? resolved_addrs().charClassBypass : 0;
 
         in_transmog().store(true, std::memory_order_relaxed);
         // Reset the host-scope cluster so the upcoming slotPop's matInst-iter hits build a fresh player-vs-NPC
@@ -195,12 +248,29 @@ namespace Transmog
         // slotPop will be redirected to the user's chosen RGB. Closes again immediately after so unrelated render
         // passes aren't tinted.
         ColorOverride::SetterSubstitute::set_apply_window(true);
-        slotPop(a1, reinterpret_cast<unsigned __int16 *>(itemData), reinterpret_cast<__int64>(swapEntry));
-        ColorOverride::SetterSubstitute::set_apply_window(false);
-        in_transmog().store(false, std::memory_order_relaxed);
+        if (bypassAddr)
+            set_char_class_bypass(bypassAddr, 0xEB);
+        // slotPop faults (structured exception) on early load before game data is ready. __finally restores the bypass
+        // byte, the apply window, and the in_transmog() flag even on an SEH unwind: a stranded in_transmog() would make
+        // BodyVariantHook rewrite the char-class bypass on real (non-transmog) equips, a stranded apply window would
+        // tint unrelated render passes, and a stranded 0xEB would force entry[0] on every later resolve (reintroducing
+        // the male-variant mis-render on all characters).
+        __try
+        {
+            slotPop(a1, reinterpret_cast<unsigned __int16 *>(itemData), reinterpret_cast<__int64>(swapEntry));
+        }
+        __finally
+        {
+            if (bypassAddr)
+                set_char_class_bypass(bypassAddr, 0x74);
+            ColorOverride::SetterSubstitute::set_apply_window(false);
+            in_transmog().store(false, std::memory_order_relaxed);
+        }
+    }
 
-        if (bypassApplied)
-            set_char_class_bypass(bypassAddr, 0x74);
+    void apply_transmog(__int64 a1, uint16_t targetId)
+    {
+        apply_transmog_core(a1, targetId, legacy_bypass_force_needed(targetId));
     }
 
     // -- Default carrier set (per character) -----------------------------
@@ -266,7 +336,7 @@ namespace Transmog
         if (table.has_variant_meta(itemId))
             return true;
 
-        // Damiane and Oongka ALWAYS use the carrier-hybrid path. The engine's tribe-gender_list filter rejects most
+        // Damiane and Oongka ALWAYS use the carrier-hybrid path. The engine's body/class-list filter rejects most
         // cross-body items at the class gate (e.g. Catfish/Madacus/Brimstone/
         // Hyena helms reject Oongka while Marni-Devotee and Oongka_PlateArmor_Helm_III pass), producing INVISIBLE
         // renders even when equip_type matches. Forcing the carrier path on every Damiane/Oongka apply uses the
@@ -336,32 +406,27 @@ namespace Transmog
         return DMK::Memory::write_bytes(reinterpret_cast<std::byte *>(addr), &byteVal, 1).has_value();
     }
 
-    // Swaps descriptor pointer, toggles char-class bypass, calls SlotPopulator, then unconditionally restores both via
-    // __finally.
+    // Swaps the carrier slot's descriptor pointer to the hybrid, calls SlotPopulator via apply_transmog_core, then
+    // unconditionally restores the descriptor via __finally. The per-body mesh selection is handled by BodyVariantHook
+    // during the apply when it is live; `forceBypass` (decided by the caller from the REAL target, not the carrier)
+    // drives the legacy bypass-force fallback for the carrier path when the hook is down.
     //
     // __finally (not __except): runs cleanup WITHOUT catching the exception. Game-internal SEH exceptions (lazy
     // loading, page faults) continue propagating to the game's own handlers. __except would intercept them and break
-    // the game.
-    //
-    // This is critical because apply_transmog faults on early load attempts (game data not ready). Without __finally,
-    // the descriptor pointer and bypass byte would be left corrupted.
+    // the game. This matters because apply_transmog_core faults on early load attempts (game data not ready); without
+    // __finally the swapped descriptor pointer would be left corrupted.
     static void carrier_swap_and_call(__int64 a1, uint16_t carrierId, uintptr_t carrierSlotAddr, uintptr_t hybridAddr,
-                                      uintptr_t bypassAddr) noexcept
+                                      bool forceBypass) noexcept
     {
         const auto savedDesc = static_cast<LONG64>(InterlockedExchange64(
             reinterpret_cast<volatile LONG64 *>(carrierSlotAddr), static_cast<LONG64>(hybridAddr)));
 
-        const bool bypassApplied = set_char_class_bypass(bypassAddr, 0xEB);
-
         __try
         {
-            apply_transmog(a1, carrierId);
+            apply_transmog_core(a1, carrierId, forceBypass);
         }
         __finally
         {
-            if (bypassApplied)
-                set_char_class_bypass(bypassAddr, 0x74);
-
             InterlockedExchange64(reinterpret_cast<volatile LONG64 *>(carrierSlotAddr), savedDesc);
         }
     }
@@ -369,17 +434,15 @@ namespace Transmog
     void apply_transmog_with_carrier(__int64 a1, uint16_t carrierId, uint16_t targetId)
     {
         auto &logger = DMK::Logger::get_instance();
+        const auto &table = ItemNameTable::instance();
 
         if (carrierId == 0 || carrierId == targetId)
         {
-            logger.trace("[carrier] carrierId={:#06x} == targetId={:#06x}, "
-                         "direct apply",
-                         carrierId, targetId);
+            logger.trace("[carrier] carrierId={:#06x} == targetId={:#06x}, direct apply", carrierId, targetId);
             apply_transmog(a1, targetId);
             return;
         }
 
-        const auto &table = ItemNameTable::instance();
         const auto ci = table.catalog_info();
         if (ci.ptrArray == 0 || ci.count == 0)
         {
@@ -449,15 +512,17 @@ namespace Transmog
         }
 
         const auto hybridAddr = reinterpret_cast<uintptr_t>(hybrid);
-        const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
 
         logger.trace("[carrier] HYBRID built: {} bytes patched, "
                      "carrier={:#06x} desc={:#018x}, "
                      "target={:#06x} desc={:#018x}, hybrid={:#018x}",
                      patchedBytes, carrierId, carrierDesc, targetId, targetDesc, hybridAddr);
 
-        // SEH-isolated: swap descriptor, toggle bypass, call SlotPopulator, then unconditionally restore both.
-        carrier_swap_and_call(a1, carrierId, carrierSlotAddr, hybridAddr, bypassAddr);
+        // SEH-isolated: swap the carrier descriptor to the hybrid, call SlotPopulator, then restore. The per-body mesh
+        // pick is handled by BodyVariantHook when it is live; forceBypass drives the legacy fallback for the REAL target
+        // (not the carrier) when it is down.
+        const bool forceBypass = legacy_bypass_force_needed(targetId);
+        carrier_swap_and_call(a1, carrierId, carrierSlotAddr, hybridAddr, forceBypass);
 
         logger.trace("[carrier] POST: carrier={:#06x} target={:#06x}", carrierId, targetId);
 
@@ -574,9 +639,12 @@ namespace Transmog
             {
                 const auto prevCarrier = last_applied_carrier_ids()[slotIdx];
                 const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
-                bool bypassApplied = false;
-                if (prevCarrier != 0)
-                    bypassApplied = set_char_class_bypass(bypassAddr, 0xEB);
+                // Only a carrier fake the wearer could NOT equip needs the bypass flipped on to be reachable; forcing
+                // it across a body-eligible fake's tear-down would restore its real item on the wrong (default) body.
+                // Matches the gate in apply_all_transmog / clear_all_transmog Phase A.
+                const bool needBypass =
+                    prevCarrier != 0 && !should_skip_bypass(static_cast<uint16_t>(prevId), current_apply_owner());
+                const bool bypassApplied = needBypass && set_char_class_bypass(bypassAddr, 0xEB);
 
                 if (prevCarrier != 0 && prevCarrier != static_cast<uint16_t>(prevId))
                 {
@@ -1069,31 +1137,13 @@ namespace Transmog
                     RealPartTearDown::get_real_item_id(reinterpret_cast<void *>(a1), k_tearDownSlots[k].gameTag);
             }
 
-            // Phase A: previous fakes (from lastIds before this apply). When the previous apply used a carrier, enable
-            // the char-class bypass so the tear-down can trace the NPC resource entries in the scene graph (they were
-            // loaded with the bypass active).
-            bool anyCarrierTearDown = false;
-            for (std::size_t k = 0; k < k_tearDownCount; ++k)
-            {
-                const auto idx = static_cast<std::size_t>(k_tearDownSlots[k].slot);
-                if (!slotNeedsWork[idx])
-                    continue;
-                if (last_applied_carrier_ids()[idx] != 0 && prevIds[idx] != 0)
-                {
-                    anyCarrierTearDown = true;
-                    break;
-                }
-            }
-
+            // Phase A: previous fakes (from lastIds before this apply). A carrier/NPC fake entered the scene graph
+            // under the char-class bypass, so tear_down_by_item_id must flip that byte back on to reach its auth row.
+            // A fake the wearer can genuinely equip was applied WITHOUT the bypass (see should_skip_bypass), so its row
+            // is reachable normally, and forcing the byte across its tear-down would restore the real item on the wrong
+            // (default) body. Toggle the byte per slot so a mix of item kinds each restores correctly.
             const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
-            bool bypassForTearDown = false;
-            if (anyCarrierTearDown)
-            {
-                bypassForTearDown = set_char_class_bypass(bypassAddr, 0xEB);
-                if (bypassForTearDown)
-                    logger.trace("[carrier] charClass bypass ENABLED "
-                                 "for Phase A tear-down");
-            }
+            const auto &teardownOwner = current_apply_owner();
 
             for (std::size_t k = 0; k < k_tearDownCount; ++k)
             {
@@ -1109,8 +1159,8 @@ namespace Transmog
                     // calls the scene-graph tear-down once; empirically that's insufficient for slots where LT hasn't
                     // previously placed a carrier (e.g. Mask/Necklace when switching to an all-none preset on first
                     // apply). Doubling the call here matches the working manual path (transmog-something -> none),
-                    // which fires Phase A on the prior carrier + Phase
-                    // B on the real entry -- same hash, same slot tag, twice.
+                    // which fires Phase A on the prior carrier + Phase B on the real entry -- same hash, same slot tag,
+                    // twice. No carrier history means the fake never entered under the bypass, so no toggle is needed.
                     const auto &m = mappings[idx];
                     if (m.active && m.targetItemId == 0 && liveRealIds[idx] != 0)
                     {
@@ -1122,6 +1172,14 @@ namespace Transmog
                     }
                     continue;
                 }
+
+                // Only a carrier fake the wearer could NOT equip needs the bypass flipped on to be reachable.
+                const bool needBypass =
+                    prevCarrier != 0 && !should_skip_bypass(static_cast<std::uint16_t>(prevId), teardownOwner);
+                const bool bypassForSlot = needBypass && set_char_class_bypass(bypassAddr, 0xEB);
+                if (bypassForSlot)
+                    logger.trace("[carrier] charClass bypass ENABLED for slot={:#06x} tear-down", td.gameTag);
+
                 // Phase A runs unconditionally: fake and real are treated equally, so even when the previous fake
                 // matched the live real item we still tear it down.
                 if (prevCarrier != 0 && prevCarrier != static_cast<std::uint16_t>(prevId))
@@ -1133,13 +1191,12 @@ namespace Transmog
                 }
                 RealPartTearDown::tear_down_by_item_id(reinterpret_cast<void *>(a1), static_cast<std::uint16_t>(prevId),
                                                        td.gameTag);
-            }
 
-            if (bypassForTearDown)
-            {
-                set_char_class_bypass(bypassAddr, 0x74);
-                logger.trace("[carrier] charClass bypass RESTORED "
-                             "after Phase A tear-down");
+                if (bypassForSlot)
+                {
+                    set_char_class_bypass(bypassAddr, 0x74);
+                    logger.trace("[carrier] charClass bypass RESTORED for slot={:#06x} tear-down", td.gameTag);
+                }
             }
 
             // Phase B: real items for any active slot. Runs unconditionally -- fake and real are treated equally, so
@@ -1531,34 +1588,15 @@ namespace Transmog
         // Pass A: tear down orphan fakes.
         if (RealPartTearDown::is_ready())
         {
-            // Toggle the char-class bypass for the duration of Pass A whenever any slot remembers a carrier item.
-            // Carrier (NPC) items are loaded with the bypass patched in so their scene-graph entries are reachable from
-            // the engine's secondary-id resolver. Without flipping the bypass back on here, tear_down_by_item_id
-            // silently fails for carrier IDs and the carrier visual persists. This is the failure mode that surfaces
-            // when toggling LT off (or hitting Clear) on a slot that has no real backing item, since carrier-loaded
-            // fakes only ever entered the scene graph under the bypass.
-            //
-            // Mirrors the bypass toggle that wraps Phase A in apply_all_transmog. set_char_class_bypass is null-safe
-            // (returns false when the address is 0) so we can call it unconditionally with the resolved address.
-            bool anyCarrierTearDown = false;
-            for (std::size_t k = 0; k < k_slotCount; ++k)
-            {
-                if (prevFakeId[k] != 0 && prevCarrierId[k] != 0)
-                {
-                    anyCarrierTearDown = true;
-                    break;
-                }
-            }
-
+            // A carrier/NPC fake entered the scene graph under the char-class bypass, so tear_down_by_item_id must flip
+            // that byte back on to reach its auth row -- otherwise the tear-down silently fails and the carrier visual
+            // persists (the failure mode that surfaces when toggling LT off or hitting Clear on such a slot). A fake
+            // the wearer can genuinely equip was applied WITHOUT the bypass (see should_skip_bypass), so its row is
+            // reachable normally, and forcing the byte across its tear-down would restore the real item on the wrong
+            // (default) body. Toggle the byte per slot so a mix of item kinds each restores correctly. Mirrors the
+            // Phase A toggle in apply_all_transmog; set_char_class_bypass is null-safe (false when the address is 0).
             const uintptr_t bypassAddr = resolved_addrs().charClassBypass;
-            bool bypassForTearDown = false;
-            if (anyCarrierTearDown)
-            {
-                bypassForTearDown = set_char_class_bypass(bypassAddr, 0xEB);
-                if (bypassForTearDown)
-                    logger.trace("[clear] charClass bypass ENABLED "
-                                 "for Pass A tear-down");
-            }
+            const auto &teardownOwner = current_apply_owner();
 
             for (std::size_t k = 0; k < k_slotCount; ++k)
             {
@@ -1575,6 +1613,13 @@ namespace Transmog
                                  gameTag, fakeId);
                     continue;
                 }
+
+                // Only a carrier fake the wearer could NOT equip needs the bypass flipped on to be reachable.
+                const bool needBypass = cId != 0 && !should_skip_bypass(fakeId, teardownOwner);
+                const bool bypassForSlot = needBypass && set_char_class_bypass(bypassAddr, 0xEB);
+                if (bypassForSlot)
+                    logger.trace("[clear] charClass bypass ENABLED for slot={:#06x} tear-down", gameTag);
+
                 // Tear down carrier identity first if used.
                 if (cId != 0 && cId != fakeId)
                 {
@@ -1587,13 +1632,12 @@ namespace Transmog
                             "(real={:#06x} carrier={:#06x})",
                             gameTag, fakeId, realId, cId);
                 RealPartTearDown::tear_down_by_item_id(reinterpret_cast<void *>(a1), fakeId, gameTag);
-            }
 
-            if (bypassForTearDown)
-            {
-                set_char_class_bypass(bypassAddr, 0x74);
-                logger.trace("[clear] charClass bypass RESTORED "
-                             "after Pass A tear-down");
+                if (bypassForSlot)
+                {
+                    set_char_class_bypass(bypassAddr, 0x74);
+                    logger.trace("[clear] charClass bypass RESTORED for slot={:#06x} tear-down", gameTag);
+                }
             }
         }
         else


### PR DESCRIPTION
## Summary

Boss and unique armor that the 1.13 update opened to a second body (Guardian of Odeck, Dark Marksman, Masked Liberator, ...) rendered as the male variant on Damiane. The old fix forced the char-class bypass for the whole apply, which also locked the engine's per-body mesh pick to the default (male) mesh for every wearer.

This adds a body-variant resolver hook that observes the engine's natural per-body match and forces the default variant only for items the wearer genuinely cannot equip, so each character now renders its correct body variant. When the hook's signatures do not resolve, the apply path falls back to the previous bypass-force behaviour so nothing turns invisible.

## Changes

- Per-body armor now renders correctly on transmog (Damiane gets the female variant), superseding the char-class bypass that mis-rendered every wearer.
- Dye button works before any preset is saved; it auto-creates one instead of dropping the click.
- Picker body filter is sourced from the display-names table body column (the 1.13 rule-classifier walk went inert), removing the temporary 1.13 disable.
- Item-to-prefab dumper links each item's per-body mesh variants and skips junk exe-static string fragments.
