### PR TITLE
fix(live-transmog): stop per-socket actor-array walk on engine threads

### DIFF
--- a/CrimsonDesertCore/include/cdcore/controlled_char.hpp
+++ b/CrimsonDesertCore/include/cdcore/controlled_char.hpp
@@ -188,6 +188,25 @@ namespace CDCore
     [[nodiscard]] std::uintptr_t equip_slot_for_ccoia(std::uintptr_t ccoia) noexcept;
 
     /**
+     * @brief Identifies which protagonist a CCOIA is, 1-based, or 0 for anyone else.
+     * @details Runs the same classifier @ref snapshot_body_cache applies while walking the actor array: the
+     *          appearance-config asset path is matched against the protagonist codenames, falling back to the CCOIA
+     *          identity byte for Kliff when the appearance chain is mid-teardown.
+     *
+     *          Exposed for consumers that cache a CCOIA and must later confirm the pointer still denotes the same
+     *          character. The engine pools these actors, so a freed CCOIA can be handed back to an unrelated actor;
+     *          a structural walk from the pointer cannot detect that, because the successor object occupies the same
+     *          layout. Re-running the classifier can, since it reads identity rather than shape.
+     *
+     *          Costs one appearance-path read plus a codename match, so it suits a per-body confirmation. It is far
+     *          too expensive to run across the whole actor array on a hot path.
+     *
+     * @param ccoia Pointer to a pa::ClientChildOnlyInGameActor instance.
+     * @return 1 Kliff, 2 Damiane, 3 Oongka, or 0 when the pointer is not a protagonist or cannot be read.
+     */
+    [[nodiscard]] std::uint32_t character_idx_for_ccoia(std::uintptr_t ccoia) noexcept;
+
+    /**
      * @brief Classify an appearance-config asset path into a protagonist index using the codename set shared with the
      *        CCOIA classifier.
      * @details Locates the `/cd_` anchor in @p path and substring-matches the suffix against the three configured

--- a/CrimsonDesertCore/src/controlled_char.cpp
+++ b/CrimsonDesertCore/src/controlled_char.cpp
@@ -701,6 +701,11 @@ namespace CDCore
         }
     }
 
+    std::uint32_t character_idx_for_ccoia(std::uintptr_t ccoia) noexcept
+    {
+        return classify_ccoia(ccoia);
+    }
+
     std::uintptr_t equip_slot_for_ccoia(std::uintptr_t ccoia) noexcept
     {
         if (ccoia < k_minValidPtr)

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -1,5 +1,3 @@
-## [Title for next release]
+## Stutter and frame drop fix
 
-- New feature
-- Bug fix
-- Improvement
+- Fixed repeated stutters and frame drops, most noticeable when one or both of your companions are not with you

--- a/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
+++ b/CrimsonDesertLiveTransmog/src/prefab_wrapper_swap.cpp
@@ -3525,6 +3525,16 @@ namespace Transmog::PrefabWrapperSwap
      * The rebuild discards uncommitted picks and re-derives everything from the active preset, which is the correct
      * meaning of entering a new world: the preset on disk is the truth, and edits that were never committed to it
      * must not dress the new body. Mid-session edits are unaffected because the stamp still matches.
+     *
+     * FIXME: the rebuild itself runs on whichever thread asked, and the per-socket descriptor detour asks from an
+     * engine thread -- so the resync, the preset re-mirror and the swap-map rebuild all land on the frame's critical
+     * path. It fires once per distinct (world generation, active character) pair, which is once per load plus once
+     * per character switch. The work is a full preset re-mirror plus a swap-map rebuild, so it scales with the
+     * catalog and the slot count, and it lands during a load or a character swap where the engine is already
+     * stalling harder on its own. That is what keeps it tolerable rather than urgent. It is still the wrong place
+     * for it, because nothing bounds the cost and nothing stops a future caller from reaching it more often. The fix
+     * is to have the load-detect worker own the rebuild the same way it owns the body-ownership table, leaving this
+     * path to read a published result.
      */
     static void ensure_target_table_current() noexcept
     {

--- a/CrimsonDesertLiveTransmog/src/shared_state.cpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.cpp
@@ -6,6 +6,8 @@
 
 #include <Windows.h>
 
+#include <mutex>
+
 namespace Transmog
 {
     std::string runtime_dir_utf8()
@@ -226,7 +228,68 @@ namespace Transmog
         s_lastAppliedCarrierIds.fill(0);
     }
 
-    std::uint32_t char_idx_for_equip_slot(std::uintptr_t a1) noexcept
+    // --- Protagonist body-ownership table ---
+    //
+    // One producer (the load-detect worker) and many readers (engine threads inside the socket-build detour). The
+    // producer owns the expensive part, the actor-array walk, so a reader never pays for it.
+    //
+    // Each row keeps the CCOIA it was derived from alongside the equip-slot address, because the address alone is not
+    // a safe key. The engine pools both objects, so between two publishes a body can be freed and its addresses handed
+    // to an unrelated actor, and a bare address compare would then report a protagonist index for somebody else's
+    // body.
+    //
+    // A hit therefore confirms two independent things before it trusts the row, because either alone leaves a hole:
+    //   - the CCOIA still classifies as the same character, which rules out the pool reissuing the actor. A structural
+    //     walk cannot detect that on its own, since the successor object occupies the identical layout;
+    //   - the CCOIA still resolves to this equip slot, which rules out the slot being reissued on its own.
+    // Both are paid only by the handful of bodies that match an entry, never by the NPCs and creatures that make up
+    // the traffic, and together they turn a silent mis-identification into an ordinary miss.
+    //
+    // A plain mutex rather than a reader/writer lock: the guarded region is a scan of at most three integers, and the
+    // detour reaches it on the order of once per second, so shared-reader parallelism would buy nothing that the
+    // narrower critical section does not already give.
+    namespace
+    {
+        /// One published protagonist body. Plain data, no invariant beyond what publish_body_owner_table enforces.
+        struct BodyOwnerRow
+        {
+            std::uintptr_t ccoia;
+            std::uintptr_t equipSlot;
+            std::uint32_t charIdx;
+        };
+
+        std::array<BodyOwnerRow, k_bodyOwnerCap> s_bodyOwners{};
+        std::size_t s_bodyOwnerCount = 0;
+        std::mutex s_bodyOwnerMutex;
+    } // namespace
+
+    void publish_body_owner_table(const std::uintptr_t *ccoias, const std::uint32_t *charIdxs, std::size_t n) noexcept
+    {
+        if (ccoias == nullptr || charIdxs == nullptr)
+            return;
+
+        // Resolve before taking the lock. equip_slot_for_ccoia walks engine memory under SEH, and holding a lock
+        // across a foreign-memory read would expose every reader to whatever that walk costs on a torn chain.
+        std::array<BodyOwnerRow, k_bodyOwnerCap> built{};
+        std::size_t written = 0;
+        for (std::size_t i = 0; i < n && i < built.size(); ++i)
+        {
+            const auto slot = CDCore::equip_slot_for_ccoia(ccoias[i]);
+            if (slot == 0)
+                continue; // component chain not wired yet; the next publish picks this body up
+            built[written] = BodyOwnerRow{ccoias[i], slot, charIdxs[i]};
+            ++written;
+        }
+
+        // An exhausted snapshot leaves written at 0, which publishes an empty table. That is deliberate: holding the
+        // previous rows through a teardown is the dangerous direction, because their bodies are freed and their
+        // addresses reissued, so a surviving row would name a dead character as the owner.
+        std::scoped_lock lk(s_bodyOwnerMutex);
+        s_bodyOwners = built;
+        s_bodyOwnerCount = written;
+    }
+
+    std::uint32_t char_idx_for_equip_slot_uncached(std::uintptr_t a1) noexcept
     {
         if (a1 < 0x10000)
             return 0;
@@ -238,6 +301,34 @@ namespace Transmog
                 return entries[i].charIdx;
         }
         return 0;
+    }
+
+    std::uint32_t char_idx_for_equip_slot(std::uintptr_t a1) noexcept
+    {
+        if (a1 < 0x10000)
+            return 0;
+
+        std::uintptr_t ccoia = 0;
+        std::uint32_t charIdx = 0;
+        {
+            std::scoped_lock lk(s_bodyOwnerMutex);
+            for (std::size_t i = 0; i < s_bodyOwnerCount; ++i)
+            {
+                if (s_bodyOwners[i].equipSlot == a1)
+                {
+                    ccoia = s_bodyOwners[i].ccoia;
+                    charIdx = s_bodyOwners[i].charIdx;
+                    break;
+                }
+            }
+        }
+        if (ccoia == 0)
+            return 0; // every NPC and creature lands here, having paid at most three integer compares
+
+        // Confirmed outside the lock, for the reasons given on the table above.
+        if (CDCore::character_idx_for_ccoia(ccoia) != charIdx)
+            return 0;
+        return CDCore::equip_slot_for_ccoia(ccoia) == a1 ? charIdx : 0;
     }
 
     std::atomic<std::uint32_t> &slot_mappings_owner() noexcept

