### PR TITLE
fix(equip-hide): stop resolving player actors on the game thread

### DIFF
--- a/CrimsonDesertCore/src/indexed_string_table.cpp
+++ b/CrimsonDesertCore/src/indexed_string_table.cpp
@@ -11,17 +11,44 @@ namespace CDCore
 {
     static constexpr std::size_t k_maxStringLen = 64;
 
-    static std::size_t read_table_entry(std::uintptr_t tableArray, std::uint32_t hash, char *buf,
-                                        std::size_t bufSize) noexcept
+    /** @brief Lowest address a populated slot's string pointer can hold; below it the slot is null or unpublished. */
+    static constexpr std::uintptr_t k_minStringPtr = 0x10000;
+
+    /** @brief Byte stride between consecutive table entries. */
+    static constexpr std::uintptr_t k_entryStride = 16;
+
+    /**
+     * @brief Copy entry[hash]'s string into @p buf, but only when it starts with @p prefix.
+     *
+     * @details The prefix test runs before the copy on purpose. The table holds the engine's entire interned-string
+     *          set, tens of thousands of entries, and only a few hundred carry the caller's prefix. Copying first and
+     *          filtering afterwards would spend a full string read on entries that were never candidates; comparing
+     *          the leading bytes first keeps a rejected entry down to the one cache line its string starts on.
+     *
+     * @return Copied length, or 0 for an empty slot, a prefix mismatch, or a faulting read. Callers cannot
+     *         distinguish the three and do not need to.
+     */
+    static std::size_t read_table_entry(std::uintptr_t tableArray, std::uint32_t hash, const char *prefix,
+                                        std::size_t prefixLen, char *buf, std::size_t bufSize) noexcept
     {
         __try
         {
-            const auto entryAddr = tableArray + static_cast<std::uintptr_t>(hash) * 16;
+            const auto entryAddr = tableArray + static_cast<std::uintptr_t>(hash) * k_entryStride;
             const auto strPtr = *reinterpret_cast<const std::uintptr_t *>(entryAddr);
-            if (strPtr < 0x10000)
+            if (strPtr < k_minStringPtr)
                 return 0;
 
             const auto *src = reinterpret_cast<const char *>(strPtr);
+
+            // Testing the terminator alongside the mismatch is what stops the compare walking past the end of a
+            // string shorter than the prefix. An empty prefix skips the loop, so every entry is a candidate.
+            for (std::size_t i = 0; i < prefixLen; ++i)
+            {
+                const char c = src[i];
+                if (c == '\0' || c != prefix[i])
+                    return 0;
+            }
+
             std::size_t len = 0;
             while (len < bufSize - 1 && src[len] != '\0')
             {
@@ -35,16 +62,6 @@ namespace CDCore
         {
             return 0;
         }
-    }
-
-    static bool matches_prefix(const char *buf, std::size_t len, const char *prefix) noexcept
-    {
-        if (!prefix || !*prefix)
-            return true;
-        const std::size_t plen = std::strlen(prefix);
-        if (len < plen)
-            return false;
-        return std::memcmp(buf, prefix, plen) == 0;
     }
 
     std::unordered_map<std::string, std::uint32_t> scan_indexed_string_table(std::uintptr_t mapLookupFunc,
@@ -83,7 +100,7 @@ namespace CDCore
         // globalPtrAddr is a RIP-resolved module slot; guard the read so a build whose layout shifted it outside
         // committed memory yields 0 (handled as "not yet initialized") rather than faulting.
         const auto globalPtr = DMKMemory::seh_read<std::uintptr_t>(globalPtrAddr).value_or(0);
-        if (globalPtr < 0x10000)
+        if (globalPtr < k_minStringPtr)
         {
             logger.trace("{}: global pointer not yet initialized (0x{:X})", cfg.logLabel, globalPtr);
             return nameToHash;
@@ -92,7 +109,7 @@ namespace CDCore
         // globalPtr is a live game heap pointer that can tear or relocate across a world reload; a faulting read yields
         // 0 and routes to the "offset moved" warning below instead of crashing the caller.
         const auto tableArray = DMKMemory::seh_read<std::uintptr_t>(globalPtr + cfg.tableArrayOffset).value_or(0);
-        if (tableArray < 0x10000)
+        if (tableArray < k_minStringPtr)
         {
             logger.warning("{}: tableArray is null/invalid (0x{:X}) -- offset 0x{:X} "
                            "inside globalPtr may have moved",
@@ -103,16 +120,17 @@ namespace CDCore
         logger.trace("{}: globalPtr=0x{:X} tableArray=0x{:X} range=0x{:X}-0x{:X}", cfg.logLabel, globalPtr, tableArray,
                      cfg.tableScanMin, cfg.tableScanMax);
 
+        const char *prefix = cfg.prefix ? cfg.prefix : "";
+        const std::size_t prefixLen = std::strlen(prefix);
+
         const auto t0 = std::chrono::steady_clock::now();
         std::uint32_t entries = 0;
         char buf[k_maxStringLen + 1];
 
         for (std::uint32_t hash = cfg.tableScanMin; hash <= cfg.tableScanMax; ++hash)
         {
-            const auto len = read_table_entry(tableArray, hash, buf, sizeof(buf));
+            const auto len = read_table_entry(tableArray, hash, prefix, prefixLen, buf, sizeof(buf));
             if (len == 0 || len >= k_maxStringLen)
-                continue;
-            if (!matches_prefix(buf, len, cfg.prefix))
                 continue;
 
             nameToHash[std::string(buf, len)] = hash;
@@ -127,7 +145,7 @@ namespace CDCore
             logger.warning("{}: 0 entries matching prefix '{}' found in range "
                            "0x{:X}..0x{:X} -- table not yet populated or prefix "
                            "missing from this build; deferring feature",
-                           cfg.logLabel, cfg.prefix ? cfg.prefix : "", cfg.tableScanMin, cfg.tableScanMax);
+                           cfg.logLabel, prefix, cfg.tableScanMin, cfg.tableScanMax);
         }
         else
         {
@@ -136,7 +154,7 @@ namespace CDCore
             // decision points.
             logger.trace("{}: {} entries for prefix '{}' in range 0x{:X}..0x{:X} "
                          "in {}ms",
-                         cfg.logLabel, entries, cfg.prefix ? cfg.prefix : "", cfg.tableScanMin, cfg.tableScanMax, ms);
+                         cfg.logLabel, entries, prefix, cfg.tableScanMin, cfg.tableScanMax, ms);
         }
 
         return nameToHash;

--- a/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertEquipHide/docs/NEXT_CHANGELOG.md
@@ -1,3 +1,6 @@
-## Crimson Desert 2.01.00 support
+## Crimson Desert 2.01.00 support and performance fixes
 
 - Updated the mod to work with Crimson Desert version 2.01.00
+- Fixed a performance drop that built up across loading screens, fast travel and zone changes
+- Sped up the equipment name lookup the mod runs while loading
+- Cut background scanning while the mod waits for late-loading equipment parts

--- a/CrimsonDesertEquipHide/src/background_threads.cpp
+++ b/CrimsonDesertEquipHide/src/background_threads.cpp
@@ -233,18 +233,27 @@ namespace EquipHide
             // Seeded with size_t-max so the first non-empty scan always wins.
             std::size_t bestUnresolved = std::numeric_limits<std::size_t>::max();
 
+            // Signal value consumed by the previous tick.
+            //
+            // The signal doubles as the interval throttle: it carries the timestamp it was armed at, and the mid-hook
+            // re-arms only when it reads 0 or a value older than k_lazyProbeIntervalMs. Consuming it by comparison
+            // keeps that throttle intact. Clearing it instead would present the producer with the "never armed"
+            // sentinel, which it re-arms on immediately, collapsing the real interval to this loop's sleep period.
+            int64_t lastSignal = 0;
+
             logger.info("Lazy probe started for demand-loaded parts "
                         "(interval: {}s)",
                         k_lazyProbeIntervalMs / 1000);
 
             while (lazy_probe_pending().load(std::memory_order_relaxed))
             {
-                if (!sleep_responsive_ms(st, 5000))
+                if (!sleep_responsive_ms(st, static_cast<int>(k_lazyProbeTickMs)))
                     return;
 
                 const auto signal = lazy_probe_signal().load(std::memory_order_relaxed);
-                if (signal == 0)
+                if (signal == 0 || signal == lastSignal)
                     continue;
+                lastSignal = signal;
 
                 ++probeCount;
                 logger.trace("Lazy probe #{}: scanning IndexedStringA table", probeCount);
@@ -266,7 +275,6 @@ namespace EquipHide
                     logger.trace("Lazy probe #{}: {} parts unresolved "
                                  "(no progress since last commit)",
                                  probeCount, unresolvedCount);
-                    lazy_probe_signal().store(0, std::memory_order_relaxed);
                     continue;
                 }
 
@@ -300,8 +308,6 @@ namespace EquipHide
                             "{} INI parts still unresolved (will keep "
                             "polling for late registrations)",
                             probeCount, newHashCount, unresolvedCount);
-
-                lazy_probe_signal().store(0, std::memory_order_relaxed);
             }
         }
 
@@ -373,21 +379,25 @@ namespace EquipHide
                 const auto curActor = read_controlled_actor_ptr_seh();
                 const bool actorRotated = (curActor != prevActor);
 
+                // Any change in roster size re-resolves, in both directions. A shrink matters as much as a growth: a
+                // despawned companion leaves its vis ctrl published, and the direct-write path would keep writing
+                // through that stale pointer. Nothing else observes a despawn -- the controlled actor does not rotate
+                // for it -- so this is the only trigger that catches one.
                 std::array<CDCore::BodyCacheEntry, k_maxProtagonists> snap{};
                 const auto curSnapshotCount = CDCore::snapshot_body_cache(snap.data(), snap.size());
-                const bool rosterGrew =
-                    (prevSnapshotCount != kSnapshotCountUninit && curSnapshotCount > prevSnapshotCount);
+                const bool rosterChanged =
+                    (prevSnapshotCount != kSnapshotCountUninit && curSnapshotCount != prevSnapshotCount);
 
                 const auto prevSnapshotCountForLog = prevSnapshotCount;
                 if (actorRotated)
                     prevActor = curActor;
                 prevSnapshotCount = curSnapshotCount;
 
-                if (!actorRotated && !rosterGrew)
+                if (!actorRotated && !rosterChanged)
                     continue;
 
-                if (rosterGrew)
-                    logger.info("Player roster grew {} -> {}; re-resolving "
+                if (rosterChanged)
+                    logger.info("Player roster changed {} -> {}; re-resolving "
                                 "vis-ctrls",
                                 prevSnapshotCountForLog, curSnapshotCount);
 

--- a/CrimsonDesertEquipHide/src/background_threads.hpp
+++ b/CrimsonDesertEquipHide/src/background_threads.hpp
@@ -4,8 +4,23 @@
 
 namespace EquipHide
 {
-    /** @brief Minimum interval between lazy probe signals (ms). */
+    /**
+     * @brief Minimum interval between lazy probe signals (ms).
+     *
+     *  Enforced on the producer side, by the EquipVisCheck mid-hook that arms the signal. The probe worker must consume
+     *  the signal by value and never reset it: the producer treats a zeroed signal as "never armed" and re-arms
+     *  immediately, which drops the real interval to k_lazyProbeTickMs.
+     */
     inline constexpr int64_t k_lazyProbeIntervalMs = 60'000;
+
+    /**
+     * @brief Lazy probe worker wake period (ms).
+     *
+     *  Not the probe interval -- that is k_lazyProbeIntervalMs above, enforced by how often the signal advances. This
+     *  is only how promptly the worker notices a freshly armed signal; a tick that finds the signal unchanged costs one
+     *  relaxed atomic load and goes back to sleep.
+     */
+    inline constexpr int64_t k_lazyProbeTickMs = 5'000;
 
     /**
      * @brief Controlled-actor watcher poll interval (ms).

--- a/CrimsonDesertEquipHide/src/player_detection.cpp
+++ b/CrimsonDesertEquipHide/src/player_detection.cpp
@@ -13,8 +13,17 @@
 
 namespace EquipHide
 {
-    static std::atomic<uint32_t> s_resolveCounter{0};
-    static constexpr uint32_t k_resolveInterval = 512;
+    /**
+     * @brief Minimum gap between inline (game-thread) resolves while no protagonist is known (ms).
+     *
+     *  A save-load wipe zeroes the published player count, so without a floor every visibility check in that window
+     *  would start its own actor sweep. 250ms stays responsive against the resolve-poll thread's 1s tick while
+     *  bounding the game thread to four sweeps a second.
+     */
+    static constexpr int64_t k_inlineResolveMinIntervalMs = 250;
+
+    /** @brief Timestamp of the last inline resolve, in @ref steady_ms units. Zero means none has run. */
+    static std::atomic<int64_t> s_lastInlineResolveMs{0};
 
     static uintptr_t s_prevVisCtrls[k_maxProtagonists]{};
     static int s_prevCount = 0;
@@ -520,10 +529,29 @@ namespace EquipHide
             return ps.count.load(std::memory_order_relaxed) > 0 && is_player_vis_ctrl(a1);
         }
 
-        // Global pointer chain mode.
-        auto cnt = s_resolveCounter.fetch_add(1, std::memory_order_relaxed);
-        if (ps.count.load(std::memory_order_relaxed) == 0 || (cnt & (k_resolveInterval - 1)) == 0)
-            resolve_player_vis_ctrls();
+        // Cold start only: resolve inline when no protagonist is published yet, never on a periodic refresh.
+        //
+        // This body runs on a game thread, and resolve_player_vis_ctrls() is not cheap. Its actor sweep runs the
+        // appearance-config classifier over the manager's actor array and only early-outs once BOTH companions have
+        // been found, so solo play, or any moment a companion is not spawned, walks the array end to end. The bound is
+        // the engine's array capacity, which ratchets up with each zone load and never shrinks: cost per call grows
+        // with the number of transitions in a session while the call rate stays flat. A periodic refresh here would
+        // therefore turn into a per-frame stall that only shows up deep into a session.
+        //
+        // The resolve-poll thread covers the steady state instead -- it re-resolves once a second off the game thread
+        // and reacts to actor rotation directly, so nothing is lost by refusing to refresh from the hook. Only the
+        // cold path stays, because until the count is non-zero this filter rejects every part and the mod is inert.
+        if (ps.count.load(std::memory_order_relaxed) == 0)
+        {
+            const auto now = steady_ms();
+            auto last = s_lastInlineResolveMs.load(std::memory_order_relaxed);
+            if ((now - last) >= k_inlineResolveMinIntervalMs &&
+                s_lastInlineResolveMs.compare_exchange_strong(last, now, std::memory_order_relaxed,
+                                                              std::memory_order_relaxed))
+            {
+                resolve_player_vis_ctrls();
+            }
+        }
 
         /* Fail-closed (see fallback branch above for rationale). */
         return ps.count.load(std::memory_order_relaxed) > 0 && is_player_vis_ctrl(a1);

--- a/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
+++ b/CrimsonDesertLiveTransmog/docs/NEXT_CHANGELOG.md
@@ -3,3 +3,4 @@
 - Updated the mod to work with Crimson Desert version 2.01.00
 - Refreshed the item name list for game version 2.01.00
 - Fixed large saved color palettes losing colors when they were loaded back
+- Sped up the equipment name lookup the mod runs while loading


### PR DESCRIPTION
## Summary

- The visibility hook re-ran a full actor sweep every 512 calls on the game thread. The sweep is bounded by the engine actor array capacity, which grows with each zone load and never shrinks, so its cost climbed with session length while the call rate stayed flat. It now runs only on the cold path, rate limited to 250ms, with the existing 1s resolve-poll thread covering the steady state off the game thread.
- Player vis ctrls now re-resolve on any roster change instead of growth only, so a despawned companion no longer leaves a stale pointer published for the direct-write path to use.
- The lazy probe now honours its documented 60s interval. It previously slept 5s and cleared the arming signal, which the producer read as "never armed" and re-armed on immediately.
- The IndexedStringA scan tests the name prefix before copying each string, cutting a full scan from roughly 11ms to 2ms. Shared with LiveTransmog.