--- a/CrimsonDesertLiveTransmog/src/shared_state.hpp
+++ b/CrimsonDesertLiveTransmog/src/shared_state.hpp
@@ -89,14 +89,57 @@ namespace Transmog
     /**
      * @brief Which protagonist owns this equip-slot component (`a1`), 1-based, or 0.
      *
-     * @details Resolved from the LIVE actor chain -- snapshot_body_cache enumerates the player CCOIAs with their
-     *          character index, and equip_slot_for_ccoia maps each to the `a1` LT applies against. Returns 0 for
-     *          companions, NPCs and wildlife, and while the chain is mid-teardown.
+     * @details Answered from the table @ref publish_body_owner_table maintains, so a caller pays three integer
+     *          compares rather than a walk of the engine's actor array. A matching row is re-derived from the actor
+     *          it came from before its index is returned, so an equip-slot address the allocator has reissued cannot
+     *          borrow a protagonist's identity.
+     *
+     *          Returns 0 for NPCs and wildlife, while the chain is mid-teardown, and also before the first table is
+     *          published or while its rows are between refreshes. Callers must treat 0 as "unknown", never as
+     *          "confirmed not a protagonist" -- see @ref char_idx_for_equip_slot_uncached where that distinction
+     *          matters.
      * @warning Use this, NOT resolve_player_component(), to answer "whose body is this?". resolve_player_component()
      *          always returns Kliff's component whatever character is controlled, so comparing against it silently
      *          accepts every other character's body.
      */
     [[nodiscard]] std::uint32_t char_idx_for_equip_slot(std::uintptr_t a1) noexcept;
+
+    /**
+     * @brief Live, uncached form of @ref char_idx_for_equip_slot.
+     * @details Walks the actor array on every call, so it always answers from current state and never reports
+     *          "unknown" merely because the published table is between refreshes. Reserve it for the apply pipeline,
+     *          which runs a handful of times a second and where a blind window would silently disarm an ownership
+     *          guard. It must never be called from an engine-driven hook: the walk is the cost this whole table
+     *          exists to keep off those threads.
+     */
+    [[nodiscard]] std::uint32_t char_idx_for_equip_slot_uncached(std::uintptr_t a1) noexcept;
+
+    /// Upper bound on published protagonist bodies: the game has exactly three playable characters.
+    inline constexpr std::size_t k_bodyOwnerCap = 3;
+
+    /**
+     * @brief Republishes the table of protagonist bodies that @ref char_idx_for_equip_slot answers from.
+     * @details Ownership is derived from a full walk of the engine's actor array. That walk can only stop early once
+     *          every companion has been found, so a party of one sweeps the array end to end -- far too expensive to
+     *          repeat per socket build on an engine thread, which is where the question is asked.
+     *
+     *          Ownership therefore has exactly one producer: the load-detect worker, which already holds a fresh
+     *          snapshot each tick. Engine threads only ever read the published result. Republishing unconditionally
+     *          (rather than on a change signal) is what makes the table self-healing: a snapshot taken while the
+     *          actor list is still filling publishes a short table, and the next tick replaces it. A change-triggered
+     *          scheme cannot recover from that, because the very signal it waits for is the one that already fired.
+     *
+     *          The two parallel arrays exist so this header stays free of a CDCore include. Its consumers pull it
+     *          in for slot mappings and flags alone, and none of them should acquire the actor-chain headers just to
+     *          reach a publish entry point.
+     *
+     * @param ccoias   Protagonist CCOIA pointers, @p n entries.
+     * @param charIdxs Matching 1-based character indices (1 Kliff, 2 Damiane, 3 Oongka), @p n entries.
+     * @param n        Number of entries; anything past @ref k_bodyOwnerCap is ignored.
+     * @note An empty snapshot publishes an empty table. Keeping the previous rows would leave them naming bodies
+     *       the engine has already freed and whose addresses it reissues.
+     */
+    void publish_body_owner_table(const std::uintptr_t *ccoias, const std::uint32_t *charIdxs, std::size_t n) noexcept;
 
     /**
      * @brief Which character `slot_mappings()` currently describes: 1 Kliff, 2 Damiane, 3 Oongka, 0 unbound.

--- a/CrimsonDesertLiveTransmog/src/socket_mesh_override.cpp
+++ b/CrimsonDesertLiveTransmog/src/socket_mesh_override.cpp
@@ -234,9 +234,12 @@ namespace Transmog::SocketMeshOverride
             // than "does this body belong to the character these targets came from" -- and a table holding one
             // protagonist's targets would pass while the engine rebuilds another, dressing the wrong character.
             //
-            // char_idx_for_equip_slot resolves the body through the live actor chain, so it cannot be fooled by state
-            // a save-load or hot reload left stale. A zero on either side means "not a protagonist body" or "table
-            // unbound" -- both fall through rather than guess.
+            // char_idx_for_equip_slot answers from a table the load-detect worker republishes once per tick in
+            // steady state and once per retry attempt during a load. A match is confirmed against the recorded actor
+            // before an index comes back, so a recycled address cannot borrow a protagonist's identity. What it can
+            // do is answer 0 for a short window after a body is rebuilt, which costs this pre-substitution pass and
+            // nothing else: the character's own apply still dresses them. A zero on either side means "not a
+            // protagonist body" or "table unbound" -- both fall through rather than guess.
             const auto tableIdx = PrefabWrapperSwap::target_table_char_idx();
             const auto hostIdx = char_idx_for_equip_slot(static_cast<std::uintptr_t>(a1));
             if (tableIdx == 0 || hostIdx == 0 || hostIdx != tableIdx)

--- a/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_apply.cpp
@@ -586,7 +586,10 @@ namespace Transmog
      */
     static bool apply_host_matches_owner(std::uintptr_t a1, const char *site) noexcept
     {
-        const auto hostIdx = char_idx_for_equip_slot(a1);
+        // Live walk, not the published table. This guard fails open on 0, so answering "unknown" disarms it
+        // silently, and the table reads unknown for a stretch after every world load. The apply pipeline runs a few
+        // times a second and already paid this walk, so it can afford the certainty; the engine-thread hooks cannot.
+        const auto hostIdx = char_idx_for_equip_slot_uncached(a1);
         if (hostIdx == 0)
             return true; // not a protagonist body, or the chain is mid-teardown -- not a mismatch
 

--- a/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
+++ b/CrimsonDesertLiveTransmog/src/transmog_worker.cpp
@@ -713,6 +713,14 @@ namespace Transmog
         else
         {
             // Full chain reached -- reset retry counter so the next world bump (save-load) starts fresh.
+            //
+            // FIXME: this zeroes the counter that the deferred-body branch at the end of this function then reads,
+            // so that branch always computes attempt 1 and its k_multiCharMaxRetries cap never trips. Whenever the
+            // chain is complete but a body is not ready, the re-arm therefore repeats indefinitely at
+            // k_multiCharRetryMs instead of stopping after the intended budget. It currently self-limits because the
+            // body does become ready, but a save where one never does would keep the worker re-arming for the whole
+            // session. The two paths need separate counters: this one bounds "chain never wired", that one bounds
+            // "body never ready", and they are not the same failure.
             s_multiCharRetryCount.store(0, std::memory_order_release);
         }
         if (n == 0)
@@ -1232,6 +1240,34 @@ namespace Transmog
      */
     static constexpr std::uint64_t k_charSwapSettleMs = 1000;
 
+    /**
+     * @brief Walks the live actor chain once and republishes the protagonist body-ownership table from it.
+     * @details This thread is the table's only producer, so wherever this thread parks the table stops being
+     *          refreshed. That matters most during a world load, which is exactly when its rows are shortest and
+     *          likeliest to name bodies the engine has already replaced, so the auto-apply retry loop refreshes
+     *          through here as well as the steady-state tick.
+     *
+     *          The snapshot is split into parallel arrays because shared_state.hpp deliberately carries no CDCore
+     *          include; see @ref publish_body_owner_table.
+     * @return Number of protagonists the snapshot found, which doubles as the roster sample the caller compares
+     *         against to detect a companion arriving.
+     */
+    static std::size_t publish_owner_table_from_live() noexcept
+    {
+        std::array<CDCore::BodyCacheEntry, k_bodyOwnerCap> snap{};
+        const auto found = CDCore::snapshot_body_cache(snap.data(), snap.size());
+
+        std::array<std::uintptr_t, k_bodyOwnerCap> ccoias{};
+        std::array<std::uint32_t, k_bodyOwnerCap> charIdxs{};
+        for (std::size_t i = 0; i < found; ++i)
+        {
+            ccoias[i] = snap[i].body;
+            charIdxs[i] = snap[i].charIdx;
+        }
+        publish_body_owner_table(ccoias.data(), charIdxs.data(), found);
+        return found;
+    }
+
     static DWORD WINAPI load_detect_thread_fn(LPVOID)
     {
         auto &logger = DMK::Logger::get_instance();
@@ -1298,6 +1334,11 @@ namespace Transmog
             static constexpr std::size_t kSnapshotCountUninit = static_cast<std::size_t>(-1);
             static std::size_t s_prevSnapshotCount = kSnapshotCountUninit;
             {
+                // Refresh the ownership table first, so the socket-build detour on the engine threads is answering
+                // from this tick's roster rather than the previous one. The count doubles as the roster sample the
+                // watcher below compares against, so the walk happens once.
+                const auto n = publish_owner_table_from_live();
+
                 const auto curWorldGen = CDCore::world_generation();
                 if (curWorldGen != prevWorldGen)
                 {
@@ -1314,8 +1355,6 @@ namespace Transmog
                 }
                 else
                 {
-                    std::array<CDCore::BodyCacheEntry, 3> snap{};
-                    const auto n = CDCore::snapshot_body_cache(snap.data(), snap.size());
                     if (s_prevSnapshotCount != kSnapshotCountUninit && n > s_prevSnapshotCount)
                     {
                         logger.info("Player roster grew {} -> {}; arming "
@@ -1609,6 +1648,11 @@ namespace Transmog
                     sleep_interruptible(delayMs);
                     if (shutdown_requested().load(std::memory_order_relaxed))
                         break;
+
+                    // The outer tick cannot run while this loop owns the thread, and this loop can hold it for a
+                    // minute or more. Refresh here too, or the engine threads spend the whole load answering from a
+                    // roster captured before it started.
+                    (void)publish_owner_table_from_live();
 
                     // Mid-retry wrapper-change abort. The engine sometimes parks user+0xD8 on a placeholder wrapper for
                     // 60+ seconds before deallocating it and allocating the real character actor at a different


### PR DESCRIPTION
## Summary

- Fixes the repeated stutters two users reported on 0.14.0, cleared by reverting to 0.13.2.
- `char_idx_for_equip_slot` ran a full actor-array sweep from the socket-build detour, once per socket per actor on an engine thread. The sweep only stops early once every companion is found, so a party without them paid it in full on every call.
- Ownership is now published instead of derived on demand: the load-detect worker walks the chain once and publishes a small protagonist body table, and the detour only reads it. A hit is confirmed against the recorded actor by identity and equip slot, so a reissued address cannot borrow a protagonist's index.
- The apply pipeline keeps the live walk, because its ownership guard fails open and a table between refreshes would silently disarm it.
- Engine threads: 33.700 ms/s and a 62 ms worst sample before, 0.000 ms/s and 1.2 us after. No host mismatches or errors across two world loads and three character switches.
- Adds `CDCore::character_idx_for_ccoia` for the per-body confirmation, plus FIXME notes on two pre-existing issues found along the way.
